### PR TITLE
perf(exec): fix HashAggregate over-spilling and preAlloc for low-cardinality GROUP BY

### DIFF
--- a/internal/coordinator/distributed_tpch_test.go
+++ b/internal/coordinator/distributed_tpch_test.go
@@ -688,6 +688,274 @@ func TestDistributedTPCHBuildCacheSF100Sample(t *testing.T) {
 	}
 }
 
+// sf100SampleCluster builds a 2-worker distributed cluster loaded with the
+// local /tmp/sf100-sample parquet files. Extracted so Q12 and Q17 repros can
+// each get a fresh process memory-wise (Q17's decorrelated subquery triggers
+// a lineitem-wide build cache that dwarfs Q12's state — running them in the
+// same process OOMs a dev box).
+func sf100SampleCluster(t *testing.T, memoryBudget int64) (context.Context, *Coordinator) {
+	return sf100SampleClusterN(t, memoryBudget, 2, 2)
+}
+
+// sf100SampleClusterN lets the caller pick worker count and max-concurrent-tasks
+// per worker — used to isolate memory-pressure issues.
+func sf100SampleClusterN(t *testing.T, memoryBudget int64, wantWorkers, maxConcurrent int) (context.Context, *Coordinator) {
+	t.Helper()
+	const sampleDir = "/tmp/sf100-sample"
+	if _, err := os.Stat(sampleDir); os.IsNotExist(err) {
+		t.Skipf("SF100 sample dir %s missing — see TestDistributedTPCHBuildCacheSF100Sample for setup", sampleDir)
+	}
+
+	origMinBytes := physical.ProbeSplitMinBytes
+	physical.ProbeSplitMinBytes = 1
+	t.Cleanup(func() { physical.ProbeSplitMinBytes = origMinBytes })
+
+	origRev := physical.ReverseBloomInnerThreshold
+	physical.ReverseBloomInnerThreshold = 1
+	t.Cleanup(func() { physical.ReverseBloomInnerThreshold = origRev })
+
+	origGroupSize := buildCacheGroupSize
+	buildCacheGroupSize = 1
+	t.Cleanup(func() { buildCacheGroupSize = origGroupSize })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	t.Cleanup(cancel)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	natsCfg := distributed.DefaultNATSConfig()
+	natsCfg.Port = -1
+	natsCfg.StoreDir = t.TempDir()
+	embeddedNATS, err := distributed.NewEmbeddedNATS(natsCfg, logger)
+	if err != nil {
+		t.Fatalf("NATS: %v", err)
+	}
+	t.Cleanup(embeddedNATS.Shutdown)
+
+	nc, err := distributed.ConnectInProcess(embeddedNATS.Server())
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { nc.Close() })
+
+	js, err := distributed.NewJetStream(nc)
+	if err != nil {
+		t.Fatalf("jetstream: %v", err)
+	}
+	if err := distributed.SetupStreams(ctx, js); err != nil {
+		t.Fatalf("streams: %v", err)
+	}
+
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(ctx, "test"); err != nil {
+		t.Fatal(err)
+	}
+	kv, err := catalog.NewNATSKV(js)
+	if err != nil {
+		t.Fatalf("kv: %v", err)
+	}
+	cat := catalog.New(kv, store, "test")
+	if err := cat.Init(ctx); err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+
+	// Match the Q05 test: probe tables get multiple files so probe-split fires
+	// (>= workerCount*2 files). Q12 probes lineitem; Q17 probes lineitem too.
+	tableFiles := map[string][]string{
+		"region":   {"region-0_0.parquet"},
+		"nation":   {"nation-0_0.parquet"},
+		"supplier": {"supplier-0_0.parquet"},
+		"customer": {"customer-0_0.parquet"},
+		"part":     {"part-0_0.parquet"},
+		"partsupp": {"partsupp-0_0.parquet"},
+		"orders":   {"orders-0_0.parquet"},
+		"lineitem": {"lineitem-0_0.parquet", "lineitem-0_1.parquet", "lineitem-0_2.parquet", "lineitem-0_3.parquet"},
+	}
+
+	for _, tbl := range []string{"region", "nation", "supplier", "customer", "part", "partsupp", "orders", "lineitem"} {
+		files := tableFiles[tbl]
+		var schema parquet.Schema
+		var entries []catalog.FileEntry
+		for i, fname := range files {
+			localPath := fmt.Sprintf("%s/%s", sampleDir, fname)
+			fi, err := os.Stat(localPath)
+			if err != nil {
+				t.Fatalf("stat %s: %v", localPath, err)
+			}
+			f, err := os.Open(localPath)
+			if err != nil {
+				t.Fatalf("open %s: %v", localPath, err)
+			}
+			pr, err := parquet.NewReader(f, fi.Size())
+			if err != nil {
+				f.Close()
+				t.Fatalf("parquet %s: %v", localPath, err)
+			}
+			if i == 0 {
+				schema = pr.Schema()
+			}
+			numRows := pr.NumRows()
+			f.Close()
+			raw, err := os.ReadFile(localPath)
+			if err != nil {
+				t.Fatalf("read %s: %v", localPath, err)
+			}
+			storePath := fmt.Sprintf("tables/%s/%s", tbl, fname)
+			if _, err := store.Put(ctx, "test", storePath, bytes.NewReader(raw), int64(len(raw)), "application/octet-stream"); err != nil {
+				t.Fatalf("put %s: %v", localPath, err)
+			}
+			entries = append(entries, catalog.FileEntry{
+				Path:      storePath,
+				SizeBytes: fi.Size(),
+				NumRows:   numRows,
+				CreatedAt: time.Now(),
+			})
+		}
+		if err := cat.CreateTable(ctx, tbl, schema, nil); err != nil {
+			t.Fatalf("create %s: %v", tbl, err)
+		}
+		if err := cat.AddFiles(ctx, tbl, nil, "tables/"+tbl+"/", entries); err != nil {
+			t.Fatalf("addfiles %s: %v", tbl, err)
+		}
+		var totalRows int64
+		var totalBytes int64
+		for _, e := range entries {
+			totalRows += e.NumRows
+			totalBytes += e.SizeBytes
+		}
+		t.Logf("loaded %s: %d rows %d bytes %d files", tbl, totalRows, totalBytes, len(entries))
+	}
+
+	coord := New(Config{
+		NATSUrl:      embeddedNATS.ClientURL(),
+		ResultBucket: "test",
+	}, cat, nc, js, logger)
+	// Leave BuildCacheThreshold at production default (2 GB). Orders at
+	// SF1-sample is 273 MB, well below — this matches production SF10, where
+	// orders (~1.5 GB) also stays below the default threshold, so the cache
+	// path does NOT fire. If we want to test the cache path explicitly, a
+	// separate test should force it.
+
+	for i := 0; i < wantWorkers; i++ {
+		w := worker.New(worker.Config{
+			NATSUrl:       embeddedNATS.ClientURL(),
+			MaxConcurrent: maxConcurrent,
+			CacheBytes:    256 * 1024 * 1024,
+			SpillDir:      t.TempDir(),
+			MemoryBudget:  memoryBudget,
+		}, store, nc, js, logger)
+		if err := w.Start(ctx); err != nil {
+			t.Fatalf("worker %d: %v", i, err)
+		}
+		t.Cleanup(w.Stop)
+		time.Sleep(50 * time.Millisecond)
+	}
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		if coord.workers.Count() >= wantWorkers {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if got := coord.workers.Count(); got < wantWorkers {
+		t.Fatalf("workers failed to register (got %d want %d)", got, wantWorkers)
+	}
+	return ctx, coord
+}
+
+// runSF100SampleQuery runs one TPC-H query against the sample cluster and
+// logs wall time + up to 10 result rows. Used by the Q12/Q17 local repro
+// tests to iterate on the distributed perf regression.
+//
+// Set WADJET_CPU_PROFILE=<path> to capture a CPU profile over just the
+// ExecuteSQL call (coordinator + in-process workers all run in the test
+// process, so one profile covers everything).
+func runSF100SampleQuery(t *testing.T, ctx context.Context, coord *Coordinator, qNum int) {
+	t.Helper()
+	q := tpch.TPCHQueries[qNum]
+	// Periodic memory log so OOM kills leave a breadcrumb trail — tells us
+	// which phase blew up even when the test process dies before completion.
+	// Also drop a heap profile every tick when WADJET_HEAP_PROFILE=<dir>.
+	stopMem := make(chan struct{})
+	heapDir := os.Getenv("WADJET_HEAP_PROFILE")
+	go func() {
+		tk := time.NewTicker(1 * time.Second)
+		defer tk.Stop()
+		var ms runtime.MemStats
+		i := 0
+		for {
+			select {
+			case <-stopMem:
+				return
+			case <-tk.C:
+				i++
+				runtime.ReadMemStats(&ms)
+				t.Logf("[heap] alloc=%dMB sys=%dMB inUse=%dMB",
+					ms.HeapAlloc/(1<<20), ms.Sys/(1<<20), ms.HeapInuse/(1<<20))
+				if heapDir != "" {
+					path := fmt.Sprintf("%s/q%02d-heap-%03d-%dMB.pprof", heapDir, qNum, i, ms.HeapAlloc/(1<<20))
+					if f, err := os.Create(path); err == nil {
+						_ = pprof.WriteHeapProfile(f)
+						_ = f.Close()
+					}
+				}
+			}
+		}
+	}()
+	defer close(stopMem)
+	if path := os.Getenv("WADJET_CPU_PROFILE"); path != "" {
+		f, err := os.Create(path)
+		if err != nil {
+			t.Fatalf("create cpu profile: %v", err)
+		}
+		defer f.Close()
+		if err := pprof.StartCPUProfile(f); err != nil {
+			t.Fatalf("start cpu profile: %v", err)
+		}
+		defer pprof.StopCPUProfile()
+		t.Logf("CPU profile → %s", path)
+	}
+	start := time.Now()
+	result, err := coord.ExecuteSQL(ctx, q.SQL)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Q%02d ExecuteSQL: %v (elapsed %s)", qNum, err, elapsed)
+	}
+	if result.Error != "" {
+		t.Fatalf("Q%02d error: %s (elapsed %s)", qNum, result.Error, elapsed)
+	}
+	rows := result.Rows()
+	t.Logf("Q%02d (%s): %d rows in %s", qNum, q.Name, len(rows), elapsed)
+	for i, r := range rows {
+		if i >= 10 {
+			t.Logf("  ... (%d more rows)", len(rows)-10)
+			break
+		}
+		t.Logf("  row %d: %v", i, r)
+	}
+}
+
+// TestDistributedTPCHQ12SF100Sample is the local repro for the Q12 SF10
+// distributed perf regression (project_q12_q17_regression_2026-04-18).
+// Historical baseline: ~2s. Current: ~60s.
+func TestDistributedTPCHQ12SF100Sample(t *testing.T) {
+	ctx, coord := sf100SampleCluster(t, 2*1024*1024*1024)
+	runSF100SampleQuery(t, ctx, coord, 12)
+}
+
+// TestDistributedTPCHQ17SF100Sample is the local repro for the Q17 SF10
+// distributed perf regression. Q17's correlated scalar subquery decorrelates
+// into a per-worker GROUP BY l_partkey over the entire lineitem partition
+// (~2M groups) on top of a 5M-row part hash join — so the worker budget
+// has to cover both.
+func TestDistributedTPCHQ17SF100Sample(t *testing.T) {
+	// 2 workers × 1 concurrent task each: one probe-split task per worker
+	// at a time. Q17's inner aggregate scans full lineitem per task, so
+	// concurrent tasks stack up memory quickly.
+	ctx, coord := sf100SampleClusterN(t, 2*1024*1024*1024, 2, 1)
+	runSF100SampleQuery(t, ctx, coord, 17)
+}
+
 // TestDistributedTPCHBuildCachePolarsQ05 is the local repro for the SF100
 // Q05 0-rows bug. It uses Polars-style schemas (INT64 keys, DATE dates) so
 // the streaming source / filter / hash join paths exercise the same types as

