### PR TITLE
fix(worker): stream build cache pre-scan to spill file (SF100 OOM)

### DIFF
--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -356,6 +356,16 @@ func (e *Executor) executePipeline(ctx context.Context, task distributed.Task, r
 		return nil
 	}
 
+	// Build-cache pre-scan tasks (StageID == "build-cache-scan") read whole
+	// tables that may not fit in worker memory. Replace the default CollectSink
+	// with a streaming shuffle sink that writes each batch to a spill file as
+	// it arrives, so memory stays bounded by one batch instead of growing to
+	// the full table size. Without this, scanning partsupp at SF100 (~12GB)
+	// peaks at ~24GB during serializeBatches and OOM-kills the worker.
+	if task.StageID == "build-cache-scan" && e.spillDir != "" {
+		return e.executeBuildCachePreScan(ctx, task, pipeline, result)
+	}
+
 	// Execute the pipeline — same path as standalone mode
 	if err := pipeline.Run(ctx); err != nil {
 		return fmt.Errorf("pipeline execution: %w", err)
@@ -385,6 +395,67 @@ func (e *Executor) executePipeline(ctx context.Context, task distributed.Task, r
 	}
 
 	return e.writeBatchResult(ctx, task, batches, result)
+}
+
+// executeBuildCachePreScan runs a build-cache pre-scan pipeline with a
+// streaming sink that writes batches to a local spill file as they arrive,
+// then uploads the file to S3. Avoids the OOM that the default CollectSink
+// path triggers when scanning very large build tables.
+func (e *Executor) executeBuildCachePreScan(ctx context.Context, task distributed.Task, pipeline *exec.Pipeline, result *distributed.ResultNotification) error {
+	streamSink := newShuffleStreamSink(e.spillDir)
+	if err := streamSink.Init(ctx); err != nil {
+		return fmt.Errorf("init build cache stream sink: %w", err)
+	}
+	// Make sure we always close the file handle and remove the spill file,
+	// even on error paths.
+	spillPath := streamSink.FilePath()
+	defer func() {
+		_ = streamSink.Close()
+		if spillPath != "" {
+			_ = os.Remove(spillPath)
+		}
+	}()
+
+	// Replace CollectSink with the streaming sink. The pipeline doesn't care
+	// what sink it has — it just calls Consume on each batch.
+	pipeline.Sink = streamSink
+
+	if err := pipeline.Run(ctx); err != nil {
+		return fmt.Errorf("build cache pre-scan pipeline: %w", err)
+	}
+
+	totalRows := streamSink.NumRows()
+	e.logger.Info("build cache pre-scan completed",
+		"task_id", task.ID,
+		"table_sql", task.SQLText,
+		"rows", totalRows,
+		"spill_file", spillPath,
+	)
+
+	result.NumRows = totalRows
+	if totalRows == 0 {
+		// Empty table: nothing to upload. Coordinator handles the no-rows case.
+		return nil
+	}
+
+	// Re-open the spill file for upload (the writer keeps an fd, but the
+	// streaming Put needs its own reader positioned at the start).
+	f, err := os.Open(spillPath)
+	if err != nil {
+		return fmt.Errorf("opening spill file for upload: %w", err)
+	}
+	defer f.Close()
+	fi, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("stat spill file: %w", err)
+	}
+	resultPath := task.ResultPrefix + task.ID + ".wshf"
+	if _, err := e.store.Put(ctx, task.ResultBucket, resultPath, f, fi.Size(), "application/octet-stream"); err != nil {
+		return fmt.Errorf("uploading build cache result to S3: %w", err)
+	}
+	result.ResultPath = resultPath
+	result.SizeBytes = fi.Size()
+	return nil
 }
 
 // getFileData retrieves raw Parquet bytes with 3-tier caching:

