### PR TITLE
fix(worker,objstore): build cache stream sink double-init + size-aware Put timeout

### DIFF
--- a/internal/coordinator/build_cache.go
+++ b/internal/coordinator/build_cache.go
@@ -19,13 +19,24 @@ import (
 // the N× duplication causes OOM (e.g., orders at SF100 ≈ 15GB, partsupp ≈ 8GB).
 const buildCacheThreshold = 2 * 1024 * 1024 * 1024 // 2 GB
 
-// buildCacheGroupSize is the number of Parquet files per pre-scan task.
-// Partitioning the pre-scan across multiple tasks prevents a single worker from
-// accumulating all rows of a large table (e.g., partsupp ~11.8GB) in RAM before
-// writing to S3. Each task writes one .wshf cache file to a group-specific prefix.
-// Declared as var (not const) so regression tests can lower it to force multiple
-// groups on tiny SF0.01 tables and exercise the file-splitting correctness path.
-var buildCacheGroupSize = 8
+// buildCacheGroupSize is the number of Parquet files per pre-scan task. It
+// also bounds the size of each individual cache (.wshf) file, which matters
+// because cachedFileStreamSource currently downloads each cache file fully
+// into memory via getFileData → io.ReadAll before streaming chunks out of
+// the resulting byte slice. With group size 8 a single SF100 partsupp cache
+// file is ~10 GB, which OOM-kills any worker that needs to load it during
+// the probe phase. Group size 2 caps each cache file at ~2.5 GB, comfortably
+// within the per-worker memory budget on c7gd.4xlarge (32 GB) instances.
+//
+// The right long-term fix is to make cachedFileStreamSource read incrementally
+// from S3 (or download to local NVMe and mmap), at which point this constant
+// can go back up to optimise S3 round-trip count. Until then, prefer many
+// small cache files over a few huge ones.
+//
+// Declared as var (not const) so regression tests can lower it further to
+// force multiple groups on tiny SF0.01 tables and exercise the file-splitting
+// correctness path.
+var buildCacheGroupSize = 2
 
 // buildCacheTimeout is the maximum time to wait for a single build cache
 // pre-scan to complete. If exceeded, the coordinator falls back to per-worker
@@ -140,8 +151,14 @@ func (c *Coordinator) preScanOneTable(parentCtx context.Context, parentQueryID s
 	cacheQueryID := fmt.Sprintf("bc-%s-%s-%d", parentQueryID, stage.ScanAlias, groupIdx)
 	resultPrefix := fmt.Sprintf("queries/%s/build-cache/%s/%d/", parentQueryID, stage.ScanAlias, groupIdx)
 
-	// Construct minimal SQL to scan just this table with the columns needed.
-	// We select all columns so the workers get full rows for hash table construction.
+	// Construct minimal SQL to scan just this table. Today this uses SELECT *
+	// because the downstream consumer (StreamingSources path in the planner)
+	// expects the cached batches to have the same schema as the original scan
+	// node, and the original scan's column-projection happens at plan time on
+	// names that may not survive a SQL round-trip (qualified vs unqualified
+	// column references). Doing column pruning here would require coordinated
+	// schema rewriting on the consumer side. Tracked as a follow-up: pruning
+	// could shrink the cache file by 3-5x on wide tables like orders.
 	scanSQL := fmt.Sprintf("SELECT * FROM %s", stage.TableName)
 
 	task := distributed.Task{

--- a/internal/coordinator/build_cache_test.go
+++ b/internal/coordinator/build_cache_test.go
@@ -178,6 +178,12 @@ func TestBuildCacheTaskHasCorrectFields(t *testing.T) {
 // TestPreScanBuildTablesInjectableThreshold verifies that BuildCacheThreshold
 // on the Coordinator overrides the default 2GB constant, allowing the pre-scan
 // path to trigger on small datasets (e.g., SF1 with a 1MB threshold).
+//
+// LargeBuildScans only returns scans when there are 2 or more (a single large
+// build table is handled fine by per-worker scan + spillable hash join, and
+// the cache adds spill+S3 round-trip overhead with no benefit), so this test
+// uses two large build tables — orders and customer — to also satisfy that
+// minimum.
 func TestPreScanBuildTablesInjectableThreshold(t *testing.T) {
 	_, coord, _ := setupDistributed(t)
 
@@ -189,17 +195,35 @@ func TestPreScanBuildTablesInjectableThreshold(t *testing.T) {
 			EstimatedBytes: 50 * 1024 * 1024, ScanFiles: []string{"l1.parquet"}},
 		{ID: "s2", Type: "scan", ScanAlias: "orders", TableName: "orders",
 			EstimatedBytes: 5 * 1024 * 1024, ScanFiles: []string{"o1.parquet"}},
-		{ID: "s3", Type: "scan", ScanAlias: "part", TableName: "part",
+		{ID: "s3", Type: "scan", ScanAlias: "customer", TableName: "customer",
+			EstimatedBytes: 4 * 1024 * 1024, ScanFiles: []string{"c1.parquet"}},
+		{ID: "s4", Type: "scan", ScanAlias: "part", TableName: "part",
 			EstimatedBytes: 500 * 1024, ScanFiles: []string{"p1.parquet"}},
 	}
 
-	// With 1MB threshold, orders (5MB) should be a candidate but part (500KB) should not.
+	// With 1MB threshold, orders (5MB) and customer (4MB) should be candidates,
+	// part (500KB) should not, lineitem (probe) should not.
 	large := physical.LargeBuildScans(stages, "lineitem", coord.BuildCacheThreshold)
-	if len(large) != 1 {
-		t.Fatalf("expected 1 large build scan with 1MB threshold, got %d", len(large))
+	if len(large) != 2 {
+		t.Fatalf("expected 2 large build scans with 1MB threshold, got %d", len(large))
 	}
-	if large[0].ScanAlias != "orders" {
-		t.Errorf("expected large scan alias 'orders', got %q", large[0].ScanAlias)
+	gotAliases := map[string]bool{}
+	for _, s := range large {
+		gotAliases[s.ScanAlias] = true
+	}
+	if !gotAliases["orders"] || !gotAliases["customer"] {
+		t.Errorf("expected large scans to include 'orders' and 'customer', got %v", gotAliases)
+	}
+
+	// Single-large-build queries deliberately skip the cache (returns nil).
+	stagesOneLarge := []physical.Stage{
+		{ID: "s1", Type: "scan", ScanAlias: "lineitem", TableName: "lineitem",
+			EstimatedBytes: 50 * 1024 * 1024, ScanFiles: []string{"l1.parquet"}},
+		{ID: "s2", Type: "scan", ScanAlias: "orders", TableName: "orders",
+			EstimatedBytes: 5 * 1024 * 1024, ScanFiles: []string{"o1.parquet"}},
+	}
+	if got := physical.LargeBuildScans(stagesOneLarge, "lineitem", coord.BuildCacheThreshold); got != nil {
+		t.Errorf("expected nil for single large build, got %d scans", len(got))
 	}
 
 	// Verify lineitem (probe table) is never included regardless of size.

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -1060,6 +1060,19 @@ func CanProbeSplit(stages []Stage, workerCount int) (probeAlias string, probeFil
 // the build-side broadcast cache: the coordinator pre-scans them once, caches the
 // result in S3, and each worker loads the shared cache instead of independently
 // scanning the large source table N times.
+//
+// Important: the cache is only worthwhile when MULTIPLE large build tables
+// would otherwise compound a worker's hash-table footprint. A single large
+// build table (e.g. Q02's partsupp:1) fits comfortably in a single worker's
+// memory and the cache adds 5+ minutes of spill+S3 round-trip overhead for
+// no real benefit. With two or more, the per-worker hash-table footprint
+// becomes the bottleneck and the cache pays for itself by deduplicating
+// the source scan and giving the planner a single shuffle-format input
+// per table that the workers can stream lazily.
+//
+// So: only return the large build scans when there are at least two of them.
+// One large table → empty result → cache skipped → per-worker scan + spillable
+// hash join handles it. Two or more → cache the lot.
 func LargeBuildScans(stages []Stage, probeAlias string, thresholdBytes int64) []Stage {
 	var large []Stage
 	for _, s := range stages {
@@ -1072,6 +1085,9 @@ func LargeBuildScans(stages []Stage, probeAlias string, thresholdBytes int64) []
 		if s.EstimatedBytes >= thresholdBytes {
 			large = append(large, s)
 		}
+	}
+	if len(large) < 2 {
+		return nil
 	}
 	return large
 }

--- a/internal/storage/objstore/circuit.go
+++ b/internal/storage/objstore/circuit.go
@@ -185,24 +185,53 @@ func (cs *CircuitStore) do(ctx context.Context, fn func(context.Context) error) 
 
 // Put implements Store.
 func (cs *CircuitStore) Put(ctx context.Context, bucket, key string, r io.Reader, size int64, contentType string) (string, error) {
-	var etag string
-	err := cs.do(ctx, func(c context.Context) error {
-		var e error
-		etag, e = cs.inner.Put(c, bucket, key, r, size, contentType)
-		return e
-	})
+	timeout := cs.putTimeout(size)
+	if err := cs.beforeRequest(); err != nil {
+		return "", err
+	}
+	tctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	etag, err := cs.inner.Put(tctx, bucket, key, r, size, contentType)
+	if err != nil {
+		cs.onFailure(err)
+	} else {
+		cs.onSuccess()
+	}
 	return etag, err
 }
 
 // PutIfMatch implements Store.
 func (cs *CircuitStore) PutIfMatch(ctx context.Context, bucket, key string, r io.Reader, size int64, contentType string, expectedETag string) (string, error) {
-	var etag string
-	err := cs.do(ctx, func(c context.Context) error {
-		var e error
-		etag, e = cs.inner.PutIfMatch(c, bucket, key, r, size, contentType, expectedETag)
-		return e
-	})
+	timeout := cs.putTimeout(size)
+	if err := cs.beforeRequest(); err != nil {
+		return "", err
+	}
+	tctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	etag, err := cs.inner.PutIfMatch(tctx, bucket, key, r, size, contentType, expectedETag)
+	if err != nil {
+		cs.onFailure(err)
+	} else {
+		cs.onSuccess()
+	}
 	return etag, err
+}
+
+// putTimeout returns a size-aware timeout for upload operations. The fixed
+// 10-second RequestTimeout is fine for the small results that originally
+// flowed through this store (~MB), but build-cache pre-scan tasks now upload
+// multi-GB shuffle files. Allow at least RequestTimeout, plus enough headroom
+// to push the payload at ~20 MB/s effective same-region S3 throughput.
+func (cs *CircuitStore) putTimeout(size int64) time.Duration {
+	timeout := cs.config.RequestTimeout
+	if size > 0 {
+		// 20 MB/s ⇒ size_bytes / (20 * 1<<20 bytes/s) seconds
+		sized := time.Duration(size/(20*1024*1024)) * time.Second
+		if sized > timeout {
+			timeout = sized
+		}
+	}
+	return timeout
 }
 
 // Get implements Store.

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -403,27 +403,29 @@ func (e *Executor) executePipeline(ctx context.Context, task distributed.Task, r
 // path triggers when scanning very large build tables.
 func (e *Executor) executeBuildCachePreScan(ctx context.Context, task distributed.Task, pipeline *exec.Pipeline, result *distributed.ResultNotification) error {
 	streamSink := newShuffleStreamSink(e.spillDir)
-	if err := streamSink.Init(ctx); err != nil {
-		return fmt.Errorf("init build cache stream sink: %w", err)
-	}
-	// Make sure we always close the file handle and remove the spill file,
-	// even on error paths.
-	spillPath := streamSink.FilePath()
-	defer func() {
-		_ = streamSink.Close()
-		if spillPath != "" {
-			_ = os.Remove(spillPath)
-		}
-	}()
 
 	// Replace CollectSink with the streaming sink. The pipeline doesn't care
 	// what sink it has — it just calls Consume on each batch.
+	//
+	// IMPORTANT: do NOT call streamSink.Init here. Pipeline.Run will call
+	// p.Sink.Init(ctx) itself; calling it twice would create two temp files
+	// (the first one then orphaned and uploaded as a 0-byte blob).
 	pipeline.Sink = streamSink
+
+	// Make sure we always close the file handle and remove the spill file,
+	// even on error paths. spillPath is captured AFTER Run (after Init).
+	defer func() {
+		_ = streamSink.Close()
+		if path := streamSink.FilePath(); path != "" {
+			_ = os.Remove(path)
+		}
+	}()
 
 	if err := pipeline.Run(ctx); err != nil {
 		return fmt.Errorf("build cache pre-scan pipeline: %w", err)
 	}
 
+	spillPath := streamSink.FilePath()
 	totalRows := streamSink.NumRows()
 	e.logger.Info("build cache pre-scan completed",
 		"task_id", task.ID,
@@ -437,6 +439,9 @@ func (e *Executor) executeBuildCachePreScan(ctx context.Context, task distribute
 		// Empty table: nothing to upload. Coordinator handles the no-rows case.
 		return nil
 	}
+	if spillPath == "" {
+		return fmt.Errorf("build cache pre-scan reported %d rows but no spill file path", totalRows)
+	}
 
 	// Re-open the spill file for upload (the writer keeps an fd, but the
 	// streaming Put needs its own reader positioned at the start).
@@ -448,6 +453,9 @@ func (e *Executor) executeBuildCachePreScan(ctx context.Context, task distribute
 	fi, err := f.Stat()
 	if err != nil {
 		return fmt.Errorf("stat spill file: %w", err)
+	}
+	if fi.Size() == 0 {
+		return fmt.Errorf("build cache pre-scan reported %d rows but spill file is empty", totalRows)
 	}
 	resultPath := task.ResultPrefix + task.ID + ".wshf"
 	if _, err := e.store.Put(ctx, task.ResultBucket, resultPath, f, fi.Size(), "application/octet-stream"); err != nil {


### PR DESCRIPTION
## Summary

Three follow-up fixes after deploying PR #31's streaming sink to SF100. The first two are correctness, the third is the latency/memory headroom we found while tracing why Q02 was 18× slower than the historical baseline and why Q03 was still OOMing the workers.

### 1. `executor.executeBuildCachePreScan` double-init bug (worker)

The helper called `streamSink.Init()` before `pipeline.Run()`, but `Pipeline.Run` *also* calls `p.Sink.Init(ctx)`. The second Init created a new temp file and reassigned `s.file`, orphaning the path captured by the helper. Result: pipeline wrote rows to the second file; upload read the first (empty) one; S3 ended up with a 0-byte cache; Q02 then failed downstream with `parquet: file too small (0 bytes)`.

Fix: don't pre-Init in the helper. Let `pipeline.Run` own the Init, capture `FilePath()` AFTER Run, and add explicit guards (`spillPath != ""`, `fi.Size() > 0` when `rows > 0`) so we error out loudly if it ever happens again.

### 2. `CircuitStore.Put` size-aware timeout (objstore)

Was hardcoded to 10 s via `cs.do()`. Fine for the small inline results the store originally handled, **not** fine for the multi-GB shuffle files the build cache pre-scan now uploads. Q02 (12 GB partsupp) and Q03 (15 GB orders) both failed with `putting object: context deadline exceeded`.

Fix: scale `Put` / `PutIfMatch` timeouts by the size hint already passed in. Floor at the original `RequestTimeout`, plus headroom to push the payload at ~20 MB/s effective same-region throughput. A 10 GB upload now gets ~8.5 minutes.

### 3. Build cache: only trigger for 2+ large builds + cap file size (planner + coordinator)

The cache was added to dedupe build-side scans of huge tables across N workers, but in practice it doesn't reduce per-worker memory — every worker still builds its own hash table from the cached source. It only saves S3 read bandwidth and switches the format to WSHF.

For a query with **one** large build (e.g. Q02's `partsupp:1` at SF100), the cache costs ~5 minutes of spill+upload+download round-trip for **zero** memory benefit. The historical pre-cache Q02 ran in 22.8 s on the same data shape; today's cached Q02 takes 6m49s.

- `LargeBuildScans` now returns `nil` unless there are 2+ large build tables. Single-large-build queries (Q02 etc.) skip the cache and rely on per-worker scan + grace hash spill.
- `buildCacheGroupSize` lowered from 8 to 2. When the cache *does* fire, each pre-scan task bundles at most 2 source files, capping the cache file at ~2.5 GB instead of ~10 GB. This works around `cachedFileStreamSource`'s in-memory `io.ReadAll` of each cache file, which OOM-killed workers loading SF100 orders. Real fix is to stream the read side from S3, tracked separately.

Test updated: `TestPreScanBuildTablesInjectableThreshold` now uses two large build tables to match the new heuristic, plus a sub-case that asserts single-large-build returns `nil`.

## Validation

- `go test -count=2 ./internal/coordinator/` clean
- `go test -race ./internal/...` clean (only nats-server upstream races remain)
- `TestDistributedTPCHBuildCache*` x N — all pass
- SF100 deploy from PR #31 produced Q02 = 100 correct rows in 6m49s. The Q02 latency improvement and Q03 unblocking from this PR will be verified in a follow-up SF100 run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)