### PR TITLE
fix(coordinator): error on malformed build cache worker response

### DIFF
--- a/internal/coordinator/build_cache.go
+++ b/internal/coordinator/build_cache.go
@@ -260,6 +260,8 @@ func (c *Coordinator) preScanOneTable(parentCtx context.Context, parentQueryID s
 		}
 		return []string{path}, nil
 	}
-	// Success, but no path, no inline, no rows — treat as empty.
-	return nil, nil
+	// NumRows > 0 but neither ResultPath nor InlineData — the worker lost
+	// the data somewhere. Treating this as empty would silently drop rows
+	// from the build cache and produce wrong query results downstream.
+	return nil, fmt.Errorf("build cache scan returned %d rows but no result path or inline data", resultRows)
 }

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -4196,7 +4196,7 @@ type catalogScanSource struct {
 	inner           exec.Source
 	cache           *scanCached           // non-nil when this table is scanned multiple times
 	replayIdx       atomic.Int64          // position in cache replay (atomic for parallel pipeline)
-	isReplay        bool                  // true when reading from cache instead of scanning
+	isReplay        bool                  // true when reading from cache instead of scanning; written once in Init before runParallel starts, so no synchronization needed
 	bloomFilter     *exec.BloomScanFilter // bloom filter pushdown from hash join build side
 	dynamicFilter   []exec.DynamicRange   // dynamic min/max range filter from hash join build side
 	rowLimit        int64                 // LIMIT pushdown: enables lazy file downloading (0 = eager)


### PR DESCRIPTION
## Summary

Follow-up to PR #29. Raj's review found a correctness gap in `preScanOneTable`:

- **Error on impossible state**: If a worker returns `NumRows>0` but neither `ResultPath` nor `InlineData`, the fallthrough silently returned `nil` — dropping rows from the build cache. Now returns an explicit error so the failure surfaces immediately instead of producing wrong query results downstream.
- **Document `isReplay` thread-safety**: Added comment that `isReplay` is written once in `Init` before `runParallel` starts, matching the explicit sync documentation on `replayIdx` added in PR #29.

## Test plan
- [x] `go test -race ./internal/...` passes (pre-push hook)
- [x] `TestDistributedTPCHBuildCache*` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)