### PR TITLE
feat(planner,worker,coordinator): shuffle-based build partitioning for SF100 OOM

### DIFF
--- a/docs/superpowers/plans/2026-04-18-shuffle-based-build-partitioning.md
+++ b/docs/superpowers/plans/2026-04-18-shuffle-based-build-partitioning.md
@@ -1,0 +1,1815 @@
+# Shuffle-Based Build Partitioning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a shuffle-distributed execution path for queries whose largest build table exceeds 4 GB, so per-worker memory scales 1/N instead of being broadcast-duplicated. Unblocks Q03/Q05/Q07 at SF100.
+
+**Architecture:** Add `TaskTypeShuffle` and a `Distribution` property on physical plan nodes. The coordinator routing decision picks shuffle over probe-split when the largest build's `EstimatedBytes` exceeds `shuffleBuildThreshold` (4 GB). A new partitioned shuffle sink writes 4N per-partition `.wshf` files; a new partition-shard source reads all `.wshf` files for an assigned partition. Coordinator orchestrates shuffle stages (build + probe) before dispatching the final co-located join stage. Phase 1 supports a single shuffle stage; Phase 2 (chained shuffles for Q09) is out of scope.
+
+**Tech Stack:** Go, NATS JetStream, S3 (MinIO in tests), `wadjet` engine `exec` package, custom WSHF on-disk format.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-shuffle-based-build-partitioning-design.md`
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `internal/distributed/messages.go` | Modify | Add `TaskTypeShuffle` constant; rely on existing `ShuffleKeys`/`NumPartitions`/`PartitionID`/`ResultFiles` fields |
+| `internal/planner/physical/distribution.go` | NEW | `Distribution` type, `DistKind`, equality/compatibility helpers |
+| `internal/planner/physical/plan.go` | Modify | Add `Distribution` field to `Stage`; add `Type = "shuffle"` stage variant; `InsertShuffleForLargeBuild()` planner pass |
+| `internal/coordinator/coordinator.go` | Modify | New routing branch: when `largestBuildBytes(stages) > shuffleBuildThreshold`, route to shuffle path |
+| `internal/coordinator/shuffle_orchestrator.go` | NEW | Dispatch shuffle stage (build side + probe side), wait for completion, build probe-stage tasks with partition assignments |
+| `internal/coordinator/scheduler.go` (or `coordinator.go`) | Modify | `createTasksForStage` handles new shuffle stage type |
+| `internal/worker/executor.go` | Modify | Switch case for `TaskTypeShuffle`; new `executeShuffle` function |
+| `internal/worker/partitioned_shuffle_sink.go` | NEW | Sink that hash-partitions into 4N `.wshf` output files (one per partition) |
+| `internal/worker/partition_shard_source.go` | NEW | Source that reads all `.wshf` files at an assigned S3 partition prefix and streams batches |
+| `internal/worker/shuffle_format.go` | Modify | No format change; reuse existing chunk format |
+| `benchmarks/local/broadcast_pressure_test.go` | NEW | Local memory-pressure repro under tight `GOMEMLIMIT` (Gate 0) |
+| `internal/coordinator/distributed_tpch_test.go` | Modify | Add SF0.01 case forcing shuffle path via lowered `shuffleBuildThreshold` |
+| `internal/planner/physical/distribution_test.go` | NEW | Unit tests for `Distribution` arithmetic |
+| `internal/planner/physical/shuffle_insertion_test.go` | NEW | Unit tests for `InsertShuffleForLargeBuild()` |
+| `internal/worker/partitioned_shuffle_sink_test.go` | NEW | Round-trip test: hash-partition then read back, verify rows-per-partition correct |
+
+---
+
+## Task 1: Add `TaskTypeShuffle` constant
+
+**Files:**
+- Modify: `internal/distributed/messages.go:10-15`
+
+- [ ] **Step 1: Read current messages.go to confirm structure**
+
+Run: `head -20 internal/distributed/messages.go`
+Expected: Confirms only `TaskTypePipeline` exists.
+
+- [ ] **Step 2: Add `TaskTypeShuffle` constant**
+
+In `internal/distributed/messages.go`, replace the const block:
+
+```go
+const (
+	TaskTypePipeline TaskType = "pipeline" // full query executed as standalone pipeline on one worker
+	TaskTypeShuffle  TaskType = "shuffle"  // hash-partitions input rows into N output partition files
+)
+```
+
+- [ ] **Step 3: Build to verify nothing breaks**
+
+Run: `go build ./...`
+Expected: PASS (no import cycles, no compile errors).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/distributed/messages.go
+git commit -m "feat(distributed): add TaskTypeShuffle constant"
+```
+
+---
+
+## Task 2: `Distribution` property type
+
+**Files:**
+- Create: `internal/planner/physical/distribution.go`
+- Create: `internal/planner/physical/distribution_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/planner/physical/distribution_test.go`:
+
+```go
+package physical
+
+import "testing"
+
+func TestDistributionEquals(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b Distribution
+		want bool
+	}{
+		{"both broadcast", Distribution{Kind: DistBroadcast}, Distribution{Kind: DistBroadcast}, true},
+		{"singleton vs broadcast", Distribution{Kind: DistSingleton}, Distribution{Kind: DistBroadcast}, false},
+		{"hash same keys same count", Distribution{Kind: DistHashPartitioned, Keys: []string{"k"}, Count: 12}, Distribution{Kind: DistHashPartitioned, Keys: []string{"k"}, Count: 12}, true},
+		{"hash different keys", Distribution{Kind: DistHashPartitioned, Keys: []string{"a"}, Count: 12}, Distribution{Kind: DistHashPartitioned, Keys: []string{"b"}, Count: 12}, false},
+		{"hash different count", Distribution{Kind: DistHashPartitioned, Keys: []string{"k"}, Count: 12}, Distribution{Kind: DistHashPartitioned, Keys: []string{"k"}, Count: 24}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.a.Equals(tt.b); got != tt.want {
+				t.Errorf("Equals = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDistributionSatisfiesJoin(t *testing.T) {
+	d := Distribution{Kind: DistHashPartitioned, Keys: []string{"orderkey"}, Count: 12}
+	if !d.SatisfiesJoinKeys([]string{"orderkey"}) {
+		t.Error("expected hash-on-orderkey to satisfy join on orderkey")
+	}
+	if d.SatisfiesJoinKeys([]string{"custkey"}) {
+		t.Error("expected hash-on-orderkey to NOT satisfy join on custkey")
+	}
+	bcast := Distribution{Kind: DistBroadcast}
+	if !bcast.SatisfiesJoinKeys([]string{"anything"}) {
+		t.Error("broadcast should always satisfy join")
+	}
+}
+```
+
+- [ ] **Step 2: Run test — should fail to compile**
+
+Run: `go test ./internal/planner/physical/ -run TestDistribution -v`
+Expected: FAIL — `Distribution`, `DistKind`, etc. undefined.
+
+- [ ] **Step 3: Implement distribution.go**
+
+Create `internal/planner/physical/distribution.go`:
+
+```go
+package physical
+
+// DistKind is the kind of partitioning a stage's output has.
+type DistKind int
+
+const (
+	DistSingleton       DistKind = iota // single worker has all rows
+	DistBroadcast                       // every worker has all rows
+	DistHashPartitioned                 // rows partitioned by hash(Keys) % Count
+)
+
+// Distribution describes how a stage's output is partitioned across workers.
+type Distribution struct {
+	Kind  DistKind
+	Keys  []string // for DistHashPartitioned
+	Count int      // for DistHashPartitioned
+}
+
+// Equals reports whether two Distributions are identical.
+func (d Distribution) Equals(other Distribution) bool {
+	if d.Kind != other.Kind {
+		return false
+	}
+	if d.Kind != DistHashPartitioned {
+		return true
+	}
+	if d.Count != other.Count || len(d.Keys) != len(other.Keys) {
+		return false
+	}
+	for i := range d.Keys {
+		if d.Keys[i] != other.Keys[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// SatisfiesJoinKeys reports whether this distribution allows a co-located
+// join on the given keys without re-shuffling. Broadcast always satisfies;
+// hash-partitioned satisfies iff the keys match exactly (in order).
+func (d Distribution) SatisfiesJoinKeys(joinKeys []string) bool {
+	switch d.Kind {
+	case DistBroadcast:
+		return true
+	case DistHashPartitioned:
+		if len(d.Keys) != len(joinKeys) {
+			return false
+		}
+		for i := range d.Keys {
+			if d.Keys[i] != joinKeys[i] {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/planner/physical/ -run TestDistribution -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/planner/physical/distribution.go internal/planner/physical/distribution_test.go
+git commit -m "feat(planner): add Distribution property type for shuffle planning"
+```
+
+---
+
+## Task 3: Add `Distribution` field to `Stage`
+
+**Files:**
+- Modify: `internal/planner/physical/plan.go:35-50` (Stage struct)
+
+- [ ] **Step 1: Add field to Stage struct**
+
+In `internal/planner/physical/plan.go`, find the `Stage` struct (currently around line 35) and add a `Distribution` field. The minimal addition:
+
+```go
+type Stage struct {
+	ID           string
+	Type         string // scan, aggregate, sort, hash_join, broadcast_join, window, shuffle, pipeline
+	// ... existing fields unchanged ...
+
+	// Distribution describes how this stage's output is partitioned.
+	// Default zero value is {Kind: DistSingleton} which is correct for
+	// most existing stages (single-worker output). Shuffle stages set this
+	// to DistHashPartitioned with Keys and Count populated. Broadcast pre-scans
+	// (build cache) set Kind: DistBroadcast.
+	Distribution Distribution
+}
+```
+
+Update the Type comment to add `shuffle` to the list.
+
+- [ ] **Step 2: Verify nothing breaks**
+
+Run: `go build ./... && go test ./internal/planner/physical/ -count=1`
+Expected: PASS — `Distribution` zero value is `DistSingleton` so no test changes needed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/planner/physical/plan.go
+git commit -m "feat(planner): add Distribution field to Stage"
+```
+
+---
+
+## Task 4: Build the partitioned shuffle sink
+
+This is the per-worker output side of a shuffle: hash-partition incoming batches into 4N output `.wshf` files (one per target partition), each written incrementally to disk to bound memory.
+
+**Files:**
+- Create: `internal/worker/partitioned_shuffle_sink.go`
+- Create: `internal/worker/partitioned_shuffle_sink_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/worker/partitioned_shuffle_sink_test.go`:
+
+```go
+package worker
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// TestPartitionedShuffleSink_RoundTrip verifies that rows hash-partitioned
+// across N output files can be read back, that no row is lost, and that
+// every row in partition p hashes to p.
+func TestPartitionedShuffleSink_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	const numParts = 4
+
+	schema := []parquet.Column{{Name: "k", Type: parquet.Int64Type}}
+	sink := newPartitionedShuffleSink(dir, []string{"k"}, numParts, schema)
+	if err := sink.Init(context.Background()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	// Build a batch of 1000 rows with sequential int64 keys.
+	const n = 1000
+	col := batch.NewInt64Vector(n)
+	for i := 0; i < n; i++ {
+		col.Set(i, int64(i))
+	}
+	b := &batch.RecordBatch{
+		Schema:  schema,
+		Columns: []batch.Vector{col},
+	}
+	if err := sink.Consume(context.Background(), b); err != nil {
+		t.Fatalf("consume: %v", err)
+	}
+	if err := sink.Finalize(context.Background()); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+
+	paths := sink.PartitionFiles()
+	if len(paths) != numParts {
+		t.Fatalf("expected %d partition files, got %d", numParts, len(paths))
+	}
+
+	// Read each partition back and verify every row's hash maps back to its partition.
+	totalRows := 0
+	for p, path := range paths {
+		if path == "" {
+			continue // empty partition
+		}
+		rows := readWSHFInts(t, filepath.Clean(path), "k")
+		for _, k := range rows {
+			got := int(hashInt64(k) % uint64(numParts))
+			if got != p {
+				t.Errorf("row k=%d ended up in partition %d, hash maps to %d", k, p, got)
+			}
+		}
+		totalRows += len(rows)
+	}
+	if totalRows != n {
+		t.Errorf("total rows across partitions = %d, want %d", totalRows, n)
+	}
+
+	if err := sink.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+// readWSHFInts reads back int64 values from a single-column WSHF file.
+// (Helper assumed elsewhere in worker tests; if not, declare locally.)
+func readWSHFInts(t *testing.T, path, col string) []int64 {
+	t.Helper()
+	rdr, err := openShuffleReader(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer rdr.Close()
+	var out []int64
+	for {
+		b, err := rdr.Next()
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if b == nil {
+			break
+		}
+		v := b.Columns[0].(*batch.Int64Vector)
+		for i := 0; i < b.ActiveLen(); i++ {
+			out = append(out, v.Get(i))
+		}
+	}
+	return out
+}
+```
+
+Note: `hashInt64`, `openShuffleReader`, and helper details may need small adjustments to match existing helpers in the package — Step 3 implementation will name them consistently.
+
+- [ ] **Step 2: Run test — should fail to compile**
+
+Run: `go test ./internal/worker/ -run TestPartitionedShuffleSink -v`
+Expected: FAIL — types undefined.
+
+- [ ] **Step 3: Implement `partitioned_shuffle_sink.go`**
+
+Create `internal/worker/partitioned_shuffle_sink.go`:
+
+```go
+package worker
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"hash/fnv"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// partitionedShuffleSink is an exec.Sink that hash-partitions incoming batches
+// into N output .wshf files, one per partition. Each partition's writer flushes
+// its accumulated rows once a per-partition buffer threshold is reached, so
+// peak memory is bounded by (N partitions × flush threshold), independent of
+// the total input size.
+//
+// This is the build-side and probe-side output sink for the shuffle execution
+// path. The N output files are uploaded by the executor to S3 under a stable
+// per-partition prefix, and downstream join tasks read all files at their
+// assigned partition prefix via partitionShardSource.
+type partitionedShuffleSink struct {
+	spillDir   string
+	keys       []string // partition key column names
+	numParts   int
+	schema     []parquet.Column
+	flushBytes int // per-partition row buffer flush threshold
+
+	mu      sync.Mutex
+	parts   []*partitionWriter
+	closed  bool
+	keyIdxs []int // resolved column indices for keys (set on first Consume)
+}
+
+type partitionWriter struct {
+	file    *os.File
+	writer  *shuffleWriter
+	rowBuf  *batch.RecordBatch // accumulator
+	bufRows int
+	numRows int64
+}
+
+// flushPartitionBytes is the per-partition accumulator size (in approx bytes
+// of row data) at which we flush a chunk to disk. 64 KB keeps memory bounded:
+// 4N partitions × 64 KB = ~768 KB per shuffle task at N=3.
+const flushPartitionBytes = 64 * 1024
+
+func newPartitionedShuffleSink(spillDir string, keys []string, numParts int, schema []parquet.Column) *partitionedShuffleSink {
+	return &partitionedShuffleSink{
+		spillDir:   spillDir,
+		keys:       keys,
+		numParts:   numParts,
+		schema:     schema,
+		flushBytes: flushPartitionBytes,
+		parts:      make([]*partitionWriter, numParts),
+	}
+}
+
+func (s *partitionedShuffleSink) Init(_ context.Context) error {
+	if s.spillDir == "" {
+		return fmt.Errorf("partitionedShuffleSink: spillDir empty")
+	}
+	if err := os.MkdirAll(s.spillDir, 0o755); err != nil {
+		return fmt.Errorf("creating spill dir: %w", err)
+	}
+	for p := 0; p < s.numParts; p++ {
+		path := filepath.Join(s.spillDir, fmt.Sprintf("part-%04d.wshf", p))
+		f, err := os.Create(path)
+		if err != nil {
+			return fmt.Errorf("creating partition %d: %w", p, err)
+		}
+		s.parts[p] = &partitionWriter{file: f}
+	}
+	return nil
+}
+
+// Consume hash-partitions each row in b into its target partition, appending
+// to that partition's row buffer. Buffers are flushed when they exceed
+// flushBytes worth of accumulated rows.
+func (s *partitionedShuffleSink) Consume(_ context.Context, b *batch.RecordBatch) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.keyIdxs) == 0 {
+		// Resolve key column indices from schema on first batch.
+		s.keyIdxs = make([]int, len(s.keys))
+		for i, k := range s.keys {
+			idx := -1
+			for j, col := range b.Schema {
+				if col.Name == k {
+					idx = j
+					break
+				}
+			}
+			if idx < 0 {
+				return fmt.Errorf("partitioned shuffle: key %q not in schema", k)
+			}
+			s.keyIdxs[i] = idx
+		}
+	}
+
+	n := b.ActiveLen()
+	for i := 0; i < n; i++ {
+		row := i
+		if b.Sel != nil {
+			row = b.Sel[i]
+		}
+		p := s.partitionFor(b, row)
+		if err := s.appendRow(p, b, row); err != nil {
+			return err
+		}
+	}
+	return s.flushIfNeeded()
+}
+
+// partitionFor computes hash(b.Columns[keyIdxs][row]) % numParts.
+func (s *partitionedShuffleSink) partitionFor(b *batch.RecordBatch, row int) int {
+	h := fnv.New64a()
+	var buf [8]byte
+	for _, idx := range s.keyIdxs {
+		// Hash the column value at row. Implementation depends on column type;
+		// a small dispatch on schema type covers our supported keys
+		// (Int32, Int64, String, Bytes — the join-key types in TPC-H).
+		hashColValue(h, b.Columns[idx], row, buf[:])
+	}
+	return int(h.Sum64() % uint64(s.numParts))
+}
+
+// appendRow copies the row into partition p's row buffer.
+// (Implementation copies typed column values into a per-partition RecordBatch.
+// The minimal correct version allocates per-partition single-row scratch
+// batches and uses batch.AppendRow; optimization can come later.)
+func (s *partitionedShuffleSink) appendRow(p int, b *batch.RecordBatch, row int) error {
+	pw := s.parts[p]
+	if pw.rowBuf == nil {
+		pw.rowBuf = batch.NewRecordBatch(b.Schema)
+	}
+	if err := pw.rowBuf.AppendRow(b, row); err != nil {
+		return err
+	}
+	pw.bufRows++
+	return nil
+}
+
+// flushIfNeeded writes any partition whose buffer exceeds the flush threshold.
+func (s *partitionedShuffleSink) flushIfNeeded() error {
+	for p, pw := range s.parts {
+		if pw.rowBuf == nil {
+			continue
+		}
+		if pw.rowBuf.EstimatedBytes() < s.flushBytes {
+			continue
+		}
+		if err := s.flushPartition(p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *partitionedShuffleSink) flushPartition(p int) error {
+	pw := s.parts[p]
+	if pw.rowBuf == nil || pw.bufRows == 0 {
+		return nil
+	}
+	if pw.writer == nil {
+		pw.writer = newShuffleWriter(pw.file, s.schema)
+		if err := pw.writer.writeHeader(); err != nil {
+			return fmt.Errorf("partition %d header: %w", p, err)
+		}
+	}
+	if err := pw.writer.writeChunk(pw.rowBuf.Columns, pw.rowBuf.Sel, pw.bufRows); err != nil {
+		return fmt.Errorf("partition %d chunk: %w", p, err)
+	}
+	pw.numRows += int64(pw.bufRows)
+	pw.rowBuf.Reset()
+	pw.bufRows = 0
+	return nil
+}
+
+func (s *partitionedShuffleSink) Finalize(_ context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for p := range s.parts {
+		if err := s.flushPartition(p); err != nil {
+			return err
+		}
+	}
+	for p, pw := range s.parts {
+		if pw.writer == nil {
+			// Empty partition — leave file at zero bytes; downstream treats as no rows.
+			if err := pw.file.Sync(); err != nil {
+				return err
+			}
+			continue
+		}
+		// Patch chunk count in header (mirrors shuffleStreamSink.Finalize).
+		if _, err := pw.file.Seek(4, 0); err != nil {
+			return fmt.Errorf("partition %d seek: %w", p, err)
+		}
+		var buf [4]byte
+		binary.LittleEndian.PutUint32(buf[:], pw.writer.numChunks)
+		if _, err := pw.file.Write(buf[:]); err != nil {
+			return fmt.Errorf("partition %d patch: %w", p, err)
+		}
+		if _, err := pw.file.Seek(0, 2); err != nil {
+			return err
+		}
+		if err := pw.file.Sync(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *partitionedShuffleSink) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	for _, pw := range s.parts {
+		if pw != nil && pw.file != nil {
+			_ = pw.file.Close()
+		}
+	}
+	return nil
+}
+
+// PartitionFiles returns the local file paths for each partition (index = partition id).
+// Empty string for a partition that received zero rows (and thus has no usable file).
+func (s *partitionedShuffleSink) PartitionFiles() []string {
+	out := make([]string, s.numParts)
+	for p, pw := range s.parts {
+		if pw == nil || pw.numRows == 0 {
+			continue
+		}
+		out[p] = pw.file.Name()
+	}
+	return out
+}
+
+// hashColValue mixes a single column value at the given row into h.
+// Supports the join-key types we encounter in TPC-H/SIEM workloads.
+func hashColValue(h interface{ Write([]byte) (int, error) }, col batch.Vector, row int, scratch []byte) {
+	switch v := col.(type) {
+	case *batch.Int32Vector:
+		binary.LittleEndian.PutUint32(scratch[:4], uint32(v.Get(row)))
+		_, _ = h.Write(scratch[:4])
+	case *batch.Int64Vector:
+		binary.LittleEndian.PutUint64(scratch[:8], uint64(v.Get(row)))
+		_, _ = h.Write(scratch[:8])
+	case *batch.StringVector:
+		_, _ = h.Write([]byte(v.Get(row)))
+	case *batch.BytesVector:
+		_, _ = h.Write(v.Get(row))
+	default:
+		// Unsupported key type — should be caught by planner before dispatch.
+		// Hash zero so partition assignment is deterministic but skewed.
+		_, _ = h.Write([]byte{0})
+	}
+}
+```
+
+> Note: This file references `batch.AppendRow`, `batch.RecordBatch.Reset()`, `batch.RecordBatch.EstimatedBytes()`, and `batch.NewRecordBatch`. If any of these helpers don't exist in the codebase, add minimal implementations in `internal/engine/batch/` as part of this task — do NOT skip and assume. Look at how `shuffleStreamSink` writes batches (`writeChunk(b.Columns, b.Sel, nRows)`) for the existing pattern, and follow it; the AppendRow/Reset helpers may already exist under different names.
+
+- [ ] **Step 4: Iterate until tests pass**
+
+Run: `go test ./internal/worker/ -run TestPartitionedShuffleSink -v`
+Expected: PASS. If a helper signature mismatch — adjust to match existing batch package API.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/worker/partitioned_shuffle_sink.go internal/worker/partitioned_shuffle_sink_test.go
+git commit -m "feat(worker): partitioned shuffle sink writes N output .wshf files"
+```
+
+---
+
+## Task 5: Build the partition shard source
+
+The downstream side of the shuffle: a Source that reads ALL `.wshf` files at a given S3 partition prefix and streams batches.
+
+**Files:**
+- Create: `internal/worker/partition_shard_source.go`
+- Modify: `internal/worker/stream_source.go` (only if a helper needs to be exported — check first)
+
+- [ ] **Step 1: Read existing stream_source.go to see the pattern**
+
+Run: `wc -l internal/worker/stream_source.go && head -80 internal/worker/stream_source.go`
+Expected: Confirms the pattern used by `cachedFileStreamSource` (which already reads `.wshf` files from S3).
+
+- [ ] **Step 2: Implement `partition_shard_source.go`**
+
+Create `internal/worker/partition_shard_source.go`:
+
+```go
+package worker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/engine/exec"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+)
+
+// partitionShardSource is an exec.Source that reads all .wshf files at a
+// given S3 prefix (one shuffle partition's contribution from every upstream
+// task) and streams batches to the downstream operator. Files are read
+// sequentially; each file is fully drained before the next one starts.
+//
+// Used by the join executor on the probe side of a shuffled join: each
+// worker is assigned a contiguous slice of partitions and instantiates one
+// partitionShardSource per assigned partition.
+type partitionShardSource struct {
+	store    objstore.Store
+	bucket   string
+	prefix   string // e.g. "shuffle/<query>/<stage>/partition=07/"
+	files    []string
+	current  *cachedFileStreamSource // reuses existing single-file reader
+	idx      int
+	initOnce bool
+}
+
+func newPartitionShardSource(store objstore.Store, bucket, prefix string) *partitionShardSource {
+	return &partitionShardSource{store: store, bucket: bucket, prefix: prefix}
+}
+
+func (s *partitionShardSource) Init(ctx context.Context) error {
+	if s.initOnce {
+		return nil
+	}
+	s.initOnce = true
+	files, err := s.store.List(ctx, s.bucket, s.prefix)
+	if err != nil {
+		return fmt.Errorf("listing partition prefix %q: %w", s.prefix, err)
+	}
+	s.files = files
+	return nil
+}
+
+func (s *partitionShardSource) Next(ctx context.Context) (*batch.RecordBatch, error) {
+	for {
+		if s.current == nil {
+			if s.idx >= len(s.files) {
+				return nil, nil // exhausted
+			}
+			s.current = newCachedFileStreamSource(s.store, s.bucket, s.files[s.idx])
+			if err := s.current.Init(ctx); err != nil {
+				return nil, err
+			}
+			s.idx++
+		}
+		b, err := s.current.Next(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if b != nil {
+			return b, nil
+		}
+		// Current file drained; close and advance.
+		_ = s.current.Close()
+		s.current = nil
+	}
+}
+
+func (s *partitionShardSource) Close() error {
+	if s.current != nil {
+		return s.current.Close()
+	}
+	return nil
+}
+
+// Compile-time check.
+var _ exec.Source = (*partitionShardSource)(nil)
+```
+
+> If `cachedFileStreamSource` is unexported and its constructor signature differs, adjust the constructor call. The intent is to delegate single-file reading to the existing reader.
+
+- [ ] **Step 3: Add a basic round-trip test**
+
+In `internal/worker/partition_shard_source_test.go`:
+
+```go
+package worker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+)
+
+func TestPartitionShardSource_ReadsAllFiles(t *testing.T) {
+	ctx := context.Background()
+	store := objstore.NewMemStore()
+	const bucket = "test"
+	prefix := "shuffle/q1/s0/partition=03/"
+
+	// Stage two .wshf files at the prefix using the partitioned sink path.
+	dir := t.TempDir()
+	// (Build two small .wshf files via shuffleStreamSink directly; upload to memstore.)
+	// ... omitted for brevity — see partitioned_shuffle_sink_test for fixture-build ...
+
+	src := newPartitionShardSource(store, bucket, prefix)
+	if err := src.Init(ctx); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	defer src.Close()
+
+	rows := 0
+	for {
+		b, err := src.Next(ctx)
+		if err != nil {
+			t.Fatalf("next: %v", err)
+		}
+		if b == nil {
+			break
+		}
+		rows += b.ActiveLen()
+	}
+	if rows == 0 {
+		t.Fatal("expected non-zero rows from 2 staged files")
+	}
+}
+```
+
+> The fixture-staging code is intentionally elided here. When implementing, use `shuffleStreamSink` to write a small `.wshf` to local disk, then upload to the `MemStore` via `store.Put(...)`. Keep the test under 80 lines.
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/worker/ -run TestPartitionShardSource -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/worker/partition_shard_source.go internal/worker/partition_shard_source_test.go
+git commit -m "feat(worker): partitionShardSource reads .wshf files at a shuffle partition prefix"
+```
+
+---
+
+## Task 6: Worker executor handles `TaskTypeShuffle`
+
+**Files:**
+- Modify: `internal/worker/executor.go:167` (add switch case)
+- Modify: `internal/worker/executor.go` (add `executeShuffle` function)
+
+- [ ] **Step 1: Add the switch case**
+
+In `internal/worker/executor.go`, find the `switch task.Type` block (around line 167) and add:
+
+```go
+switch task.Type {
+case distributed.TaskTypePipeline:
+    // ... existing ...
+case distributed.TaskTypeShuffle:
+    return e.executeShuffle(ctx, task)
+default:
+    return nil, fmt.Errorf("unknown task type: %s", task.Type)
+}
+```
+
+- [ ] **Step 2: Implement `executeShuffle`**
+
+Add a new function in `internal/worker/executor.go`:
+
+```go
+// executeShuffle reads input data (either source files via SQLText projection,
+// or pre-staged shuffle inputs via task.Files), hash-partitions on
+// task.ShuffleKeys into task.NumPartitions output .wshf files, and uploads
+// each non-empty partition to S3 under:
+//   <ResultBucket>/<ResultPrefix>/partition=<NNNN>/<TaskID>.wshf
+//
+// On success, ResultNotification.ResultFiles contains one entry per non-empty
+// partition: "<ResultPrefix>/partition=<NNNN>/<TaskID>.wshf".
+func (e *Executor) executeShuffle(ctx context.Context, task *distributed.Task) (*distributed.ResultNotification, error) {
+	if len(task.ShuffleKeys) == 0 {
+		return nil, fmt.Errorf("shuffle task missing ShuffleKeys")
+	}
+	if task.NumPartitions <= 0 {
+		return nil, fmt.Errorf("shuffle task NumPartitions must be > 0")
+	}
+
+	// Build a Source that reads the assigned input. Two cases:
+	//   1. task.SQLText set → execute SQL pipeline, collect output stream as input
+	//      (used for the build-side of a shuffle: full table scan with optional projection)
+	//   2. task.Files set → read those .wshf files directly
+	//      (used when shuffle input is itself a previous stage's output)
+	src, schema, err := e.buildShuffleInputSource(ctx, task)
+	if err != nil {
+		return nil, fmt.Errorf("building shuffle input: %w", err)
+	}
+	defer src.Close()
+
+	spillDir := e.spillDirFor(task.QueryID, task.ID)
+	sink := newPartitionedShuffleSink(spillDir, task.ShuffleKeys, task.NumPartitions, schema)
+	if err := sink.Init(ctx); err != nil {
+		return nil, fmt.Errorf("sink init: %v", err)
+	}
+	defer sink.Close()
+
+	// Pump batches from source through the sink.
+	for {
+		b, err := src.Next(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("reading shuffle input: %w", err)
+		}
+		if b == nil {
+			break
+		}
+		if err := sink.Consume(ctx, b); err != nil {
+			return nil, fmt.Errorf("partitioning batch: %w", err)
+		}
+	}
+	if err := sink.Finalize(ctx); err != nil {
+		return nil, fmt.Errorf("sink finalize: %w", err)
+	}
+
+	// Upload each non-empty partition file to S3.
+	resultFiles := make([]string, 0, task.NumPartitions)
+	var totalBytes int64
+	for p, localPath := range sink.PartitionFiles() {
+		if localPath == "" {
+			continue
+		}
+		key := fmt.Sprintf("%s/partition=%04d/%s.wshf", task.ResultPrefix, p, task.ID)
+		size, upErr := e.uploadFile(ctx, task.ResultBucket, key, localPath)
+		if upErr != nil {
+			return nil, fmt.Errorf("upload partition %d: %w", p, upErr)
+		}
+		resultFiles = append(resultFiles, key)
+		totalBytes += size
+		// Best-effort cleanup of local spill.
+		_ = os.Remove(localPath)
+	}
+
+	return &distributed.ResultNotification{
+		TaskID:      task.ID,
+		QueryID:     task.QueryID,
+		StageID:     task.StageID,
+		WorkerID:    e.workerID,
+		Success:     true,
+		ResultFiles: resultFiles,
+		SizeBytes:   totalBytes,
+		Timestamp:   time.Now(),
+	}, nil
+}
+```
+
+> `buildShuffleInputSource`, `spillDirFor`, and `uploadFile` are stubs — wire them to whatever the existing executor uses for the same primitives (look at how `executePipeline` reads input + uploads results). Keep this function focused on the shuffle-specific orchestration.
+
+- [ ] **Step 3: Add a unit test for the executor's shuffle path using MemStore**
+
+Create `internal/worker/executor_shuffle_test.go` with one happy-path test that:
+1. Stages a small input file on `MemStore`.
+2. Constructs a `Task` with `Type=TaskTypeShuffle`, `Files=[that file]`, `ShuffleKeys=["k"]`, `NumPartitions=4`.
+3. Calls `executor.Execute(ctx, task)`.
+4. Asserts `ResultFiles` contains files and the union of all partition file row counts equals input row count.
+
+(Mirror the existing test pattern in `executor_pipeline_test.go`.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/worker/ -run Shuffle -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/worker/executor.go internal/worker/executor_shuffle_test.go
+git commit -m "feat(worker): execute TaskTypeShuffle by hash-partitioning to N output files"
+```
+
+---
+
+## Task 7: Local memory-pressure repro (Validation Gate 0)
+
+A standalone test that reproduces the broadcast-duplication OOM signature locally so we can iterate without burning EC2 dollars.
+
+**Files:**
+- Create: `benchmarks/local/broadcast_pressure_test.go`
+
+- [ ] **Step 1: Confirm `benchmarks/local/` doesn't exist yet**
+
+Run: `ls benchmarks/`
+Expected: shows `security/` and `tpch/`. We're creating a new directory.
+
+- [ ] **Step 2: Create the test**
+
+Create `benchmarks/local/broadcast_pressure_test.go`:
+
+```go
+//go:build pressure
+// +build pressure
+
+// Package local contains memory-pressure repros that intentionally allocate
+// large amounts of memory under tight GOMEMLIMIT to validate that
+// broadcast-replacement code paths actually reduce peak heap.
+//
+// Build tag `pressure` keeps these out of normal `go test ./...` runs; they
+// are explicitly invoked via:
+//
+//   GOMEMLIMIT=8GiB go test -tags=pressure -v ./benchmarks/local/ -run BroadcastPressure -timeout 10m
+package local
+
+import (
+	"context"
+	"runtime"
+	"runtime/debug"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet"
+)
+
+// TestBroadcastPressure_OrdersHashOOM_ReproducesSignature loads the SF100-sample
+// orders table into a hash table TWICE concurrently within a single process
+// under GOMEMLIMIT=8 GiB. With the legacy broadcast path, two copies of the
+// orders hash should push the process near its memory limit. With the shuffled
+// build path (lowered shuffleBuildThreshold), each "worker" only loads its
+// shard, peak heap stays bounded.
+//
+// This test is the local gate before any EC2 deploy of the shuffle change.
+func TestBroadcastPressure_OrdersHashOOM_ReproducesSignature(t *testing.T) {
+	if testing.Short() {
+		t.Skip("pressure repro skipped in -short mode")
+	}
+
+	// Use SF100-sample orders table from the public test bucket.
+	// (Path/data setup adapted from existing TPC-H bench helpers.)
+	tableDir := requireSF100SampleOrders(t)
+
+	db, err := wadjet.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+	if err := db.AttachParquet(context.Background(), "orders", tableDir); err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+
+	// Sample peak heap throughout the run.
+	var peakHeapBytes atomic.Uint64
+	stopSampler := make(chan struct{})
+	go func() {
+		var ms runtime.MemStats
+		ticker := time.NewTicker(50 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stopSampler:
+				return
+			case <-ticker.C:
+				runtime.ReadMemStats(&ms)
+				if ms.HeapAlloc > peakHeapBytes.Load() {
+					peakHeapBytes.Store(ms.HeapAlloc)
+				}
+			}
+		}
+	}()
+
+	// Run two concurrent SELECT * FROM orders queries that fully materialize
+	// each row into a hash on o_orderkey — mimicking the build-side of a join.
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, qerr := db.Query(context.Background(),
+				`SELECT o_orderkey, o_custkey, o_orderdate FROM orders`)
+			if qerr != nil {
+				t.Logf("query error (expected under tight limit): %v", qerr)
+			}
+		}()
+	}
+	wg.Wait()
+	close(stopSampler)
+
+	gomemlimit := debug.SetMemoryLimit(-1) // read current
+	peak := peakHeapBytes.Load()
+	t.Logf("peak heap: %d MiB; GOMEMLIMIT: %d MiB", peak/(1<<20), gomemlimit/(1<<20))
+
+	// With shuffled build: peak should stay below ~50% of GOMEMLIMIT.
+	// With broadcast: peak typically pushes near the limit (or OOMs).
+	// We don't fail on the threshold here — this test's value is the heap
+	// number it prints, used to compare before/after a shuffle change.
+}
+```
+
+- [ ] **Step 3: Run the baseline (BEFORE the shuffle path is wired)**
+
+Run: `GOMEMLIMIT=8GiB go test -tags=pressure -v ./benchmarks/local/ -run BroadcastPressure -timeout 10m 2>&1 | tee /tmp/pressure-before.txt`
+Expected: Test runs, logs peak heap. We want this to be high (close to GOMEMLIMIT).
+
+> If the SF100 sample is too big to download here, scale to SF10 or a synthetic 5 GB table — the goal is to reproduce the *signature*, not match SF100 exactly.
+
+- [ ] **Step 4: Commit (no shuffle wiring yet — we'll re-run after Tasks 8-12)**
+
+```bash
+git add benchmarks/local/broadcast_pressure_test.go
+git commit -m "test(local): broadcast-pressure repro for shuffle validation gate"
+```
+
+---
+
+## Task 8: Planner: identify shuffle candidate and shape the shuffled plan
+
+**Files:**
+- Modify: `internal/planner/physical/plan.go` (add `InsertShuffleForLargeBuild`)
+- Create: `internal/planner/physical/shuffle_insertion_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/planner/physical/shuffle_insertion_test.go`:
+
+```go
+package physical
+
+import "testing"
+
+func TestInsertShuffleForLargeBuild_PicksLargestBuildAboveThreshold(t *testing.T) {
+	stages := []Stage{
+		{ID: "scan-orders", Type: "scan", ScanAlias: "orders", EstimatedBytes: 8 << 30},          // 8 GB - above
+		{ID: "scan-customer", Type: "scan", ScanAlias: "customer", EstimatedBytes: 100 << 20},     // 100 MB - below
+		{ID: "scan-lineitem", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 80 << 30},      // 80 GB - probe
+		{ID: "join-1", Type: "hash_join", BuildTableAlias: "orders", JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"}, Dependencies: []string{"scan-orders", "scan-lineitem"}},
+		{ID: "join-2", Type: "hash_join", BuildTableAlias: "customer", JoinLeftKeys: []string{"o_custkey"}, JoinRightKeys: []string{"c_custkey"}, Dependencies: []string{"join-1", "scan-customer"}},
+	}
+	cand, ok := PickShuffleCandidate(stages, 4<<30 /* threshold */)
+	if !ok {
+		t.Fatal("expected shuffle candidate")
+	}
+	if cand.BuildAlias != "orders" {
+		t.Errorf("BuildAlias = %q, want orders", cand.BuildAlias)
+	}
+	if cand.ProbeAlias != "lineitem" {
+		t.Errorf("ProbeAlias = %q, want lineitem", cand.ProbeAlias)
+	}
+	if len(cand.JoinKeys) != 1 || cand.JoinKeys[0] != "o_orderkey" {
+		t.Errorf("JoinKeys = %v, want [o_orderkey]", cand.JoinKeys)
+	}
+}
+
+func TestInsertShuffleForLargeBuild_NoCandidateBelowThreshold(t *testing.T) {
+	stages := []Stage{
+		{ID: "scan-orders", Type: "scan", ScanAlias: "orders", EstimatedBytes: 1 << 30},  // 1 GB - below 4 GB threshold
+		{ID: "scan-lineitem", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 80 << 30},
+		{ID: "join-1", Type: "hash_join", BuildTableAlias: "orders", JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"}},
+	}
+	if _, ok := PickShuffleCandidate(stages, 4<<30); ok {
+		t.Error("expected no shuffle candidate below threshold")
+	}
+}
+```
+
+- [ ] **Step 2: Run test — should fail**
+
+Run: `go test ./internal/planner/physical/ -run InsertShuffle -v`
+Expected: FAIL — `PickShuffleCandidate` undefined.
+
+- [ ] **Step 3: Implement `PickShuffleCandidate`**
+
+Add to `internal/planner/physical/plan.go`:
+
+```go
+// ShuffleCandidate describes a join in the plan whose build side is large
+// enough to warrant the shuffle execution path instead of broadcast.
+type ShuffleCandidate struct {
+	JoinStageID string   // the join stage to be served by shuffled inputs
+	BuildAlias  string   // which scan stage produces the build side
+	ProbeAlias  string   // which scan stage produces the probe side (the largest scan)
+	BuildKeys   []string // build-side join keys (the JoinRightKeys of the join)
+	ProbeKeys   []string // probe-side join keys (the JoinLeftKeys of the join)
+	JoinKeys    []string // canonical (build-side) join key names for partitioning
+	BuildBytes  int64    // EstimatedBytes of the build scan (for logging)
+}
+
+// PickShuffleCandidate finds the join in `stages` whose build-side scan has
+// the largest EstimatedBytes above `thresholdBytes`. Returns ok=false if no
+// build exceeds the threshold.
+//
+// Phase 1 only: returns a single candidate. Phase 2 will return all candidates
+// for chained shuffles.
+func PickShuffleCandidate(stages []Stage, thresholdBytes int64) (ShuffleCandidate, bool) {
+	// Build alias → scan stage lookup.
+	byAlias := map[string]Stage{}
+	for _, s := range stages {
+		if s.Type == "scan" && s.ScanAlias != "" {
+			byAlias[s.ScanAlias] = s
+		}
+	}
+
+	// Find largest probe (largest scan, period — the one CanProbeSplit would pick).
+	var probeAlias string
+	var probeBytes int64
+	for _, s := range stages {
+		if s.Type == "scan" && s.EstimatedBytes > probeBytes {
+			probeAlias = s.ScanAlias
+			probeBytes = s.EstimatedBytes
+		}
+	}
+
+	var best ShuffleCandidate
+	var bestBytes int64
+	for _, s := range stages {
+		if s.Type != "hash_join" {
+			continue
+		}
+		buildAlias := s.BuildTableAlias
+		if buildAlias == "" || buildAlias == probeAlias {
+			continue
+		}
+		buildScan, ok := byAlias[buildAlias]
+		if !ok {
+			continue
+		}
+		if buildScan.EstimatedBytes <= thresholdBytes {
+			continue
+		}
+		if buildScan.EstimatedBytes > bestBytes {
+			best = ShuffleCandidate{
+				JoinStageID: s.ID,
+				BuildAlias:  buildAlias,
+				ProbeAlias:  probeAlias,
+				BuildKeys:   append([]string(nil), s.JoinRightKeys...),
+				ProbeKeys:   append([]string(nil), s.JoinLeftKeys...),
+				JoinKeys:    append([]string(nil), s.JoinRightKeys...),
+				BuildBytes:  buildScan.EstimatedBytes,
+			}
+			bestBytes = buildScan.EstimatedBytes
+		}
+	}
+	return best, bestBytes > 0
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/planner/physical/ -run InsertShuffle -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/planner/physical/plan.go internal/planner/physical/shuffle_insertion_test.go
+git commit -m "feat(planner): PickShuffleCandidate identifies large-build joins above threshold"
+```
+
+---
+
+## Task 9: Coordinator orchestrator — dispatch shuffle stages then probe stage
+
+**Files:**
+- Create: `internal/coordinator/shuffle_orchestrator.go`
+
+- [ ] **Step 1: Implement `shuffle_orchestrator.go`**
+
+Create `internal/coordinator/shuffle_orchestrator.go`:
+
+```go
+package coordinator
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/planner/physical"
+)
+
+// shuffleBuildThreshold gates the routing decision: if the largest build
+// table's EstimatedBytes exceeds this, route to shuffle-distributed instead
+// of probe-split. Declared as var so tests can lower it to exercise the path
+// on small data.
+var shuffleBuildThreshold int64 = 4 * 1024 * 1024 * 1024 // 4 GB
+
+// shufflePartitionMultiplier sets partition count = workerCount × this. A
+// modest multiplier reduces hot-key skew impact while keeping the file
+// count bounded. With 3 workers and multiplier=4, we get 12 partitions.
+const shufflePartitionMultiplier = 4
+
+// shuffleStageTimeout is the per-shuffle-stage timeout. If exceeded, the
+// query fails — there is no per-stage retry in Phase 1.
+const shuffleStageTimeout = 10 * time.Minute
+
+// orchestrateShuffleQuery runs a query through the shuffle execution path:
+//
+//  1. Dispatch a shuffle stage for the build side: each worker reads a slice
+//     of build files, hash-partitions on the join keys, writes 4N output
+//     .wshf files keyed by partition.
+//  2. Dispatch a shuffle stage for the probe side: same, on the probe table.
+//  3. Wait for both shuffle stages to complete.
+//  4. Dispatch one final pipeline task per worker; each task is assigned a
+//     contiguous slice of partitions (e.g., worker 0 → partitions [0..3] when
+//     N=3 and numPartitions=12). Each task sequentially loads its assigned
+//     partitions' build shards and joins against probe shards.
+//  5. Coordinator merges per-worker partials as in the existing probe-split
+//     path (re-aggregate / sort / limit).
+func (c *Coordinator) orchestrateShuffleQuery(
+	ctx context.Context,
+	queryID string,
+	sql string,
+	cand physical.ShuffleCandidate,
+	stages []physical.Stage,
+	workerCount int,
+) error {
+	numParts := workerCount * shufflePartitionMultiplier
+
+	buildFiles, probeFiles, err := splitScansForShuffle(stages, cand)
+	if err != nil {
+		return fmt.Errorf("split scans: %w", err)
+	}
+
+	resultPrefix := fmt.Sprintf("queries/%s/shuffle", queryID)
+
+	// Stage 1+2: build-side and probe-side shuffles in parallel.
+	buildPrefix := resultPrefix + "/build"
+	probePrefix := resultPrefix + "/probe"
+
+	buildTasks := buildShuffleTasks(queryID, "shuffle-build", c.resultBucket, buildPrefix,
+		cand.BuildKeys, numParts, workerCount, buildFiles, cand.BuildAlias)
+	probeTasks := buildShuffleTasks(queryID, "shuffle-probe", c.resultBucket, probePrefix,
+		cand.ProbeKeys, numParts, workerCount, probeFiles, cand.ProbeAlias)
+
+	// Dispatch in parallel.
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	for _, batchOfTasks := range [][]distributed.Task{buildTasks, probeTasks} {
+		wg.Add(1)
+		go func(tasks []distributed.Task) {
+			defer wg.Done()
+			if err := c.dispatchAndWait(ctx, queryID, tasks, shuffleStageTimeout); err != nil {
+				errs <- err
+			}
+		}(batchOfTasks)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			return fmt.Errorf("shuffle stage: %w", err)
+		}
+	}
+
+	// Stage 3: probe pipeline tasks with partition assignments.
+	probeStageTasks := buildProbePipelineTasks(queryID, sql, c.resultBucket,
+		buildPrefix, probePrefix, numParts, workerCount, cand)
+
+	if err := c.dispatchAndWait(ctx, queryID, probeStageTasks, shuffleStageTimeout); err != nil {
+		return fmt.Errorf("probe stage: %w", err)
+	}
+
+	return nil
+}
+
+// splitScansForShuffle returns (buildFiles, probeFiles) by looking up the
+// scan stages for the candidate's build and probe aliases.
+func splitScansForShuffle(stages []physical.Stage, cand physical.ShuffleCandidate) (buildFiles, probeFiles []string, err error) {
+	for _, s := range stages {
+		if s.Type != "scan" {
+			continue
+		}
+		switch s.ScanAlias {
+		case cand.BuildAlias:
+			buildFiles = s.ScanFiles
+		case cand.ProbeAlias:
+			probeFiles = s.ScanFiles
+		}
+	}
+	if len(buildFiles) == 0 {
+		return nil, nil, fmt.Errorf("no scan files for build alias %q", cand.BuildAlias)
+	}
+	if len(probeFiles) == 0 {
+		return nil, nil, fmt.Errorf("no scan files for probe alias %q", cand.ProbeAlias)
+	}
+	return buildFiles, probeFiles, nil
+}
+
+// buildShuffleTasks slices `files` evenly into `workerCount` shuffle tasks.
+// Each task is responsible for reading its slice and hash-partitioning into
+// numParts output files. The task type is TaskTypeShuffle.
+func buildShuffleTasks(
+	queryID, stageID, bucket, prefix string,
+	keys []string,
+	numParts, workerCount int,
+	files []string,
+	tableAlias string,
+) []distributed.Task {
+	slices := splitFilesEvenly(files, workerCount)
+	tasks := make([]distributed.Task, 0, len(slices))
+	for i, slice := range slices {
+		if len(slice) == 0 {
+			continue
+		}
+		tasks = append(tasks, distributed.Task{
+			ID:            fmt.Sprintf("%s-%s-%d", queryID, stageID, i),
+			QueryID:       queryID,
+			StageID:       stageID,
+			Type:          distributed.TaskTypeShuffle,
+			TableName:     tableAlias,
+			Files:         slice,
+			ShuffleKeys:   keys,
+			NumPartitions: numParts,
+			ResultBucket:  bucket,
+			ResultPrefix:  prefix,
+			CreatedAt:     time.Now(),
+		})
+	}
+	return tasks
+}
+
+// buildProbePipelineTasks creates one TaskTypePipeline task per worker.
+// Each task is assigned partitions [w*partsPerWorker, (w+1)*partsPerWorker).
+// The pipeline task reads its assigned partitions' shuffled build + probe
+// shards and executes the original query SQL with the join's inputs replaced
+// by the shard sources.
+//
+// PartitionID is set to the FIRST partition this worker handles; partitions
+// per worker are derived as [PartitionID, PartitionID + numParts/workerCount).
+// (Single-int partition assignment fits the existing field; if richer
+// assignment is needed, extend the Task message in a follow-up.)
+func buildProbePipelineTasks(
+	queryID, sql, bucket, buildPrefix, probePrefix string,
+	numParts, workerCount int,
+	cand physical.ShuffleCandidate,
+) []distributed.Task {
+	partsPerWorker := numParts / workerCount
+	tasks := make([]distributed.Task, 0, workerCount)
+	for w := 0; w < workerCount; w++ {
+		startPart := w * partsPerWorker
+		tasks = append(tasks, distributed.Task{
+			ID:           fmt.Sprintf("%s-shuffle-probe-pipeline-%d", queryID, w),
+			QueryID:      queryID,
+			StageID:      "shuffle-pipeline",
+			Type:         distributed.TaskTypePipeline,
+			SQLText:      sql,
+			ShuffleKeys:  cand.JoinKeys, // signals: this is a shuffled-input pipeline
+			NumPartitions: numParts,
+			PartitionID:  startPart,
+			// Two prefixes encoded in PreScannedInputs by alias for lookup at the worker.
+			PreScannedInputs: map[string][]string{
+				cand.BuildAlias + "@@shuffle": {bucket + "/" + buildPrefix},
+				cand.ProbeAlias + "@@shuffle": {bucket + "/" + probePrefix},
+			},
+			PartialAggregate: true,
+			ResultBucket:     bucket,
+			ResultPrefix:     fmt.Sprintf("queries/%s/results", queryID),
+			CreatedAt:        time.Now(),
+		})
+	}
+	return tasks
+}
+
+// splitFilesEvenly divides files into n contiguous slices of as-equal-as-
+// possible size.
+func splitFilesEvenly(files []string, n int) [][]string {
+	if n <= 0 || len(files) == 0 {
+		return nil
+	}
+	out := make([][]string, n)
+	per := (len(files) + n - 1) / n
+	for i := 0; i < n; i++ {
+		start := i * per
+		if start >= len(files) {
+			break
+		}
+		end := start + per
+		if end > len(files) {
+			end = len(files)
+		}
+		out[i] = files[start:end]
+	}
+	return out
+}
+```
+
+> `c.dispatchAndWait` and `c.resultBucket` may not exist as named — adapt to whatever pattern the existing coordinator uses for "publish tasks and wait for all results" (likely the same machinery used by `preScanBuildTables` for the build cache). Reuse rather than re-invent.
+
+- [ ] **Step 2: Build to verify**
+
+Run: `go build ./...`
+Expected: PASS (modulo helper-name adjustments).
+
+- [ ] **Step 3: Add a unit test for `splitFilesEvenly`**
+
+Append to a small test file (or create `shuffle_orchestrator_test.go`):
+
+```go
+package coordinator
+
+import "testing"
+
+func TestSplitFilesEvenly(t *testing.T) {
+	files := []string{"a", "b", "c", "d", "e", "f", "g"}
+	out := splitFilesEvenly(files, 3)
+	if len(out) != 3 {
+		t.Fatalf("len=%d, want 3", len(out))
+	}
+	total := 0
+	for _, s := range out {
+		total += len(s)
+	}
+	if total != len(files) {
+		t.Errorf("total assigned = %d, want %d", total, len(files))
+	}
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `go test ./internal/coordinator/ -run SplitFiles -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/coordinator/shuffle_orchestrator.go internal/coordinator/shuffle_orchestrator_test.go
+git commit -m "feat(coordinator): orchestrate two-stage shuffle then partition-assigned probe pipeline"
+```
+
+---
+
+## Task 10: Wire the coordinator routing decision
+
+**Files:**
+- Modify: `internal/coordinator/coordinator.go:468-509` (the routing block in `ExecuteSQL`)
+
+- [ ] **Step 1: Insert shuffle-routing branch ahead of the existing probe-split branch**
+
+Replace the routing block currently at `coordinator.go:468-509` with:
+
+```go
+// Route all queries through pipeline execution. Three modes:
+// 1. Shuffle-distributed: when the largest build table exceeds
+//    shuffleBuildThreshold (4 GB), partition both sides on the join key
+//    and run a co-located join — peak per-worker memory scales 1/N.
+// 2. Probe-split: partition probe table files across workers; build tables
+//    are broadcast (or cached) — fast for small/medium builds.
+// 3. Single-worker: entire query on one worker.
+var probeSplitMergeInfo *logical.MergeInfo
+probeAlias, probeFiles, canProbeSplit := physical.CanProbeSplit(physStages, c.workers.Count())
+mergeInfo := logical.ExtractMergeInfo(logicalPlan)
+
+shuffleCand, shuffleApplicable := physical.PickShuffleCandidate(physStages, shuffleBuildThreshold)
+
+switch {
+case shuffleApplicable && mergeInfo != nil:
+	c.logger.Info("routing to shuffle-distributed",
+		"query", queryID,
+		"build_alias", shuffleCand.BuildAlias,
+		"build_bytes", shuffleCand.BuildBytes,
+		"probe_alias", shuffleCand.ProbeAlias,
+		"workers", c.workers.Count(),
+		"partitions", c.workers.Count()*shufflePartitionMultiplier)
+	probeSplitMergeInfo = mergeInfo
+	if err := c.orchestrateShuffleQuery(ctx, queryID, sql, shuffleCand, physStages, c.workers.Count()); err != nil {
+		return nil, err
+	}
+	// Skip the standard pipeline path below — orchestrateShuffleQuery owns
+	// dispatch and result gathering.
+	physStages = nil
+
+case canProbeSplit && mergeInfo != nil:
+	// ... existing probe-split branch unchanged ...
+
+default:
+	// ... existing single-worker branch unchanged ...
+}
+```
+
+> The exact integration with the existing `subscribeResults` / `doneCh` / `readFinalResults` flow needs care. The cleanest pattern: have `orchestrateShuffleQuery` populate the same `queryMetas` entry as probe-split would (so `readFinalResults` picks up the right files), and return after that — letting the existing wait-and-merge code path handle the rest. **Read the full `ExecuteSQL` body before integrating** to confirm where the seam should land.
+
+- [ ] **Step 2: Build**
+
+Run: `go build ./...`
+Expected: PASS.
+
+- [ ] **Step 3: Run all coordinator tests**
+
+Run: `go test ./internal/coordinator/ -count=1`
+Expected: PASS — existing tests should not be affected (they don't trip the 4 GB threshold).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/coordinator/coordinator.go
+git commit -m "feat(coordinator): route large-build queries through shuffle path"
+```
+
+---
+
+## Task 11: Worker-side handling of shuffled-input pipeline tasks
+
+The probe pipeline task carries `ShuffleKeys`, `NumPartitions`, `PartitionID`, and `PreScannedInputs[alias+"@@shuffle"] = [bucket+prefix]`. The worker needs to recognize this shape and substitute `partitionShardSource` for the build and probe scan inputs.
+
+**Files:**
+- Modify: `internal/worker/executor.go` (existing `executePipeline` or its plan-building helper)
+
+- [ ] **Step 1: Identify the seam**
+
+Run: `grep -n "PreScannedInputs\|ScanFileFilter" internal/worker/executor.go`
+Expected: shows where the existing executor swaps in pre-scanned inputs for scan operators. We add a parallel branch for the `@@shuffle` suffix.
+
+- [ ] **Step 2: Add shuffled-input substitution**
+
+In the helper that builds the pipeline plan from the task, add:
+
+```go
+// If task.ShuffleKeys is set and PreScannedInputs contains @@shuffle entries,
+// this is a shuffled-input pipeline. For each scan alias whose key
+// "<alias>@@shuffle" appears in PreScannedInputs, replace the scan source
+// with a sequential partition-shard reader covering this worker's assigned
+// partitions: [PartitionID, PartitionID + NumPartitions/workerCount).
+if len(task.ShuffleKeys) > 0 {
+	partsPerWorker := task.NumPartitions / e.workerCount
+	for alias, prefixes := range task.PreScannedInputs {
+		if !strings.HasSuffix(alias, "@@shuffle") {
+			continue
+		}
+		realAlias := strings.TrimSuffix(alias, "@@shuffle")
+		bucketPrefix := prefixes[0] // "<bucket>/<prefix>"
+		bucket, prefix := splitBucketPrefix(bucketPrefix)
+		sources := make([]exec.Source, 0, partsPerWorker)
+		for p := task.PartitionID; p < task.PartitionID+partsPerWorker; p++ {
+			partPrefix := fmt.Sprintf("%s/partition=%04d/", prefix, p)
+			sources = append(sources, newPartitionShardSource(e.objStore, bucket, partPrefix))
+		}
+		// Concatenate sources sequentially so memory holds at most one
+		// partition's hash table at a time.
+		plan.SubstituteScanSource(realAlias, exec.Concat(sources...))
+	}
+}
+```
+
+> `SubstituteScanSource` and `exec.Concat` may not exist verbatim — locate the existing primitive used to inject `PreScannedInputs` files into the plan and use it. The intent is: replace the source for `realAlias` with a sequential reader over this worker's assigned partition shards.
+
+- [ ] **Step 3: Add a small integration test**
+
+In `internal/worker/executor_shuffle_test.go`, add a test that:
+1. Stages partitioned build and probe shards in `MemStore` under fake prefixes (use `partitionedShuffleSink` to produce them).
+2. Constructs a pipeline task with `ShuffleKeys`, `NumPartitions=4`, `PartitionID=0`, `PreScannedInputs` mapping aliases to prefixes.
+3. Runs the executor; asserts results match a baseline non-shuffled join over the same input rows.
+
+- [ ] **Step 4: Run**
+
+Run: `go test ./internal/worker/ -run Shuffle -v -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/worker/executor.go internal/worker/executor_shuffle_test.go
+git commit -m "feat(worker): substitute partition-shard sources for shuffled-input pipeline tasks"
+```
+
+---
+
+## Task 12: SF0.01 integration test forcing the shuffle path
+
+**Files:**
+- Modify: `internal/coordinator/distributed_tpch_test.go`
+
+- [ ] **Step 1: Add a Q03 shuffle-forced test**
+
+Append to `distributed_tpch_test.go`:
+
+```go
+// TestDistributedTPCH_Q03_ShuffleForced runs Q03 at SF0.01 with
+// shuffleBuildThreshold lowered to 1 byte, forcing the shuffle path.
+// Validates correctness end-to-end: planner picks the candidate, both
+// shuffle stages dispatch, partitioned shards are produced and consumed,
+// and the merged result matches the expected SF0.01 Q03 output.
+func TestDistributedTPCH_Q03_ShuffleForced(t *testing.T) {
+	prev := shuffleBuildThreshold
+	shuffleBuildThreshold = 1
+	t.Cleanup(func() { shuffleBuildThreshold = prev })
+
+	// Reuse the existing SF0.01 distributed harness setup; mirror an
+	// existing Q03 test in this file. Assert row count and first-row values
+	// against the same baseline.
+	// ... (full test body mirrors existing TPC-H distributed test pattern) ...
+}
+```
+
+> Implement by copying the existing `TestDistributedTPCH_Q03` (or equivalent) test in this file and prepending the threshold flip. The shuffle threshold flip + cleanup is the only behavioral change.
+
+- [ ] **Step 2: Run all 22 queries with the threshold lowered**
+
+Optionally add a parametric variant that runs all 22 queries with `shuffleBuildThreshold = 1` to confirm no correctness regression on the shuffled path. Mark as `t.Parallel()` only if existing distributed tests are parallel-safe.
+
+- [ ] **Step 3: Run**
+
+Run: `go test ./internal/coordinator/ -run ShuffleForced -v -timeout 5m`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/coordinator/distributed_tpch_test.go
+git commit -m "test(coordinator): SF0.01 integration test forces shuffle path for correctness gate"
+```
+
+---
+
+## Task 13: Re-run the local memory-pressure repro and confirm peak heap drop
+
+**Files:**
+- (No file changes — verification step)
+
+- [ ] **Step 1: Run the pressure test against the new shuffle path**
+
+Run: `GOMEMLIMIT=8GiB go test -tags=pressure -v ./benchmarks/local/ -run BroadcastPressure -timeout 10m 2>&1 | tee /tmp/pressure-after.txt`
+
+> Note: the pressure test as written in Task 7 calls into the embedded `wadjet` API with a single-process scenario. To exercise the shuffle path locally, the test needs to either:
+>   (a) run a 3-process in-process cluster (mirror the harness in `distributed_tpch_test.go`), or
+>   (b) be augmented with a build-side concurrency gating that simulates the broadcast vs sharded difference.
+> Pick whichever is closer to the existing local test scaffolding. The test's value is the printed peak-heap number, which we compare:
+
+- [ ] **Step 2: Compare before/after**
+
+Run: `diff <(grep "peak heap" /tmp/pressure-before.txt) <(grep "peak heap" /tmp/pressure-after.txt)`
+Expected: "after" peak heap is substantially lower than "before" — ideally < 50% of GOMEMLIMIT.
+
+- [ ] **Step 3: If the drop is NOT visible, STOP. Do not deploy to EC2.**
+
+The whole point of Gate 0 is to confirm locally that the change reduces peak memory. If it doesn't, debug here — re-check the partition-shard substitution at the worker, the partitioning function, and the sequential-vs-concurrent partition processing.
+
+- [ ] **Step 4: Commit the captured before/after numbers as part of the PR description (no file commit needed)**
+
+---
+
+## Task 14: SF10 EC2 distributed gate (Gate 3)
+
+**Files:**
+- (No file changes — deploy + run)
+
+- [ ] **Step 1: Build the bench binary locally and upload to S3**
+
+Per `feedback_benchmark_consistency.md` and `feedback_deploy_binary.md`:
+
+```bash
+GOOS=linux GOARCH=arm64 go build -o tpch-bench ./cmd/tpch-bench
+aws --profile citc s3 cp tpch-bench s3://wadjet-bench-sf10-use2/bin/latest/tpch-bench
+```
+
+- [ ] **Step 2: Deploy the standard SF10 cluster**
+
+Per `feedback_benchmark_consistency.md`: coordinator c7g.2xlarge + 3× c7g.4xlarge workers, us-east-2, bucket `wadjet-bench-sf10-use2`.
+
+```bash
+cd deploy/benchmark/terraform
+tofu apply -var bin_version=latest -var data_bucket=wadjet-bench-sf10-use2
+```
+
+- [ ] **Step 3: Run all 22 queries**
+
+```bash
+ssh-into-coordinator
+./tpch-bench --scale=10 --queries=all 2>&1 | tee /tmp/sf10-shuffle.txt
+```
+
+- [ ] **Step 4: Tear down regardless of outcome**
+
+```bash
+tofu destroy -auto-approve
+```
+
+- [ ] **Step 5: Validate**
+
+- All 22 queries return >0 rows
+- Q03/Q05/Q07 took the shuffle path (grep coordinator log for `routing to shuffle-distributed`)
+- Wall-clock for shuffle-routed queries within 2× of the pre-change baseline
+
+If any query regresses or returns 0 rows, do NOT proceed to SF100. Debug locally first.
+
+---
+
+## Task 15: SF100 final validation (Gate 4)
+
+**Files:**
+- (No file changes — deploy + run)
+
+- [ ] **Step 1: Run Q03 in isolation first**
+
+```bash
+# After deploying the SF100 cluster (per feedback_benchmark_consistency.md)
+SKIP_QUERIES=1,2,4-22 ./tpch-bench --scale=100 2>&1 | tee /tmp/sf100-q03-shuffle.txt
+```
+
+Expected: Q03 completes (was OOMing at 26 min on prior runs).
+
+- [ ] **Step 2: If Q03 passes, run all 22**
+
+```bash
+./tpch-bench --scale=100 --queries=all 2>&1 | tee /tmp/sf100-all-shuffle.txt
+```
+
+- [ ] **Step 3: Tear down**
+
+```bash
+tofu destroy -auto-approve
+```
+
+- [ ] **Step 4: Update memory**
+
+Save a project memory recording the SF100 shuffle results. Replace `project_sf100_q03_broadcast_duplication_2026-04-18.md` with an updated status note.
+
+---
+
+## Self-Review Checklist (run before declaring plan complete)
+
+**Spec coverage:** ✓ Each spec section maps to one or more tasks above:
+- Architecture (Distribution, shuffle stage, co-located join) → Tasks 2, 3, 4, 5, 6, 9, 11
+- Routing decision → Task 10
+- Validation gates 0–4 → Tasks 7, 12, 13, 14, 15
+- Phase 2 explicitly out of scope → respected (no chained-shuffle code)
+
+**Placeholder scan:** Several tasks contain notes like "look at how the existing executor uses X" rather than full code. These are deliberate references-to-existing-pattern, not TODOs — the implementer must read those files. Flagged here so the implementer knows to expect this.
+
+**Type consistency:**
+- `Distribution.Kind`, `DistKind`, `DistSingleton`/`DistBroadcast`/`DistHashPartitioned` — used consistently
+- `ShuffleCandidate` fields (`BuildAlias`, `ProbeAlias`, `JoinKeys`, `BuildKeys`, `ProbeKeys`, `JoinStageID`, `BuildBytes`) — consistent across Tasks 8, 9, 10
+- `shuffleBuildThreshold` (var) — consistent across Tasks 9, 10, 12
+- `partitionedShuffleSink` / `partitionShardSource` / `executeShuffle` — consistent across Tasks 4, 5, 6, 11
+- `TaskTypeShuffle` — Tasks 1, 6, 9
+- `ShuffleKeys`, `NumPartitions`, `PartitionID`, `ResultFiles`, `PreScannedInputs[alias+"@@shuffle"]` — consistent
+
+**Open implementation choices documented inline (not blockers):**
+- Exact name of the source-substitution primitive (`SubstituteScanSource`) — to be matched to whatever the existing codebase uses for `PreScannedInputs`.
+- Helper functions in coordinator (`dispatchAndWait`, `resultBucket`) — to be matched to existing coordinator state machine.
+- Local pressure test — single-process vs in-process 3-worker cluster scaffolding choice noted in Task 13.
+
+These are intentional — the implementer reads the surrounding code in those files and matches existing patterns rather than inventing new names.

--- a/docs/superpowers/specs/2026-04-18-shuffle-based-build-partitioning-design.md
+++ b/docs/superpowers/specs/2026-04-18-shuffle-based-build-partitioning-design.md
@@ -1,0 +1,169 @@
+# Shuffle-Based Build Partitioning
+
+**Status:** Draft
+**Date:** 2026-04-18
+**Author:** Derek Wright (with Claude)
+**Related:** PR #38 (spill fragmentation fixes), `project_sf100_q03_broadcast_duplication_2026-04-18`
+
+## Problem
+
+At SF100, Q03 OOMs all three workers ~26 min into execution. Heap profiles confirm the binding constraint is **broadcast duplication of the `orders` hash table**: each worker independently builds the full ~7-8 GB `orders` hash, and at 2 concurrent tasks per worker the per-worker live memory exceeds the 23 GB `GOMEMLIMIT` on c7gd.4xlarge. PR #38's spill batching reduced cumulative allocation by 23% but did not address the broadcast itself; the OOM moved from 14 min to 26 min, not eliminated.
+
+The same pattern affects Q05, Q07, Q09 — any TPC-H query that broadcasts a build table larger than per-worker memory headroom allows.
+
+The existing `BuildCache` (pre-scan large build tables once into shared S3 `.wshf` files) reduces source I/O but does not reduce per-worker memory: each worker still loads the full cached table into a hash table.
+
+## Goals
+
+1. Eliminate broadcast-duplication memory pressure for SF100-scale queries with large build tables.
+2. Preserve the broadcast/cache fast path for the common SIEM/network-analytics workload (small dimension tables joined to large fact tables), which is what Wadjet is optimized for.
+3. Validate Q03/Q05/Q07 SF100 pass after this change.
+4. Lay the architectural groundwork for Q09 (multi-large-build) without shipping it in this spec.
+
+## Non-Goals
+
+- Replacing or retiring the existing `BuildCache` for medium-size tables.
+- Multi-stage chained shuffle (Q09). Architecture supports it; implementation is Phase 2 / follow-up.
+- Reorganizing the planner around shuffle-by-default. Broadcast remains the default for tables under threshold.
+- Optimizing the shuffle transport for latency (S3-mediated is the chosen tradeoff).
+
+## Workload Framing
+
+Wadjet's primary workload is SIEM and network analytics: high-cardinality event/flow streams joined against small dimension tables (assets, users, threat intel). For that workload, broadcast-build is the right default — small builds fit in worker RAM, and a shuffle round-trip would only add latency.
+
+TPC-H queries like Q03 are not representative of the primary workload, but passing them at SF100 establishes credibility at scale. The design here intentionally adds shuffle as an *opt-in path triggered only when broadcast would fail*, rather than as a new default.
+
+## Design
+
+### Approach Summary
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Trigger | Single threshold on largest build's `EstimatedBytes` (4 GB to start) | Reuses the same shape as `buildCacheThreshold`; one comparison; easy to tune. Memory-headroom-relative trigger documented as future work. |
+| Shuffle stage location | Coordinator-orchestrated pre-shuffle stages (synchronous, S3-mediated) | Reuses `shuffleStreamSink` and `cachedFileStreamSource` patterns; durable shards in S3; no new transport semantics. |
+| Both sides shuffled | Yes — textbook distributed hash join | Maps cleanly onto preserved `TaskTypeShuffle` path; memory scales 1/N on both sides. |
+| Partition count | 4N (where N = active worker count) | Modest insurance against key skew in real-world joins (e.g., hot `src_ip`); bounded file count. |
+| Multi-join scope | Architecture supports chained shuffles via a `Distribution` property; Phase 1 implementation handles a single shuffle stage per query. | Q03/Q05/Q07 are single-large-build queries. Q09 deferred to Phase 2 with the same infrastructure. |
+| Validation | Local memory-pressure repro harness → SF0.01 in-process tests → SF10 EC2 gate → SF100 final validation | Avoids burning EC2 dollars on changes that don't actually reduce peak memory. |
+
+### Architecture: Distribution Property
+
+Every node in the physical plan carries a `Distribution` property describing how its output rows are partitioned across workers:
+
+```go
+type Distribution struct {
+    Kind  DistKind   // Singleton | Broadcast | HashPartitioned
+    Keys  []string   // for HashPartitioned: the column names rows are partitioned on
+    Count int        // number of partitions (4N for shuffles)
+}
+```
+
+Joins demand that both inputs match the join key:
+- If both inputs are `HashPartitioned` on the join keys → join locally on each worker
+- If one input is small and `Broadcast` → join locally (existing path)
+- If neither holds → planner inserts a `Shuffle` node that re-partitions on the join keys
+
+In Phase 1, the planner inserts exactly one shuffle per side of one join — specifically the join whose build input has the largest `EstimatedBytes` above `shuffleBuildThreshold`. The shuffle keys are that join's equality keys. All other joins in the same query continue to use broadcast.
+
+In Phase 2, the planner walks the join tree and inserts shuffles wherever distribution doesn't match — multi-stage chained shuffles fall out of this naturally.
+
+### Execution: Shuffle Stage
+
+A `TaskTypeShuffle` task does:
+
+1. Read assigned source files (build table) or assigned upstream output (intermediate).
+2. For each row, compute `hash(partition_keys) % (4 × N_workers)` to get target partition `p`.
+3. Append the row to a per-partition output buffer.
+4. When buffer fills, flush to a local `.wshf` spill file partitioned by `p`.
+5. On finalize, upload one `.wshf` per partition to S3 under `s3://.../shuffle/<query>/<stage>/partition=<p>/<task>.wshf`.
+
+Memory bound: 4N output buffers × batch-flush-size. With N=3 workers and 64 KB flush threshold, that's ~768 KB per shuffle task — bounded regardless of source table size.
+
+### Execution: Probe-Side Co-located Join
+
+After the shuffle stage completes, the coordinator dispatches probe tasks. Each worker is assigned a contiguous slice of the 4N partitions (e.g., partitions 0-3 for worker 0 in a 3-worker cluster, with 4N=12 partitions = 4 each).
+
+For each assigned partition `p`, the worker:
+1. Loads the build shard (concatenation of all `.wshf` files at `partition=p/`).
+2. Builds an in-memory hash table on the join key.
+3. Streams the probe shard for partition `p` (concatenation of all probe-side `.wshf` files at the corresponding S3 prefix), performs the hash join, emits results.
+4. Releases the hash table before moving to the next partition.
+
+Per-worker peak memory: `(build_table_size / 4N) × 4 (assigned partitions)` if held concurrently, or `build_table_size / 4N` if processed sequentially. We process **sequentially per partition** to maintain the memory-scales-1/N property.
+
+### Routing Decision
+
+Inserted in the existing `coordinator.ExecuteSQL` routing block, after `CanProbeSplit`:
+
+```
+if largest_build.EstimatedBytes > shuffleBuildThreshold (4 GB):
+    route to shuffle-distributed path
+else if probe-split applicable:
+    route to probe-split (existing path, possibly with build cache)
+else:
+    route to single-worker pipeline
+```
+
+The threshold is `var shuffleBuildThreshold = 4 << 30` so tests can lower it to exercise the path on small data.
+
+### Failure Handling
+
+Standard coordinator semantics apply unchanged:
+- Worker death during shuffle stage → query fails (same as today's broadcast).
+- S3 write failure → task fails → coordinator marks query failed.
+- No partial-shuffle retry in this spec (architecturally compatible if added later).
+
+### Memory Accounting
+
+The shuffle task's per-partition buffers are charged against the existing per-task memory budget. With 4N=12 partitions and a 64 KB flush threshold, this is negligible (~768 KB) and does not require budget changes.
+
+The probe-side hash table on each shard is charged against the per-task budget as today. Because shard size is `build_size / 4N`, even a 12 GB original build table becomes a ~1 GB hash table per shard with N=3 — comfortably within the 4-8 GB per-task budget.
+
+## Files Touched (Phase 1, Estimated)
+
+| File | Change |
+|---|---|
+| `internal/planner/physical/distribution.go` | NEW: `Distribution` type, equality/compatibility helpers |
+| `internal/planner/physical/plan.go` | Annotate nodes with `Distribution`; add `Shuffle` node type; insertion pass for single shuffle |
+| `internal/coordinator/coordinator.go` | New routing branch for shuffle-distributed; orchestration of shuffle stage → probe stage |
+| `internal/coordinator/shuffle_orchestrator.go` | NEW: dispatches shuffle tasks, waits for completion, plans probe partition assignment |
+| `internal/worker/executor.go` | Handle `TaskTypeShuffle` task with hash-partitioning sink |
+| `internal/worker/shuffle_sink.go` | Extend with `partitionedShuffleSink` variant (per-partition flush) |
+| `internal/worker/stream_source.go` | New `partitionShardSource` that reads all `.wshf` files for an assigned partition |
+| `internal/engine/exec/hash.go` (or equivalent) | Reuse the existing partition-key hash function — no change expected |
+| `benchmarks/local/broadcast_pressure_test.go` | NEW: local memory-pressure repro under tight `GOMEMLIMIT` |
+| `internal/coordinator/distributed_tpch_test.go` | New SF0.01 case forcing shuffle path via lowered threshold |
+
+## Validation Plan
+
+**Gate 0 — Local memory-pressure repro (NEW).** Write a Go test that, in a single process under `GOMEMLIMIT=8GB`, loads the SF100-sample `orders` table into a hash twice concurrently to reproduce the broadcast-duplication signature. Confirm it OOMs without the change. With the change (using lowered `shuffleBuildThreshold`), confirm peak heap stays bounded.
+
+**Gate 1 — Unit tests.** `Distribution` property arithmetic, shuffle insertion logic, partitioned sink correctness (round-trip through hash and back), partition assignment.
+
+**Gate 2 — SF0.01 correctness.** All 22 TPC-H queries pass with `shuffleBuildThreshold` lowered to force shuffle on multiple queries. Verify result correctness against the existing baseline.
+
+**Gate 3 — SF10 EC2 distributed run.** Full 22 queries on the standard 3-worker c7g.4xlarge cluster. Confirm:
+- No correctness regressions
+- Shuffle-routed queries (Q03, Q05, Q07) complete
+- Wall-clock for shuffle queries within ~2x of probe-split baseline (extra S3 round-trip is acceptable)
+
+**Gate 4 — SF100 final validation.** Q03 isolated run first (the gate that's been failing). Then full 22 if Q03 passes. Heap profile to confirm peak per-worker memory stays bounded.
+
+## Phase 2 — Out of Scope (Documented for Continuity)
+
+- **Chained shuffle stages** for queries with multiple large builds on different keys (Q09).
+- **Memory-headroom-relative trigger** (option B from brainstorming Q4): compute expected per-worker live build bytes and compare against `GOMEMLIMIT × headroom_fraction`. Replaces or augments the static 4 GB threshold.
+- **Re-shuffle insertion** when a join's required distribution doesn't match its input's distribution (the general-case planner pass).
+- **Inline NATS-based shuffle** (option B from brainstorming Q2): worker-to-worker shuffle without S3, if profiling shows S3 round-trip is on the critical path.
+- **Skew handling beyond 4N partitions:** dynamic re-partitioning of hot keys.
+
+## Risks
+
+- **Wall-clock regression on SF100.** Shuffle adds an extra S3 write+read of both build and probe tables. Probe is the big one (~100 GB at SF100). We accept this trade for memory safety; if profiling shows it dominates, revisit transport (Phase 2 inline NATS).
+- **Routing thrash.** A static 4 GB threshold may misroute borderline queries. Mitigation: easy to tune; unit tests cover both sides of the threshold.
+- **Skew on real-world keys.** 4N partitions reduce but do not eliminate hot-key impact. Mitigation: documented; future skew-handling work tracked separately.
+- **Phase 1 interaction with `BuildCache`.** Both paths exist; routing must pick exactly one. Cleanly handled by the threshold: builds above 4 GB → shuffle (no cache); builds 2-4 GB → cache; builds < 2 GB → broadcast.
+
+## Open Questions
+
+None blocking. Phase 2 questions (chained shuffle planner pass, memory-headroom trigger, skew handling) are deferred by design.

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -52,6 +52,10 @@ type queryMeta struct {
 	trace              distributed.TraceContext // distributed tracing context
 	policyDecisionJSON json.RawMessage          // pre-evaluated ABAC decisions for worker enforcement
 	mergeInfo          *logical.MergeInfo // non-nil for probe-split queries needing merge
+	// prebuiltTasks, if non-nil for a given stage, supplies the publish loop's
+	// task list instead of calling createTasksForStage. Set by the shuffle path
+	// where each worker's task carries different PreScannedInputs.
+	prebuiltTasks map[string][]distributed.Task
 }
 
 // Coordinator accepts queries, plans them, dispatches tasks, and tracks results.
@@ -465,14 +469,47 @@ func (c *Coordinator) ExecuteSQL(ctx context.Context, sql string) (*SQLResult, e
 			"buildAlias", s.BuildTableAlias)
 	}
 
-	// Route all queries through pipeline execution. Two modes:
-	// 1. Probe-split: partition probe table files across workers (multi-task)
-	// 2. Single-worker: entire query on one worker
+	// Route all queries through pipeline execution. Three modes:
+	// 1. Shuffle-distributed: when the largest build table exceeds
+	//    shuffleBuildThreshold (4 GB), partition both join sides on the join
+	//    keys so per-worker memory scales 1/N instead of being broadcast-duplicated.
+	// 2. Probe-split: partition probe table files across workers; build tables
+	//    are broadcast (or cached). Fast path for small/medium builds.
+	// 3. Single-worker: entire query on one worker.
 	var probeSplitMergeInfo *logical.MergeInfo
+	var shuffleTasks map[string][]distributed.Task
 	probeAlias, probeFiles, canProbeSplit := physical.CanProbeSplit(physStages, c.workers.Count())
 	mergeInfo := logical.ExtractMergeInfo(logicalPlan)
+	shuffleCand, shuffleApplicable := physical.PickShuffleCandidate(physStages, shuffleBuildThreshold)
 
-	if canProbeSplit && mergeInfo != nil {
+	switch {
+	case shuffleApplicable && mergeInfo != nil:
+		workerCount := c.workers.Count()
+		probeSplitMergeInfo = mergeInfo
+
+		c.logger.Info("routing to shuffle-distributed",
+			"query", queryID,
+			"build_alias", shuffleCand.BuildAlias,
+			"build_bytes", shuffleCand.BuildBytes,
+			"probe_alias", shuffleCand.ProbeAlias,
+			"workers", workerCount,
+			"partitions", workerCount*shufflePartitionMultiplier)
+
+		layout, err := c.orchestrateShuffleStages(ctx, queryID, shuffleCand, physStages, workerCount)
+		if err != nil {
+			return nil, fmt.Errorf("shuffle stages failed for query %s: %w", queryID, err)
+		}
+
+		probeTasks := buildShufflePipelineTasks(queryID, sql, c.config.ResultBucket, layout, workerCount)
+
+		physStages = []physical.Stage{{
+			ID:    "pipeline-0",
+			Type:  "pipeline",
+			Tasks: len(probeTasks),
+		}}
+		shuffleTasks = map[string][]distributed.Task{"pipeline-0": probeTasks}
+
+	case canProbeSplit && mergeInfo != nil:
 		workerCount := c.workers.Count()
 		probeSplitMergeInfo = mergeInfo
 
@@ -498,7 +535,8 @@ func (c *Coordinator) ExecuteSQL(ctx context.Context, sql string) (*SQLResult, e
 			"probe_files", len(probeFiles), "workers", workerCount,
 			"has_merge", probeSplitMergeInfo != nil,
 			"build_cache_tables", len(buildCache))
-	} else {
+
+	default:
 		c.logger.Info("routing to single worker pipeline",
 			"query", queryID)
 		physStages = []physical.Stage{{
@@ -517,7 +555,7 @@ func (c *Coordinator) ExecuteSQL(ctx context.Context, sql string) (*SQLResult, e
 
 	// Store query metadata for task creation and result retrieval
 	c.mu.Lock()
-	qm := &queryMeta{stages: physStages, planStr: planStr, sqlText: sql, mergeInfo: probeSplitMergeInfo}
+	qm := &queryMeta{stages: physStages, planStr: planStr, sqlText: sql, mergeInfo: probeSplitMergeInfo, prebuiltTasks: shuffleTasks}
 	// Propagate or create distributed trace context.
 	// If OTel tracing is active, use the OTel span's IDs so worker spans
 	// appear as children in the trace backend.
@@ -576,7 +614,23 @@ func (c *Coordinator) ExecuteSQL(ctx context.Context, sql string) (*SQLResult, e
 		if len(s.Dependencies) > 0 {
 			continue
 		}
-		tasks := c.createTasksForStage(queryID, s, nil)
+		var tasks []distributed.Task
+		if qm.prebuiltTasks != nil {
+			if pre, ok := qm.prebuiltTasks[s.ID]; ok {
+				tasks = pre
+				// Enrich each prebuilt task with query-level context (trace, identity,
+				// policy) — same enrichment that createTasksForStage applies.
+				c.mu.Lock()
+				qmLive := c.queryMetas[queryID]
+				c.mu.Unlock()
+				for i := range tasks {
+					c.enrichTaskWithQueryContext(qmLive, &tasks[i])
+				}
+			}
+		}
+		if tasks == nil {
+			tasks = c.createTasksForStage(queryID, s, nil)
+		}
 		// Update tracker with actual task count and mark as scheduled
 		// (prevents GetReadyStages from re-scheduling these).
 		c.tracker.SetStageTasks(queryID, s.ID, len(tasks))
@@ -660,6 +714,24 @@ func (c *Coordinator) ExecuteSQL(ctx context.Context, sql string) (*SQLResult, e
 }
 
 // createTasksForStage creates distributed tasks for a given stage.
+// enrichTaskWithQueryContext propagates trace, identity, and policy fields from
+// the query's metadata into a task. Call this on every task (prebuilt or not)
+// before publishing, after qm is stored in c.queryMetas.
+func (c *Coordinator) enrichTaskWithQueryContext(qm *queryMeta, t *distributed.Task) {
+	if t.ClusterID == "" {
+		t.ClusterID = c.catalog.ClusterID()
+	}
+	if qm == nil {
+		return
+	}
+	t.IdentityName = qm.identityName
+	t.IdentityRole = qm.identityRole
+	t.TraceID = qm.trace.TraceID
+	t.SpanID = qm.trace.SpanID
+	t.TraceFlags = qm.trace.TraceFlags
+	t.PolicyDecisionJSON = qm.policyDecisionJSON
+}
+
 func (c *Coordinator) createTasksForStage(queryID string, stage physical.Stage, depResults map[string][]string) []distributed.Task {
 	resultPrefix := fmt.Sprintf("queries/%s/%s/", queryID, stage.ID)
 
@@ -674,22 +746,14 @@ func (c *Coordinator) createTasksForStage(queryID string, stage physical.Stage, 
 
 	// Propagate cluster routing and identity context
 	clusterID := stage.ClusterID
-	if clusterID == "" {
-		clusterID = c.catalog.ClusterID()
-	}
 	c.mu.Lock()
 	qm := c.queryMetas[queryID]
 	c.mu.Unlock()
 	for i := range tasks {
-		tasks[i].ClusterID = clusterID
-		if qm != nil {
-			tasks[i].IdentityName = qm.identityName
-			tasks[i].IdentityRole = qm.identityRole
-			tasks[i].TraceID = qm.trace.TraceID
-			tasks[i].SpanID = qm.trace.SpanID
-			tasks[i].TraceFlags = qm.trace.TraceFlags
-			tasks[i].PolicyDecisionJSON = qm.policyDecisionJSON
+		if clusterID != "" {
+			tasks[i].ClusterID = clusterID
 		}
+		c.enrichTaskWithQueryContext(qm, &tasks[i])
 	}
 	return tasks
 }

--- a/internal/coordinator/distributed_tpch_test.go
+++ b/internal/coordinator/distributed_tpch_test.go
@@ -862,6 +862,75 @@ func TestDistributedTPCHBuildCache(t *testing.T) {
 	}
 }
 
+// TestDistributedTPCHForcedShuffle runs join-heavy TPC-H queries at SF0.01
+// with shuffleBuildThreshold lowered to 1 byte, forcing the shuffle execution
+// path. Validates correctness end-to-end: the planner picks the candidate,
+// both shuffle stages dispatch and complete, partitioned shards are produced
+// and consumed, and the merged result matches the expected row counts.
+//
+// This is the local correctness gate before any deploy of the shuffle change.
+// It also captures peak heap per query so we can compare shuffle-on vs
+// shuffle-off in T13.
+func TestDistributedTPCHForcedShuffle(t *testing.T) {
+	// Force probe-split to activate (so mergeInfo is non-nil and the shuffle
+	// branch is reachable). Same trick as TestDistributedTPCHBuildCache.
+	origMinBytes := physical.ProbeSplitMinBytes
+	physical.ProbeSplitMinBytes = 1
+	t.Cleanup(func() { physical.ProbeSplitMinBytes = origMinBytes })
+
+	// Force shuffle path on every join-heavy query by lowering the threshold
+	// to 1 byte.
+	origShuffle := shuffleBuildThreshold
+	shuffleBuildThreshold = 1
+	t.Cleanup(func() { shuffleBuildThreshold = origShuffle })
+
+	ctx, coord := setupTPCHDistributed(t)
+	t.Logf("Worker count: %d (shuffleBuildThreshold=1)", coord.workers.Count())
+
+	tests := []struct {
+		qNum     int
+		expected int
+	}{
+		{3, 10},  // shipping priority — orders+lineitem+customer (THE Q03 we care about at SF100)
+		{5, 5},   // customer/orders/lineitem/supplier/nation/region
+		{7, 4},   // supplier/lineitem/orders/customer/nation
+		{9, 150}, // part/supplier/lineitem/partsupp/orders/nation
+		{10, 20}, // customer/orders/lineitem/nation
+		{12, 2},  // orders/lineitem
+	}
+
+	for _, tt := range tests {
+		q := tpch.TPCHQueries[tt.qNum]
+		t.Run(fmt.Sprintf("Q%02d_%s", tt.qNum, q.Name), func(t *testing.T) {
+			runtime.GC()
+			var memBefore runtime.MemStats
+			runtime.ReadMemStats(&memBefore)
+
+			start := time.Now()
+			result, err := coord.ExecuteSQL(ctx, q.SQL)
+			elapsed := time.Since(start)
+
+			var memAfter runtime.MemStats
+			runtime.ReadMemStats(&memAfter)
+			heapDelta := int64(memAfter.HeapAlloc) - int64(memBefore.HeapAlloc)
+			peakHeap := memAfter.HeapSys
+
+			if err != nil {
+				t.Fatalf("Q%02d shuffle path: ExecuteSQL failed: %v", tt.qNum, err)
+			}
+			if result.Error != "" {
+				t.Fatalf("Q%02d shuffle path: %s", tt.qNum, result.Error)
+			}
+			rows := result.Rows()
+			t.Logf("Q%02d: %d rows in %v (shuffle ON, heap_delta=%d KB, heap_sys=%d KB)",
+				tt.qNum, len(rows), elapsed, heapDelta/1024, peakHeap/1024)
+			if len(rows) != tt.expected {
+				t.Errorf("Q%02d: got %d rows, want %d", tt.qNum, len(rows), tt.expected)
+			}
+		})
+	}
+}
+
 // TestDistributedTPCHBuildCacheDuplicateAlias is a regression test for a bug
 // where build cache pre-scan tasks silently scanned the full table (not their
 // assigned file subset) when the original query had duplicate scans of the same

--- a/internal/coordinator/shuffle_orchestrator.go
+++ b/internal/coordinator/shuffle_orchestrator.go
@@ -125,7 +125,10 @@ func (c *Coordinator) runShuffleSide(
 	ctx, cancel := context.WithTimeout(ctx, shuffleStageTimeout)
 	defer cancel()
 
-	resultPrefix := fmt.Sprintf("queries/%s/shuffle/%s", parentQueryID, sideName)
+	// Convention A: resultPrefix always ends with "/" so that the worker's
+	// "%spartition=%04d/%s.wshf" format string produces a valid S3 key with
+	// the segment "partition=NNNN" cleanly separated. Never omit the slash.
+	resultPrefix := fmt.Sprintf("queries/%s/shuffle/%s/", parentQueryID, sideName)
 	shuffleQueryID := fmt.Sprintf("sh-%s-%s", sideName, parentQueryID)
 	stageID := fmt.Sprintf("shuffle-%s", sideName)
 

--- a/internal/coordinator/shuffle_orchestrator.go
+++ b/internal/coordinator/shuffle_orchestrator.go
@@ -1,0 +1,370 @@
+package coordinator
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/planner/physical"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/google/uuid"
+	"github.com/nats-io/nats.go"
+	"golang.org/x/sync/errgroup"
+)
+
+// shuffleBuildThreshold gates the routing decision: if the largest build
+// table's EstimatedBytes exceeds this, route to shuffle-distributed instead
+// of probe-split. Declared as var so tests can lower it.
+var shuffleBuildThreshold int64 = 4 * 1024 * 1024 * 1024 // 4 GB
+
+// shufflePartitionMultiplier sets numPartitions = workerCount × this.
+// 4 reduces hot-key skew impact while keeping file count bounded.
+const shufflePartitionMultiplier = 4
+
+// shuffleStageTimeout is the per-shuffle-stage timeout. Phase 1: no per-stage retry.
+const shuffleStageTimeout = 10 * time.Minute
+
+// ShuffleLayout describes the shard file layout produced by the two-sided
+// shuffle stages. The caller (coordinator routing path) constructs probe
+// pipeline tasks from this layout by assigning contiguous partition slices to
+// each worker and populating PreScannedInputs with the corresponding shard files.
+type ShuffleLayout struct {
+	BuildAlias    string
+	ProbeAlias    string
+	NumPartitions int
+	// BuildShardFiles[p] contains the S3 keys for build partition p.
+	// May be nil/empty for a partition if no build rows hashed there.
+	BuildShardFiles [][]string
+	// ProbeShardFiles[p] contains the S3 keys for probe partition p.
+	ProbeShardFiles [][]string
+}
+
+// orchestrateShuffleStages runs both shuffle stages (build side and probe side)
+// in parallel and returns the resulting shard layout. The caller is responsible
+// for dispatching the downstream probe pipeline tasks built from this layout.
+func (c *Coordinator) orchestrateShuffleStages(
+	ctx context.Context,
+	queryID string,
+	cand physical.ShuffleCandidate,
+	stages []physical.Stage,
+	workerCount int,
+) (*ShuffleLayout, error) {
+	numParts := workerCount * shufflePartitionMultiplier
+
+	// Locate the scan stages for both sides.
+	buildStage, probeStage, err := findShuffleScanStages(stages, cand)
+	if err != nil {
+		return nil, err
+	}
+
+	c.logger.Info("shuffle orchestrator: starting two-sided shuffle",
+		"query_id", queryID,
+		"build_alias", cand.BuildAlias,
+		"probe_alias", cand.ProbeAlias,
+		"num_partitions", numParts,
+		"worker_count", workerCount,
+		"build_bytes", cand.BuildBytes,
+	)
+
+	// Run build and probe shuffles in parallel. Failure of either cancels both.
+	var buildShards, probeShards [][]string
+	g, gctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		shards, err := c.runShuffleSide(gctx, queryID, "build", buildStage, cand.BuildKeys, numParts, workerCount)
+		if err != nil {
+			return fmt.Errorf("build-side shuffle for %s: %w", cand.BuildAlias, err)
+		}
+		buildShards = shards
+		return nil
+	})
+
+	g.Go(func() error {
+		shards, err := c.runShuffleSide(gctx, queryID, "probe", probeStage, cand.ProbeKeys, numParts, workerCount)
+		if err != nil {
+			return fmt.Errorf("probe-side shuffle for %s: %w", cand.ProbeAlias, err)
+		}
+		probeShards = shards
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("orchestrateShuffleStages: %w", err)
+	}
+
+	c.logger.Info("shuffle orchestrator: both sides complete",
+		"query_id", queryID,
+		"num_partitions", numParts,
+	)
+
+	return &ShuffleLayout{
+		BuildAlias:      cand.BuildAlias,
+		ProbeAlias:      cand.ProbeAlias,
+		NumPartitions:   numParts,
+		BuildShardFiles: buildShards,
+		ProbeShardFiles: probeShards,
+	}, nil
+}
+
+// runShuffleSide dispatches workerCount TaskTypeShuffle tasks for one side
+// (build or probe), each reading its file slice and hash-partitioning into
+// numParts outputs. Waits for all tasks. Returns shardFiles[p] = slice of
+// S3 keys for partition p (concatenated from each task's per-partition output).
+func (c *Coordinator) runShuffleSide(
+	ctx context.Context,
+	parentQueryID string,
+	sideName string, // "build" or "probe" — used in stage IDs and S3 prefix
+	sourceStage physical.Stage,
+	keys []string,
+	numParts int,
+	workerCount int,
+) ([][]string, error) {
+	ctx, cancel := context.WithTimeout(ctx, shuffleStageTimeout)
+	defer cancel()
+
+	resultPrefix := fmt.Sprintf("queries/%s/shuffle/%s", parentQueryID, sideName)
+	shuffleQueryID := fmt.Sprintf("sh-%s-%s", sideName, parentQueryID)
+	stageID := fmt.Sprintf("shuffle-%s", sideName)
+
+	// Determine column projection. Use prunedScanColumns to avoid writing
+	// columns that belong to sibling tables in the optimizer's over-approximated
+	// stage.Columns. If pruning fails (catalog miss or empty columns), fall back
+	// to nil which causes the worker to select all columns — correct but larger.
+	cols := c.prunedScanColumns(ctx, sourceStage)
+	// Note: intentionally accepting nil here (SELECT * fallback) rather than
+	// returning an error for a catalog miss during shuffle setup.
+
+	// Split source files across workers. splitFilesEvenly handles the case where
+	// there are fewer files than workers by capping n at len(files), so
+	// actualTasks ≤ workerCount.
+	fileSets := splitFilesEvenly(sourceStage.ScanFiles, workerCount)
+	actualTasks := len(fileSets)
+	if actualTasks == 0 {
+		// No files — nothing to shuffle. Return empty partition layout.
+		return make([][]string, numParts), nil
+	}
+
+	// Register an ephemeral tracker entry for this shuffle stage.
+	trackerStages := map[string]*StageInfo{
+		stageID: {
+			StageID:    stageID,
+			Type:       distributed.TaskTypeShuffle,
+			TotalTasks: actualTasks,
+		},
+	}
+	c.tracker.Register(shuffleQueryID, "", trackerStages, []string{stageID})
+	c.tracker.Start(shuffleQueryID)
+	defer c.tracker.Delete(shuffleQueryID)
+
+	// Subscribe for results before publishing to avoid the race.
+	subject := distributed.QueryResultSubject(shuffleQueryID)
+	type taskResult struct {
+		files []string
+		err   string
+	}
+	collected := make([]taskResult, 0, actualTasks)
+	var mu sync.Mutex
+	done := make(chan struct{}, 1)
+
+	sub, err := c.nc.Subscribe(subject, func(msg *nats.Msg) {
+		var r distributed.ResultNotification
+		if unmarshalErr := distributed.Unmarshal(msg.Data, &r); unmarshalErr != nil {
+			return
+		}
+		mu.Lock()
+		if !r.Success {
+			collected = append(collected, taskResult{err: r.Error})
+		} else {
+			collected = append(collected, taskResult{files: r.ResultFiles})
+		}
+		got := len(collected)
+		mu.Unlock()
+		if got >= actualTasks {
+			select {
+			case done <- struct{}{}:
+			default:
+			}
+		}
+	})
+	if err != nil {
+		return nil, fmt.Errorf("subscribing for shuffle-%s results: %w", sideName, err)
+	}
+	defer sub.Unsubscribe()
+
+	// Build and publish all tasks at once.
+	tasks := make([]distributed.Task, actualTasks)
+	for i, files := range fileSets {
+		t := distributed.Task{
+			ID:           uuid.New().String()[:8],
+			QueryID:      shuffleQueryID,
+			StageID:      stageID,
+			Type:         distributed.TaskTypeShuffle,
+			TableName:    sourceStage.TableName,
+			Files:        files,
+			Columns:      cols,
+			ShuffleKeys:  keys,
+			NumPartitions: numParts,
+			DataBucket:   c.config.ResultBucket,
+			ResultBucket: c.config.ResultBucket,
+			ResultPrefix: resultPrefix,
+			CreatedAt:    time.Now(),
+		}
+		if clusterID := c.catalog.ClusterID(); clusterID != "" {
+			t.ClusterID = clusterID
+		}
+		tasks[i] = t
+	}
+
+	if err := c.scheduler.PublishTasks(ctx, tasks); err != nil {
+		return nil, fmt.Errorf("publishing shuffle-%s tasks: %w", sideName, err)
+	}
+
+	// Wait for all tasks to complete.
+	select {
+	case <-done:
+	case <-ctx.Done():
+		return nil, fmt.Errorf("shuffle-%s timed out after %s: %w", sideName, shuffleStageTimeout, ctx.Err())
+	}
+
+	// Check for any task failures.
+	mu.Lock()
+	results := make([]taskResult, len(collected))
+	copy(results, collected)
+	mu.Unlock()
+
+	for _, r := range results {
+		if r.err != "" {
+			return nil, fmt.Errorf("shuffle-%s task failed: %s", sideName, r.err)
+		}
+	}
+
+	// Bucket result files by partition. Each file has a path like:
+	// <prefix>/partition=NNNN/<task-id>.wshf
+	// We parse the partition number from the "partition=NNNN" path segment.
+	// This format is fixed by the worker's executeShuffle (partitionedShuffleSink).
+	shardFiles := make([][]string, numParts)
+	for _, r := range results {
+		for _, f := range r.files {
+			p, parseErr := parsePartitionFromPath(f)
+			if parseErr != nil {
+				return nil, fmt.Errorf("shuffle-%s: parsing partition from %q: %w", sideName, f, parseErr)
+			}
+			if p < 0 || p >= numParts {
+				return nil, fmt.Errorf("shuffle-%s: partition %d out of range [0,%d) in path %q", sideName, p, numParts, f)
+			}
+			shardFiles[p] = append(shardFiles[p], f)
+		}
+	}
+
+	// Enumerate any shard files that were written to S3 but not reported in
+	// ResultFiles (e.g., workers that produced zero rows for some partitions
+	// may omit them — this is fine; nil slice for a partition is correct).
+	// If the worker was thorough with ResultFiles we don't need List. Doing
+	// a List pass here as a cross-check is safe but adds latency, so we skip
+	// it. If a future bug shows missing shards, add a List-based reconciliation
+	// here keyed on resultPrefix.
+
+	c.logger.Info("shuffle side complete",
+		"query_id", parentQueryID,
+		"side", sideName,
+		"tasks", actualTasks,
+		"num_partitions", numParts,
+	)
+
+	return shardFiles, nil
+}
+
+// parsePartitionFromPath extracts the partition index from an S3 key that
+// contains a segment of the form "partition=NNNN". Returns an error if no
+// such segment is found or if NNNN is not a valid non-negative integer.
+func parsePartitionFromPath(path string) (int, error) {
+	const prefix = "partition="
+	for _, seg := range strings.Split(path, "/") {
+		if strings.HasPrefix(seg, prefix) {
+			numStr := seg[len(prefix):]
+			n, err := strconv.Atoi(numStr)
+			if err != nil {
+				return 0, fmt.Errorf("segment %q: %w", seg, err)
+			}
+			return n, nil
+		}
+	}
+	return 0, fmt.Errorf("no %q segment found", prefix)
+}
+
+// assignPartitionsToWorker returns the contiguous partition IDs assigned to
+// worker w (zero-indexed) when there are workerCount workers and numParts
+// total partitions. numParts must be divisible by workerCount; partsPerWorker
+// = numParts / workerCount.
+func assignPartitionsToWorker(w, workerCount, numParts int) []int {
+	if workerCount <= 0 || numParts <= 0 || w < 0 || w >= workerCount {
+		return nil
+	}
+	partsPerWorker := numParts / workerCount
+	if partsPerWorker == 0 {
+		// More workers than partitions — worker w gets partition w if w < numParts.
+		if w < numParts {
+			return []int{w}
+		}
+		return nil
+	}
+	start := w * partsPerWorker
+	parts := make([]int, partsPerWorker)
+	for i := range parts {
+		parts[i] = start + i
+	}
+	return parts
+}
+
+// findShuffleScanStages locates the build and probe scan stages corresponding
+// to the ShuffleCandidate's aliases.
+func findShuffleScanStages(stages []physical.Stage, cand physical.ShuffleCandidate) (build, probe physical.Stage, err error) {
+	var buildFound, probeFound bool
+	for _, s := range stages {
+		if s.Type != "scan" {
+			continue
+		}
+		if s.ScanAlias == cand.BuildAlias {
+			build = s
+			buildFound = true
+		}
+		if s.ScanAlias == cand.ProbeAlias {
+			probe = s
+			probeFound = true
+		}
+	}
+	if !buildFound {
+		return physical.Stage{}, physical.Stage{}, fmt.Errorf("build scan stage for alias %q not found", cand.BuildAlias)
+	}
+	if !probeFound {
+		return physical.Stage{}, physical.Stage{}, fmt.Errorf("probe scan stage for alias %q not found", cand.ProbeAlias)
+	}
+	return build, probe, nil
+}
+
+// collectShardFilesFromS3 lists all shard files under a shuffle side prefix
+// from object storage. This is a fallback reconciliation helper: if ResultFiles
+// from task notifications are incomplete (e.g., due to a bug or truncation),
+// the caller can use this to enumerate the actual output from S3.
+// Not called in the hot path — kept for diagnostic use.
+func (c *Coordinator) collectShardFilesFromS3(ctx context.Context, bucket, prefix string, numParts int) ([][]string, error) {
+	shards := make([][]string, numParts)
+	objs, err := c.catalog.Store().List(ctx, bucket, objstore.ListOptions{Prefix: prefix})
+	if err != nil {
+		return nil, fmt.Errorf("listing shuffle shards at %s/%s: %w", bucket, prefix, err)
+	}
+	for _, obj := range objs {
+		p, parseErr := parsePartitionFromPath(obj.Key)
+		if parseErr != nil {
+			continue // skip non-shard files (manifests, etc.)
+		}
+		if p >= 0 && p < numParts {
+			shards[p] = append(shards[p], obj.Key)
+		}
+	}
+	return shards, nil
+}

--- a/internal/coordinator/shuffle_orchestrator.go
+++ b/internal/coordinator/shuffle_orchestrator.go
@@ -319,6 +319,46 @@ func assignPartitionsToWorker(w, workerCount, numParts int) []int {
 	return parts
 }
 
+// buildShufflePipelineTasks creates one probe pipeline task per worker.
+// Each task gets PreScannedInputs populated with the shard files for the
+// partitions assigned to that worker (contiguous slice of layout's partitions).
+func buildShufflePipelineTasks(
+	queryID, sql, resultBucket string,
+	layout *ShuffleLayout,
+	workerCount int,
+) []distributed.Task {
+	resultPrefix := fmt.Sprintf("queries/%s/pipeline-0/", queryID)
+	tasks := make([]distributed.Task, 0, workerCount)
+	for w := 0; w < workerCount; w++ {
+		parts := assignPartitionsToWorker(w, workerCount, layout.NumPartitions)
+		if len(parts) == 0 {
+			continue
+		}
+		var buildFiles, probeFiles []string
+		for _, p := range parts {
+			buildFiles = append(buildFiles, layout.BuildShardFiles[p]...)
+			probeFiles = append(probeFiles, layout.ProbeShardFiles[p]...)
+		}
+		tasks = append(tasks, distributed.Task{
+			ID:           uuid.New().String()[:8],
+			QueryID:      queryID,
+			StageID:      "pipeline-0",
+			Type:         distributed.TaskTypePipeline,
+			SQLText:      sql,
+			DataBucket:   resultBucket,
+			ResultBucket: resultBucket,
+			ResultPrefix: resultPrefix,
+			PartialAggregate: true,
+			PreScannedInputs: map[string][]string{
+				layout.BuildAlias: buildFiles,
+				layout.ProbeAlias: probeFiles,
+			},
+			CreatedAt: time.Now(),
+		})
+	}
+	return tasks
+}
+
 // findShuffleScanStages locates the build and probe scan stages corresponding
 // to the ShuffleCandidate's aliases.
 func findShuffleScanStages(stages []physical.Stage, cand physical.ShuffleCandidate) (build, probe physical.Stage, err error) {

--- a/internal/coordinator/shuffle_orchestrator.go
+++ b/internal/coordinator/shuffle_orchestrator.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/citc-tech/wadjet/internal/distributed"
 	"github.com/citc-tech/wadjet/internal/planner/physical"
-	"github.com/citc-tech/wadjet/internal/storage/objstore"
 	"github.com/google/uuid"
 	"github.com/nats-io/nats.go"
 	"golang.org/x/sync/errgroup"
@@ -346,25 +345,3 @@ func findShuffleScanStages(stages []physical.Stage, cand physical.ShuffleCandida
 	return build, probe, nil
 }
 
-// collectShardFilesFromS3 lists all shard files under a shuffle side prefix
-// from object storage. This is a fallback reconciliation helper: if ResultFiles
-// from task notifications are incomplete (e.g., due to a bug or truncation),
-// the caller can use this to enumerate the actual output from S3.
-// Not called in the hot path — kept for diagnostic use.
-func (c *Coordinator) collectShardFilesFromS3(ctx context.Context, bucket, prefix string, numParts int) ([][]string, error) {
-	shards := make([][]string, numParts)
-	objs, err := c.catalog.Store().List(ctx, bucket, objstore.ListOptions{Prefix: prefix})
-	if err != nil {
-		return nil, fmt.Errorf("listing shuffle shards at %s/%s: %w", bucket, prefix, err)
-	}
-	for _, obj := range objs {
-		p, parseErr := parsePartitionFromPath(obj.Key)
-		if parseErr != nil {
-			continue // skip non-shard files (manifests, etc.)
-		}
-		if p >= 0 && p < numParts {
-			shards[p] = append(shards[p], obj.Key)
-		}
-	}
-	return shards, nil
-}

--- a/internal/coordinator/shuffle_orchestrator_test.go
+++ b/internal/coordinator/shuffle_orchestrator_test.go
@@ -236,6 +236,8 @@ func TestParsePartitionFromPath(t *testing.T) {
 		{"no-partition-segment/file.wshf", 0, true},
 		{"queries/qid/partition=/file.wshf", 0, true}, // empty number
 		{"", 0, true},
+		{"shuffle/q1/build/partition=7/abc.wshf", 7, false},
+		{"shuffle/q1/build/partition=abc/file.wshf", 0, true},
 	}
 	for _, tc := range cases {
 		got, err := parsePartitionFromPath(tc.path)

--- a/internal/coordinator/shuffle_orchestrator_test.go
+++ b/internal/coordinator/shuffle_orchestrator_test.go
@@ -1,0 +1,265 @@
+package coordinator
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitFilesEvenly(t *testing.T) {
+	cases := []struct {
+		name    string
+		files   []string
+		n       int
+		wantLen int   // expected number of non-nil slices
+		wantTotal int // expected total files across all slices
+	}{
+		{
+			name:      "even split 6 into 3",
+			files:     []string{"a", "b", "c", "d", "e", "f"},
+			n:         3,
+			wantLen:   3,
+			wantTotal: 6,
+		},
+		{
+			name:      "uneven split 7 into 3",
+			files:     []string{"a", "b", "c", "d", "e", "f", "g"},
+			n:         3,
+			wantLen:   3,
+			wantTotal: 7,
+		},
+		{
+			name:      "more workers than files: 2 files 3 workers",
+			files:     []string{"a", "b"},
+			n:         3,
+			wantLen:   2, // splitFilesEvenly caps n at len(files)
+			wantTotal: 2,
+		},
+		{
+			name:      "exact 1 file 1 worker",
+			files:     []string{"only"},
+			n:         1,
+			wantLen:   1,
+			wantTotal: 1,
+		},
+		{
+			name:      "12 files 4 workers",
+			files:     makeFiles(12),
+			n:         4,
+			wantLen:   4,
+			wantTotal: 12,
+		},
+		{
+			name:      "1 file 4 workers",
+			files:     []string{"solo"},
+			n:         4,
+			wantLen:   1,
+			wantTotal: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := splitFilesEvenly(tc.files, tc.n)
+			if len(got) != tc.wantLen {
+				t.Errorf("got %d slices, want %d", len(got), tc.wantLen)
+			}
+			total := 0
+			for _, s := range got {
+				total += len(s)
+			}
+			if total != tc.wantTotal {
+				t.Errorf("got %d total files, want %d", total, tc.wantTotal)
+			}
+			// Verify no duplicates and all original files are present.
+			seen := make(map[string]bool)
+			for _, s := range got {
+				for _, f := range s {
+					if seen[f] {
+						t.Errorf("duplicate file %q", f)
+					}
+					seen[f] = true
+				}
+			}
+			for _, f := range tc.files[:tc.wantTotal] {
+				if !seen[f] {
+					t.Errorf("file %q missing from output", f)
+				}
+			}
+		})
+	}
+}
+
+func TestSplitFilesEvenlyEmpty(t *testing.T) {
+	if got := splitFilesEvenly(nil, 4); got != nil {
+		t.Errorf("splitFilesEvenly(nil, 4) = %v, want nil", got)
+	}
+	if got := splitFilesEvenly([]string{}, 4); got != nil {
+		t.Errorf("splitFilesEvenly([], 4) = %v, want nil", got)
+	}
+	if got := splitFilesEvenly([]string{"a"}, 0); got != nil {
+		t.Errorf("splitFilesEvenly([a], 0) = %v, want nil", got)
+	}
+	if got := splitFilesEvenly([]string{"a"}, -1); got != nil {
+		t.Errorf("splitFilesEvenly([a], -1) = %v, want nil", got)
+	}
+}
+
+func TestAssignPartitionsToWorker(t *testing.T) {
+	cases := []struct {
+		name        string
+		w           int
+		workerCount int
+		numParts    int
+		want        []int
+	}{
+		{
+			name:        "3 workers 12 partitions — worker 0",
+			w:           0,
+			workerCount: 3,
+			numParts:    12,
+			want:        []int{0, 1, 2, 3},
+		},
+		{
+			name:        "3 workers 12 partitions — worker 1",
+			w:           1,
+			workerCount: 3,
+			numParts:    12,
+			want:        []int{4, 5, 6, 7},
+		},
+		{
+			name:        "3 workers 12 partitions — worker 2",
+			w:           2,
+			workerCount: 3,
+			numParts:    12,
+			want:        []int{8, 9, 10, 11},
+		},
+		{
+			name:        "4 workers 16 partitions — worker 3",
+			w:           3,
+			workerCount: 4,
+			numParts:    16,
+			want:        []int{12, 13, 14, 15},
+		},
+		{
+			name:        "1 worker 4 partitions",
+			w:           0,
+			workerCount: 1,
+			numParts:    4,
+			want:        []int{0, 1, 2, 3},
+		},
+		{
+			name:        "out-of-range worker",
+			w:           5,
+			workerCount: 3,
+			numParts:    12,
+			want:        nil,
+		},
+		{
+			name:        "zero workers",
+			w:           0,
+			workerCount: 0,
+			numParts:    12,
+			want:        nil,
+		},
+		{
+			name:        "zero partitions",
+			w:           0,
+			workerCount: 3,
+			numParts:    0,
+			want:        nil,
+		},
+		{
+			name:        "negative worker index",
+			w:           -1,
+			workerCount: 3,
+			numParts:    12,
+			want:        nil,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := assignPartitionsToWorker(tc.w, tc.workerCount, tc.numParts)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("assignPartitionsToWorker(%d, %d, %d) = %v, want %v",
+					tc.w, tc.workerCount, tc.numParts, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAssignPartitionsToWorkerCoverage verifies that, when numParts is evenly
+// divisible by workerCount, every partition is assigned to exactly one worker.
+func TestAssignPartitionsToWorkerCoverage(t *testing.T) {
+	cases := []struct {
+		workerCount int
+		numParts    int
+	}{
+		{3, 12},
+		{4, 16},
+		{1, 4},
+		{2, 8},
+		{5, 20},
+	}
+	for _, tc := range cases {
+		assigned := make(map[int]int) // partition → worker
+		for w := 0; w < tc.workerCount; w++ {
+			parts := assignPartitionsToWorker(w, tc.workerCount, tc.numParts)
+			for _, p := range parts {
+				if prev, ok := assigned[p]; ok {
+					t.Errorf("workers=%d parts=%d: partition %d assigned to both worker %d and %d",
+						tc.workerCount, tc.numParts, p, prev, w)
+				}
+				assigned[p] = w
+			}
+		}
+		if len(assigned) != tc.numParts {
+			t.Errorf("workers=%d parts=%d: only %d/%d partitions assigned",
+				tc.workerCount, tc.numParts, len(assigned), tc.numParts)
+		}
+	}
+}
+
+// TestParsePartitionFromPath tests the path parsing helper.
+func TestParsePartitionFromPath(t *testing.T) {
+	cases := []struct {
+		path    string
+		want    int
+		wantErr bool
+	}{
+		{"queries/qid/shuffle/build/partition=0000/task01.wshf", 0, false},
+		{"queries/qid/shuffle/build/partition=0007/abc123.wshf", 7, false},
+		{"queries/qid/shuffle/probe/partition=0042/xyz.wshf", 42, false},
+		{"queries/qid/shuffle/probe/partition=1023/xyz.wshf", 1023, false},
+		{"no-partition-segment/file.wshf", 0, true},
+		{"queries/qid/partition=/file.wshf", 0, true}, // empty number
+		{"", 0, true},
+	}
+	for _, tc := range cases {
+		got, err := parsePartitionFromPath(tc.path)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("parsePartitionFromPath(%q) = %d, nil; want error", tc.path, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parsePartitionFromPath(%q) error: %v", tc.path, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("parsePartitionFromPath(%q) = %d, want %d", tc.path, got, tc.want)
+		}
+	}
+}
+
+// makeFiles creates a slice of n file path strings for testing.
+func makeFiles(n int) []string {
+	files := make([]string, n)
+	for i := range files {
+		files[i] = "file" + string(rune('a'+i%26)) + string(rune('0'+i/26))
+	}
+	return files
+}

--- a/internal/distributed/messages.go
+++ b/internal/distributed/messages.go
@@ -12,6 +12,7 @@ type TaskType string
 
 const (
 	TaskTypePipeline TaskType = "pipeline" // full query executed as standalone pipeline on one worker
+	TaskTypeShuffle  TaskType = "shuffle"  // hash-partitions input rows into N output partition files
 )
 
 // Task is the unit of distributed work published to NATS JetStream.

--- a/internal/planner/physical/distribution.go
+++ b/internal/planner/physical/distribution.go
@@ -1,0 +1,58 @@
+package physical
+
+// DistKind is the kind of partitioning a stage's output has.
+type DistKind int
+
+const (
+	DistSingleton       DistKind = iota // single worker has all rows
+	DistBroadcast                       // every worker has all rows
+	DistHashPartitioned                 // rows partitioned by hash(Keys) % Count
+)
+
+// Distribution describes how a stage's output is partitioned across workers.
+type Distribution struct {
+	Kind  DistKind
+	Keys  []string // for DistHashPartitioned
+	Count int      // for DistHashPartitioned
+}
+
+// Equals reports whether two Distributions are identical.
+func (d Distribution) Equals(other Distribution) bool {
+	if d.Kind != other.Kind {
+		return false
+	}
+	if d.Kind != DistHashPartitioned {
+		return true
+	}
+	if d.Count != other.Count || len(d.Keys) != len(other.Keys) {
+		return false
+	}
+	for i := range d.Keys {
+		if d.Keys[i] != other.Keys[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// SatisfiesJoinKeys reports whether this distribution allows a co-located
+// join on the given keys without re-shuffling. Broadcast always satisfies;
+// hash-partitioned satisfies iff the keys match exactly (in order).
+func (d Distribution) SatisfiesJoinKeys(joinKeys []string) bool {
+	switch d.Kind {
+	case DistBroadcast:
+		return true
+	case DistHashPartitioned:
+		if len(d.Keys) != len(joinKeys) {
+			return false
+		}
+		for i := range d.Keys {
+			if d.Keys[i] != joinKeys[i] {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/planner/physical/distribution_test.go
+++ b/internal/planner/physical/distribution_test.go
@@ -1,0 +1,38 @@
+package physical
+
+import "testing"
+
+func TestDistributionEquals(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b Distribution
+		want bool
+	}{
+		{"both broadcast", Distribution{Kind: DistBroadcast}, Distribution{Kind: DistBroadcast}, true},
+		{"singleton vs broadcast", Distribution{Kind: DistSingleton}, Distribution{Kind: DistBroadcast}, false},
+		{"hash same keys same count", Distribution{Kind: DistHashPartitioned, Keys: []string{"k"}, Count: 12}, Distribution{Kind: DistHashPartitioned, Keys: []string{"k"}, Count: 12}, true},
+		{"hash different keys", Distribution{Kind: DistHashPartitioned, Keys: []string{"a"}, Count: 12}, Distribution{Kind: DistHashPartitioned, Keys: []string{"b"}, Count: 12}, false},
+		{"hash different count", Distribution{Kind: DistHashPartitioned, Keys: []string{"k"}, Count: 12}, Distribution{Kind: DistHashPartitioned, Keys: []string{"k"}, Count: 24}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.a.Equals(tt.b); got != tt.want {
+				t.Errorf("Equals = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDistributionSatisfiesJoin(t *testing.T) {
+	d := Distribution{Kind: DistHashPartitioned, Keys: []string{"orderkey"}, Count: 12}
+	if !d.SatisfiesJoinKeys([]string{"orderkey"}) {
+		t.Error("expected hash-on-orderkey to satisfy join on orderkey")
+	}
+	if d.SatisfiesJoinKeys([]string{"custkey"}) {
+		t.Error("expected hash-on-orderkey to NOT satisfy join on custkey")
+	}
+	bcast := Distribution{Kind: DistBroadcast}
+	if !bcast.SatisfiesJoinKeys([]string{"anything"}) {
+		t.Error("broadcast should always satisfy join")
+	}
+}

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -1125,7 +1125,7 @@ func PickShuffleCandidate(stages []Stage, thresholdBytes int64) (ShuffleCandidat
 	var best ShuffleCandidate
 	var bestBytes int64
 	for _, s := range stages {
-		if s.Type != "hash_join" {
+		if s.Type != "hash_join" && s.Type != "broadcast_join" {
 			continue
 		}
 		buildAlias := s.BuildTableAlias

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -1156,6 +1156,48 @@ func PickShuffleCandidate(stages []Stage, thresholdBytes int64) (ShuffleCandidat
 		return ShuffleCandidate{}, false
 	}
 
+	// candidateCols is the set of column names the candidate scan exposes in its
+	// raw Parquet files. Used to validate that join keys are actually rooted in
+	// the candidate scan and not in a fused-join output (e.g. Q10: orders is the
+	// left dep of join-4, but join-4's left key c_nationkey comes from the fused
+	// customer join, not from orders' Parquet files).
+	// If Columns is empty (not annotated), validation is skipped and the original
+	// dep-match logic applies unchanged.
+	candidateCols := make(map[string]bool, len(candidateScan.Columns))
+	for _, c := range candidateScan.Columns {
+		candidateCols[c] = true
+	}
+	// keysInCols returns true iff all keys are present in cols.
+	// Returns true when cols is empty (no annotation = skip validation).
+	keysInCols := func(keys []string, cols map[string]bool) bool {
+		if len(cols) == 0 {
+			// No column annotation: cannot validate, assume valid.
+			return true
+		}
+		if len(keys) == 0 {
+			return false
+		}
+		for _, k := range keys {
+			if !cols[k] {
+				return false
+			}
+		}
+		return true
+	}
+
+	// probeCols is the set of column names the probe scan exposes in its raw
+	// Parquet files. Used to validate that probe-side keys are directly readable
+	// from the probe table, not from an intermediate join output.
+	probeCols := make(map[string]bool)
+	for _, s := range stages {
+		if s.Type == "scan" && s.ScanAlias == probeAlias {
+			for _, c := range s.Columns {
+				probeCols[c] = true
+			}
+			break
+		}
+	}
+
 	// Step 3: walk join stages to find the one referencing the candidate.
 	for _, j := range stages {
 		if j.Type != "hash_join" && j.Type != "broadcast_join" {
@@ -1163,9 +1205,12 @@ func PickShuffleCandidate(stages []Stage, thresholdBytes int64) (ShuffleCandidat
 		}
 
 		// Direct left-dep match: candidate is on the left (probe) side of the join.
-		// Safety check: only accept if the OTHER side (right) is not an intermediate
-		// join — the left keys must be from the candidate's Parquet files.
-		if j.LeftDepStage == candidateScanID {
+		// Guard: the join's left keys must actually live in the candidate scan's raw
+		// Parquet columns. If they don't (e.g. Q10: join-4 has LeftDepStage=orders
+		// but JoinLeftKeys=[c_nationkey] which originates from the fused customer
+		// join, not from orders files), skip this match and let the column-anchored
+		// fallback below find the correct join.
+		if j.LeftDepStage == candidateScanID && keysInCols(j.JoinLeftKeys, candidateCols) {
 			return ShuffleCandidate{
 				JoinStageID: j.ID,
 				BuildAlias:  candidateScan.ScanAlias,
@@ -1214,6 +1259,46 @@ func PickShuffleCandidate(stages []Stage, thresholdBytes int64) (ShuffleCandidat
 					BuildKeys:   append([]string(nil), fj.JoinRightKeys...),
 					ProbeKeys:   append([]string(nil), fj.JoinLeftKeys...),
 					JoinKeys:    append([]string(nil), fj.JoinRightKeys...),
+					BuildBytes:  candidateScan.EstimatedBytes,
+				}, true
+			}
+		}
+	}
+
+	// Column-anchored fallback: the candidate appears as a left dep somewhere in
+	// the join chain, but the matching join's keys were not valid for the raw
+	// candidate scan (e.g. Q10: orders appears as the left dep of join-4 but with
+	// c_nationkey keys from a fused join output). Find any join where:
+	//   - JoinLeftKeys are all present in the candidate scan's raw columns, AND
+	//   - JoinRightKeys are all present in the probe scan's raw columns.
+	// This anchors both sides to their actual Parquet files regardless of the
+	// dep-chain topology.
+	if len(candidateCols) > 0 && len(probeCols) > 0 {
+		for _, j := range stages {
+			if j.Type != "hash_join" && j.Type != "broadcast_join" {
+				continue
+			}
+			if keysInCols(j.JoinLeftKeys, candidateCols) && keysInCols(j.JoinRightKeys, probeCols) {
+				return ShuffleCandidate{
+					JoinStageID: j.ID,
+					BuildAlias:  candidateScan.ScanAlias,
+					ProbeAlias:  probeAlias,
+					BuildKeys:   append([]string(nil), j.JoinLeftKeys...),
+					ProbeKeys:   append([]string(nil), j.JoinRightKeys...),
+					JoinKeys:    append([]string(nil), j.JoinLeftKeys...),
+					BuildBytes:  candidateScan.EstimatedBytes,
+				}, true
+			}
+			// Also check if the keys are swapped: candidate provides the right
+			// keys and probe provides the left keys.
+			if keysInCols(j.JoinRightKeys, candidateCols) && keysInCols(j.JoinLeftKeys, probeCols) {
+				return ShuffleCandidate{
+					JoinStageID: j.ID,
+					BuildAlias:  candidateScan.ScanAlias,
+					ProbeAlias:  probeAlias,
+					BuildKeys:   append([]string(nil), j.JoinRightKeys...),
+					ProbeKeys:   append([]string(nil), j.JoinLeftKeys...),
+					JoinKeys:    append([]string(nil), j.JoinRightKeys...),
 					BuildBytes:  candidateScan.EstimatedBytes,
 				}, true
 			}

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -1084,6 +1084,77 @@ func CanProbeSplit(stages []Stage, workerCount int) (probeAlias string, probeFil
 	return bestAlias, bestFiles, true
 }
 
+// ShuffleCandidate describes a join in the plan whose build side is large
+// enough to warrant the shuffle execution path instead of broadcast.
+type ShuffleCandidate struct {
+	JoinStageID string   // the join stage to be served by shuffled inputs
+	BuildAlias  string   // which scan stage produces the build side
+	ProbeAlias  string   // which scan stage produces the probe side (the largest scan)
+	BuildKeys   []string // build-side join keys (the join's JoinRightKeys)
+	ProbeKeys   []string // probe-side join keys (the join's JoinLeftKeys)
+	JoinKeys    []string // canonical (build-side) join key names for partitioning
+	BuildBytes  int64    // EstimatedBytes of the build scan (for logging)
+}
+
+// PickShuffleCandidate finds the join whose build-side scan has the largest
+// EstimatedBytes above thresholdBytes. Returns ok=false if no build exceeds
+// the threshold or if no eligible join exists.
+//
+// Phase 1: returns a single candidate. Phase 2 (Q09 / chained shuffles) will
+// return all candidates.
+func PickShuffleCandidate(stages []Stage, thresholdBytes int64) (ShuffleCandidate, bool) {
+	// Build alias -> scan stage lookup.
+	byAlias := map[string]Stage{}
+	for _, s := range stages {
+		if s.Type == "scan" && s.ScanAlias != "" {
+			byAlias[s.ScanAlias] = s
+		}
+	}
+
+	// Identify the largest scan as the probe alias (mirrors CanProbeSplit's
+	// largest-scan heuristic).
+	var probeAlias string
+	var probeBytes int64
+	for _, s := range stages {
+		if s.Type == "scan" && s.EstimatedBytes > probeBytes {
+			probeAlias = s.ScanAlias
+			probeBytes = s.EstimatedBytes
+		}
+	}
+
+	var best ShuffleCandidate
+	var bestBytes int64
+	for _, s := range stages {
+		if s.Type != "hash_join" {
+			continue
+		}
+		buildAlias := s.BuildTableAlias
+		if buildAlias == "" || buildAlias == probeAlias {
+			continue
+		}
+		buildScan, ok := byAlias[buildAlias]
+		if !ok {
+			continue
+		}
+		if buildScan.EstimatedBytes <= thresholdBytes {
+			continue
+		}
+		if buildScan.EstimatedBytes > bestBytes {
+			best = ShuffleCandidate{
+				JoinStageID: s.ID,
+				BuildAlias:  buildAlias,
+				ProbeAlias:  probeAlias,
+				BuildKeys:   append([]string(nil), s.JoinRightKeys...),
+				ProbeKeys:   append([]string(nil), s.JoinLeftKeys...),
+				JoinKeys:    append([]string(nil), s.JoinRightKeys...),
+				BuildBytes:  buildScan.EstimatedBytes,
+			}
+			bestBytes = buildScan.EstimatedBytes
+		}
+	}
+	return best, bestBytes > 0
+}
+
 // LargeBuildScans returns scan stages that are build-side (not the probe alias)
 // and whose estimated size exceeds the given threshold. These are candidates for
 // the build-side broadcast cache: the coordinator pre-scans them once, caches the

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -1096,75 +1096,132 @@ type ShuffleCandidate struct {
 	BuildBytes  int64    // EstimatedBytes of the build scan (for logging)
 }
 
-// PickShuffleCandidate finds the join whose build-side scan has the largest
-// EstimatedBytes above thresholdBytes. Returns ok=false if no build exceeds
-// the threshold or if no eligible join exists.
+// PickShuffleCandidate identifies the largest non-probe scan above
+// thresholdBytes as the shuffle candidate — the table that would otherwise be
+// broadcast-duplicated as the runtime build side — and returns the join stage
+// that connects it to the probe.
 //
-// Phase 1: returns a single candidate. Phase 2 (Q09 / chained shuffles) will
-// return all candidates.
+// The approach deliberately does NOT read BuildTableAlias on the join stage
+// because in probe-split mode the planner's logical build/probe assignment is
+// inverted at runtime: the planner labels the largest scan as the build (e.g.
+// "lineitem"), but probe-split partitions that scan across workers, making the
+// second-largest scan (e.g. "orders") the actual broadcast hash table.
+// Shuffling orders instead of broadcasting it is the correction.
+//
+// Algorithm:
+//  1. probeAlias = largest scan (matches CanProbeSplit's heuristic).
+//  2. candidate = largest non-probe scan above thresholdBytes.
+//  3. Walk join stages to find one that directly references the candidate
+//     scan (via LeftDepStage or RightDepStage) or via a FusedJoin entry
+//     whose BuildTableAlias matches the candidate alias.
+//  4. Extract build/probe keys from the matching join or fused-join entry.
+//
+// Phase 1: returns the single best candidate. Phase 2 (chained shuffles)
+// will return all candidates.
 func PickShuffleCandidate(stages []Stage, thresholdBytes int64) (ShuffleCandidate, bool) {
-	// Build alias -> scan stage lookup and stage-id -> stage lookup.
-	byAlias := map[string]Stage{}
+	// stage-id → stage lookup.
 	byID := map[string]Stage{}
 	for _, s := range stages {
 		byID[s.ID] = s
-		if s.Type == "scan" && s.ScanAlias != "" {
-			byAlias[s.ScanAlias] = s
-		}
 	}
 
-	// Identify the largest scan as the probe alias (mirrors CanProbeSplit's
-	// largest-scan heuristic).
+	// Step 1: identify probe alias (largest scan, mirrors CanProbeSplit).
 	var probeAlias string
 	var probeBytes int64
-	var probeScanID string
 	for _, s := range stages {
 		if s.Type == "scan" && s.EstimatedBytes > probeBytes {
 			probeAlias = s.ScanAlias
 			probeBytes = s.EstimatedBytes
-			probeScanID = s.ID
 		}
 	}
 
-	var best ShuffleCandidate
-	var bestBytes int64
+	// Step 2: find the largest non-probe scan above the threshold.
+	var candidateScan Stage
+	var candidateScanID string
+	var candidateFound bool
 	for _, s := range stages {
-		if s.Type != "hash_join" && s.Type != "broadcast_join" {
+		if s.Type != "scan" || s.ScanAlias == probeAlias {
 			continue
 		}
-		buildAlias := s.BuildTableAlias
-		if buildAlias == "" || buildAlias == probeAlias {
+		if s.EstimatedBytes <= thresholdBytes {
 			continue
 		}
-		buildScan, ok := byAlias[buildAlias]
-		if !ok {
-			continue
-		}
-		if buildScan.EstimatedBytes <= thresholdBytes {
-			continue
-		}
-		// Safety: the join's left (probe) dep must be the probeAlias scan
-		// directly. If it isn't, the JoinLeftKeys may reference columns from
-		// intermediate join outputs rather than the raw probeAlias Parquet
-		// files, causing "key not in schema" at shuffle time. We skip any
-		// join where the probe side is not directly the probeAlias scan.
-		if s.LeftDepStage != probeScanID {
-			continue
-		}
-		if buildScan.EstimatedBytes > bestBytes {
-			best = ShuffleCandidate{
-				JoinStageID: s.ID,
-				BuildAlias:  buildAlias,
-				ProbeAlias:  probeAlias,
-				BuildKeys:   append([]string(nil), s.JoinRightKeys...),
-				ProbeKeys:   append([]string(nil), s.JoinLeftKeys...),
-				JoinKeys:    append([]string(nil), s.JoinRightKeys...),
-				BuildBytes:  buildScan.EstimatedBytes,
-			}
-			bestBytes = buildScan.EstimatedBytes
+		if !candidateFound || s.EstimatedBytes > candidateScan.EstimatedBytes {
+			candidateScan = s
+			candidateScanID = s.ID
+			candidateFound = true
 		}
 	}
-	return best, bestBytes > 0
+	if !candidateFound {
+		return ShuffleCandidate{}, false
+	}
+
+	// Step 3: walk join stages to find the one referencing the candidate.
+	for _, j := range stages {
+		if j.Type != "hash_join" && j.Type != "broadcast_join" {
+			continue
+		}
+
+		// Direct left-dep match: candidate is on the left (probe) side of the join.
+		// Safety check: only accept if the OTHER side (right) is not an intermediate
+		// join — the left keys must be from the candidate's Parquet files.
+		if j.LeftDepStage == candidateScanID {
+			return ShuffleCandidate{
+				JoinStageID: j.ID,
+				BuildAlias:  candidateScan.ScanAlias,
+				ProbeAlias:  probeAlias,
+				BuildKeys:   append([]string(nil), j.JoinLeftKeys...),
+				ProbeKeys:   append([]string(nil), j.JoinRightKeys...),
+				JoinKeys:    append([]string(nil), j.JoinLeftKeys...),
+				BuildBytes:  candidateScan.EstimatedBytes,
+			}, true
+		}
+
+		// Direct right-dep match: candidate is on the right (build) side of the join.
+		// The left dep must be the probe scan directly (not an intermediate join)
+		// to ensure JoinLeftKeys map to raw probe Parquet columns.
+		if j.RightDepStage == candidateScanID {
+			probeScanID := ""
+			for _, s := range stages {
+				if s.Type == "scan" && s.ScanAlias == probeAlias {
+					probeScanID = s.ID
+					break
+				}
+			}
+			if j.LeftDepStage != probeScanID {
+				continue
+			}
+			return ShuffleCandidate{
+				JoinStageID: j.ID,
+				BuildAlias:  candidateScan.ScanAlias,
+				ProbeAlias:  probeAlias,
+				BuildKeys:   append([]string(nil), j.JoinRightKeys...),
+				ProbeKeys:   append([]string(nil), j.JoinLeftKeys...),
+				JoinKeys:    append([]string(nil), j.JoinRightKeys...),
+				BuildBytes:  candidateScan.EstimatedBytes,
+			}, true
+		}
+
+		// FusedJoin match: candidate is the build of a secondary join fused into
+		// this join stage. This covers Q03's shape where orders is not the top-level
+		// join's direct dep but is referenced as a fused build.
+		for _, fj := range j.FusedJoins {
+			if fj.BuildTableAlias == candidateScan.ScanAlias {
+				return ShuffleCandidate{
+					JoinStageID: j.ID,
+					BuildAlias:  candidateScan.ScanAlias,
+					ProbeAlias:  probeAlias,
+					BuildKeys:   append([]string(nil), fj.JoinRightKeys...),
+					ProbeKeys:   append([]string(nil), fj.JoinLeftKeys...),
+					JoinKeys:    append([]string(nil), fj.JoinRightKeys...),
+					BuildBytes:  candidateScan.EstimatedBytes,
+				}, true
+			}
+		}
+	}
+
+	// No join stage references the candidate.
+	return ShuffleCandidate{}, false
 }
 
 // LargeBuildScans returns scan stages that are build-side (not the probe alias)

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -34,7 +34,7 @@ type PhysicalPlan struct {
 // Stage represents a unit of distributed work with metadata for task creation.
 type Stage struct {
 	ID           string
-	Type         string // scan, aggregate, sort, hash_join, broadcast_join, window
+	Type         string // scan, aggregate, sort, hash_join, broadcast_join, window, shuffle, pipeline
 	ClusterID    string // target cluster for routing ("" = local/coordinator's cluster)
 	Dependencies []string
 	Tasks        int
@@ -103,6 +103,13 @@ type Stage struct {
 	// Cost estimation (populated at plan time from manifest metadata)
 	EstimatedBytes int64
 	EstimatedRows  int64
+
+	// Distribution describes how this stage's output is partitioned.
+	// Default zero value is {Kind: DistSingleton} which is correct for
+	// most existing stages (single-worker output). Shuffle stages set this
+	// to DistHashPartitioned with Keys and Count populated. Broadcast pre-scans
+	// (build cache) set Kind: DistBroadcast.
+	Distribution Distribution
 }
 
 // WindowColSpec defines a window function column in a stage.

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -1103,9 +1103,11 @@ type ShuffleCandidate struct {
 // Phase 1: returns a single candidate. Phase 2 (Q09 / chained shuffles) will
 // return all candidates.
 func PickShuffleCandidate(stages []Stage, thresholdBytes int64) (ShuffleCandidate, bool) {
-	// Build alias -> scan stage lookup.
+	// Build alias -> scan stage lookup and stage-id -> stage lookup.
 	byAlias := map[string]Stage{}
+	byID := map[string]Stage{}
 	for _, s := range stages {
+		byID[s.ID] = s
 		if s.Type == "scan" && s.ScanAlias != "" {
 			byAlias[s.ScanAlias] = s
 		}
@@ -1115,10 +1117,12 @@ func PickShuffleCandidate(stages []Stage, thresholdBytes int64) (ShuffleCandidat
 	// largest-scan heuristic).
 	var probeAlias string
 	var probeBytes int64
+	var probeScanID string
 	for _, s := range stages {
 		if s.Type == "scan" && s.EstimatedBytes > probeBytes {
 			probeAlias = s.ScanAlias
 			probeBytes = s.EstimatedBytes
+			probeScanID = s.ID
 		}
 	}
 
@@ -1137,6 +1141,14 @@ func PickShuffleCandidate(stages []Stage, thresholdBytes int64) (ShuffleCandidat
 			continue
 		}
 		if buildScan.EstimatedBytes <= thresholdBytes {
+			continue
+		}
+		// Safety: the join's left (probe) dep must be the probeAlias scan
+		// directly. If it isn't, the JoinLeftKeys may reference columns from
+		// intermediate join outputs rather than the raw probeAlias Parquet
+		// files, causing "key not in schema" at shuffle time. We skip any
+		// join where the probe side is not directly the probeAlias scan.
+		if s.LeftDepStage != probeScanID {
 			continue
 		}
 		if buildScan.EstimatedBytes > bestBytes {

--- a/internal/planner/physical/shuffle_insertion_test.go
+++ b/internal/planner/physical/shuffle_insertion_test.go
@@ -7,10 +7,21 @@ func TestPickShuffleCandidate_PicksLargestBuildAboveThreshold(t *testing.T) {
 		{ID: "scan-orders", Type: "scan", ScanAlias: "orders", EstimatedBytes: 8 << 30},      // 8 GB - above
 		{ID: "scan-customer", Type: "scan", ScanAlias: "customer", EstimatedBytes: 100 << 20}, // 100 MB - below
 		{ID: "scan-lineitem", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 80 << 30},  // 80 GB - probe
-		// join-1: lineitem (probe, left) JOIN orders (build, right) — LeftDepStage must be the probe scan.
-		{ID: "join-1", Type: "hash_join", BuildTableAlias: "orders", LeftDepStage: "scan-lineitem", JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"}, Dependencies: []string{"scan-lineitem", "scan-orders"}},
+		// join-1: lineitem (probe, left) JOIN orders (build, right).
+		// LeftDepStage=scan-lineitem (probe scan directly), RightDepStage=scan-orders (candidate).
+		{
+			ID: "join-1", Type: "hash_join", BuildTableAlias: "orders",
+			LeftDepStage: "scan-lineitem", RightDepStage: "scan-orders",
+			JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"},
+			Dependencies: []string{"scan-lineitem", "scan-orders"},
+		},
 		// join-2: left dep is join-1 (not the probe scan directly) — skipped by candidate selection.
-		{ID: "join-2", Type: "hash_join", BuildTableAlias: "customer", LeftDepStage: "join-1", JoinLeftKeys: []string{"o_custkey"}, JoinRightKeys: []string{"c_custkey"}, Dependencies: []string{"join-1", "scan-customer"}},
+		{
+			ID: "join-2", Type: "hash_join", BuildTableAlias: "customer",
+			LeftDepStage: "join-1", RightDepStage: "scan-customer",
+			JoinLeftKeys: []string{"o_custkey"}, JoinRightKeys: []string{"c_custkey"},
+			Dependencies: []string{"join-1", "scan-customer"},
+		},
 	}
 	cand, ok := PickShuffleCandidate(stages, 4<<30 /* threshold */)
 	if !ok {
@@ -37,22 +48,31 @@ func TestPickShuffleCandidate_NoCandidateBelowThreshold(t *testing.T) {
 	stages := []Stage{
 		{ID: "scan-orders", Type: "scan", ScanAlias: "orders", EstimatedBytes: 1 << 30}, // 1 GB - below 4 GB threshold
 		{ID: "scan-lineitem", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 80 << 30},
-		{ID: "join-1", Type: "hash_join", BuildTableAlias: "orders", JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"}},
+		{
+			ID: "join-1", Type: "hash_join", BuildTableAlias: "orders",
+			LeftDepStage: "scan-lineitem", RightDepStage: "scan-orders",
+			JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"},
+		},
 	}
 	if _, ok := PickShuffleCandidate(stages, 4<<30); ok {
 		t.Error("expected no shuffle candidate below threshold")
 	}
 }
 
-func TestPickShuffleCandidate_BuildEqualsProbeAliasIsRejected(t *testing.T) {
-	// Pathological / self-join case: if the only "build" is the same scan as the
-	// probe, we shouldn't shuffle (no separate build to partition).
+// TestPickShuffleCandidate_PathologicalNoOtherScans checks that a query with only
+// a single (probe) scan and no other above-threshold scans returns false. The old
+// "build alias == probe alias" test is subsumed by this: with only one scan, there
+// is no non-probe candidate above threshold.
+func TestPickShuffleCandidate_PathologicalNoOtherScans(t *testing.T) {
 	stages := []Stage{
 		{ID: "scan-orders", Type: "scan", ScanAlias: "orders", EstimatedBytes: 80 << 30},
-		{ID: "join-1", Type: "hash_join", BuildTableAlias: "orders", JoinLeftKeys: []string{"a"}, JoinRightKeys: []string{"b"}},
+		{
+			ID: "join-1", Type: "hash_join",
+			LeftDepStage: "scan-orders", JoinLeftKeys: []string{"a"}, JoinRightKeys: []string{"b"},
+		},
 	}
 	if _, ok := PickShuffleCandidate(stages, 4<<30); ok {
-		t.Error("expected no candidate when build alias == probe alias")
+		t.Error("expected no candidate when there is no other above-threshold non-probe scan")
 	}
 }
 
@@ -66,38 +86,38 @@ func TestPickShuffleCandidate_NoJoins(t *testing.T) {
 }
 
 // TestPickShuffleCandidate_RejectsIndirectProbeJoin checks that a join where the
-// build is above threshold but the probe (left dep) is not the probeAlias scan
-// directly is NOT selected. This guards against "key not in schema" at shuffle
-// time when the JoinLeftKeys belong to an intermediate join output rather than
-// the raw probeAlias Parquet files (the Q05/Q07/Q10 regression pattern).
+// candidate is the right dep but the left dep (probe) is NOT the probe scan
+// directly is rejected. This guards against "key not in schema" at shuffle time
+// when JoinLeftKeys belong to an intermediate join output rather than the raw
+// probeAlias Parquet files (the Q05/Q07/Q10 regression pattern).
 func TestPickShuffleCandidate_RejectsIndirectProbeJoin(t *testing.T) {
-	// Simulates Q05: nation is the build, lineitem is the probe, but the only
-	// join stage referencing nation has LeftDepStage=join-1 (not scan-lineitem).
-	// JoinLeftKeys=[s_nationkey] would fail against raw lineitem files.
+	// nation (8 GB) is the candidate (largest non-probe above 100 MB threshold).
+	// join-2 references nation as RightDepStage, but LeftDepStage=join-1 (indirect).
+	// JoinLeftKeys=[s_nationkey] would fail against raw lineitem files, so it must
+	// be rejected. No other join references nation, so result is ok=false.
 	stages := []Stage{
 		{ID: "scan-nation", Type: "scan", ScanAlias: "nation", EstimatedBytes: 8 << 30},
 		{ID: "scan-lineitem", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 80 << 30},
 		{ID: "scan-supplier", Type: "scan", ScanAlias: "supplier", EstimatedBytes: 500 << 20},
 		// join-1: lineitem JOIN supplier — probe (lineitem) is direct left dep.
-		{ID: "join-1", Type: "hash_join", BuildTableAlias: "supplier", LeftDepStage: "scan-lineitem",
-			JoinLeftKeys: []string{"l_suppkey"}, JoinRightKeys: []string{"s_suppkey"}},
+		{
+			ID: "join-1", Type: "hash_join", BuildTableAlias: "supplier",
+			LeftDepStage: "scan-lineitem", RightDepStage: "scan-supplier",
+			JoinLeftKeys: []string{"l_suppkey"}, JoinRightKeys: []string{"s_suppkey"},
+		},
 		// join-2: join-1 JOIN nation — left dep is join-1, not scan-lineitem.
-		// JoinLeftKeys=[s_nationkey] belongs to supplier's output, not raw lineitem.
-		{ID: "join-2", Type: "hash_join", BuildTableAlias: "nation", LeftDepStage: "join-1",
-			JoinLeftKeys: []string{"s_nationkey"}, JoinRightKeys: []string{"n_nationkey"}},
+		// nation is the candidate, but LeftDepStage is indirect → rejected.
+		{
+			ID: "join-2", Type: "hash_join", BuildTableAlias: "nation",
+			LeftDepStage: "join-1", RightDepStage: "scan-nation",
+			JoinLeftKeys: []string{"s_nationkey"}, JoinRightKeys: []string{"n_nationkey"},
+		},
 	}
-	// With threshold below supplier (500 MB) and nation (8 GB), both qualify.
-	// join-1 (supplier build) should be selected because it directly connects probe.
-	// join-2 (nation build) must be rejected because LeftDepStage != probeScanID.
-	cand, ok := PickShuffleCandidate(stages, 100<<20)
-	if !ok {
-		t.Fatal("expected shuffle candidate for join-1 (direct probe join)")
-	}
-	if cand.BuildAlias != "supplier" {
-		t.Errorf("BuildAlias = %q, want supplier (join-1 is the only valid direct candidate)", cand.BuildAlias)
-	}
-	if cand.JoinStageID != "join-1" {
-		t.Errorf("JoinStageID = %q, want join-1", cand.JoinStageID)
+	// nation (8 GB) is the candidate; join-2 references it but has an indirect
+	// left dep → rejected. No valid join found for nation → ok=false.
+	_, ok := PickShuffleCandidate(stages, 100<<20)
+	if ok {
+		t.Error("expected no shuffle candidate: nation's only join has an indirect probe dep")
 	}
 }
 
@@ -106,10 +126,12 @@ func TestPickShuffleCandidate_MatchesBroadcastJoin(t *testing.T) {
 		{ID: "scan-orders", Type: "scan", ScanAlias: "orders", EstimatedBytes: 8 << 30},
 		{ID: "scan-lineitem", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 80 << 30},
 		// Same shape as the hash_join test, but the join is classified as broadcast_join.
-		// LeftDepStage must be the probe scan for the candidate to be selected.
-		{ID: "join-1", Type: "broadcast_join", BuildTableAlias: "orders",
-			LeftDepStage: "scan-lineitem",
-			JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"}},
+		// orders (8 GB) is the candidate; it's the right dep with lineitem as direct left dep.
+		{
+			ID: "join-1", Type: "broadcast_join", BuildTableAlias: "orders",
+			LeftDepStage: "scan-lineitem", RightDepStage: "scan-orders",
+			JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"},
+		},
 	}
 	cand, ok := PickShuffleCandidate(stages, 4<<30)
 	if !ok {
@@ -117,5 +139,101 @@ func TestPickShuffleCandidate_MatchesBroadcastJoin(t *testing.T) {
 	}
 	if cand.JoinKeys[0] != "o_orderkey" {
 		t.Errorf("JoinKeys = %v, want [o_orderkey]", cand.JoinKeys)
+	}
+}
+
+// TestPickShuffleCandidate_Q03Shape mirrors the actual physical plan structure
+// of Q03: a single fused broadcast_join with lineitem as the planner-labeled
+// build (largest, will be probe-partitioned at runtime), orders as the
+// LeftDepStage (the runtime broadcast build we want to shuffle), customer
+// fused as a secondary build below threshold.
+func TestPickShuffleCandidate_Q03Shape(t *testing.T) {
+	stages := []Stage{
+		{ID: "scan-orders", Type: "scan", ScanAlias: "orders", EstimatedBytes: 8 << 30},
+		{ID: "scan-customer", Type: "scan", ScanAlias: "customer", EstimatedBytes: 1500 << 20},
+		{ID: "scan-lineitem", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 75 << 30},
+		{
+			ID: "join-1", Type: "broadcast_join",
+			BuildTableAlias: "lineitem",                    // planner's label; NOT what we shuffle
+			LeftDepStage:    "scan-orders",                 // orders is the runtime broadcast build
+			RightDepStage:   "scan-lineitem",               // lineitem is the probe (probe-split)
+			JoinLeftKeys:    []string{"o_orderkey"},
+			JoinRightKeys:   []string{"l_orderkey"},
+			FusedJoins: []FusedJoinSpec{
+				{
+					BuildTableAlias: "customer",
+					JoinLeftKeys:    []string{"o_custkey"},
+					JoinRightKeys:   []string{"c_custkey"},
+				},
+			},
+		},
+	}
+	cand, ok := PickShuffleCandidate(stages, 4<<30)
+	if !ok {
+		t.Fatal("expected shuffle candidate (orders)")
+	}
+	if cand.BuildAlias != "orders" {
+		t.Errorf("BuildAlias = %q, want orders", cand.BuildAlias)
+	}
+	if cand.ProbeAlias != "lineitem" {
+		t.Errorf("ProbeAlias = %q, want lineitem", cand.ProbeAlias)
+	}
+	if len(cand.BuildKeys) != 1 || cand.BuildKeys[0] != "o_orderkey" {
+		t.Errorf("BuildKeys = %v, want [o_orderkey]", cand.BuildKeys)
+	}
+	if len(cand.ProbeKeys) != 1 || cand.ProbeKeys[0] != "l_orderkey" {
+		t.Errorf("ProbeKeys = %v, want [l_orderkey]", cand.ProbeKeys)
+	}
+	if cand.JoinStageID != "join-1" {
+		t.Errorf("JoinStageID = %q, want join-1", cand.JoinStageID)
+	}
+}
+
+// TestPickShuffleCandidate_FusedJoinMatch covers the case where the shuffle
+// candidate is referenced only via a FusedJoin entry, not the top-level join
+// deps. The candidate (large_dim at 6 GB) is the build of a fused secondary
+// join; the top-level join connects lineitem (probe) to supplier directly.
+func TestPickShuffleCandidate_FusedJoinMatch(t *testing.T) {
+	stages := []Stage{
+		{ID: "scan-lineitem", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 75 << 30},
+		{ID: "scan-supplier", Type: "scan", ScanAlias: "supplier", EstimatedBytes: 500 << 20},
+		{ID: "scan-large_dim", Type: "scan", ScanAlias: "large_dim", EstimatedBytes: 6 << 30},
+		{
+			// Top-level join: lineitem (probe, left) JOIN supplier (build, right).
+			// large_dim is fused in as a secondary build.
+			ID: "join-1", Type: "broadcast_join",
+			BuildTableAlias: "supplier",
+			LeftDepStage:    "scan-lineitem",
+			RightDepStage:   "scan-supplier",
+			JoinLeftKeys:    []string{"l_suppkey"},
+			JoinRightKeys:   []string{"s_suppkey"},
+			FusedJoins: []FusedJoinSpec{
+				{
+					BuildTableAlias: "large_dim",
+					JoinLeftKeys:    []string{"l_dimkey"},
+					JoinRightKeys:   []string{"d_dimkey"},
+				},
+			},
+		},
+	}
+	cand, ok := PickShuffleCandidate(stages, 4<<30)
+	if !ok {
+		t.Fatal("expected shuffle candidate (large_dim via fused join)")
+	}
+	if cand.BuildAlias != "large_dim" {
+		t.Errorf("BuildAlias = %q, want large_dim", cand.BuildAlias)
+	}
+	if cand.ProbeAlias != "lineitem" {
+		t.Errorf("ProbeAlias = %q, want lineitem", cand.ProbeAlias)
+	}
+	// FusedJoin keys: JoinRightKeys=d_dimkey (build), JoinLeftKeys=l_dimkey (probe).
+	if len(cand.BuildKeys) != 1 || cand.BuildKeys[0] != "d_dimkey" {
+		t.Errorf("BuildKeys = %v, want [d_dimkey]", cand.BuildKeys)
+	}
+	if len(cand.ProbeKeys) != 1 || cand.ProbeKeys[0] != "l_dimkey" {
+		t.Errorf("ProbeKeys = %v, want [l_dimkey]", cand.ProbeKeys)
+	}
+	if cand.JoinStageID != "join-1" {
+		t.Errorf("JoinStageID = %q, want join-1", cand.JoinStageID)
 	}
 }

--- a/internal/planner/physical/shuffle_insertion_test.go
+++ b/internal/planner/physical/shuffle_insertion_test.go
@@ -7,8 +7,10 @@ func TestPickShuffleCandidate_PicksLargestBuildAboveThreshold(t *testing.T) {
 		{ID: "scan-orders", Type: "scan", ScanAlias: "orders", EstimatedBytes: 8 << 30},      // 8 GB - above
 		{ID: "scan-customer", Type: "scan", ScanAlias: "customer", EstimatedBytes: 100 << 20}, // 100 MB - below
 		{ID: "scan-lineitem", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 80 << 30},  // 80 GB - probe
-		{ID: "join-1", Type: "hash_join", BuildTableAlias: "orders", JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"}, Dependencies: []string{"scan-orders", "scan-lineitem"}},
-		{ID: "join-2", Type: "hash_join", BuildTableAlias: "customer", JoinLeftKeys: []string{"o_custkey"}, JoinRightKeys: []string{"c_custkey"}, Dependencies: []string{"join-1", "scan-customer"}},
+		// join-1: lineitem (probe, left) JOIN orders (build, right) — LeftDepStage must be the probe scan.
+		{ID: "join-1", Type: "hash_join", BuildTableAlias: "orders", LeftDepStage: "scan-lineitem", JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"}, Dependencies: []string{"scan-lineitem", "scan-orders"}},
+		// join-2: left dep is join-1 (not the probe scan directly) — skipped by candidate selection.
+		{ID: "join-2", Type: "hash_join", BuildTableAlias: "customer", LeftDepStage: "join-1", JoinLeftKeys: []string{"o_custkey"}, JoinRightKeys: []string{"c_custkey"}, Dependencies: []string{"join-1", "scan-customer"}},
 	}
 	cand, ok := PickShuffleCandidate(stages, 4<<30 /* threshold */)
 	if !ok {
@@ -63,12 +65,50 @@ func TestPickShuffleCandidate_NoJoins(t *testing.T) {
 	}
 }
 
+// TestPickShuffleCandidate_RejectsIndirectProbeJoin checks that a join where the
+// build is above threshold but the probe (left dep) is not the probeAlias scan
+// directly is NOT selected. This guards against "key not in schema" at shuffle
+// time when the JoinLeftKeys belong to an intermediate join output rather than
+// the raw probeAlias Parquet files (the Q05/Q07/Q10 regression pattern).
+func TestPickShuffleCandidate_RejectsIndirectProbeJoin(t *testing.T) {
+	// Simulates Q05: nation is the build, lineitem is the probe, but the only
+	// join stage referencing nation has LeftDepStage=join-1 (not scan-lineitem).
+	// JoinLeftKeys=[s_nationkey] would fail against raw lineitem files.
+	stages := []Stage{
+		{ID: "scan-nation", Type: "scan", ScanAlias: "nation", EstimatedBytes: 8 << 30},
+		{ID: "scan-lineitem", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 80 << 30},
+		{ID: "scan-supplier", Type: "scan", ScanAlias: "supplier", EstimatedBytes: 500 << 20},
+		// join-1: lineitem JOIN supplier — probe (lineitem) is direct left dep.
+		{ID: "join-1", Type: "hash_join", BuildTableAlias: "supplier", LeftDepStage: "scan-lineitem",
+			JoinLeftKeys: []string{"l_suppkey"}, JoinRightKeys: []string{"s_suppkey"}},
+		// join-2: join-1 JOIN nation — left dep is join-1, not scan-lineitem.
+		// JoinLeftKeys=[s_nationkey] belongs to supplier's output, not raw lineitem.
+		{ID: "join-2", Type: "hash_join", BuildTableAlias: "nation", LeftDepStage: "join-1",
+			JoinLeftKeys: []string{"s_nationkey"}, JoinRightKeys: []string{"n_nationkey"}},
+	}
+	// With threshold below supplier (500 MB) and nation (8 GB), both qualify.
+	// join-1 (supplier build) should be selected because it directly connects probe.
+	// join-2 (nation build) must be rejected because LeftDepStage != probeScanID.
+	cand, ok := PickShuffleCandidate(stages, 100<<20)
+	if !ok {
+		t.Fatal("expected shuffle candidate for join-1 (direct probe join)")
+	}
+	if cand.BuildAlias != "supplier" {
+		t.Errorf("BuildAlias = %q, want supplier (join-1 is the only valid direct candidate)", cand.BuildAlias)
+	}
+	if cand.JoinStageID != "join-1" {
+		t.Errorf("JoinStageID = %q, want join-1", cand.JoinStageID)
+	}
+}
+
 func TestPickShuffleCandidate_MatchesBroadcastJoin(t *testing.T) {
 	stages := []Stage{
 		{ID: "scan-orders", Type: "scan", ScanAlias: "orders", EstimatedBytes: 8 << 30},
 		{ID: "scan-lineitem", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 80 << 30},
 		// Same shape as the hash_join test, but the join is classified as broadcast_join.
+		// LeftDepStage must be the probe scan for the candidate to be selected.
 		{ID: "join-1", Type: "broadcast_join", BuildTableAlias: "orders",
+			LeftDepStage: "scan-lineitem",
 			JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"}},
 	}
 	cand, ok := PickShuffleCandidate(stages, 4<<30)

--- a/internal/planner/physical/shuffle_insertion_test.go
+++ b/internal/planner/physical/shuffle_insertion_test.go
@@ -1,0 +1,64 @@
+package physical
+
+import "testing"
+
+func TestPickShuffleCandidate_PicksLargestBuildAboveThreshold(t *testing.T) {
+	stages := []Stage{
+		{ID: "scan-orders", Type: "scan", ScanAlias: "orders", EstimatedBytes: 8 << 30},      // 8 GB - above
+		{ID: "scan-customer", Type: "scan", ScanAlias: "customer", EstimatedBytes: 100 << 20}, // 100 MB - below
+		{ID: "scan-lineitem", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 80 << 30},  // 80 GB - probe
+		{ID: "join-1", Type: "hash_join", BuildTableAlias: "orders", JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"}, Dependencies: []string{"scan-orders", "scan-lineitem"}},
+		{ID: "join-2", Type: "hash_join", BuildTableAlias: "customer", JoinLeftKeys: []string{"o_custkey"}, JoinRightKeys: []string{"c_custkey"}, Dependencies: []string{"join-1", "scan-customer"}},
+	}
+	cand, ok := PickShuffleCandidate(stages, 4<<30 /* threshold */)
+	if !ok {
+		t.Fatal("expected shuffle candidate")
+	}
+	if cand.BuildAlias != "orders" {
+		t.Errorf("BuildAlias = %q, want orders", cand.BuildAlias)
+	}
+	if cand.ProbeAlias != "lineitem" {
+		t.Errorf("ProbeAlias = %q, want lineitem", cand.ProbeAlias)
+	}
+	if len(cand.JoinKeys) != 1 || cand.JoinKeys[0] != "o_orderkey" {
+		t.Errorf("JoinKeys = %v, want [o_orderkey]", cand.JoinKeys)
+	}
+	if cand.JoinStageID != "join-1" {
+		t.Errorf("JoinStageID = %q, want join-1", cand.JoinStageID)
+	}
+	if cand.BuildBytes != 8<<30 {
+		t.Errorf("BuildBytes = %d, want %d", cand.BuildBytes, int64(8<<30))
+	}
+}
+
+func TestPickShuffleCandidate_NoCandidateBelowThreshold(t *testing.T) {
+	stages := []Stage{
+		{ID: "scan-orders", Type: "scan", ScanAlias: "orders", EstimatedBytes: 1 << 30}, // 1 GB - below 4 GB threshold
+		{ID: "scan-lineitem", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 80 << 30},
+		{ID: "join-1", Type: "hash_join", BuildTableAlias: "orders", JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"}},
+	}
+	if _, ok := PickShuffleCandidate(stages, 4<<30); ok {
+		t.Error("expected no shuffle candidate below threshold")
+	}
+}
+
+func TestPickShuffleCandidate_BuildEqualsProbeAliasIsRejected(t *testing.T) {
+	// Pathological / self-join case: if the only "build" is the same scan as the
+	// probe, we shouldn't shuffle (no separate build to partition).
+	stages := []Stage{
+		{ID: "scan-orders", Type: "scan", ScanAlias: "orders", EstimatedBytes: 80 << 30},
+		{ID: "join-1", Type: "hash_join", BuildTableAlias: "orders", JoinLeftKeys: []string{"a"}, JoinRightKeys: []string{"b"}},
+	}
+	if _, ok := PickShuffleCandidate(stages, 4<<30); ok {
+		t.Error("expected no candidate when build alias == probe alias")
+	}
+}
+
+func TestPickShuffleCandidate_NoJoins(t *testing.T) {
+	stages := []Stage{
+		{ID: "scan-only", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 80 << 30},
+	}
+	if _, ok := PickShuffleCandidate(stages, 4<<30); ok {
+		t.Error("expected no candidate when there are no join stages")
+	}
+}

--- a/internal/planner/physical/shuffle_insertion_test.go
+++ b/internal/planner/physical/shuffle_insertion_test.go
@@ -62,3 +62,20 @@ func TestPickShuffleCandidate_NoJoins(t *testing.T) {
 		t.Error("expected no candidate when there are no join stages")
 	}
 }
+
+func TestPickShuffleCandidate_MatchesBroadcastJoin(t *testing.T) {
+	stages := []Stage{
+		{ID: "scan-orders", Type: "scan", ScanAlias: "orders", EstimatedBytes: 8 << 30},
+		{ID: "scan-lineitem", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 80 << 30},
+		// Same shape as the hash_join test, but the join is classified as broadcast_join.
+		{ID: "join-1", Type: "broadcast_join", BuildTableAlias: "orders",
+			JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"}},
+	}
+	cand, ok := PickShuffleCandidate(stages, 4<<30)
+	if !ok {
+		t.Fatal("expected shuffle candidate for broadcast_join above threshold")
+	}
+	if cand.JoinKeys[0] != "o_orderkey" {
+		t.Errorf("JoinKeys = %v, want [o_orderkey]", cand.JoinKeys)
+	}
+}

--- a/internal/planner/physical/shuffle_insertion_test.go
+++ b/internal/planner/physical/shuffle_insertion_test.go
@@ -189,6 +189,76 @@ func TestPickShuffleCandidate_Q03Shape(t *testing.T) {
 	}
 }
 
+// TestPickShuffleCandidate_Q10Shape mirrors Q10's actual physical plan structure:
+// customer JOIN orders JOIN lineitem JOIN nation. The planner emits two broadcast
+// joins — join-4 (orders×nation, with customer fused) and join-6 (join-4×lineitem).
+// orders is the shuffle candidate (second largest), but join-4 has LeftDepStage=orders
+// with JoinLeftKeys=[c_nationkey] — a key that comes from the fused customer join
+// output, NOT from raw orders Parquet. The column-anchored fallback must reject
+// c_nationkey (not in orders.Columns) and instead pick join-6 whose JoinLeftKeys=
+// [o_orderkey] ARE in orders.Columns.
+func TestPickShuffleCandidate_Q10Shape(t *testing.T) {
+	stages := []Stage{
+		// orders: 2nd largest (shuffle candidate)
+		{
+			ID: "scan-orders", Type: "scan", ScanAlias: "orders", EstimatedBytes: 8 << 30,
+			Columns: []string{"o_orderkey", "o_custkey", "o_orderdate"},
+		},
+		{
+			ID: "scan-customer", Type: "scan", ScanAlias: "customer", EstimatedBytes: 1500 << 20,
+			Columns: []string{"c_custkey", "c_nationkey", "c_name", "c_acctbal"},
+		},
+		{
+			ID: "scan-nation", Type: "scan", ScanAlias: "nation", EstimatedBytes: 5 << 20,
+			Columns: []string{"n_nationkey", "n_name"},
+		},
+		// lineitem: largest (probe)
+		{
+			ID: "scan-lineitem", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 75 << 30,
+			Columns: []string{"l_orderkey", "l_extendedprice", "l_discount", "l_returnflag"},
+		},
+		// join-4: orders (direct left dep) JOIN nation, fused with customer.
+		// JoinLeftKeys=[c_nationkey] — this key comes from the fused customer output,
+		// NOT from raw orders files. Should be rejected by column validation.
+		{
+			ID: "join-4", Type: "broadcast_join", BuildTableAlias: "nation",
+			LeftDepStage: "scan-orders", RightDepStage: "scan-nation",
+			JoinLeftKeys: []string{"c_nationkey"}, JoinRightKeys: []string{"n_nationkey"},
+			FusedJoins: []FusedJoinSpec{
+				{BuildTableAlias: "customer", JoinLeftKeys: []string{"o_custkey"}, JoinRightKeys: []string{"c_custkey"}},
+			},
+		},
+		// join-6: join-4 (indirect left dep) JOIN lineitem.
+		// JoinLeftKeys=[o_orderkey] — this key IS in orders.Columns.
+		// The column-anchored fallback should pick this join.
+		{
+			ID: "join-6", Type: "broadcast_join", BuildTableAlias: "lineitem",
+			LeftDepStage: "join-4", RightDepStage: "scan-lineitem",
+			JoinLeftKeys: []string{"o_orderkey"}, JoinRightKeys: []string{"l_orderkey"},
+		},
+	}
+	cand, ok := PickShuffleCandidate(stages, 4<<30)
+	if !ok {
+		t.Fatal("expected shuffle candidate (orders)")
+	}
+	if cand.BuildAlias != "orders" {
+		t.Errorf("BuildAlias = %q, want orders", cand.BuildAlias)
+	}
+	if cand.ProbeAlias != "lineitem" {
+		t.Errorf("ProbeAlias = %q, want lineitem", cand.ProbeAlias)
+	}
+	// Must use o_orderkey (from orders.Columns), not c_nationkey (from fused join output).
+	if len(cand.BuildKeys) != 1 || cand.BuildKeys[0] != "o_orderkey" {
+		t.Errorf("BuildKeys = %v, want [o_orderkey]", cand.BuildKeys)
+	}
+	if len(cand.ProbeKeys) != 1 || cand.ProbeKeys[0] != "l_orderkey" {
+		t.Errorf("ProbeKeys = %v, want [l_orderkey]", cand.ProbeKeys)
+	}
+	if cand.JoinStageID != "join-6" {
+		t.Errorf("JoinStageID = %q, want join-6", cand.JoinStageID)
+	}
+}
+
 // TestPickShuffleCandidate_FusedJoinMatch covers the case where the shuffle
 // candidate is referenced only via a FusedJoin entry, not the top-level join
 // deps. The candidate (large_dim at 6 GB) is the build of a fused secondary

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -167,6 +168,8 @@ func (e *Executor) Execute(ctx context.Context, task distributed.Task, workerID 
 	switch task.Type {
 	case distributed.TaskTypePipeline:
 		err = e.executePipeline(ctx, task, &result)
+	case distributed.TaskTypeShuffle:
+		err = e.executeShuffle(ctx, task, &result)
 	default:
 		err = fmt.Errorf("unsupported task type: %s", task.Type)
 	}
@@ -468,6 +471,131 @@ func (e *Executor) executeBuildCachePreScan(ctx context.Context, task distribute
 	}
 	result.ResultPath = resultPath
 	result.SizeBytes = fi.Size()
+	return nil
+}
+
+// executeShuffle reads source Parquet files from S3, hash-partitions every row
+// on task.ShuffleKeys into task.NumPartitions output .wshf files, and uploads
+// each non-empty partition file to S3 under
+//
+//	<ResultBucket>/<ResultPrefix>/partition=NNNN/<TaskID>.wshf
+//
+// Populated result fields: ResultFiles, NumRows, SizeBytes.
+func (e *Executor) executeShuffle(ctx context.Context, task distributed.Task, result *distributed.ResultNotification) error {
+	if len(task.ShuffleKeys) == 0 {
+		return fmt.Errorf("shuffle task %s: ShuffleKeys must not be empty", task.ID)
+	}
+	if task.NumPartitions <= 0 {
+		return fmt.Errorf("shuffle task %s: NumPartitions must be > 0, got %d", task.ID, task.NumPartitions)
+	}
+	if len(task.Files) == 0 {
+		return fmt.Errorf("shuffle task %s: Files must not be empty", task.ID)
+	}
+
+	bucket := task.DataBucket
+	if bucket == "" {
+		bucket = task.ResultBucket
+	}
+
+	// Read all source Parquet files into batches. Uses the executor's
+	// existing range-read + LRU cache path; no planner/catalog needed.
+	batches, err := e.readParquetFilesConcurrentBatches(ctx, bucket, task.Files, task.Columns)
+	if err != nil {
+		return fmt.Errorf("shuffle task %s: reading source files: %w", task.ID, err)
+	}
+	if len(batches) == 0 {
+		// Source files produced no rows — nothing to upload.
+		return nil
+	}
+
+	// Extract schema from first non-empty batch.
+	var schema []parquet.Column
+	for _, b := range batches {
+		if b != nil && len(b.Schema) > 0 {
+			schema = b.Schema
+			break
+		}
+	}
+	if schema == nil {
+		return fmt.Errorf("shuffle task %s: could not determine schema from source batches", task.ID)
+	}
+
+	// Set up the spill directory for the sink's partition files.
+	spillDir := filepath.Join(e.spillDir, "shuffle-"+task.ID)
+	if e.spillDir == "" {
+		spillDir = filepath.Join(os.TempDir(), "shuffle-"+task.ID)
+	}
+	if err := os.MkdirAll(spillDir, 0o755); err != nil {
+		return fmt.Errorf("shuffle task %s: creating spill dir: %w", task.ID, err)
+	}
+
+	sink := newPartitionedShuffleSink(spillDir, task.ShuffleKeys, task.NumPartitions, schema)
+	if err := sink.Init(ctx); err != nil {
+		return fmt.Errorf("shuffle task %s: init sink: %w", task.ID, err)
+	}
+	defer sink.Close()
+
+	// Feed all batches into the sink and count rows.
+	var totalRows int64
+	for _, b := range batches {
+		if b == nil {
+			continue
+		}
+		n := int64(b.ActiveLen())
+		if n == 0 {
+			continue
+		}
+		if err := sink.Consume(ctx, b); err != nil {
+			return fmt.Errorf("shuffle task %s: consuming batch: %w", task.ID, err)
+		}
+		totalRows += n
+	}
+
+	if err := sink.Finalize(ctx); err != nil {
+		return fmt.Errorf("shuffle task %s: finalizing sink: %w", task.ID, err)
+	}
+
+	// Upload each non-empty partition file to S3.
+	partFiles := sink.PartitionFiles()
+	for p, localPath := range partFiles {
+		if localPath == "" {
+			continue // empty partition
+		}
+		f, err := os.Open(localPath)
+		if err != nil {
+			return fmt.Errorf("shuffle task %s: opening partition %d: %w", task.ID, p, err)
+		}
+		fi, err := f.Stat()
+		if err != nil {
+			f.Close()
+			return fmt.Errorf("shuffle task %s: stat partition %d: %w", task.ID, p, err)
+		}
+
+		key := fmt.Sprintf("%spartition=%04d/%s.wshf", task.ResultPrefix, p, task.ID)
+		_, uploadErr := e.store.Put(ctx, task.ResultBucket, key, f, fi.Size(), "application/octet-stream")
+		f.Close()
+		if uploadErr != nil {
+			return fmt.Errorf("shuffle task %s: uploading partition %d: %w", task.ID, p, uploadErr)
+		}
+
+		result.ResultFiles = append(result.ResultFiles, key)
+		result.SizeBytes += fi.Size()
+
+		// Remove local file best-effort.
+		if removeErr := os.Remove(localPath); removeErr != nil {
+			e.logger.Warn("shuffle: failed to remove local partition file",
+				"task_id", task.ID, "partition", p, "path", localPath, "error", removeErr)
+		}
+	}
+
+	result.NumRows = totalRows
+
+	e.logger.Info("shuffle task completed",
+		"task_id", task.ID,
+		"rows", totalRows,
+		"partitions", len(result.ResultFiles),
+		"size_bytes", result.SizeBytes,
+	)
 	return nil
 }
 

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -528,6 +528,7 @@ func (e *Executor) executeShuffle(ctx context.Context, task distributed.Task, re
 	if err := os.MkdirAll(spillDir, 0o755); err != nil {
 		return fmt.Errorf("shuffle task %s: creating spill dir: %w", task.ID, err)
 	}
+	defer os.RemoveAll(spillDir)
 
 	sink := newPartitionedShuffleSink(spillDir, task.ShuffleKeys, task.NumPartitions, schema)
 	if err := sink.Init(ctx); err != nil {
@@ -579,6 +580,8 @@ func (e *Executor) executeShuffle(ctx context.Context, task distributed.Task, re
 		}
 
 		result.ResultFiles = append(result.ResultFiles, key)
+		// SizeBytes uses the local file size; the object store does not re-encode
+		// .wshf data so this matches the uploaded byte count.
 		result.SizeBytes += fi.Size()
 
 		// Remove local file best-effort.

--- a/internal/worker/executor_shuffle_test.go
+++ b/internal/worker/executor_shuffle_test.go
@@ -1,0 +1,318 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// TestExecuteShuffle_HappyPath verifies that a shuffle task reads source Parquet
+// files, hash-partitions rows across NumPartitions output files, uploads each
+// non-empty partition to MemStore, and reports the correct total row count.
+func TestExecuteShuffle_HappyPath(t *testing.T) {
+	ctx := context.Background()
+	const bucket = "test-shuffle-exec"
+	const numParts = 4
+	const numRows = 100
+
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(ctx, bucket); err != nil {
+		t.Fatalf("MakeBucket: %v", err)
+	}
+
+	// Write a Parquet file with 100 rows of (k INT64, v STRING).
+	rows := make([]map[string]any, numRows)
+	for i := 0; i < numRows; i++ {
+		rows[i] = map[string]any{
+			"k": int64(i),
+			"v": fmt.Sprintf("value-%d", i),
+		}
+	}
+	writeParquetFile(t, store, bucket, "tables/src/part-0.parquet", rows)
+
+	cache := NewLRUCache(64 * 1024 * 1024)
+	executor := NewExecutor(store, cache, nil /* js — not needed for shuffle */)
+	executor.SetMemoryBudget(0, t.TempDir())
+
+	task := distributed.Task{
+		ID:            "shuf-1",
+		QueryID:       "q-shuf",
+		StageID:       "shuffle-0",
+		Type:          distributed.TaskTypeShuffle,
+		Files:         []string{"tables/src/part-0.parquet"},
+		ShuffleKeys:   []string{"k"},
+		NumPartitions: numParts,
+		DataBucket:    bucket,
+		ResultBucket:  bucket,
+		ResultPrefix:  "shuffle/q-shuf/s0/",
+	}
+
+	result := executor.Execute(ctx, task, "w1")
+	if !result.Success {
+		t.Fatalf("shuffle task failed: %s", result.Error)
+	}
+	if result.NumRows != numRows {
+		t.Errorf("expected %d rows, got %d", numRows, result.NumRows)
+	}
+	if len(result.ResultFiles) == 0 {
+		t.Fatal("expected at least one partition file in ResultFiles")
+	}
+	t.Logf("shuffle: %d rows → %d partition files, %d bytes",
+		result.NumRows, len(result.ResultFiles), result.SizeBytes)
+
+	// Verify each ResultFile key follows the expected naming convention and exists.
+	for _, key := range result.ResultFiles {
+		if !strings.Contains(key, "partition=") {
+			t.Errorf("result file key %q does not contain partition= prefix", key)
+		}
+		if !strings.HasSuffix(key, ".wshf") {
+			t.Errorf("result file key %q does not end with .wshf", key)
+		}
+		rc, _, err := store.Get(ctx, bucket, key)
+		if err != nil {
+			t.Fatalf("result file %q not found in store: %v", key, err)
+		}
+		rc.Close()
+	}
+
+	// Read back all output files and sum rows to verify no row is lost.
+	totalBack := int64(0)
+	for _, key := range result.ResultFiles {
+		rc, _, err := store.Get(ctx, bucket, key)
+		if err != nil {
+			t.Fatalf("reading back %q: %v", key, err)
+		}
+		data, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			t.Fatalf("reading back %q data: %v", key, err)
+		}
+		r, err := newShuffleChunkReader(data)
+		if err != nil {
+			t.Fatalf("parsing %q: %v", key, err)
+		}
+		for {
+			b, err := r.Next()
+			if err != nil {
+				t.Fatalf("chunk reader Next from %q: %v", key, err)
+			}
+			if b == nil {
+				break
+			}
+			totalBack += int64(b.ActiveLen())
+		}
+	}
+	if totalBack != numRows {
+		t.Errorf("read-back total rows = %d, want %d", totalBack, numRows)
+	}
+}
+
+// TestExecuteShuffle_ColumnProjection verifies that Columns projection is respected:
+// only the projected columns appear in the output.
+func TestExecuteShuffle_ColumnProjection(t *testing.T) {
+	ctx := context.Background()
+	const bucket = "test-shuffle-proj"
+
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(ctx, bucket); err != nil {
+		t.Fatalf("MakeBucket: %v", err)
+	}
+
+	rows := []map[string]any{
+		{"k": int64(1), "v": "a", "extra": "x"},
+		{"k": int64(2), "v": "b", "extra": "y"},
+		{"k": int64(3), "v": "c", "extra": "z"},
+	}
+	writeParquetFile(t, store, bucket, "tables/src/proj-0.parquet", rows)
+
+	cache := NewLRUCache(64 * 1024 * 1024)
+	executor := NewExecutor(store, cache, nil)
+	executor.SetMemoryBudget(0, t.TempDir())
+
+	task := distributed.Task{
+		ID:            "shuf-proj",
+		QueryID:       "q-proj",
+		StageID:       "shuffle-0",
+		Type:          distributed.TaskTypeShuffle,
+		Files:         []string{"tables/src/proj-0.parquet"},
+		Columns:       []string{"k", "v"},
+		ShuffleKeys:   []string{"k"},
+		NumPartitions: 2,
+		DataBucket:    bucket,
+		ResultBucket:  bucket,
+		ResultPrefix:  "shuffle/q-proj/s0/",
+	}
+
+	result := executor.Execute(ctx, task, "w1")
+	if !result.Success {
+		t.Fatalf("shuffle (projection) failed: %s", result.Error)
+	}
+	if result.NumRows != 3 {
+		t.Errorf("expected 3 rows, got %d", result.NumRows)
+	}
+
+	// Confirm projected columns only (k, v) appear — not "extra".
+	for _, key := range result.ResultFiles {
+		rc, _, err := store.Get(ctx, bucket, key)
+		if err != nil {
+			t.Fatalf("reading back %q: %v", key, err)
+		}
+		data, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			t.Fatalf("reading data %q: %v", key, err)
+		}
+		if len(data) == 0 {
+			continue
+		}
+		r, err := newShuffleChunkReader(data)
+		if err != nil {
+			t.Fatalf("parsing %q: %v", key, err)
+		}
+		for _, col := range r.schema {
+			if col.Name == "extra" {
+				t.Errorf("unexpected column %q in projected output file %q", col.Name, key)
+			}
+		}
+	}
+}
+
+// TestExecuteShuffle_ValidationErrors checks that missing required fields cause
+// early failures with descriptive errors.
+func TestExecuteShuffle_ValidationErrors(t *testing.T) {
+	ctx := context.Background()
+	store := objstore.NewMemStore()
+	cache := NewLRUCache(1024 * 1024)
+	executor := NewExecutor(store, cache, nil)
+
+	base := distributed.Task{
+		ID:            "shuf-err",
+		QueryID:       "q-err",
+		Type:          distributed.TaskTypeShuffle,
+		Files:         []string{"tables/src/f.parquet"},
+		ShuffleKeys:   []string{"k"},
+		NumPartitions: 4,
+		DataBucket:    "b",
+		ResultBucket:  "b",
+		ResultPrefix:  "p/",
+	}
+
+	cases := []struct {
+		name    string
+		mutate  func(*distributed.Task)
+		wantErr string
+	}{
+		{
+			name:    "no_shuffle_keys",
+			mutate:  func(t *distributed.Task) { t.ShuffleKeys = nil },
+			wantErr: "ShuffleKeys",
+		},
+		{
+			name:    "zero_num_partitions",
+			mutate:  func(t *distributed.Task) { t.NumPartitions = 0 },
+			wantErr: "NumPartitions",
+		},
+		{
+			name:    "no_files",
+			mutate:  func(t *distributed.Task) { t.Files = nil },
+			wantErr: "Files",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			task := base
+			tc.mutate(&task)
+			result := executor.Execute(ctx, task, "w1")
+			if result.Success {
+				t.Fatal("expected failure, got success")
+			}
+			if !strings.Contains(result.Error, tc.wantErr) {
+				t.Errorf("error %q does not mention %q", result.Error, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestExecuteShuffle_SchemaRoundTrip verifies that the output schema matches
+// the input schema (preserving column names and types).
+func TestExecuteShuffle_SchemaRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	const bucket = "test-shuffle-schema"
+
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(ctx, bucket); err != nil {
+		t.Fatalf("MakeBucket: %v", err)
+	}
+
+	rows := []map[string]any{
+		{"id": int64(1), "score": float64(9.5)},
+		{"id": int64(2), "score": float64(7.2)},
+	}
+	writeParquetFile(t, store, bucket, "tables/src/schema-0.parquet", rows)
+
+	cache := NewLRUCache(64 * 1024 * 1024)
+	executor := NewExecutor(store, cache, nil)
+	executor.SetMemoryBudget(0, t.TempDir())
+
+	task := distributed.Task{
+		ID:            "shuf-schema",
+		QueryID:       "q-schema",
+		StageID:       "shuffle-0",
+		Type:          distributed.TaskTypeShuffle,
+		Files:         []string{"tables/src/schema-0.parquet"},
+		ShuffleKeys:   []string{"id"},
+		NumPartitions: 2,
+		DataBucket:    bucket,
+		ResultBucket:  bucket,
+		ResultPrefix:  "shuffle/q-schema/s0/",
+	}
+
+	result := executor.Execute(ctx, task, "w1")
+	if !result.Success {
+		t.Fatalf("shuffle failed: %s", result.Error)
+	}
+	if result.NumRows != 2 {
+		t.Errorf("expected 2 rows, got %d", result.NumRows)
+	}
+
+	wantSchema := map[string]parquet.TypeID{
+		"id":    parquet.TypeInt64,
+		"score": parquet.TypeFloat64,
+	}
+
+	for _, key := range result.ResultFiles {
+		rc, _, err := store.Get(ctx, bucket, key)
+		if err != nil {
+			t.Fatalf("reading %q: %v", key, err)
+		}
+		data, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			t.Fatalf("reading data %q: %v", key, err)
+		}
+		if len(data) == 0 {
+			continue
+		}
+		r, err := newShuffleChunkReader(data)
+		if err != nil {
+			t.Fatalf("parsing %q: %v", key, err)
+		}
+		for _, col := range r.schema {
+			wantType, ok := wantSchema[col.Name]
+			if !ok {
+				t.Errorf("unexpected column %q in output", col.Name)
+				continue
+			}
+			if col.Type != wantType {
+				t.Errorf("column %q: type = %v, want %v", col.Name, col.Type, wantType)
+			}
+		}
+	}
+}

--- a/internal/worker/executor_shuffle_test.go
+++ b/internal/worker/executor_shuffle_test.go
@@ -63,6 +63,9 @@ func TestExecuteShuffle_HappyPath(t *testing.T) {
 	if len(result.ResultFiles) == 0 {
 		t.Fatal("expected at least one partition file in ResultFiles")
 	}
+	if result.SizeBytes == 0 {
+		t.Errorf("result.SizeBytes = 0; expected nonzero after writing 100 rows")
+	}
 	t.Logf("shuffle: %d rows → %d partition files, %d bytes",
 		result.NumRows, len(result.ResultFiles), result.SizeBytes)
 

--- a/internal/worker/partition_shard_source.go
+++ b/internal/worker/partition_shard_source.go
@@ -1,0 +1,28 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+)
+
+// newPartitionShardSource lists all .wshf files at the given S3 prefix and
+// returns a streaming source over them. Used by the probe-side worker in a
+// shuffle-distributed query: each worker is assigned one or more partition
+// prefixes, and instantiates one source per assigned partition to read the
+// hash-shard rows that belong to its partition.
+//
+// Files are read sequentially; each is fully drained before the next one
+// starts. This matches the existing cachedFileStreamSource semantics.
+func newPartitionShardSource(ctx context.Context, executor *Executor, bucket, prefix string) (*cachedFileStreamSource, error) {
+	infos, err := executor.store.List(ctx, bucket, objstore.ListOptions{Prefix: prefix})
+	if err != nil {
+		return nil, fmt.Errorf("listing partition prefix %q: %w", prefix, err)
+	}
+	files := make([]string, 0, len(infos))
+	for _, info := range infos {
+		files = append(files, info.Key)
+	}
+	return newCachedFileStreamSource(executor, bucket, files), nil
+}

--- a/internal/worker/partition_shard_source_test.go
+++ b/internal/worker/partition_shard_source_test.go
@@ -1,0 +1,188 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// makeWshfBytes serializes rows (int64 values) into a WSHF byte slice using
+// the same code path that the production sink uses.
+func makeWshfBytes(t *testing.T, vals []int64) []byte {
+	t.Helper()
+	schema := []parquet.Column{{Name: "v", Type: parquet.TypeInt64}}
+	var buf bytes.Buffer
+	sw := newShuffleWriter(&buf, schema)
+	if err := sw.writeHeader(); err != nil {
+		t.Fatalf("makeWshfBytes writeHeader: %v", err)
+	}
+	b := batch.NewRecordBatch(schema, len(vals))
+	for i, v := range vals {
+		b.Columns[0].Int64Data[i] = v
+		b.Columns[0].Nulls.SetValid(i)
+	}
+	if err := sw.writeChunk(b.Columns, nil, len(vals)); err != nil {
+		t.Fatalf("makeWshfBytes writeChunk: %v", err)
+	}
+	// Patch chunk count in header (offset 4, uint32 LE).
+	data := buf.Bytes()
+	data[4] = byte(sw.numChunks)
+	data[5] = byte(sw.numChunks >> 8)
+	data[6] = byte(sw.numChunks >> 16)
+	data[7] = byte(sw.numChunks >> 24)
+	return data
+}
+
+// TestPartitionShardSource_ReadsAllFiles stages two .wshf files at a single
+// partition prefix in MemStore and confirms the source streams every row
+// from both.
+func TestPartitionShardSource_ReadsAllFiles(t *testing.T) {
+	ctx := context.Background()
+	const bucket = "test-shuffle"
+	const prefix = "shuffle/q1/s0/partition=03/"
+
+	// Build two small WSHF payloads.
+	file0Data := makeWshfBytes(t, []int64{10, 20, 30})
+	file1Data := makeWshfBytes(t, []int64{40, 50})
+
+	// Stage them in MemStore.
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(ctx, bucket); err != nil {
+		t.Fatalf("MakeBucket: %v", err)
+	}
+	key0 := prefix + "file-0.wshf"
+	key1 := prefix + "file-1.wshf"
+	if _, err := store.Put(ctx, bucket, key0, bytes.NewReader(file0Data), int64(len(file0Data)), "application/octet-stream"); err != nil {
+		t.Fatalf("Put file-0: %v", err)
+	}
+	if _, err := store.Put(ctx, bucket, key1, bytes.NewReader(file1Data), int64(len(file1Data)), "application/octet-stream"); err != nil {
+		t.Fatalf("Put file-1: %v", err)
+	}
+
+	// Construct a minimal Executor wired to the MemStore. Pass nil for the
+	// LRU cache and JetStream — newPartitionShardSource only needs the store.
+	// The cachedFileStreamSource will fall back to the in-memory WSHF path
+	// (openShuffleInMemory) because spillDir is empty.
+	cache := NewLRUCache(4 * 1024 * 1024)
+	executor := NewExecutor(store, cache, nil /* js — not needed */)
+
+	src, err := newPartitionShardSource(ctx, executor, bucket, prefix)
+	if err != nil {
+		t.Fatalf("newPartitionShardSource: %v", err)
+	}
+	defer src.Close()
+
+	if err := src.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	var totalRows int
+	for {
+		b, err := src.Next(ctx)
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+		if b == nil {
+			break
+		}
+		totalRows += b.ActiveLen()
+	}
+
+	const want = 5 // 3 from file-0 + 2 from file-1
+	if totalRows != want {
+		t.Errorf("total rows = %d, want %d", totalRows, want)
+	}
+}
+
+// TestPartitionShardSource_EmptyPrefix verifies that listing a prefix with no
+// matching files returns a source that immediately yields nil (EOF).
+func TestPartitionShardSource_EmptyPrefix(t *testing.T) {
+	ctx := context.Background()
+	const bucket = "test-shuffle-empty"
+
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(ctx, bucket); err != nil {
+		t.Fatalf("MakeBucket: %v", err)
+	}
+
+	cache := NewLRUCache(4 * 1024 * 1024)
+	executor := NewExecutor(store, cache, nil)
+
+	src, err := newPartitionShardSource(ctx, executor, bucket, "shuffle/no-such-prefix/")
+	if err != nil {
+		t.Fatalf("newPartitionShardSource: %v", err)
+	}
+	defer src.Close()
+
+	if err := src.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	b, err := src.Next(ctx)
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if b != nil {
+		t.Errorf("expected nil batch from empty prefix, got %d rows", b.ActiveLen())
+	}
+}
+
+// TestPartitionShardSource_SpillDir exercises the mmap/spill path when a spill
+// directory is available (the production worker code path).
+func TestPartitionShardSource_SpillDir(t *testing.T) {
+	ctx := context.Background()
+	const bucket = "test-shuffle-spill"
+	const prefix = "shuffle/q2/s0/partition=01/"
+
+	file0Data := makeWshfBytes(t, []int64{100, 200, 300, 400})
+
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(ctx, bucket); err != nil {
+		t.Fatalf("MakeBucket: %v", err)
+	}
+	key0 := prefix + "file-0.wshf"
+	if _, err := store.Put(ctx, bucket, key0, bytes.NewReader(file0Data), int64(len(file0Data)), "application/octet-stream"); err != nil {
+		t.Fatalf("Put file-0: %v", err)
+	}
+
+	spillDir := t.TempDir()
+	// Verify the spill directory is writable.
+	if _, err := os.Stat(spillDir); err != nil {
+		t.Fatalf("spill dir: %v", err)
+	}
+
+	cache := NewLRUCache(4 * 1024 * 1024)
+	executor := NewExecutor(store, cache, nil)
+	executor.SetMemoryBudget(0, spillDir)
+
+	src, err := newPartitionShardSource(ctx, executor, bucket, prefix)
+	if err != nil {
+		t.Fatalf("newPartitionShardSource: %v", err)
+	}
+	defer src.Close()
+
+	if err := src.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	var totalRows int
+	for {
+		b, err := src.Next(ctx)
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+		if b == nil {
+			break
+		}
+		totalRows += b.ActiveLen()
+	}
+
+	if totalRows != 4 {
+		t.Errorf("total rows = %d, want 4", totalRows)
+	}
+}

--- a/internal/worker/partitioned_shuffle_sink.go
+++ b/internal/worker/partitioned_shuffle_sink.go
@@ -84,7 +84,8 @@ func (s *partitionedShuffleSink) Init(_ context.Context) error {
 
 // Consume hash-partitions each row in b into its target partition, appending
 // to that partition's row buffer. Buffers are flushed when they exceed
-// flushBytes worth of accumulated rows.
+// flushBytes worth of accumulated rows. Safe for concurrent calls from
+// parallel pipeline workers — serialized via mu.
 func (s *partitionedShuffleSink) Consume(_ context.Context, b *batch.RecordBatch) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -298,10 +299,8 @@ func (s *partitionedShuffleSink) flushPartition(p int) error {
 		switch col.Type {
 		case parquet.TypeString, parquet.TypeBytes, parquet.TypeIPv6, parquet.TypeCIDR, parquet.TypeUUID:
 			col.BytesData.Data = col.BytesData.Data[:0]
-			// Keep Offsets slice; reset all to 0.
-			for i := range col.BytesData.Offsets {
-				col.BytesData.Offsets[i] = 0
-			}
+			col.BytesData.Offsets = col.BytesData.Offsets[:1]
+			col.BytesData.Offsets[0] = 0
 		}
 	}
 	return nil
@@ -309,6 +308,10 @@ func (s *partitionedShuffleSink) flushPartition(p int) error {
 
 // Finalize flushes all partition buffers, then patches the chunk count in each
 // file header (mirrors shuffleStreamSink.Finalize exactly for the patch logic).
+//
+// On error, partitions after the failing one may be left with numChunks=0
+// in their headers (an inconsistent on-disk state). Callers MUST NOT upload
+// any partition file if Finalize returns a non-nil error.
 func (s *partitionedShuffleSink) Finalize(_ context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -362,8 +365,12 @@ func (s *partitionedShuffleSink) Close() error {
 	return nil
 }
 
-// PartitionFiles returns the local file paths for each partition (index = partition id).
-// Empty string for a partition that received zero rows.
+// PartitionFiles returns the local file paths produced for each partition,
+// indexed by partition id. An empty string indicates the partition received
+// zero rows.
+//
+// Must be called AFTER Finalize. Calling it earlier will return empty strings
+// for partitions whose buffered rows had not yet flushed.
 func (s *partitionedShuffleSink) PartitionFiles() []string {
 	out := make([]string, s.numParts)
 	for p, pw := range s.parts {
@@ -373,16 +380,6 @@ func (s *partitionedShuffleSink) PartitionFiles() []string {
 		out[p] = pw.file.Name()
 	}
 	return out
-}
-
-// hashInt64 hashes a single int64 value using FNV-1a. Exported for use in
-// tests to verify that partition assignments match expected routing.
-func hashInt64(v int64) uint64 {
-	h := fnv.New64a()
-	var buf [8]byte
-	binary.LittleEndian.PutUint64(buf[:], uint64(v))
-	_, _ = h.Write(buf[:])
-	return h.Sum64()
 }
 
 // hashVectorValue mixes a single column value at the given row into h using

--- a/internal/worker/partitioned_shuffle_sink.go
+++ b/internal/worker/partitioned_shuffle_sink.go
@@ -1,0 +1,411 @@
+package worker
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"hash/fnv"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// partitionedShuffleSink is an exec.Sink that hash-partitions incoming batches
+// into N output .wshf files, one per partition. Each partition's writer flushes
+// its accumulated rows once a per-partition buffer threshold is reached, so
+// peak memory is bounded by (N partitions × flush threshold), independent of
+// the total input size.
+//
+// This is the build-side and probe-side output sink for the shuffle execution
+// path. The N output files are uploaded by the executor to S3 under a stable
+// per-partition prefix, and downstream join tasks read all files at their
+// assigned partition prefix via partitionShardSource.
+type partitionedShuffleSink struct {
+	spillDir   string
+	keys       []string // partition key column names
+	numParts   int
+	schema     []parquet.Column
+	flushBytes int // per-partition row buffer flush threshold
+
+	mu      sync.Mutex
+	parts   []*partitionWriter
+	closed  bool
+	keyIdxs []int // resolved column indices for keys (set on first Consume)
+}
+
+// partitionWriter holds the open file handle and incremental state for one
+// output partition.
+type partitionWriter struct {
+	file    *os.File
+	writer  *shuffleWriter
+	rowBuf  *batch.RecordBatch // accumulator: rows destined for this partition
+	bufRows int                // rows currently in rowBuf
+	bufBytes int               // approximate byte count of buffered rows
+	numRows int64              // total rows written to disk
+}
+
+// flushPartitionBytes is the per-partition accumulator size (in approx bytes
+// of row data) at which we flush a chunk to disk. 64 KB keeps memory bounded:
+// 4N partitions × 64 KB = ~768 KB per shuffle task at N=3.
+const flushPartitionBytes = 64 * 1024
+
+func newPartitionedShuffleSink(spillDir string, keys []string, numParts int, schema []parquet.Column) *partitionedShuffleSink {
+	return &partitionedShuffleSink{
+		spillDir:   spillDir,
+		keys:       keys,
+		numParts:   numParts,
+		schema:     schema,
+		flushBytes: flushPartitionBytes,
+		parts:      make([]*partitionWriter, numParts),
+	}
+}
+
+// Init creates the per-partition spill files.
+func (s *partitionedShuffleSink) Init(_ context.Context) error {
+	if s.spillDir == "" {
+		return fmt.Errorf("partitionedShuffleSink: spillDir empty")
+	}
+	if err := os.MkdirAll(s.spillDir, 0o755); err != nil {
+		return fmt.Errorf("creating spill dir: %w", err)
+	}
+	for p := 0; p < s.numParts; p++ {
+		path := filepath.Join(s.spillDir, fmt.Sprintf("part-%04d.wshf", p))
+		f, err := os.Create(path)
+		if err != nil {
+			return fmt.Errorf("creating partition %d: %w", p, err)
+		}
+		s.parts[p] = &partitionWriter{file: f}
+	}
+	return nil
+}
+
+// Consume hash-partitions each row in b into its target partition, appending
+// to that partition's row buffer. Buffers are flushed when they exceed
+// flushBytes worth of accumulated rows.
+func (s *partitionedShuffleSink) Consume(_ context.Context, b *batch.RecordBatch) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.keyIdxs) == 0 {
+		// Resolve key column indices from schema on first batch.
+		s.keyIdxs = make([]int, len(s.keys))
+		for i, k := range s.keys {
+			idx := -1
+			for j, col := range b.Schema {
+				if col.Name == k {
+					idx = j
+					break
+				}
+			}
+			if idx < 0 {
+				return fmt.Errorf("partitioned shuffle: key %q not in schema", k)
+			}
+			s.keyIdxs[i] = idx
+		}
+	}
+
+	n := b.ActiveLen()
+	for i := 0; i < n; i++ {
+		row := i
+		if b.Sel != nil {
+			row = int(b.Sel[i])
+		}
+		p := s.partitionFor(b, row)
+		if err := s.appendRow(p, b, row); err != nil {
+			return err
+		}
+	}
+	return s.flushIfNeeded()
+}
+
+// partitionFor computes hash(b.Columns[keyIdxs][row]) % numParts using FNV-1a.
+func (s *partitionedShuffleSink) partitionFor(b *batch.RecordBatch, row int) int {
+	h := fnv.New64a()
+	var buf [8]byte
+	for _, idx := range s.keyIdxs {
+		hashVectorValue(h, b.Columns[idx], row, buf[:])
+	}
+	return int(h.Sum64() % uint64(s.numParts))
+}
+
+// appendRow copies a single row from b at physical row index `row` into the
+// accumulator buffer for partition p. The buffer is a RecordBatch that grows
+// one row at a time; we copy typed column data directly, mirroring the approach
+// used by batch.Compact.
+func (s *partitionedShuffleSink) appendRow(p int, b *batch.RecordBatch, row int) error {
+	pw := s.parts[p]
+	if pw.rowBuf == nil {
+		// Allocate buffer with a reasonable initial capacity to reduce resizes.
+		const initCap = 256
+		pw.rowBuf = batch.NewRecordBatch(b.Schema, initCap)
+		pw.rowBuf.Len = 0
+		// Reset BytesData offsets so we can append incrementally.
+		for _, col := range pw.rowBuf.Columns {
+			if col.BytesData.Offsets != nil {
+				col.BytesData.Offsets = col.BytesData.Offsets[:1]
+				col.BytesData.Offsets[0] = 0
+				col.BytesData.Data = col.BytesData.Data[:0]
+			}
+		}
+	}
+
+	dst := pw.rowBuf
+	di := dst.Len
+
+	// Grow typed column storage if needed.
+	s.growBatch(dst, di)
+
+	// Copy each column value at physical row `row` from b into dst at index di.
+	var rowBytes int
+	for ci, srcCol := range b.Columns {
+		dstCol := dst.Columns[ci]
+
+		if srcCol.Nulls.IsNullFast(row) {
+			dstCol.Nulls.SetNull(di)
+			// For bytes/string columns keep offsets aligned.
+			switch dstCol.Type {
+			case parquet.TypeString, parquet.TypeBytes, parquet.TypeIPv6, parquet.TypeCIDR, parquet.TypeUUID:
+				dstCol.BytesData.Set(di, nil)
+			}
+			continue
+		}
+
+		dstCol.Nulls.SetValid(di)
+
+		switch dstCol.Type {
+		case parquet.TypeBool:
+			dstCol.BoolData[di] = srcCol.BoolData[row]
+			rowBytes++
+
+		case parquet.TypeInt32, parquet.TypePort, parquet.TypeProtocol, parquet.TypeDate:
+			dstCol.Int32Data[di] = srcCol.Int32Data[row]
+			rowBytes += 4
+
+		case parquet.TypeInt64, parquet.TypeTimestamp, parquet.TypeIPv4, parquet.TypeMAC, parquet.TypeDuration:
+			dstCol.Int64Data[di] = srcCol.Int64Data[row]
+			rowBytes += 8
+
+		case parquet.TypeFloat32:
+			dstCol.Float32Data[di] = srcCol.Float32Data[row]
+			rowBytes += 4
+
+		case parquet.TypeFloat64:
+			dstCol.Float64Data[di] = srcCol.Float64Data[row]
+			rowBytes += 8
+
+		case parquet.TypeString, parquet.TypeBytes, parquet.TypeIPv6, parquet.TypeCIDR, parquet.TypeUUID:
+			val := srcCol.BytesData.Value(row)
+			dstCol.BytesData.Set(di, val)
+			rowBytes += len(val) + 4 // data + offset entry
+
+		case parquet.TypeDecimal:
+			dstCol.DecimalData.Data[di] = srcCol.DecimalData.Data[row]
+			rowBytes += 16
+		}
+	}
+
+	dst.Len = di + 1
+	pw.bufRows++
+	pw.bufBytes += rowBytes
+	return nil
+}
+
+// growBatch ensures the destination batch has storage for at least di+1 rows.
+// We grow by doubling when capacity is exhausted — same strategy as Go slices.
+func (s *partitionedShuffleSink) growBatch(dst *batch.RecordBatch, di int) {
+	for _, col := range dst.Columns {
+		col.Len = di + 1 // keep Len in sync for null bitmap ops
+
+		switch col.Type {
+		case parquet.TypeBool:
+			for len(col.BoolData) <= di {
+				col.BoolData = append(col.BoolData, false)
+			}
+		case parquet.TypeInt32, parquet.TypePort, parquet.TypeProtocol, parquet.TypeDate:
+			for len(col.Int32Data) <= di {
+				col.Int32Data = append(col.Int32Data, 0)
+			}
+		case parquet.TypeInt64, parquet.TypeTimestamp, parquet.TypeIPv4, parquet.TypeMAC, parquet.TypeDuration:
+			for len(col.Int64Data) <= di {
+				col.Int64Data = append(col.Int64Data, 0)
+			}
+		case parquet.TypeFloat32:
+			for len(col.Float32Data) <= di {
+				col.Float32Data = append(col.Float32Data, 0)
+			}
+		case parquet.TypeFloat64:
+			for len(col.Float64Data) <= di {
+				col.Float64Data = append(col.Float64Data, 0)
+			}
+		case parquet.TypeString, parquet.TypeBytes, parquet.TypeIPv6, parquet.TypeCIDR, parquet.TypeUUID:
+			// BytesData.Offsets must have di+2 entries (offsets[0..di+1]).
+			for len(col.BytesData.Offsets) <= di+1 {
+				col.BytesData.Offsets = append(col.BytesData.Offsets, col.BytesData.Offsets[len(col.BytesData.Offsets)-1])
+			}
+		case parquet.TypeDecimal:
+			for len(col.DecimalData.Data) <= di {
+				col.DecimalData.Data = append(col.DecimalData.Data, batch.Int128{})
+			}
+		}
+
+		// Grow the null bitmap if needed.
+		col.Nulls = col.Nulls.Grow(di + 1)
+	}
+}
+
+// flushIfNeeded writes any partition whose buffer exceeds the flush threshold.
+func (s *partitionedShuffleSink) flushIfNeeded() error {
+	for p, pw := range s.parts {
+		if pw.rowBuf == nil || pw.bufRows == 0 {
+			continue
+		}
+		if pw.bufBytes < s.flushBytes {
+			continue
+		}
+		if err := s.flushPartition(p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *partitionedShuffleSink) flushPartition(p int) error {
+	pw := s.parts[p]
+	if pw.rowBuf == nil || pw.bufRows == 0 {
+		return nil
+	}
+	if pw.writer == nil {
+		pw.writer = newShuffleWriter(pw.file, s.schema)
+		if err := pw.writer.writeHeader(); err != nil {
+			return fmt.Errorf("partition %d header: %w", p, err)
+		}
+	}
+	if err := pw.writer.writeChunk(pw.rowBuf.Columns, nil, pw.bufRows); err != nil {
+		return fmt.Errorf("partition %d chunk: %w", p, err)
+	}
+	pw.numRows += int64(pw.bufRows)
+
+	// Reset the accumulator in-place. Re-use the same RecordBatch memory.
+	pw.rowBuf.Len = 0
+	pw.bufRows = 0
+	pw.bufBytes = 0
+	for _, col := range pw.rowBuf.Columns {
+		col.Len = 0
+		col.Nulls.ResetNonNull(0)
+		switch col.Type {
+		case parquet.TypeString, parquet.TypeBytes, parquet.TypeIPv6, parquet.TypeCIDR, parquet.TypeUUID:
+			col.BytesData.Data = col.BytesData.Data[:0]
+			// Keep Offsets slice; reset all to 0.
+			for i := range col.BytesData.Offsets {
+				col.BytesData.Offsets[i] = 0
+			}
+		}
+	}
+	return nil
+}
+
+// Finalize flushes all partition buffers, then patches the chunk count in each
+// file header (mirrors shuffleStreamSink.Finalize exactly for the patch logic).
+func (s *partitionedShuffleSink) Finalize(_ context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for p := range s.parts {
+		if err := s.flushPartition(p); err != nil {
+			return err
+		}
+	}
+	for p, pw := range s.parts {
+		if pw.writer == nil {
+			// Empty partition — leave file at zero bytes; downstream treats as no rows.
+			if err := pw.file.Sync(); err != nil {
+				return err
+			}
+			continue
+		}
+		// Patch chunk count in header. Layout (see shuffle_format.go):
+		//   offset 0..4 = magic "WSHF"
+		//   offset 4..8 = numChunks (uint32 LE) — placeholder written by writeHeader
+		if _, err := pw.file.Seek(4, 0); err != nil {
+			return fmt.Errorf("partition %d seek: %w", p, err)
+		}
+		var buf [4]byte
+		binary.LittleEndian.PutUint32(buf[:], pw.writer.numChunks)
+		if _, err := pw.file.Write(buf[:]); err != nil {
+			return fmt.Errorf("partition %d patch: %w", p, err)
+		}
+		if _, err := pw.file.Seek(0, 2); err != nil {
+			return fmt.Errorf("partition %d seek end: %w", p, err)
+		}
+		if err := pw.file.Sync(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Close releases all file handles. Idempotent.
+func (s *partitionedShuffleSink) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	for _, pw := range s.parts {
+		if pw != nil && pw.file != nil {
+			_ = pw.file.Close()
+		}
+	}
+	return nil
+}
+
+// PartitionFiles returns the local file paths for each partition (index = partition id).
+// Empty string for a partition that received zero rows.
+func (s *partitionedShuffleSink) PartitionFiles() []string {
+	out := make([]string, s.numParts)
+	for p, pw := range s.parts {
+		if pw == nil || pw.numRows == 0 {
+			continue
+		}
+		out[p] = pw.file.Name()
+	}
+	return out
+}
+
+// hashInt64 hashes a single int64 value using FNV-1a. Exported for use in
+// tests to verify that partition assignments match expected routing.
+func hashInt64(v int64) uint64 {
+	h := fnv.New64a()
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(v))
+	_, _ = h.Write(buf[:])
+	return h.Sum64()
+}
+
+// hashVectorValue mixes a single column value at the given row into h using
+// FNV-1a. Supports the join-key types we encounter in TPC-H/SIEM workloads.
+// For unsupported types, hashes a zero byte (deterministic but skewed — the
+// planner is responsible for not picking these as partition keys).
+func hashVectorValue(h interface{ Write([]byte) (int, error) }, col *batch.Vector, row int, scratch []byte) {
+	if col.Nulls.IsNullFast(row) {
+		// Null contributes a distinct marker so that null rows are consistently
+		// routed (all nulls land in the same partition).
+		_, _ = h.Write([]byte{0xff})
+		return
+	}
+	switch col.Type {
+	case parquet.TypeInt32, parquet.TypePort, parquet.TypeProtocol, parquet.TypeDate:
+		binary.LittleEndian.PutUint32(scratch[:4], uint32(col.Int32Data[row]))
+		_, _ = h.Write(scratch[:4])
+	case parquet.TypeInt64, parquet.TypeTimestamp, parquet.TypeIPv4, parquet.TypeMAC, parquet.TypeDuration:
+		binary.LittleEndian.PutUint64(scratch[:8], uint64(col.Int64Data[row]))
+		_, _ = h.Write(scratch[:8])
+	case parquet.TypeString, parquet.TypeBytes, parquet.TypeIPv6, parquet.TypeCIDR, parquet.TypeUUID:
+		_, _ = h.Write(col.BytesData.Value(row))
+	default:
+		_, _ = h.Write([]byte{0x00})
+	}
+}

--- a/internal/worker/partitioned_shuffle_sink_test.go
+++ b/internal/worker/partitioned_shuffle_sink_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"hash/fnv"
 	"os"
 	"path/filepath"
 	"testing"
@@ -44,6 +45,10 @@ func TestPartitionedShuffleSink_RoundTrip(t *testing.T) {
 	}
 
 	// Read each partition back and verify every row's hash maps back to its partition.
+	// Use hashVectorValue directly — the same code path the sink uses — so the
+	// test is sensitive to any routing divergence in partitionFor.
+	keySchema := []parquet.Column{{Name: "k", Type: parquet.TypeInt64}}
+	var scratch [8]byte
 	totalRows := 0
 	for p, path := range paths {
 		if path == "" {
@@ -51,7 +56,12 @@ func TestPartitionedShuffleSink_RoundTrip(t *testing.T) {
 		}
 		rows := readWSHFInts(t, filepath.Clean(path), "k")
 		for _, k := range rows {
-			got := int(hashInt64(k) % uint64(numParts))
+			keyBatch := batch.NewRecordBatch(keySchema, 1)
+			keyBatch.Columns[0].Int64Data[0] = k
+			keyBatch.Columns[0].Nulls.SetValid(0)
+			h := fnv.New64a()
+			hashVectorValue(h, keyBatch.Columns[0], 0, scratch[:])
+			got := int(h.Sum64() % uint64(numParts))
 			if got != p {
 				t.Errorf("row k=%d ended up in partition %d, hash maps to %d", k, p, got)
 			}

--- a/internal/worker/partitioned_shuffle_sink_test.go
+++ b/internal/worker/partitioned_shuffle_sink_test.go
@@ -1,0 +1,245 @@
+package worker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// TestPartitionedShuffleSink_RoundTrip verifies that rows hash-partitioned
+// across N output files can be read back, that no row is lost, and that
+// every row in partition p hashes to p.
+func TestPartitionedShuffleSink_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	const numParts = 4
+
+	schema := []parquet.Column{{Name: "k", Type: parquet.TypeInt64}}
+	sink := newPartitionedShuffleSink(dir, []string{"k"}, numParts, schema)
+	if err := sink.Init(context.Background()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	// Build a batch of 1000 rows with sequential int64 keys.
+	const n = 1000
+	b := batch.NewRecordBatch(schema, n)
+	for i := 0; i < n; i++ {
+		b.Columns[0].Int64Data[i] = int64(i)
+		b.Columns[0].Nulls.SetValid(i)
+	}
+
+	if err := sink.Consume(context.Background(), b); err != nil {
+		t.Fatalf("consume: %v", err)
+	}
+	if err := sink.Finalize(context.Background()); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+
+	paths := sink.PartitionFiles()
+	if len(paths) != numParts {
+		t.Fatalf("expected %d partition files, got %d", numParts, len(paths))
+	}
+
+	// Read each partition back and verify every row's hash maps back to its partition.
+	totalRows := 0
+	for p, path := range paths {
+		if path == "" {
+			continue // empty partition
+		}
+		rows := readWSHFInts(t, filepath.Clean(path), "k")
+		for _, k := range rows {
+			got := int(hashInt64(k) % uint64(numParts))
+			if got != p {
+				t.Errorf("row k=%d ended up in partition %d, hash maps to %d", k, p, got)
+			}
+		}
+		totalRows += len(rows)
+	}
+	if totalRows != n {
+		t.Errorf("total rows across partitions = %d, want %d", totalRows, n)
+	}
+
+	if err := sink.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+// TestPartitionedShuffleSink_MultiColumn verifies that multi-key hashing
+// assigns rows consistently and all rows are accounted for.
+func TestPartitionedShuffleSink_MultiColumn(t *testing.T) {
+	dir := t.TempDir()
+	const numParts = 3
+
+	schema := []parquet.Column{
+		{Name: "a", Type: parquet.TypeInt64},
+		{Name: "b", Type: parquet.TypeString},
+	}
+	sink := newPartitionedShuffleSink(dir, []string{"a", "b"}, numParts, schema)
+	if err := sink.Init(context.Background()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	const n = 100
+	b := batch.NewRecordBatch(schema, n)
+	for i := 0; i < n; i++ {
+		b.Columns[0].Int64Data[i] = int64(i)
+		b.Columns[0].Nulls.SetValid(i)
+		b.Columns[1].BytesData.Set(i, []byte("val"))
+		b.Columns[1].Nulls.SetValid(i)
+	}
+
+	if err := sink.Consume(context.Background(), b); err != nil {
+		t.Fatalf("consume: %v", err)
+	}
+	if err := sink.Finalize(context.Background()); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	paths := sink.PartitionFiles()
+	total := 0
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		rows := readWSHFInts(t, path, "a")
+		total += len(rows)
+	}
+	if total != n {
+		t.Errorf("total rows = %d, want %d", total, n)
+	}
+}
+
+// TestPartitionedShuffleSink_EmptyPartitions verifies that PartitionFiles
+// returns "" for partitions that received no rows.
+func TestPartitionedShuffleSink_EmptyPartitions(t *testing.T) {
+	dir := t.TempDir()
+	const numParts = 8
+
+	// Use a single row: only one partition gets a row, rest are empty.
+	schema := []parquet.Column{{Name: "k", Type: parquet.TypeInt64}}
+	sink := newPartitionedShuffleSink(dir, []string{"k"}, numParts, schema)
+	if err := sink.Init(context.Background()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	b := batch.NewRecordBatch(schema, 1)
+	b.Columns[0].Int64Data[0] = int64(42)
+	b.Columns[0].Nulls.SetValid(0)
+
+	if err := sink.Consume(context.Background(), b); err != nil {
+		t.Fatalf("consume: %v", err)
+	}
+	if err := sink.Finalize(context.Background()); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	paths := sink.PartitionFiles()
+	nonEmpty := 0
+	for _, p := range paths {
+		if p != "" {
+			nonEmpty++
+		}
+	}
+	if nonEmpty != 1 {
+		t.Errorf("expected 1 non-empty partition, got %d", nonEmpty)
+	}
+}
+
+// TestPartitionedShuffleSink_SelectionVector verifies that when the input
+// batch has a selection vector, only active rows are written.
+func TestPartitionedShuffleSink_SelectionVector(t *testing.T) {
+	dir := t.TempDir()
+	const numParts = 4
+
+	schema := []parquet.Column{{Name: "k", Type: parquet.TypeInt64}}
+	sink := newPartitionedShuffleSink(dir, []string{"k"}, numParts, schema)
+	if err := sink.Init(context.Background()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	// Batch of 10 rows, select only rows 0, 2, 4, 6 (4 active).
+	b := batch.NewRecordBatch(schema, 10)
+	for i := 0; i < 10; i++ {
+		b.Columns[0].Int64Data[i] = int64(i * 10)
+		b.Columns[0].Nulls.SetValid(i)
+	}
+	b.Sel = []uint32{0, 2, 4, 6}
+
+	if err := sink.Consume(context.Background(), b); err != nil {
+		t.Fatalf("consume: %v", err)
+	}
+	if err := sink.Finalize(context.Background()); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	paths := sink.PartitionFiles()
+	total := 0
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		rows := readWSHFInts(t, path, "k")
+		total += len(rows)
+	}
+	if total != 4 {
+		t.Errorf("expected 4 rows (selection vector), got %d", total)
+	}
+}
+
+// readWSHFInts reads back int64 values from the named column in a WSHF file.
+func readWSHFInts(t *testing.T, path, colName string) []int64 {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("readWSHFInts: open %s: %v", path, err)
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	r, err := newShuffleChunkReader(data)
+	if err != nil {
+		t.Fatalf("readWSHFInts: parse %s: %v", path, err)
+	}
+	// Find column index by name.
+	colIdx := -1
+	for i, col := range r.schema {
+		if col.Name == colName {
+			colIdx = i
+			break
+		}
+	}
+	if colIdx < 0 {
+		t.Fatalf("readWSHFInts: column %q not found in %s", colName, path)
+	}
+	var out []int64
+	for {
+		b, err := r.Next()
+		if err != nil {
+			t.Fatalf("readWSHFInts: read chunk from %s: %v", path, err)
+		}
+		if b == nil {
+			break
+		}
+		vec := b.Columns[colIdx]
+		for i := 0; i < b.ActiveLen(); i++ {
+			row := i
+			if b.Sel != nil {
+				row = int(b.Sel[i])
+			}
+			out = append(out, vec.Int64Data[row])
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

- Add `TaskTypeShuffle` distributed task that hash-partitions input rows into N output `.wshf` files
- Add `Distribution` value type + `Stage.Distribution` field as planner groundwork for partition-aware execution
- New `partitionedShuffleSink` (FNV-1a, 64 KB per-partition flush, full WSHF round-trip with file leak fix)
- New `partitionShardSource` thin helper that lists S3 partition prefix and feeds existing `cachedFileStreamSource`
- `PickShuffleCandidate` planner helper: identifies the largest non-probe scan above threshold (4 GB default), uses column-anchored fallback for fused-join chains
- Coordinator orchestrator runs both shuffle stages in parallel via errgroup, ephemeral query IDs, NATS subscription before publish, partition-bucketed shard layout
- Routing switch with `prebuiltTasks` seam in `queryMeta`
- SF0.01 forced-shuffle integration test as the local correctness gate

## Why

Phase 1 of the SF100 OOM mitigation. At SF100, broadcasting `orders` (~7-8 GB hash per worker × 2 concurrent tasks) exceeds the 23 GB GOMEMLIMIT on c7gd.4xlarge. Shuffle partitions the build instead of broadcasting it, so per-worker memory scales 1/N.

Architecturally orthogonal to the bloom prefilter (which is being removed in #fix/remove-bloom-prefilter). This is the cleaner replacement for SF100 OOM protection.

## Test plan

- [x] SF0.01 forced-shuffle test: 6/6 join-heavy queries pass through shuffle path with correct row counts
- [x] SF10 EC2 confirmed shuffle correctly does NOT fire (orders 1.5 GB < 4 GB threshold) — production behavior preserved
- [ ] SF100 EC2 — actual Q03 OOM target (deferred; recommend after merge)

## Phase 2 (out of scope, follow-up)

- Chained shuffle stages for queries with multiple large builds on different keys (Q09)
- Cardinality-aware budget interaction once Phase 1 lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)