### PR TITLE
fix(engine): spill-fragmentation fixes for aggregate + join build, lower heap-pressure ratio

### DIFF
--- a/internal/engine/exec/aggregate.go
+++ b/internal/engine/exec/aggregate.go
@@ -142,10 +142,24 @@ type HashAggregate struct {
 	keyBuf         []byte
 	inputSchema   []parquet.Column // schema from first input batch (for spill recovery)
 	spillFiles    []string
+	// spillBuffer holds rows from Consume calls in the spill branch that
+	// have not yet been flushed to disk. Rows are accumulated here across
+	// many Consume calls so that each physical spill file contains a
+	// non-trivial amount of data. Without this batching the old code wrote
+	// one file per Consume, producing millions of ~4 KB files at SF100 and
+	// making Finalize unable to complete in reasonable time.
+	spillBuffer      []map[string]any
+	spillBufferBytes int64 // tracker bytes attributable to rows in spillBuffer
 	trackedGroupMem int64 // bytes charged to Spill tracker for group state growth
 	outputPos     int              // position in keys for batched Next() output
 	gsPool        groupStatePool   // chunk allocator for groupState (reduces GC pressure)
 }
+
+// spillFileTargetBytes is the approximate size at which the spill buffer is
+// flushed to a new file. Sized to amortize per-file open/close and header
+// overhead across many rows. Exposed as a var so regression tests can
+// override it to exercise the flush path deterministically.
+var spillFileTargetBytes int64 = 64 * 1024 * 1024
 
 type groupState struct {
 	keyValues    []any
@@ -392,19 +406,26 @@ func (h *HashAggregate) Consume(_ context.Context, b *batch.RecordBatch) error {
 	}
 
 	// Track memory usage for spill pressure detection
+	var batchBytes int64
 	if h.Spill != nil {
-		h.Spill.TrackBatch(EstimateBatchBytes(b))
+		batchBytes = EstimateBatchBytes(b)
+		h.Spill.TrackBatch(batchBytes)
 	}
 
 	// Spill input batch to disk if memory pressure is high.
+	// Rows are accumulated in h.spillBuffer and flushed to a new file only
+	// when the buffer crosses spillFileTargetBytes. This prevents pathological
+	// file-count explosion at SF100 (see TestHashAggregateSpillBatching).
 	// The spilled rows are re-processed during Finalize.
 	if h.Spill != nil && h.Spill.ShouldSpill() {
 		rows := b.ToRows()
-		path, err := h.Spill.SpillRows(rows)
-		if err != nil {
-			return err
+		h.spillBuffer = append(h.spillBuffer, rows...)
+		h.spillBufferBytes += batchBytes
+		if h.spillBufferBytes >= spillFileTargetBytes {
+			if err := h.flushSpillBuffer(); err != nil {
+				return err
+			}
 		}
-		h.spillFiles = append(h.spillFiles, path)
 		return nil
 	}
 
@@ -1831,8 +1852,28 @@ func (h *HashAggregate) updateGroup(gs *groupState, b *batch.RecordBatch, row in
 	}
 }
 
+// flushSpillBuffer writes h.spillBuffer to a new spill file and releases the
+// tracker bytes for those rows. Caller must hold h.mu.
+func (h *HashAggregate) flushSpillBuffer() error {
+	if len(h.spillBuffer) == 0 {
+		return nil
+	}
+	path, err := h.Spill.SpillRows(h.spillBuffer)
+	if err != nil {
+		return err
+	}
+	h.spillFiles = append(h.spillFiles, path)
+	// The rows are now on disk — release the tracker bytes charged for them
+	// so ShouldSpill can flip back to false and subsequent batches can be
+	// consumed directly into the hash table again.
+	h.Spill.ReleaseTracking(h.spillBufferBytes)
+	h.spillBuffer = nil
+	h.spillBufferBytes = 0
+	return nil
+}
+
 func (h *HashAggregate) Finalize(_ context.Context) error {
-	if len(h.spillFiles) == 0 {
+	if len(h.spillFiles) == 0 && len(h.spillBuffer) == 0 {
 		return nil
 	}
 
@@ -1862,6 +1903,23 @@ func (h *HashAggregate) Finalize(_ context.Context) error {
 		h.consumeBatch(b)
 	}
 	h.spillFiles = nil
+
+	// Drain any rows that were buffered but never crossed the flush
+	// threshold — they're still in memory and can be consumed directly
+	// without a round-trip through disk.
+	if len(h.spillBuffer) > 0 {
+		b := batch.FromRows(h.inputSchema, h.spillBuffer)
+		if !h.resolved {
+			h.resolveIndices(b)
+		}
+		h.consumeBatch(b)
+		if h.Spill != nil {
+			h.Spill.ReleaseTracking(h.spillBufferBytes)
+		}
+		h.spillBuffer = nil
+		h.spillBufferBytes = 0
+	}
+
 	return nil
 }
 

--- a/internal/engine/exec/exec_test.go
+++ b/internal/engine/exec/exec_test.go
@@ -590,8 +590,11 @@ func TestHashAggregateMergeThenSpillFinalize(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(primary.spillFiles) == 0 {
-		t.Fatal("expected spill files but none were created")
+	// After the spill-fragmentation fix, small spilled payloads land in the
+	// in-memory buffer rather than a new file. Either indicates the spill
+	// path was exercised.
+	if len(primary.spillFiles) == 0 && len(primary.spillBuffer) == 0 {
+		t.Fatal("expected spill path to be exercised but nothing was written or buffered")
 	}
 
 	// Clone aggregate with different groups (simulates worker 1).
@@ -644,6 +647,188 @@ func TestHashAggregateMergeThenSpillFinalize(t *testing.T) {
 			if total != 140.0 {
 				t.Fatalf("expected total=140 for (2024,1), got %v", total)
 			}
+		}
+	}
+}
+
+// TestHashAggregateSpillBatching feeds 200 small batches under a tight memory
+// budget so every Consume after the first lands in the spill branch.
+// Regression for SF100 Q03 where per-batch flushing produced millions of
+// ~4 KB spill files, making Finalize unable to complete in reasonable time.
+// With the fix, the number of spill files must be bounded by the total rows
+// spilled divided by the per-file target, not by the number of Consume calls.
+func TestHashAggregateSpillBatching(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "key", Type: parquet.TypeInt64},
+		{Name: "val", Type: parquet.TypeInt64},
+	}
+
+	ctx := context.Background()
+	spillDir := t.TempDir()
+	// 1 KB budget — any TrackBatch on a real batch will push us into the
+	// spill branch for all subsequent Consume calls.
+	tracker := memory.NewTracker("test", 1_000)
+	sm, err := memory.NewSpillManager(spillDir, tracker)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h := NewHashAggregate([]string{"key"}, []AggColumn{
+		{Func: AggSum, InputCol: "val", OutputCol: "total", OutputType: parquet.TypeInt64},
+	})
+	h.Spill = sm
+	if err := h.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	const numBatches = 200
+	const rowsPerBatch = 10
+	expected := make(map[int64]int64) // key → sum(val)
+
+	for i := 0; i < numBatches; i++ {
+		rows := make([]map[string]any, 0, rowsPerBatch)
+		for j := 0; j < rowsPerBatch; j++ {
+			k := int64(i*rowsPerBatch + j)
+			v := int64(i + j + 1)
+			rows = append(rows, map[string]any{"key": k, "val": v})
+			expected[k] += v
+		}
+		b := batch.FromRows(schema, rows)
+		if err := h.Consume(ctx, b); err != nil {
+			t.Fatalf("Consume batch %d: %v", i, err)
+		}
+	}
+
+	// Sanity: we exercised the spill path. Before the fix this manifests as
+	// many spillFiles; after the fix it may manifest as buffered rows that
+	// haven't yet been flushed to disk.
+	if len(h.spillFiles) == 0 && len(h.spillBuffer) == 0 {
+		t.Fatal("spill path was never exercised; tracker/budget setup is wrong for this test")
+	}
+
+	// THE REGRESSION: before the fix, len(spillFiles) was ~= numBatches-1.
+	// After the fix, files accumulate only when the spill buffer crosses the
+	// per-file byte target. 200 batches of 10 small rows is ~60 KB total —
+	// well under any reasonable target — so we expect <=5 files.
+	if got := len(h.spillFiles); got > 5 {
+		t.Errorf("spill-file fragmentation: got %d files for %d batches of %d rows, want <=5",
+			got, numBatches, rowsPerBatch)
+	}
+
+	// Finalize must drain both h.spillFiles and any pending buffer and produce
+	// correct aggregation totals.
+	if err := h.Finalize(ctx); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+
+	got := make(map[int64]int64)
+	for {
+		out, err := h.Next(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out == nil {
+			break
+		}
+		for _, row := range out.ToRows() {
+			k := row["key"].(int64)
+			v := row["total"].(int64)
+			got[k] = v
+		}
+	}
+
+	if len(got) != len(expected) {
+		t.Fatalf("group count: got %d, want %d", len(got), len(expected))
+	}
+	for k, want := range expected {
+		if got[k] != want {
+			t.Errorf("key=%d: got total=%d, want %d", k, got[k], want)
+		}
+	}
+}
+
+// TestHashAggregateSpillBufferFlush exercises the flush path by lowering
+// spillFileTargetBytes so the buffer crosses the threshold during Consume,
+// producing a bounded (non-zero) number of files.
+func TestHashAggregateSpillBufferFlush(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "key", Type: parquet.TypeInt64},
+		{Name: "val", Type: parquet.TypeInt64},
+	}
+
+	orig := spillFileTargetBytes
+	spillFileTargetBytes = 10_000 // flush aggressively, but accommodate a few batches per file
+	t.Cleanup(func() { spillFileTargetBytes = orig })
+
+	ctx := context.Background()
+	spillDir := t.TempDir()
+	tracker := memory.NewTracker("test", 1_000) // tight budget
+	sm, err := memory.NewSpillManager(spillDir, tracker)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h := NewHashAggregate([]string{"key"}, []AggColumn{
+		{Func: AggSum, InputCol: "val", OutputCol: "total", OutputType: parquet.TypeInt64},
+	})
+	h.Spill = sm
+	if err := h.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	const numBatches = 50
+	const rowsPerBatch = 50
+	expected := make(map[int64]int64)
+
+	for i := 0; i < numBatches; i++ {
+		rows := make([]map[string]any, 0, rowsPerBatch)
+		for j := 0; j < rowsPerBatch; j++ {
+			k := int64(i*rowsPerBatch + j)
+			v := int64(i + j + 1)
+			rows = append(rows, map[string]any{"key": k, "val": v})
+			expected[k] += v
+		}
+		b := batch.FromRows(schema, rows)
+		if err := h.Consume(ctx, b); err != nil {
+			t.Fatalf("Consume batch %d: %v", i, err)
+		}
+	}
+
+	// With a tiny flush threshold, we should have produced multiple files
+	// (but far fewer than numBatches).
+	if got := len(h.spillFiles); got == 0 {
+		t.Error("expected flush path to produce at least one spill file")
+	}
+	if got := len(h.spillFiles); got >= numBatches {
+		t.Errorf("flush did not batch across Consume calls: got %d files for %d batches", got, numBatches)
+	}
+
+	if err := h.Finalize(ctx); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+
+	got := make(map[int64]int64)
+	for {
+		out, err := h.Next(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out == nil {
+			break
+		}
+		for _, row := range out.ToRows() {
+			k := row["key"].(int64)
+			v := row["total"].(int64)
+			got[k] = v
+		}
+	}
+
+	if len(got) != len(expected) {
+		t.Fatalf("group count: got %d, want %d", len(got), len(expected))
+	}
+	for k, want := range expected {
+		if got[k] != want {
+			t.Errorf("key=%d: got total=%d, want %d", k, got[k], want)
 		}
 	}
 }

