### PR TITLE
fix(worker): stream build cache reads from S3 to mmap'd local NVMe

### DIFF
--- a/internal/worker/shuffle_format.go
+++ b/internal/worker/shuffle_format.go
@@ -660,6 +660,19 @@ func CompressShuffleData(data []byte) []byte {
 	return buf.Bytes()
 }
 
+// streamDecompressShuffle reads the s2 body that follows a WSHC magic header
+// from src and writes the decompressed bytes to dst. The caller is responsible
+// for writing the WSHF magic header to dst beforehand if needed. This is used
+// by the build-cache stream source to transcode WSHC payloads to WSHF on disk
+// without first materializing the entire compressed body in memory.
+func streamDecompressShuffle(src io.Reader, dst io.Writer) error {
+	r := s2.NewReader(src)
+	if _, err := io.Copy(dst, r); err != nil {
+		return fmt.Errorf("decompressing shuffle stream: %w", err)
+	}
+	return nil
+}
+
 // DecompressShuffleData detects and decompresses a WSHC payload back to raw WSHF.
 // If the data is already plain WSHF (or non-shuffle), it is returned unchanged.
 func DecompressShuffleData(data []byte) ([]byte, error) {

--- a/internal/worker/stream_source.go
+++ b/internal/worker/stream_source.go
@@ -4,6 +4,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
 
 	"github.com/citc-tech/wadjet/internal/engine/batch"
 	"github.com/citc-tech/wadjet/internal/engine/scan"
@@ -11,13 +15,20 @@ import (
 )
 
 // cachedFileStreamSource lazily reads pre-scanned build-cache files one at a
-// time, yielding batches from each file before moving to the next. This avoids
-// materializing all files into memory upfront — the hash join's grace spill
-// handles memory pressure naturally as batches flow through.
+// time, yielding batches from each file before moving to the next.
 //
-// WSHF files are streamed one chunk at a time via shuffleChunkReader, so only
-// one RecordBatch worth of data is allocated at a time per file. Parquet files
-// are buffered per row-group (already lazy by design).
+// For shuffle-format (.wshf) files, the source streams the S3 object directly
+// to a local spill file on the worker's NVMe and then mmaps the local file.
+// The shuffleChunkReader walks the mmap'd region in place; the kernel pages
+// in pieces lazily, so peak resident memory is bounded by the kernel's page
+// cache for the active region rather than the full file size. Without this,
+// the previous io.ReadAll path would allocate a single byte slice the size of
+// the cache file (10+ GB at SF100) and OOM the worker before it could
+// process a single batch.
+//
+// For Parquet files (only used by older shuffle paths) we still buffer
+// row-group batches eagerly via scan.ReadFileBatches because they're already
+// lazy by row-group in the parquet reader and the file sizes are bounded.
 type cachedFileStreamSource struct {
 	executor *Executor
 	bucket   string
@@ -25,8 +36,12 @@ type cachedFileStreamSource struct {
 
 	fileIdx int
 
-	// Active WSHF chunk reader for the current file (nil if current file is Parquet).
+	// Active WSHF chunk reader for the current file (nil if current file is
+	// Parquet or no file is open). The reader walks an mmap'd byte slice
+	// owned by mmapData below.
 	chunkReader *shuffleChunkReader
+	mmapData    []byte // mmap'd view of the current local cache file (nil if Parquet)
+	localPath   string // path of the current local cache file on the spill volume
 
 	// Buffered batches for the current Parquet file.
 	batches  []*batch.RecordBatch
@@ -54,7 +69,11 @@ func (s *cachedFileStreamSource) Next(ctx context.Context) (*batch.RecordBatch, 
 			if b != nil {
 				return b, nil
 			}
-			s.chunkReader = nil // file exhausted — move to next
+			// Current file exhausted — release its mmap and remove the local
+			// copy before moving on. The chunkReader's batches have already
+			// copied their column data into RecordBatch arrays, so dropping
+			// the mmap region here is safe.
+			s.releaseCurrentFile()
 		}
 
 		// Yield buffered Parquet batches.
@@ -78,12 +97,26 @@ func (s *cachedFileStreamSource) Next(ctx context.Context) (*batch.RecordBatch, 
 }
 
 func (s *cachedFileStreamSource) Close() error {
-	s.chunkReader = nil
+	s.releaseCurrentFile()
 	for i := s.batchIdx; i < len(s.batches); i++ {
 		s.batches[i] = nil
 	}
 	s.batches = nil
 	return nil
+}
+
+// releaseCurrentFile munmaps and deletes the local cache file backing the
+// current chunkReader. Safe to call multiple times.
+func (s *cachedFileStreamSource) releaseCurrentFile() {
+	s.chunkReader = nil
+	if s.mmapData != nil {
+		_ = syscall.Munmap(s.mmapData)
+		s.mmapData = nil
+	}
+	if s.localPath != "" {
+		_ = os.Remove(s.localPath)
+		s.localPath = ""
+	}
 }
 
 // openNextFile downloads and opens the next file, setting either chunkReader
@@ -92,26 +125,37 @@ func (s *cachedFileStreamSource) openNextFile(ctx context.Context) error {
 	filePath := s.files[s.fileIdx]
 	s.fileIdx++
 
-	data, err := s.executor.getFileData(ctx, s.bucket, filePath)
+	// Try the streaming path first: open a streaming reader from S3, peek
+	// at the magic bytes, and decide whether this is a WSHF (or compressed
+	// WSHC) shuffle file or some legacy Parquet payload.
+	rc, _, err := s.executor.store.Get(ctx, s.bucket, filePath)
 	if err != nil {
-		return fmt.Errorf("streaming file %s: %w", filePath, err)
+		return fmt.Errorf("opening cached file %s: %w", filePath, err)
+	}
+	defer rc.Close()
+
+	// Read enough header bytes to detect the format. Both WSHF and WSHC
+	// have a 4-byte magic at offset 0.
+	var magic [4]byte
+	if _, err := io.ReadFull(rc, magic[:]); err != nil {
+		return fmt.Errorf("reading magic from %s: %w", filePath, err)
 	}
 
-	data, err = DecompressShuffleData(data)
+	wshf := magic == shuffleMagic
+	wshc := magic == compressedMagic
+
+	if wshf || wshc {
+		return s.openShuffleFile(ctx, filePath, magic[:], rc, wshc)
+	}
+
+	// Legacy Parquet path: download the rest of the body, hand to the
+	// parquet reader. These payloads are bounded by the inline-result
+	// threshold (KB to a few MB) so io.ReadAll is fine here.
+	rest, err := io.ReadAll(rc)
 	if err != nil {
-		return fmt.Errorf("decompressing file %s: %w", filePath, err)
+		return fmt.Errorf("reading parquet body for %s: %w", filePath, err)
 	}
-
-	if isShuffleFormat(data) {
-		r, err := newShuffleChunkReader(data)
-		if err != nil {
-			return fmt.Errorf("opening shuffle file %s: %w", filePath, err)
-		}
-		s.chunkReader = r
-		return nil
-	}
-
-	// Parquet: buffer row-group batches (already lazy by row group in the reader).
+	data := append(magic[:], rest...)
 	reader, err := parquet.NewReader(bytes.NewReader(data), int64(len(data)))
 	if err != nil {
 		return fmt.Errorf("opening parquet file %s: %w", filePath, err)
@@ -124,3 +168,126 @@ func (s *cachedFileStreamSource) openNextFile(ctx context.Context) error {
 	s.batchIdx = 0
 	return nil
 }
+
+// openShuffleFile streams the (possibly compressed) shuffle body from rc to a
+// local spill file, decompressing on the fly if needed, then mmaps the result
+// and hands it to a shuffleChunkReader. Memory is bounded by the kernel's
+// page cache footprint over the active mmap region rather than the full file
+// size.
+func (s *cachedFileStreamSource) openShuffleFile(_ context.Context, srcPath string, magic []byte, rc io.Reader, compressed bool) error {
+	spillDir := s.executor.spillDir
+	if spillDir == "" {
+		// Fall back to the in-memory path if no NVMe spill is available.
+		// This is primarily a test-environment safety net; production
+		// workers always have a spill dir.
+		return s.openShuffleInMemory(srcPath, magic, rc, compressed)
+	}
+	if err := os.MkdirAll(spillDir, 0o755); err != nil {
+		return fmt.Errorf("creating spill dir: %w", err)
+	}
+	tmp, err := os.CreateTemp(spillDir, "build-cache-load-*.wshf")
+	if err != nil {
+		return fmt.Errorf("creating local cache file: %w", err)
+	}
+	localPath := tmp.Name()
+	// On any error before we successfully mmap, the deferred close+remove
+	// here releases the resources. On success we transfer ownership to s
+	// and clear localPath so this defer is a no-op.
+	cleanupLocal := true
+	defer func() {
+		if cleanupLocal {
+			tmp.Close()
+			_ = os.Remove(localPath)
+		}
+	}()
+
+	// We already consumed the magic bytes from rc; write them back first.
+	if _, err := tmp.Write(magic); err != nil {
+		return fmt.Errorf("writing magic to local cache: %w", err)
+	}
+
+	if compressed {
+		// Stream-decompress the body. After writing the WSHF magic to disk,
+		// the body is the s2 stream that follows the WSHC magic. The shuffle
+		// reader expects a plain WSHF file, so we transcode here.
+		if err := streamDecompressShuffle(rc, tmp); err != nil {
+			return fmt.Errorf("decompressing %s into local cache: %w", srcPath, err)
+		}
+	} else {
+		// Plain WSHF: just stream the body to disk.
+		if _, err := io.Copy(tmp, rc); err != nil {
+			return fmt.Errorf("streaming %s to local cache: %w", srcPath, err)
+		}
+	}
+	if err := tmp.Sync(); err != nil {
+		return fmt.Errorf("syncing local cache: %w", err)
+	}
+
+	fi, err := tmp.Stat()
+	if err != nil {
+		return fmt.Errorf("stat local cache: %w", err)
+	}
+	if fi.Size() == 0 {
+		return fmt.Errorf("local cache for %s is empty after stream", srcPath)
+	}
+
+	mmapData, err := syscall.Mmap(int(tmp.Fd()), 0, int(fi.Size()), syscall.PROT_READ, syscall.MAP_SHARED)
+	if err != nil {
+		return fmt.Errorf("mmap local cache %s: %w", localPath, err)
+	}
+	// We can close the file descriptor immediately — the mmap keeps the
+	// underlying inode alive until Munmap.
+	if err := tmp.Close(); err != nil {
+		_ = syscall.Munmap(mmapData)
+		return fmt.Errorf("closing local cache fd: %w", err)
+	}
+
+	// Build a chunk reader over the mmap'd region. The reader walks the
+	// slice in place; readColumnData copies bytes into the RecordBatch's
+	// typed column arrays, so subsequent batches don't depend on the mmap
+	// region after they're returned to the caller.
+	r, err := newShuffleChunkReader(mmapData)
+	if err != nil {
+		_ = syscall.Munmap(mmapData)
+		return fmt.Errorf("opening shuffle file %s: %w", srcPath, err)
+	}
+
+	cleanupLocal = false
+	s.chunkReader = r
+	s.mmapData = mmapData
+	s.localPath = localPath
+	return nil
+}
+
+// openShuffleInMemory is the legacy fallback for environments without a
+// spill directory (mainly tests). Downloads the full payload, decompresses
+// in memory, and hands the resulting byte slice to a chunk reader. Bounded
+// by the test data sizes.
+func (s *cachedFileStreamSource) openShuffleInMemory(srcPath string, magic []byte, rc io.Reader, compressed bool) error {
+	rest, err := io.ReadAll(rc)
+	if err != nil {
+		return fmt.Errorf("reading shuffle body for %s: %w", srcPath, err)
+	}
+	data := append(magic[:], rest...)
+	if compressed {
+		decoded, err := DecompressShuffleData(data)
+		if err != nil {
+			return fmt.Errorf("decompressing %s: %w", srcPath, err)
+		}
+		data = decoded
+	}
+	r, err := newShuffleChunkReader(data)
+	if err != nil {
+		return fmt.Errorf("opening shuffle file %s: %w", srcPath, err)
+	}
+	s.chunkReader = r
+	return nil
+}
+
+// localCachePath returns a deterministic-but-unique local spill path for a
+// given remote object key. Used for debugging.
+func localCachePath(spillDir, key string) string {
+	return filepath.Join(spillDir, "build-cache-"+filepath.Base(key))
+}
+
+var _ = localCachePath // currently unused, kept for future cache reuse


### PR DESCRIPTION
## Summary

Replaces \`cachedFileStreamSource\`'s in-memory \`io.ReadAll\` of each cache file with a streaming-download → \`mmap\`-from-NVMe path. Memory used while loading a cache file is now bounded by the kernel's page cache footprint over the active mmap region rather than the full file size.

## Why

\`getFileData(...) → io.ReadAll\` allocated a single \`[]byte\` the size of the entire cache file. With the previous \`buildCacheGroupSize = 8\` default that was a ~10 GB allocation per file at SF100, which OOM-killed workers loading orders for Q03 before they could process a single batch.

PR #32 mitigated by lowering \`buildCacheGroupSize\` to 2 (capping each file at ~2.5 GB). This PR removes the underlying constraint, so we can later restore a higher group size to minimise S3 round-trip count without re-introducing the OOM.

## How

\`cachedFileStreamSource.openShuffleFile\`:

1. Open a streaming reader from S3 (no \`io.ReadAll\`).
2. Peek at the 4-byte magic to detect WSHF / WSHC / Parquet.
3. For shuffle payloads: stream the body to a temp file on the worker's spill volume (NVMe on c7gd). \`io.Copy\` uses a 32 KB scratch buffer.
4. If the payload was WSHC, decompress on the fly via the new \`streamDecompressShuffle\` helper instead of buffering the compressed body in memory first.
5. \`syscall.Mmap\` the local file with \`PROT_READ + MAP_SHARED\`. Close the fd immediately — the mmap keeps the inode alive until \`Munmap\`.
6. Hand the mmap'd \`[]byte\` to the existing \`shuffleChunkReader\`. \`readColumnData\` copies bytes into the \`RecordBatch\`'s typed column arrays per chunk, so emitted batches are independent of the mmap region.
7. \`releaseCurrentFile\` munmaps and removes the local copy when the file is exhausted (or on \`Close\`).

Parquet payloads (legacy) still take the in-memory path because they're bounded by the inline-result threshold (KB to a few MB).

\`openShuffleInMemory\` is the test-environment fallback for when the executor has no spill directory configured.

## Test plan

- [x] \`go test -count=2 ./internal/coordinator/ ./internal/worker/\` — clean
- [x] \`go test -race ./internal/...\` — clean (only nats-server upstream races remain in skipped distributed tests)
- [x] \`TestDistributedTPCH*\` — pass with the new in-memory fallback path
- [ ] SF100 deploy: verify Q02 latency improvement (skip cache for single-large-build) AND that Q03 makes it past the orders cache load. Will run in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)