--- a/internal/worker/shuffle_sink.go
+++ b/internal/worker/shuffle_sink.go
@@ -1,0 +1,139 @@
+package worker
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// shuffleStreamSink is an exec.Sink that writes consumed batches to a local
+// spill file in WSHF format as they arrive, instead of accumulating them in
+// memory like CollectSink does. After Finalize, the caller uploads the spill
+// file to S3 and obtains its path via FilePath().
+//
+// This is the build-cache pre-scan path. Without it, a worker tasked with
+// "SELECT * FROM partsupp" at SF100 would accumulate ~12GB of partsupp rows
+// in CollectSink, then serialize them again into a 12GB byte buffer, then
+// compress that — peaking at ~24GB+ which OOM-kills 32GB workers. With this
+// sink each batch is written to disk and released back to the pool before
+// the next batch arrives, so memory stays bounded by one batch.
+type shuffleStreamSink struct {
+	spillDir string
+
+	mu      sync.Mutex
+	file    *os.File
+	writer  *shuffleWriter
+	schema  []parquet.Column
+	numRows int64
+	closed  bool
+}
+
+func newShuffleStreamSink(spillDir string) *shuffleStreamSink {
+	return &shuffleStreamSink{spillDir: spillDir}
+}
+
+// Init creates the spill file. The header is deferred to the first Consume
+// because the schema isn't known until then.
+func (s *shuffleStreamSink) Init(_ context.Context) error {
+	if s.spillDir == "" {
+		return fmt.Errorf("shuffleStreamSink: spillDir is empty")
+	}
+	if err := os.MkdirAll(s.spillDir, 0o755); err != nil {
+		return fmt.Errorf("creating spill dir: %w", err)
+	}
+	f, err := os.CreateTemp(s.spillDir, "build-cache-*.wshf")
+	if err != nil {
+		return fmt.Errorf("opening spill file: %w", err)
+	}
+	s.file = f
+	return nil
+}
+
+// Consume writes the batch as a WSHF chunk to the spill file. Safe for
+// concurrent calls from parallel pipeline workers — serialized via mu.
+func (s *shuffleStreamSink) Consume(_ context.Context, b *batch.RecordBatch) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.file == nil {
+		return fmt.Errorf("shuffleStreamSink: not initialized")
+	}
+
+	if s.writer == nil {
+		s.schema = b.Schema
+		s.writer = newShuffleWriter(s.file, s.schema)
+		if err := s.writer.writeHeader(); err != nil {
+			return fmt.Errorf("writing shuffle header: %w", err)
+		}
+	}
+
+	nRows := b.ActiveLen()
+	if nRows == 0 {
+		return nil
+	}
+
+	if err := s.writer.writeChunk(b.Columns, b.Sel, nRows); err != nil {
+		return fmt.Errorf("writing shuffle chunk: %w", err)
+	}
+	s.numRows += int64(nRows)
+	return nil
+}
+
+// Finalize patches the chunk count in the header and flushes the file.
+// The file remains open so the caller can upload it; Close releases the fd.
+func (s *shuffleStreamSink) Finalize(_ context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.file == nil {
+		return nil
+	}
+	if s.writer == nil {
+		// No batches consumed — leave the file empty so upstream sees zero rows.
+		return s.file.Sync()
+	}
+
+	// Patch chunk count in the header. Layout (see shuffle_format.go):
+	//   offset 0..4 = magic "WSHF"
+	//   offset 4..8 = numChunks (uint32 LE) — placeholder written by writeHeader
+	if _, err := s.file.Seek(4, 0); err != nil {
+		return fmt.Errorf("seeking to patch chunk count: %w", err)
+	}
+	var buf [4]byte
+	binary.LittleEndian.PutUint32(buf[:], s.writer.numChunks)
+	if _, err := s.file.Write(buf[:]); err != nil {
+		return fmt.Errorf("patching chunk count: %w", err)
+	}
+	if _, err := s.file.Seek(0, 2); err != nil { // back to end
+		return fmt.Errorf("seeking back to end: %w", err)
+	}
+	return s.file.Sync()
+}
+
+// Close releases the file handle. The spill file itself is left on disk for
+// the caller to upload + remove.
+func (s *shuffleStreamSink) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed || s.file == nil {
+		return nil
+	}
+	s.closed = true
+	return s.file.Close()
+}
+
+// FilePath returns the path to the spill file. Empty string if Init failed.
+func (s *shuffleStreamSink) FilePath() string {
+	if s.file == nil {
+		return ""
+	}
+	return s.file.Name()
+}
+
+// NumRows returns the total number of rows written across all chunks.
+func (s *shuffleStreamSink) NumRows() int64 { return s.numRows }


### PR DESCRIPTION
## Summary

Fixes the **actual SF100 Q02 regression** that PR #29 surfaced as a loud error. The build cache pre-scan path was accumulating the entire pre-scanned table in `CollectSink.batches` + a `bytes.Buffer` before uploading to S3, peaking at ~24 GB for partsupp at SF100 and OOM-killing 32 GB workers.

## Root cause

The build cache feature has a streaming **read** path (`cachedFileStreamSource` from PR #28) but no streaming **write** path. The pre-scan task runs `SELECT * FROM partsupp` through a normal pipeline whose sink is `CollectSink`, which:

1. Accumulates all batches in `CollectSink.batches` (~12 GB for SF100 partsupp)
2. `serializeBatches` writes them all to a `bytes.Buffer` (~12 GB more)
3. `CompressShuffleData` copies again
4. Uploads the resulting blob

Confirmed OOM in dmesg from yesterday's deploy:
\`\`\`
Out of memory: Killed process 3036 (wadjet)
total-vm:33082572kB anon-rss:31712096kB
\`\`\`

## Fix

New `internal/worker/shuffle_sink.go` defines `shuffleStreamSink` — an `exec.Sink` that:
- Opens a temp file on the worker's spill directory (NVMe on c7gd)
- On the first `Consume`, learns the schema and writes the WSHF header
- On each subsequent `Consume`, calls `writeChunk` directly into the file (bounded buffer)
- On `Finalize`, seeks back and patches the chunk count placeholder
- Provides `FilePath()` and `NumRows()` for the caller to upload

`executor.executePipeline` detects build-cache pre-scan tasks via `task.StageID == \"build-cache-scan\"` and routes them through a new `executeBuildCachePreScan` helper that:
- Replaces `pipeline.Sink` with the streaming sink
- Runs the pipeline
- Re-opens the spill file with a streaming reader
- Uploads it to S3 via `store.Put`
- Removes the spill file on the way out

Memory now stays bounded by **one batch** (~MB) instead of the full table size, on both the streaming read and streaming write sides.

## Test plan

- [x] \`go test -count=2 ./internal/coordinator/\` — clean
- [x] \`go test -race ./internal/...\` — clean
- [x] \`TestDistributedTPCHBuildCacheDuplicateAlias\` x20 — 20/20 pass
- [x] \`TestDistributedTPCH/Q02\` x20 — 20/20 pass
- [ ] SF100 deploy — Q02 should now make it past the build cache pre-scan (manual, follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)