--- a/internal/engine/exec/join_spill.go
+++ b/internal/engine/exec/join_spill.go
@@ -59,9 +59,13 @@ type spillState struct {
 	numPartitions int
 	spilledParts  map[int]bool // which partitions have been spilled to disk
 
-	// Build-side: per-partition batch lists (in-memory) and spill files (on disk)
+	// Build-side: per-partition batch lists (in-memory) and spill files (on disk).
+	// partBuildWriters is a long-lived per-partition writer that appends
+	// subsequent batches for a spilled partition to a single file instead of
+	// producing one tiny file per batch (see writeBuildBatch for rationale).
 	partBuildBatches map[int][]*batch.RecordBatch
 	partBuildFiles   map[int][]string // spilled build file paths per partition
+	partBuildWriters map[int]*spillBatchWriter
 
 	// Probe-side: per-partition buffered batches (flushed to disk files)
 	partProbeFiles   map[int][]string
@@ -81,11 +85,47 @@ func newSpillState(dir string, schema []parquet.Column) *spillState {
 		spilledParts:     make(map[int]bool),
 		partBuildBatches: make(map[int][]*batch.RecordBatch),
 		partBuildFiles:   make(map[int][]string),
+		partBuildWriters: make(map[int]*spillBatchWriter),
 		partProbeFiles:   make(map[int][]string),
 		partProbeWriters: make(map[int]*spillBatchWriter),
 		partMemory:       make(map[int]int64),
 		schema:           schema,
 	}
+}
+
+// writeBuildBatch appends a build-side batch for an already-spilled partition
+// to that partition's long-lived spill writer. Creates the writer lazily on
+// first write. This replaces a prior pattern that created one tiny file per
+// batch, producing tens of thousands of ~100 KB files under SF100 workloads
+// and dominating wall time with file-open/close syscalls during probe flush.
+func (s *spillState) writeBuildBatch(partID int, b *batch.RecordBatch) error {
+	w, ok := s.partBuildWriters[partID]
+	if !ok {
+		var err error
+		w, err = newSpillBatchWriter(s.dir, "build-spill")
+		if err != nil {
+			return err
+		}
+		s.partBuildWriters[partID] = w
+	}
+	return w.writeBatch(b)
+}
+
+// closeBuildWriters flushes and closes all build-side spill writers, attaching
+// their output files to partBuildFiles. Caller must invoke this before probe
+// begins reading the spilled partitions.
+func (s *spillState) closeBuildWriters() error {
+	for partID, w := range s.partBuildWriters {
+		path, err := w.close()
+		if err != nil {
+			return err
+		}
+		if path != "" {
+			s.partBuildFiles[partID] = append(s.partBuildFiles[partID], path)
+		}
+	}
+	s.partBuildWriters = nil
+	return nil
 }
 
 // largestInMemoryPartition returns the partition ID with the most memory usage.
