### PR TITLE
feat(exec): EXPLAIN ANALYZE with decorator-based pipeline profiling

### DIFF
--- a/internal/engine/exec/profile.go
+++ b/internal/engine/exec/profile.go
@@ -1,0 +1,241 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+)
+
+// ProfileStats holds execution statistics for a single pipeline operator.
+type ProfileStats struct {
+	Name       string        // operator name (e.g., "Filter", "HashAggregate")
+	WallTime   time.Duration // total wall time spent in this operator
+	RowsIn     int64         // total input rows
+	RowsOut    int64         // total output rows
+	Calls      int64         // number of calls (Next/Execute/Consume)
+}
+
+// ProfileCollector aggregates stats from all operators in a pipeline.
+type ProfileCollector struct {
+	stats []*ProfileStats
+}
+
+// NewProfileCollector creates a new collector.
+func NewProfileCollector() *ProfileCollector {
+	return &ProfileCollector{}
+}
+
+// Add registers a stats entry and returns it. The caller (wrapper) writes to it.
+func (c *ProfileCollector) Add(name string) *ProfileStats {
+	s := &ProfileStats{Name: name}
+	c.stats = append(c.stats, s)
+	return s
+}
+
+// Stats returns all collected stats in pipeline order.
+func (c *ProfileCollector) Stats() []*ProfileStats {
+	return c.stats
+}
+
+// ProfiledSource wraps a Source to collect timing and row count stats.
+type ProfiledSource struct {
+	inner Source
+	stats *ProfileStats
+}
+
+// WrapSource decorates a Source with profiling. Only call when EXPLAIN ANALYZE is active.
+func WrapSource(src Source, collector *ProfileCollector, name string) *ProfiledSource {
+	return &ProfiledSource{
+		inner: src,
+		stats: collector.Add(name),
+	}
+}
+
+func (p *ProfiledSource) Init(ctx context.Context) error {
+	return p.inner.Init(ctx)
+}
+
+func (p *ProfiledSource) Next(ctx context.Context) (*batch.RecordBatch, error) {
+	start := time.Now()
+	b, err := p.inner.Next(ctx)
+	p.stats.WallTime += time.Since(start)
+	atomic.AddInt64(&p.stats.Calls, 1)
+	if b != nil {
+		atomic.AddInt64(&p.stats.RowsOut, int64(b.ActiveLen()))
+	}
+	return b, err
+}
+
+func (p *ProfiledSource) Close() error {
+	return p.inner.Close()
+}
+
+// Inner returns the wrapped source (for type assertions like ScanStatsProvider).
+func (p *ProfiledSource) Inner() Source {
+	return p.inner
+}
+
+// ProfiledOperator wraps a UnaryOperator to collect timing and row count stats.
+type ProfiledOperator struct {
+	inner UnaryOperator
+	stats *ProfileStats
+}
+
+// WrapOperator decorates a UnaryOperator with profiling.
+func WrapOperator(op UnaryOperator, collector *ProfileCollector, name string) *ProfiledOperator {
+	return &ProfiledOperator{
+		inner: op,
+		stats: collector.Add(name),
+	}
+}
+
+func (p *ProfiledOperator) Init(ctx context.Context) error {
+	return p.inner.Init(ctx)
+}
+
+func (p *ProfiledOperator) Execute(ctx context.Context, in *batch.RecordBatch) (*batch.RecordBatch, error) {
+	rowsIn := int64(0)
+	if in != nil {
+		rowsIn = int64(in.ActiveLen())
+	}
+	start := time.Now()
+	out, err := p.inner.Execute(ctx, in)
+	p.stats.WallTime += time.Since(start)
+	atomic.AddInt64(&p.stats.Calls, 1)
+	atomic.AddInt64(&p.stats.RowsIn, rowsIn)
+	if out != nil {
+		atomic.AddInt64(&p.stats.RowsOut, int64(out.ActiveLen()))
+	}
+	return out, err
+}
+
+func (p *ProfiledOperator) Close() error {
+	return p.inner.Close()
+}
+
+// Inner returns the wrapped operator (for type assertions like DoneSignaler).
+func (p *ProfiledOperator) Inner() UnaryOperator {
+	return p.inner
+}
+
+// Done delegates to the inner operator if it implements DoneSignaler.
+func (p *ProfiledOperator) Done() bool {
+	if ds, ok := p.inner.(DoneSignaler); ok {
+		return ds.Done()
+	}
+	return false
+}
+
+// Clone delegates to the inner operator if it implements Cloneable.
+func (p *ProfiledOperator) Clone() UnaryOperator {
+	if c, ok := p.inner.(Cloneable); ok {
+		return c.Clone()
+	}
+	return p
+}
+
+// ProfiledSink wraps a Sink to collect timing and row count stats.
+type ProfiledSink struct {
+	inner Sink
+	stats *ProfileStats
+}
+
+// WrapSink decorates a Sink with profiling.
+func WrapSink(sink Sink, collector *ProfileCollector, name string) *ProfiledSink {
+	return &ProfiledSink{
+		inner: sink,
+		stats: collector.Add(name),
+	}
+}
+
+func (p *ProfiledSink) Init(ctx context.Context) error {
+	return p.inner.Init(ctx)
+}
+
+func (p *ProfiledSink) Consume(ctx context.Context, b *batch.RecordBatch) error {
+	rowsIn := int64(0)
+	if b != nil {
+		rowsIn = int64(b.ActiveLen())
+	}
+	start := time.Now()
+	err := p.inner.Consume(ctx, b)
+	p.stats.WallTime += time.Since(start)
+	atomic.AddInt64(&p.stats.Calls, 1)
+	atomic.AddInt64(&p.stats.RowsIn, rowsIn)
+	return err
+}
+
+func (p *ProfiledSink) Finalize(ctx context.Context) error {
+	start := time.Now()
+	err := p.inner.Finalize(ctx)
+	p.stats.WallTime += time.Since(start)
+	return err
+}
+
+func (p *ProfiledSink) Close() error {
+	return p.inner.Close()
+}
+
+// Inner returns the wrapped sink.
+func (p *ProfiledSink) Inner() Sink {
+	return p.inner
+}
+
+// WrapPipeline wraps all operators in a pipeline with profiling decorators.
+// Returns the collector for reading stats after execution.
+func WrapPipeline(pipeline *Pipeline) *ProfileCollector {
+	collector := NewProfileCollector()
+
+	// Wrap source
+	srcName := operatorName(pipeline.Source)
+	pipeline.Source = WrapSource(pipeline.Source, collector, srcName)
+
+	// Wrap operators
+	for i, op := range pipeline.Ops {
+		opName := operatorName(op)
+		pipeline.Ops[i] = WrapOperator(op, collector, opName)
+	}
+
+	// Wrap sink
+	sinkName := operatorName(pipeline.Sink)
+	pipeline.Sink = WrapSink(pipeline.Sink, collector, sinkName)
+
+	return collector
+}
+
+// operatorName returns a human-readable name for an operator based on its type.
+func operatorName(op any) string {
+	t := fmt.Sprintf("%T", op)
+	// Strip package prefix: "*exec.KernelFilter" → "KernelFilter"
+	if idx := strings.LastIndex(t, "."); idx >= 0 {
+		t = t[idx+1:]
+	}
+	return t
+}
+
+// FormatAnalyzeStats formats profiling stats as annotation lines.
+// Each entry becomes: "  OperatorName (actual rows=N, time=Xms, calls=N)"
+func FormatAnalyzeStats(stats []*ProfileStats) []string {
+	lines := make([]string, 0, len(stats))
+	for _, s := range stats {
+		line := fmt.Sprintf("  → %s (rows_in=%d, rows_out=%d, time=%s, calls=%d)",
+			s.Name, s.RowsIn, s.RowsOut, formatDuration(s.WallTime), s.Calls)
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+// formatDuration formats a duration for human display.
+func formatDuration(d time.Duration) string {
+	if d < time.Millisecond {
+		return fmt.Sprintf("%.1fµs", float64(d.Microseconds()))
+	}
+	if d < time.Second {
+		return fmt.Sprintf("%.1fms", float64(d.Microseconds())/1000.0)
+	}
+	return fmt.Sprintf("%.2fs", d.Seconds())
+}

--- a/internal/engine/exec/profile.go
+++ b/internal/engine/exec/profile.go
@@ -62,7 +62,7 @@ func (p *ProfiledSource) Init(ctx context.Context) error {
 func (p *ProfiledSource) Next(ctx context.Context) (*batch.RecordBatch, error) {
 	start := time.Now()
 	b, err := p.inner.Next(ctx)
-	p.stats.WallTime += time.Since(start)
+	atomic.AddInt64((*int64)(&p.stats.WallTime), int64(time.Since(start)))
 	atomic.AddInt64(&p.stats.Calls, 1)
 	if b != nil {
 		atomic.AddInt64(&p.stats.RowsOut, int64(b.ActiveLen()))
@@ -104,7 +104,7 @@ func (p *ProfiledOperator) Execute(ctx context.Context, in *batch.RecordBatch) (
 	}
 	start := time.Now()
 	out, err := p.inner.Execute(ctx, in)
-	p.stats.WallTime += time.Since(start)
+	atomic.AddInt64((*int64)(&p.stats.WallTime), int64(time.Since(start)))
 	atomic.AddInt64(&p.stats.Calls, 1)
 	atomic.AddInt64(&p.stats.RowsIn, rowsIn)
 	if out != nil {
@@ -131,11 +131,20 @@ func (p *ProfiledOperator) Done() bool {
 }
 
 // Clone delegates to the inner operator if it implements Cloneable.
+// Returns a new ProfiledOperator wrapping the cloned inner, with fresh stats.
 func (p *ProfiledOperator) Clone() UnaryOperator {
 	if c, ok := p.inner.(Cloneable); ok {
-		return c.Clone()
+		return &ProfiledOperator{
+			inner: c.Clone(),
+			stats: &ProfileStats{Name: p.stats.Name},
+		}
 	}
-	return p
+	// Inner is not cloneable — return a new wrapper with its own stats
+	// to avoid shared-stats corruption.
+	return &ProfiledOperator{
+		inner: p.inner,
+		stats: &ProfileStats{Name: p.stats.Name},
+	}
 }
 
 // ProfiledSink wraps a Sink to collect timing and row count stats.
@@ -163,7 +172,7 @@ func (p *ProfiledSink) Consume(ctx context.Context, b *batch.RecordBatch) error 
 	}
 	start := time.Now()
 	err := p.inner.Consume(ctx, b)
-	p.stats.WallTime += time.Since(start)
+	atomic.AddInt64((*int64)(&p.stats.WallTime), int64(time.Since(start)))
 	atomic.AddInt64(&p.stats.Calls, 1)
 	atomic.AddInt64(&p.stats.RowsIn, rowsIn)
 	return err
@@ -172,7 +181,7 @@ func (p *ProfiledSink) Consume(ctx context.Context, b *batch.RecordBatch) error 
 func (p *ProfiledSink) Finalize(ctx context.Context) error {
 	start := time.Now()
 	err := p.inner.Finalize(ctx)
-	p.stats.WallTime += time.Since(start)
+	atomic.AddInt64((*int64)(&p.stats.WallTime), int64(time.Since(start)))
 	return err
 }
 

--- a/internal/engine/exec/profile_test.go
+++ b/internal/engine/exec/profile_test.go
@@ -1,0 +1,252 @@
+package exec
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+func TestProfiledSource(t *testing.T) {
+	schema := []Column{
+		{Name: "id", Type: parquet.TypeInt64},
+	}
+	rows := []map[string]any{
+		{"id": int64(1)},
+		{"id": int64(2)},
+		{"id": int64(3)},
+	}
+	src := NewSliceSource(schema, rows)
+	collector := NewProfileCollector()
+	profiled := WrapSource(src, collector, "TestSource")
+
+	ctx := context.Background()
+	if err := profiled.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	totalRows := int64(0)
+	calls := 0
+	for {
+		b, err := profiled.Next(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if b == nil {
+			break
+		}
+		totalRows += int64(b.ActiveLen())
+		calls++
+	}
+
+	stats := collector.Stats()
+	if len(stats) != 1 {
+		t.Fatalf("expected 1 stat entry, got %d", len(stats))
+	}
+	s := stats[0]
+	if s.Name != "TestSource" {
+		t.Errorf("expected name TestSource, got %s", s.Name)
+	}
+	if s.RowsOut != totalRows {
+		t.Errorf("expected %d rows out, got %d", totalRows, s.RowsOut)
+	}
+	if s.WallTime <= 0 {
+		t.Error("expected non-zero wall time")
+	}
+	// Calls includes the final nil-returning call
+	if s.Calls != int64(calls+1) {
+		t.Errorf("expected %d calls, got %d", calls+1, s.Calls)
+	}
+
+	if err := profiled.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestProfiledOperator(t *testing.T) {
+	schema := []Column{
+		{Name: "id", Type: parquet.TypeInt64},
+	}
+	collector := NewProfileCollector()
+	inner := &passthroughOp{}
+	profiled := WrapOperator(inner, collector, "TestOp")
+
+	ctx := context.Background()
+	if err := profiled.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	b := batch.FromRows(schema, []map[string]any{
+		{"id": int64(1)},
+		{"id": int64(2)},
+	})
+
+	out, err := profiled.Execute(ctx, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out == nil {
+		t.Fatal("expected non-nil output")
+	}
+
+	stats := collector.Stats()
+	if len(stats) != 1 {
+		t.Fatalf("expected 1 stat entry, got %d", len(stats))
+	}
+	s := stats[0]
+	if s.RowsIn != int64(b.ActiveLen()) {
+		t.Errorf("expected %d rows in, got %d", b.ActiveLen(), s.RowsIn)
+	}
+	if s.RowsOut != int64(out.ActiveLen()) {
+		t.Errorf("expected %d rows out, got %d", out.ActiveLen(), s.RowsOut)
+	}
+	if s.Calls != 1 {
+		t.Errorf("expected 1 call, got %d", s.Calls)
+	}
+
+	if err := profiled.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestProfiledSink(t *testing.T) {
+	schema := []Column{
+		{Name: "id", Type: parquet.TypeInt64},
+	}
+	collector := NewProfileCollector()
+	inner := &CollectSink{}
+	profiled := WrapSink(inner, collector, "TestSink")
+
+	ctx := context.Background()
+	if err := profiled.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	b := batch.FromRows(schema, []map[string]any{
+		{"id": int64(1)},
+		{"id": int64(2)},
+		{"id": int64(3)},
+	})
+
+	if err := profiled.Consume(ctx, b); err != nil {
+		t.Fatal(err)
+	}
+	if err := profiled.Finalize(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	stats := collector.Stats()
+	if len(stats) != 1 {
+		t.Fatalf("expected 1 stat entry, got %d", len(stats))
+	}
+	s := stats[0]
+	if s.RowsIn != 3 {
+		t.Errorf("expected 3 rows in, got %d", s.RowsIn)
+	}
+	if s.Calls != 1 {
+		t.Errorf("expected 1 call, got %d", s.Calls)
+	}
+	if s.WallTime <= 0 {
+		t.Error("expected non-zero wall time")
+	}
+
+	if err := profiled.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWrapPipeline(t *testing.T) {
+	schema := []Column{
+		{Name: "id", Type: parquet.TypeInt64},
+	}
+	rows := []map[string]any{
+		{"id": int64(1)},
+		{"id": int64(2)},
+	}
+
+	pipeline := &Pipeline{
+		Source: NewSliceSource(schema, rows),
+		Ops:    []UnaryOperator{&passthroughOp{}},
+		Sink:   &CollectSink{},
+	}
+
+	collector := WrapPipeline(pipeline)
+
+	// Verify all operators are now wrapped
+	if _, ok := pipeline.Source.(*ProfiledSource); !ok {
+		t.Error("source should be wrapped")
+	}
+	if _, ok := pipeline.Ops[0].(*ProfiledOperator); !ok {
+		t.Error("operator should be wrapped")
+	}
+	if _, ok := pipeline.Sink.(*ProfiledSink); !ok {
+		t.Error("sink should be wrapped")
+	}
+
+	// Execute the pipeline
+	ctx := context.Background()
+	if err := pipeline.Run(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer pipeline.Close()
+
+	// Verify stats were collected
+	stats := collector.Stats()
+	if len(stats) != 3 { // source + 1 op + sink
+		t.Fatalf("expected 3 stat entries, got %d", len(stats))
+	}
+
+	// Source should have produced rows
+	if stats[0].RowsOut == 0 {
+		t.Error("source should have produced rows")
+	}
+	// Operator should have processed rows
+	if stats[1].RowsIn == 0 {
+		t.Error("operator should have received rows")
+	}
+	// Sink should have consumed rows
+	if stats[2].RowsIn == 0 {
+		t.Error("sink should have consumed rows")
+	}
+}
+
+func TestFormatAnalyzeStats(t *testing.T) {
+	stats := []*ProfileStats{
+		{Name: "ScanSource", RowsIn: 0, RowsOut: 1000, WallTime: 5_500_000, Calls: 2},  // 5.5ms
+		{Name: "KernelFilter", RowsIn: 1000, RowsOut: 100, WallTime: 800_000, Calls: 2}, // 800µs
+		{Name: "CollectSink", RowsIn: 100, RowsOut: 0, WallTime: 200_000_000, Calls: 2},  // 200ms
+	}
+
+	lines := FormatAnalyzeStats(stats)
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(lines))
+	}
+
+	// Verify format contains expected fields
+	if !strings.Contains(lines[0], "ScanSource") {
+		t.Errorf("line 0 should contain ScanSource: %s", lines[0])
+	}
+	if !strings.Contains(lines[0], "rows_out=1000") {
+		t.Errorf("line 0 should contain rows_out=1000: %s", lines[0])
+	}
+	if !strings.Contains(lines[1], "KernelFilter") {
+		t.Errorf("line 1 should contain KernelFilter: %s", lines[1])
+	}
+	if !strings.Contains(lines[1], "rows_in=1000") {
+		t.Errorf("line 1 should contain rows_in=1000: %s", lines[1])
+	}
+	if !strings.Contains(lines[2], "CollectSink") {
+		t.Errorf("line 2 should contain CollectSink: %s", lines[2])
+	}
+}
+
+// passthroughOp is a minimal UnaryOperator that passes batches through unchanged.
+type passthroughOp struct{}
+
+func (p *passthroughOp) Init(_ context.Context) error { return nil }
+func (p *passthroughOp) Execute(_ context.Context, in *batch.RecordBatch) (*batch.RecordBatch, error) {
+	return in, nil
+}
+func (p *passthroughOp) Close() error { return nil }

--- a/internal/planner/sql/lexer.go
+++ b/internal/planner/sql/lexer.go
@@ -60,6 +60,7 @@ const (
 	TokenKWFrom
 	TokenKWExplain
 	TokenKWVerbose
+	TokenKWAnalyze
 	TokenKWDescribe
 	TokenKWDesc
 	TokenKWWith
@@ -165,6 +166,7 @@ var keywords = map[string]TokenType{
 	"FROM":      TokenKWFrom,
 	"EXPLAIN":   TokenKWExplain,
 	"VERBOSE":   TokenKWVerbose,
+	"ANALYZE":   TokenKWAnalyze,
 	"DESCRIBE":  TokenKWDescribe,
 	"DESC":      TokenKWDesc,
 	"WITH":      TokenKWWith,

--- a/internal/planner/sql/parser.go
+++ b/internal/planner/sql/parser.go
@@ -82,6 +82,7 @@ type CTEDef struct {
 // ExplainInfo holds details for an EXPLAIN statement.
 type ExplainInfo struct {
 	Verbose  bool
+	Analyze  bool
 	InnerSQL string
 }
 
@@ -360,9 +361,15 @@ type OrderByItem struct {
 
 // --- Lexer-based pre-parse functions ---
 
-// lexParseExplain handles: EXPLAIN [VERBOSE] <query>
+// lexParseExplain handles: EXPLAIN [ANALYZE] [VERBOSE] <query>
 func lexParseExplain(sql string, l *lexer) (*ParsedQuery, error) {
 	l.nextToken() // consume EXPLAIN
+
+	analyze := false
+	if l.peekToken().typ == TokenKWAnalyze {
+		l.nextToken() // consume ANALYZE
+		analyze = true
+	}
 
 	verbose := false
 	if l.peekToken().typ == TokenKWVerbose {
@@ -383,6 +390,7 @@ func lexParseExplain(sql string, l *lexer) (*ParsedQuery, error) {
 		SelectInfo: inner.SelectInfo,
 		Explain: &ExplainInfo{
 			Verbose:  verbose,
+			Analyze:  analyze,
 			InnerSQL: rest,
 		},
 	}, nil

--- a/internal/planner/sql/parser_test.go
+++ b/internal/planner/sql/parser_test.go
@@ -248,6 +248,44 @@ func TestParseExplainVerbose(t *testing.T) {
 	}
 }
 
+func TestParseExplainAnalyze(t *testing.T) {
+	parsed, err := Parse("EXPLAIN ANALYZE SELECT * FROM events WHERE id > 5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Type != QueryExplain {
+		t.Fatalf("expected QueryExplain, got %v", parsed.Type)
+	}
+	if parsed.Explain == nil {
+		t.Fatal("Explain info is nil")
+	}
+	if !parsed.Explain.Analyze {
+		t.Error("should have analyze flag")
+	}
+	if parsed.Explain.Verbose {
+		t.Error("should not be verbose")
+	}
+	if parsed.Explain.InnerSQL != "SELECT * FROM events WHERE id > 5" {
+		t.Errorf("unexpected inner SQL: %s", parsed.Explain.InnerSQL)
+	}
+}
+
+func TestParseExplainAnalyzeVerbose(t *testing.T) {
+	parsed, err := Parse("EXPLAIN ANALYZE VERBOSE SELECT id FROM events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Type != QueryExplain {
+		t.Fatalf("expected QueryExplain, got %v", parsed.Type)
+	}
+	if !parsed.Explain.Analyze {
+		t.Error("should have analyze flag")
+	}
+	if !parsed.Explain.Verbose {
+		t.Error("should be verbose")
+	}
+}
+
 func TestParseDescribe(t *testing.T) {
 	tests := []struct {
 		sql       string

--- a/wadjet/wadjet.go
+++ b/wadjet/wadjet.go
@@ -217,6 +217,12 @@ func (db *DB) explain(ctx context.Context, parsed *plansql.ParsedQuery) (*QueryR
 	}
 
 	db.planner.AnnotateScanColumns(ctx, logicalPlan)
+
+	// ABAC enforcement: inject row filters and column policies at plan level
+	logicalPlan, err = db.enforceAccessPolicies(ctx, selectInfo, logicalPlan)
+	if err != nil {
+		return nil, err
+	}
 	logicalPlan = logical.Optimize(logicalPlan, func(plan *logical.Node) {
 		db.planner.AnnotateScanColumns(ctx, plan)
 	})

--- a/wadjet/wadjet.go
+++ b/wadjet/wadjet.go
@@ -222,6 +222,10 @@ func (db *DB) explain(ctx context.Context, parsed *plansql.ParsedQuery) (*QueryR
 	})
 	plan := logicalPlan.PrettyPrint(0)
 
+	if parsed.Explain.Analyze {
+		return db.explainAnalyze(ctx, logicalPlan, plan, parsed.Explain.Verbose)
+	}
+
 	if parsed.Explain.Verbose {
 		physPlan, err := db.planner.Plan(ctx, logicalPlan)
 		if err != nil {
@@ -241,6 +245,66 @@ func (db *DB) explain(ctx context.Context, parsed *plansql.ParsedQuery) (*QueryR
 		Columns: []string{"plan"},
 		Rows:    rows,
 		Plan:    plan,
+	}, nil
+}
+
+// explainAnalyze builds and executes the query with profiling wrappers,
+// then returns the plan annotated with actual execution statistics.
+func (db *DB) explainAnalyze(ctx context.Context, logicalPlan *logical.Node, logicalStr string, verbose bool) (*QueryResult, error) {
+	physPlan, err := db.planner.Plan(ctx, logicalPlan)
+	if err != nil {
+		return nil, fmt.Errorf("building physical plan: %w", err)
+	}
+	if physPlan.Cleanup != nil {
+		defer physPlan.Cleanup()
+	}
+
+	pipeline := physPlan.Pipeline
+
+	// Wrap all operators with profiling decorators before execution
+	collector := exec.WrapPipeline(pipeline)
+
+	if err := pipeline.Run(ctx); err != nil {
+		return nil, fmt.Errorf("executing query for EXPLAIN ANALYZE: %w", err)
+	}
+	defer pipeline.Close()
+
+	// Count result rows from the sink
+	var totalRows int64
+	if profiledSink, ok := pipeline.Sink.(*exec.ProfiledSink); ok {
+		if inner, ok := profiledSink.Inner().(*exec.CollectSink); ok {
+			totalRows = int64(len(inner.ToRows()))
+		}
+	}
+
+	// Build annotated output
+	var out strings.Builder
+	out.WriteString("-- Logical Plan --\n")
+	out.WriteString(logicalStr)
+
+	if verbose {
+		out.WriteString("\n\n-- Physical Plan --\n")
+		out.WriteString(physPlan.PrettyPrint())
+	}
+
+	out.WriteString("\n\n-- Execution Stats --\n")
+	for _, line := range exec.FormatAnalyzeStats(collector.Stats()) {
+		out.WriteString(line)
+		out.WriteString("\n")
+	}
+	out.WriteString(fmt.Sprintf("\nTotal rows returned: %d", totalRows))
+
+	planStr := out.String()
+	lines := strings.Split(planStr, "\n")
+	rows := make([]map[string]any, len(lines))
+	for i, line := range lines {
+		rows[i] = map[string]any{"plan": line}
+	}
+
+	return &QueryResult{
+		Columns: []string{"plan"},
+		Rows:    rows,
+		Plan:    planStr,
 	}, nil
 }
 

--- a/wadjet/wadjet_test.go
+++ b/wadjet/wadjet_test.go
@@ -479,3 +479,115 @@ func TestWithRecursiveCTE(t *testing.T) {
 		}
 	})
 }
+
+func TestExplainAnalyze(t *testing.T) {
+	ctx := context.Background()
+	store := objstore.NewMemStore()
+	db, err := Open(ctx, Config{Store: store, Bucket: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	schema := parquet.Schema{
+		Columns: []parquet.Column{
+			{Name: "id", Type: parquet.TypeInt64},
+			{Name: "severity", Type: parquet.TypeString},
+		},
+	}
+	if err := db.CreateTable(ctx, "findings", schema, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	ing := db.NewIngester("findings", schema, nil, ingest.Config{
+		MaxBufferRows: 100,
+		RowGroupSize:  100,
+	})
+	if err := ing.Ingest(ctx, []map[string]any{
+		{"id": int64(1), "severity": "high"},
+		{"id": int64(2), "severity": "low"},
+		{"id": int64(3), "severity": "high"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ing.FlushAll(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("basic", func(t *testing.T) {
+		result, err := db.Query(ctx, "EXPLAIN ANALYZE SELECT * FROM findings WHERE severity = 'high'")
+		if err != nil {
+			t.Fatalf("EXPLAIN ANALYZE failed: %v", err)
+		}
+
+		if len(result.Columns) != 1 || result.Columns[0] != "plan" {
+			t.Fatalf("expected single 'plan' column, got %v", result.Columns)
+		}
+
+		plan := result.Plan
+
+		// Must contain logical plan section
+		if !strings.Contains(plan, "-- Logical Plan --") {
+			t.Error("missing logical plan section")
+		}
+
+		// Must contain execution stats section
+		if !strings.Contains(plan, "-- Execution Stats --") {
+			t.Error("missing execution stats section")
+		}
+
+		// Must contain operator stats with timing
+		if !strings.Contains(plan, "rows_in=") || !strings.Contains(plan, "rows_out=") {
+			t.Error("missing row count stats")
+		}
+		if !strings.Contains(plan, "time=") {
+			t.Error("missing timing stats")
+		}
+
+		// Must report total rows
+		if !strings.Contains(plan, "Total rows returned:") {
+			t.Error("missing total rows")
+		}
+
+		t.Logf("EXPLAIN ANALYZE output:\n%s", plan)
+	})
+
+	t.Run("verbose", func(t *testing.T) {
+		result, err := db.Query(ctx, "EXPLAIN ANALYZE VERBOSE SELECT * FROM findings")
+		if err != nil {
+			t.Fatalf("EXPLAIN ANALYZE VERBOSE failed: %v", err)
+		}
+
+		plan := result.Plan
+
+		// Must contain both logical and physical plan sections
+		if !strings.Contains(plan, "-- Logical Plan --") {
+			t.Error("missing logical plan section")
+		}
+		if !strings.Contains(plan, "-- Physical Plan --") {
+			t.Error("missing physical plan section")
+		}
+		if !strings.Contains(plan, "-- Execution Stats --") {
+			t.Error("missing execution stats section")
+		}
+
+		t.Logf("EXPLAIN ANALYZE VERBOSE output:\n%s", plan)
+	})
+
+	t.Run("plain_explain_unchanged", func(t *testing.T) {
+		// Verify that plain EXPLAIN (no ANALYZE) still works and does NOT execute
+		result, err := db.Query(ctx, "EXPLAIN SELECT * FROM findings")
+		if err != nil {
+			t.Fatalf("EXPLAIN failed: %v", err)
+		}
+
+		plan := result.Plan
+
+		// Should NOT contain execution stats
+		if strings.Contains(plan, "-- Execution Stats --") {
+			t.Error("plain EXPLAIN should not contain execution stats")
+		}
+		if strings.Contains(plan, "Total rows returned:") {
+			t.Error("plain EXPLAIN should not contain total rows")
+		}
+	})
+}

--- a/wadjet/wadjet_test.go
+++ b/wadjet/wadjet_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/citc-tech/wadjet/internal/auth"
 	"github.com/citc-tech/wadjet/internal/storage/ingest"
 	"github.com/citc-tech/wadjet/internal/storage/objstore"
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
@@ -588,6 +589,148 @@ func TestExplainAnalyze(t *testing.T) {
 		}
 		if strings.Contains(plan, "Total rows returned:") {
 			t.Error("plain EXPLAIN should not contain total rows")
+		}
+	})
+}
+
+func TestExplainAnalyzeABACEnforcement(t *testing.T) {
+	ctx := context.Background()
+	store := objstore.NewMemStore()
+	db, err := Open(ctx, Config{Store: store, Bucket: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	schema := parquet.Schema{
+		Columns: []parquet.Column{
+			{Name: "id", Type: parquet.TypeInt64},
+			{Name: "severity", Type: parquet.TypeString},
+			{Name: "secret_col", Type: parquet.TypeString},
+		},
+	}
+	if err := db.CreateTable(ctx, "findings", schema, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	ing := db.NewIngester("findings", schema, nil, ingest.Config{
+		MaxBufferRows: 100,
+		RowGroupSize:  100,
+	})
+	if err := ing.Ingest(ctx, []map[string]any{
+		{"id": int64(1), "severity": "high", "secret_col": "classified-a"},
+		{"id": int64(2), "severity": "low", "secret_col": "classified-b"},
+		{"id": int64(3), "severity": "high", "secret_col": "classified-c"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ing.FlushAll(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up ABAC: deny secret_col and inject row filter severity='high'
+	evaluator := auth.NewPolicyEvaluator([]auth.AccessControlPolicy{
+		{
+			Name:    "test-policy",
+			Version: 1,
+			Enabled: true,
+			Rules: []auth.PolicyRule{
+				{
+					ID:        "restrict-findings",
+					EffectStr: "allow",
+					Priority:  10,
+					Subjects: []auth.Condition{
+						{Attribute: "subject.role", Op: "eq", Value: "analyst"},
+					},
+					Resources: []auth.Condition{
+						{Attribute: "resource.name", Op: "eq", Value: "findings"},
+					},
+					Actions: []auth.Action{auth.ActionRead},
+					Obligations: []auth.Obligation{
+						{Type: "deny_column", Target: "secret_col"},
+						{Type: "row_filter", Value: "severity = 'high'"},
+					},
+				},
+			},
+		},
+	})
+
+	authn, authz := auth.New(auth.Config{
+		Enabled: true,
+		APIKeys: []auth.APIKeyDef{
+			{Key: "test-key", Name: "analyst", Role: "analyst"},
+		},
+		Roles: []auth.RoleConfig{
+			{Name: "analyst", Tables: []string{"*"}, Allow: []string{"read"}},
+		},
+	})
+	provider := auth.NewProvider(authn, authz, nil, nil)
+	provider.UpdateWithEvaluator(authn, authz, nil, evaluator)
+	db.SetAuthProvider(provider)
+
+	identity := &auth.Identity{
+		Name:   "analyst",
+		Role:   "analyst",
+		Method: "apikey",
+	}
+	authCtx := auth.ContextWithIdentity(ctx, identity)
+
+	t.Run("explain_analyze_respects_deny_column", func(t *testing.T) {
+		// EXPLAIN ANALYZE with SELECT * -- secret_col should be stripped by ABAC
+		result, err := db.Query(authCtx, "EXPLAIN ANALYZE SELECT * FROM findings")
+		if err != nil {
+			t.Fatalf("EXPLAIN ANALYZE failed: %v", err)
+		}
+		plan := result.Plan
+		t.Logf("EXPLAIN ANALYZE deny_column plan:\n%s", plan)
+
+		// The denied column must not appear in plan output
+		if strings.Contains(plan, "secret_col") {
+			t.Errorf("denied column 'secret_col' should not appear in EXPLAIN ANALYZE output, plan:\n%s", plan)
+		}
+	})
+
+	t.Run("explain_respects_deny_column", func(t *testing.T) {
+		// EXPLAIN with SELECT * -- secret_col should be stripped by ABAC
+		result, err := db.Query(authCtx, "EXPLAIN SELECT * FROM findings")
+		if err != nil {
+			t.Fatalf("EXPLAIN failed: %v", err)
+		}
+		plan := result.Plan
+		t.Logf("EXPLAIN deny_column plan:\n%s", plan)
+
+		// The denied column must not appear in plan output
+		if strings.Contains(plan, "secret_col") {
+			t.Errorf("denied column 'secret_col' should not appear in EXPLAIN output, plan:\n%s", plan)
+		}
+	})
+
+	t.Run("explain_analyze_respects_row_filter", func(t *testing.T) {
+		result, err := db.Query(authCtx, "EXPLAIN ANALYZE SELECT id, severity FROM findings")
+		if err != nil {
+			t.Fatalf("EXPLAIN ANALYZE failed: %v", err)
+		}
+
+		plan := result.Plan
+		t.Logf("EXPLAIN ANALYZE with ABAC:\n%s", plan)
+
+		// Row filter severity='high' should limit results to 2 rows, not 3
+		if !strings.Contains(plan, "Total rows returned: 2") {
+			t.Errorf("expected exactly 2 rows (row filter severity='high'), plan:\n%s", plan)
+		}
+	})
+
+	t.Run("explain_shows_row_filter_in_plan", func(t *testing.T) {
+		result, err := db.Query(authCtx, "EXPLAIN SELECT id, severity FROM findings")
+		if err != nil {
+			t.Fatalf("EXPLAIN failed: %v", err)
+		}
+
+		plan := result.Plan
+		t.Logf("EXPLAIN with ABAC:\n%s", plan)
+
+		// The row filter should appear in the logical plan
+		if !strings.Contains(plan, "severity") {
+			t.Errorf("expected row filter predicate in plan, got:\n%s", plan)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Adds `EXPLAIN ANALYZE` support using a decorator pattern that wraps pipeline operators to capture per-operator timing, row counts, and batch stats without modifying operator implementations
- Enforces ABAC policies in both `EXPLAIN` and `EXPLAIN ANALYZE` paths to prevent metadata leakage to unauthorized callers

## Changes
- `feat(exec): add EXPLAIN ANALYZE with decorator-based pipeline profiling`
- `fix(exec): enforce ABAC policies in EXPLAIN/EXPLAIN ANALYZE paths`

## Test plan
- [ ] `EXPLAIN ANALYZE SELECT ...` returns timing tree with operator-level stats
- [ ] Unauthorized user cannot `EXPLAIN ANALYZE` a table they lack access to
- [ ] `EXPLAIN` (non-analyze) still works and is unaffected
- [ ] Run `go test ./internal/...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)