--- a/internal/engine/exec/aggregate.go
+++ b/internal/engine/exec/aggregate.go
@@ -405,22 +405,19 @@ func (h *HashAggregate) Consume(_ context.Context, b *batch.RecordBatch) error {
 		h.resolveIndices(b)
 	}
 
-	// Track memory usage for spill pressure detection
-	var batchBytes int64
-	if h.Spill != nil {
-		batchBytes = EstimateBatchBytes(b)
-		h.Spill.TrackBatch(batchBytes)
-	}
-
-	// Spill input batch to disk if memory pressure is high.
-	// Rows are accumulated in h.spillBuffer and flushed to a new file only
-	// when the buffer crosses spillFileTargetBytes. This prevents pathological
-	// file-count explosion at SF100 (see TestHashAggregateSpillBatching).
-	// The spilled rows are re-processed during Finalize.
+	// Spill decision is based on current group state size, not input
+	// throughput. Input batches are transient — they're GC'd after Consume
+	// returns. Only the hash table + accumulator arrays persist, and
+	// reconcileGroupMemory (below) is what drives that tracking. An earlier
+	// design also called TrackBatch(batchBytes) on every input batch, which
+	// monotonically accumulated cumulative throughput into the tracker and
+	// forced spill-every-batch once inputBytes crossed the budget — even
+	// when the actual group state was a handful of rows (e.g. Q12 with 7
+	// shipmode groups). That inflated 250ms Q12 work to 37s of spill I/O.
 	if h.Spill != nil && h.Spill.ShouldSpillFor(memory.SpillCheap) {
 		rows := b.ToRows()
 		h.spillBuffer = append(h.spillBuffer, rows...)
-		h.spillBufferBytes += batchBytes
+		h.spillBufferBytes += EstimateBatchBytes(b)
 		if h.spillBufferBytes >= spillFileTargetBytes {
 			if err := h.flushSpillBuffer(); err != nil {
 				return err
@@ -433,9 +430,8 @@ func (h *HashAggregate) Consume(_ context.Context, b *batch.RecordBatch) error {
 	h.consumeBatch(b)
 
 	// Track group state memory growth so spill triggers at the right time.
-	// consumeBatch grows hash tables and accumulator arrays, but TrackBatch
-	// above only saw input batch size. Without this, group states at SF100
-	// can grow to 20+ GB untracked while ShouldSpill sees only batch cost.
+	// consumeBatch grows hash tables and accumulator arrays; this is the
+	// sole signal for HashAggregate spill pressure.
 	h.reconcileGroupMemory()
 
 	return nil
@@ -551,15 +547,24 @@ func (h *HashAggregate) resolveIndices(b *batch.RecordBatch) {
 		}
 	}
 
-	// Pre-sizing hint: use InputRowHint to estimate initial hash table capacity.
-	// Use inputRows/8 capped at 16M — balances memory usage against growth cost.
-	// At SF100, high-cardinality GROUP BY (Q17: ~20M distinct l_partkey values)
-	// needs a large initial size to avoid expensive rehash doublings.
+	// Pre-sizing hint: initial hash-table capacity. InputRowHint reflects the
+	// aggregate's INPUT row count (derived from scan estimates), which is a
+	// poor proxy for GROUP CARDINALITY — the actual thing the hash table
+	// needs to hold. Q12 has 7 groups but its InputRowHint is 50M+ rows
+	// from the orders+lineitem scans; sizing the hash to inputRows/8 would
+	// preAlloc ~750MB of groupState for 7 slots (confirmed on SF1-sample
+	// distributed: Q12 group pool = 750MB).
+	//
+	// Until the planner has NDV stats, cap the initial allocation at 64K.
+	// Organic doubling handles high-cardinality cases (Q17 ~20M groups) with
+	// ~2x amortized memcopy overhead — acceptable compared to over-allocating
+	// 300–1900 MB for low-cardinality queries.
+	const htInitCap = 64 * 1024
 	htInitSize := 4096
 	if h.InputRowHint > int64(htInitSize)*8 {
 		est := int(h.InputRowHint / 8)
-		if est > 16*1024*1024 {
-			est = 16 * 1024 * 1024
+		if est > htInitCap {
+			est = htInitCap
 		}
 		htInitSize = est
 	}
@@ -2776,13 +2781,19 @@ func vecToFloat64(v *batch.Vector, row int) float64 {
 // initFlatAccums initializes SoA accumulator arrays for the intGroupKey fast path.
 // Called once from resolveIndices when useIntGroupKey is true.
 func (h *HashAggregate) initFlatAccums(b *batch.RecordBatch) {
+	// Flat accumulator arrays: same sizing principle as the group-state pool
+	// above. InputRowHint overshoots for low-cardinality GROUP BY (Q12: 7
+	// groups but 50M-row InputRowHint would preAlloc 2M × 8B × nAggs here).
+	// Cap at 64K slots; ensureCapacity doubles organically for high-cardinality
+	// aggregates.
 	nAggs := len(h.Aggs)
 	h.intFlatAccs = make([]flatAccumArrays, nAggs)
+	const flatInitCap = 64 * 1024
 	initCap := 4096
 	if h.InputRowHint > int64(initCap)*8 {
 		est := int(h.InputRowHint / 8)
-		if est > 2*1024*1024 {
-			est = 2 * 1024 * 1024
+		if est > flatInitCap {
+			est = flatInitCap
 		}
 		initCap = est
 	}


### PR DESCRIPTION
## Summary

Two latent bugs in `HashAggregate` that caused low-cardinality GROUP BY queries to spill-thrash at scale. Both fixes are scale-correct — they stop over-allocating and over-spilling for all scales, not just SF10.

### Bug 1 — input-batch bytes accumulated into spill tracker

`HashAggregate.Consume` called `Spill.TrackBatch(batchBytes)` on every input batch. `TrackBatch` → `ForceReserve` is monotonic with no release. After cumulative input bytes crossed the `SpillCheap` threshold (60% of budget), every remaining batch was written to disk and re-read at Finalize, even for 7-group queries.

Input batches are transient — they're GC'd after `Consume` returns. Only the hash table state persists, and `reconcileGroupMemory()` tracks that correctly. The `TrackBatch(batchBytes)` call was a legacy undercount-era artifact that became an over-count after `reconcileGroupMemory` was added. Removed it.

### Bug 2 — htInitSize preAlloc based on raw scan sizes, not group cardinality

Commit `26ffa55` (2026-03-25) raised the HashAgg initial hash-table cap from 2M to 16M for Q17-style high-cardinality queries. The formula is `htInitSize = InputRowHint/8` capped at 16M, where `InputRowHint = findScanRowEstimate(aggregate.child)` sums raw scan estimates.

Q12 has 7 groups but its child is `Join(orders, lineitem)`. `findScanRowEstimate` sums the two scans → 50M+ rows. Result: `preAlloc(6.25M) = ~750 MB of groupState memory for 7 actual groups`. Same issue for `intFlatAccs`.

Fix: cap `htInitSize` at 64K. Organic doubling via the existing 4096-per-chunk pool growth handles high-cardinality cases (Q17 ~20M groups = ~5000 chunks) with acceptable amortized memcopy overhead (~2x final size).

## SF10 EC2 measurements

Baseline @ main (`bf47bf8`) vs this branch:

| Query | Baseline | Fix |
|---|---|---|
| Q08 | 1m14s | 8.22s (−89%) |
| Q12 | 42.17s | 18.51s (−56%) |
| Q15 | 5.16s | 2.49s (−52%) |
| Q07 | 8.68s | 4.56s (−47%) |
| Q10 | 17.25s | 11.74s (−32%) |
| Q09 | 12.99s | 9.71s (−25%) |
| Q03 | 16.71s | 12.85s (−23%) |

Q05 showed noise regression (3.83→8.21) in that run but recovered on subsequent runs — spot/scheduling variance.

## Test plan

- [x] All 22 TPC-H queries pass correctness at SF0.01
- [x] New `TestDistributedTPCHQ12SF100Sample` regression test (in-process, SF1-sample)
- [x] SF10 EC2 run — 22/22 pass, wall-time improvements above
- [x] No regressions in existing distributed test suites (`TestDistributedTPCH`, `TestDistributedTPCHBuildCache`, `TestDistributedTPCHForcedShuffle`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)