@@ -210,13 +250,11 @@ func (h *HashJoin) partitionBuildBatch(b *batch.RecordBatch) {
 	// Create per-partition batches
 	for partID, rows := range partRows {
 		if ss.spilledParts[partID] {
-			// This partition is already spilled — write directly to disk
+			// This partition is already spilled — append to its long-lived
+			// writer so a run of post-spill batches concatenates into a
+			// single file instead of fragmenting into one file per batch.
 			partBatch := compactBatchForRows(b, rows)
-			// Best effort: write to partition's build files
-			path, err := writeSpillBatches(ss.dir, []*batch.RecordBatch{partBatch})
-			if err == nil {
-				ss.partBuildFiles[partID] = append(ss.partBuildFiles[partID], path)
-			}
+			_ = ss.writeBuildBatch(partID, partBatch) // best-effort
 			continue
 		}
 		partBatch := compactBatchForRows(b, rows)
@@ -935,11 +973,14 @@ func (p *HashJoinProbe) NextFlush(ctx context.Context) (*batch.RecordBatch, erro
 		return nil, nil
 	}
 
-	// One-time init: collect partition IDs and close probe writers so probe
-	// spill files are flushed and readable.
+	// One-time init: collect partition IDs and close probe + build writers so
+	// spill files are flushed and readable before the probe reader opens them.
 	if !p.spillFlushInit {
 		if err := ss.closeProbeWriters(); err != nil {
 			return nil, fmt.Errorf("closing probe writers: %w", err)
+		}
+		if err := ss.closeBuildWriters(); err != nil {
+			return nil, fmt.Errorf("closing build writers: %w", err)
 		}
 		p.spillFlushPartIDs = make([]int, 0, len(ss.spilledParts))
 		for id := range ss.spilledParts {

--- a/internal/engine/memory/spill.go
+++ b/internal/engine/memory/spill.go
@@ -85,10 +85,19 @@ func (sm *SpillManager) ShouldSpill() bool {
 }
 
 // heapPressureRatio is the fraction of GOMEMLIMIT at which we trigger
-// spill. 0.7 = spill when the heap is at 70% of the soft memory limit.
-// Tunable upward for more aggressive caching, downward for more aggressive
-// spilling on memory-tight workloads.
-const heapPressureRatio = 0.7
+// spill. 0.5 = spill when the heap is at 50% of the soft memory limit.
+//
+// At SF100 the gap between the spill trigger and the kernel OOM-killer
+// was the main failure mode: workers reached 31 GB RSS on a 32 GB box
+// while only reporting tracker-visible memory of ~1.4 GB per task,
+// because a large fraction of live memory (broadcast build caches,
+// parquet decompression buffers, spill I/O buffers) does not route
+// through the per-operator tracker. Triggering spill earlier gives the
+// runtime more headroom to react before the heap hits GOMEMLIMIT.
+//
+// Tunable upward for cache-heavy workloads on roomy instances; downward
+// for memory-tight workloads.
+const heapPressureRatio = 0.5
 
 var (
 	heapPressureMu        sync.Mutex


### PR DESCRIPTION
## Summary

Three related fixes that reduce peak live memory during distributed query execution. Motivated by the SF100 Q03 OOM investigation (see `project_sf100_q03_spill_fragmentation_2026-04-17.md`) where workers reached 31 GB RSS on a 32 GB box during the join build phase. These fixes don't solve the broadcast-duplication root cause (that's a separate architectural follow-up) but reclaim measurable headroom and eliminate two fragmentation bugs that had real operational cost.

**Commits:**

1. `fix(exec): batch HashAggregate spill writes to avoid file-count explosion` — mirrors the Sort operator's spill pattern. HashAggregate was writing one file per batch once memory pressure fired, producing 3.24M ~4 KB files per worker at SF100 Q03 (confirmed via pprof on an aborted run). Now buffers rows and flushes at a 64 MB target.

2. `fix(engine): earlier spill trigger + batch join-build spill writes`:
   - `heapPressureRatio` 0.7 → 0.5 in `internal/engine/memory/spill.go`. The gap between tracker-visible memory (≤ GOMEMLIMIT × 0.7) and actual RSS at OOM was where we died — a lot of live memory (broadcast build caches, parquet decompression, spill I/O buffers) doesn't route through the per-operator tracker.
   - `internal/engine/exec/join_spill.go:216` had the same per-batch fragmentation bug as HashAggregate, on the grace-hash-join build side for already-spilled partitions (26,880 files at ~114 KB each observed in field). Mirrored the existing probe-side long-lived-writer pattern (`partProbeWriters`).

## Heap-profile impact on the local SF100 sample test

| Metric | Before | After | Δ |
|---|---|---|---|
| Total cumulative alloc | 39.8 GB | 30.6 GB | -23% |
| `HashJoin.Build` cumulative | 12.4 GB | 7.9 GB | -36% |
| `bufio.NewReaderSize` | 4.9 GB | 312 MB | -94% |
| `bufio.NewWriterSize` | 4.9 GB | 291 MB | -94% |

## Test plan

- [x] `go test ./internal/engine/exec/ ./internal/engine/memory/` — all pass
- [x] `go test -v -run TestTPCHQueries ./benchmarks/tpch/` — 22/22 SF0.01 green (correctness gate)
- [x] `go test -run TestDistributedTPCHBuildCacheSF100Sample ./internal/coordinator/` — identical 5-row Q05 result, same revenues, 32s runtime vs 29s baseline (noise)
- [x] `go build ./...` + `go vet ./internal/engine/...` — clean
- [ ] CI green on this PR
- [ ] SF100 redeploy to confirm Q03 now completes (expected after this merges; if still OOMs, we move to the architectural fix for probe-split broadcast duplication)

## Not in scope

- **Probe-split broadcast-duplication** (the bigger architectural problem). Each worker still builds the full orders hash (~7-8 GB at SF100) independently. A separate PR will address this via shuffle-based partitioning or dynamic filter pushdown. This PR reclaims headroom so the shipped fixes can buy us time.
- The `project_sf100_q03_spill_fragmentation_2026-04-17.md` memory noted Q03 was regressing from 04-05 baseline. The 2m12s Q03 pass from 04-05 predates some later changes; full SF100 re-verification will tell us whether (a) the underlying regression is gone after these fixes, or (b) the broadcast duplication bound still fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)