### PR TITLE
feat(planner): distribution-property pass — phase 1 (types + algebra)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,8 @@ Thumbs.db
 # Codeparty agent workspaces
 .codeparty/
 
+# Git worktrees
+/.worktrees/
+
 # Terraform state backups
 *.tfstate.backup

--- a/docs/superpowers/plans/2026-04-19-broadcast-hazard-mitigation-pass.md
+++ b/docs/superpowers/plans/2026-04-19-broadcast-hazard-mitigation-pass.md
@@ -1,0 +1,2155 @@
+# Broadcast-Hazard Mitigation Pass Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `PickShuffleCandidate` (PR #40) and `PickAggregateShuffleCandidate` (PR #43) with a single per-join planner pass `IdentifyBroadcastHazards` that returns every broadcast-duplication hazard above a per-worker memory budget. Each hazard is matched to a remedy (`RemedyShuffleScan` reusing PR #40 mechanism, `RemedyPreComputeAggregate` reusing PR #43 mechanism). Coordinator becomes a thin dispatch loop. Threshold constants are deleted; `broadcastBudget` derives from `GOMEMLIMIT × fraction / workerCount`. Establishes the architectural invariant: *no query in the optimized plan broadcast-duplicates a build whose per-worker bytes exceed budget.*
+
+**Architecture:** New file `internal/planner/physical/broadcast_hazard.go` defines `BroadcastHazard`, `BuildShape`, `Remedy`, and `IdentifyBroadcastHazards`. New file `internal/coordinator/broadcast_remedies.go` defines `applyBroadcastRemedies` (group hazards, dispatch to existing orchestrators). New file `internal/coordinator/budget.go` defines `broadcastBudget()`. `ShuffleLayout` and `orchestrateShuffleStages` evolve to handle multi-build groups (Q21 has two semi/anti builds sharing `l_orderkey`). All deletions of old primitives and threshold vars happen in this same change — no parallel old/new code paths.
+
+**Tech Stack:** Go 1.22+, existing `internal/planner/physical` (Stage / candidate types, `followToAggregate`, `followToScan`, `keysCovered`), existing `internal/coordinator` (NATS task dispatch, `runShuffleSide`, `preComputeDerivedAggregate`), `testing` package with table-driven tests against synthetic `[]Stage`.
+
+**Spec:** `docs/superpowers/specs/2026-04-19-broadcast-hazard-mitigation-pass.md`
+
+---
+
+## Phase 1 — `broadcast_hazard.go` foundation (planner-layer, no external deps)
+
+### Task 1: Define core types
+
+**Files:**
+- Create: `internal/planner/physical/broadcast_hazard.go`
+
+- [ ] **Step 1: Create the file with the type definitions only**
+
+```go
+package physical
+
+// BroadcastHazard records one join in the physical plan whose build side, if
+// left as a broadcast, would cause every worker to materialize the same hash
+// table — a per-cluster memory pressure equal to N × build_size that scales
+// with worker count instead of being bounded by it. The pass that returns
+// these picks a remedy per hazard (shuffle the build by join keys, or
+// pre-compute a smaller representation centrally) such that no remaining
+// build above budget broadcasts.
+type BroadcastHazard struct {
+	JoinStageID string     // the join whose build poses the hazard
+	BuildBytes  int64      // estimated per-worker bytes if the build broadcasts (full size)
+	BuildShape  BuildShape // RawScan | AggregateOverScan | Unsupported
+	Remedy      Remedy
+
+	// Remedy-specific payloads. Exactly one is populated based on Remedy.Kind:
+	//   RemedyShuffleScan          → ShuffleCand
+	//   RemedyPreComputeAggregate  → AggregateCand
+	//   RemedyNone                 → both zero
+	ShuffleCand   ShuffleCandidate
+	AggregateCand AggregateShuffleCandidate
+}
+
+// BuildShape classifies the structural pattern of a join's build subplan.
+// The classification is what tells the remedy selector which remedies are
+// applicable. New shapes should only be added when there's a corresponding
+// new remedy that handles them — otherwise the hazard would be classified
+// but unfixable.
+type BuildShape int
+
+const (
+	BuildShapeUnknown           BuildShape = iota
+	BuildShapeRawScan                      // build is a single base-table scan (with optional pushed filters)
+	BuildShapeAggregateOverScan            // build is aggregate(GROUP BY K, scan(T))
+	BuildShapeUnsupported                  // shape doesn't match any current remedy
+)
+
+// String renders a BuildShape for log lines. Stable text identifiers — do
+// not change without checking telemetry consumers.
+func (s BuildShape) String() string {
+	switch s {
+	case BuildShapeRawScan:
+		return "raw_scan"
+	case BuildShapeAggregateOverScan:
+		return "aggregate_over_scan"
+	case BuildShapeUnsupported:
+		return "unsupported"
+	default:
+		return "unknown"
+	}
+}
+
+// Remedy is the per-hazard plan transformation chosen by the pass. EstCost
+// is the estimated per-worker bytes of build state AFTER the remedy applies
+// — the value the remedy selector compares to pick the lowest-cost
+// applicable option.
+type Remedy struct {
+	Kind    RemedyKind
+	EstCost int64
+}
+
+type RemedyKind int
+
+const (
+	RemedyNone                RemedyKind = iota // no applicable remedy; broadcast remains, hazard logged
+	RemedyShuffleScan                           // partition the build's input scan by join keys (PR #40 mechanism)
+	RemedyPreComputeAggregate                   // pre-compute the aggregate output centrally, broadcast cache paths (PR #43 mechanism)
+	// Future:
+	//   RemedyPreComputeDistinctKeys
+	//   RemedyShuffleAggregate
+)
+
+// String renders a RemedyKind for log lines.
+func (r RemedyKind) String() string {
+	switch r {
+	case RemedyNone:
+		return "none"
+	case RemedyShuffleScan:
+		return "shuffle_scan"
+	case RemedyPreComputeAggregate:
+		return "pre_compute_aggregate"
+	default:
+		return "unknown"
+	}
+}
+```
+
+- [ ] **Step 2: Verify the file compiles**
+
+Run: `go build ./internal/planner/physical/`
+Expected: success (no output)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/planner/physical/broadcast_hazard.go
+git commit -m "feat(planner): broadcast-hazard types — BroadcastHazard, BuildShape, Remedy"
+```
+
+---
+
+### Task 2: `computeBuildBytes` helper
+
+**Files:**
+- Modify: `internal/planner/physical/broadcast_hazard.go`
+- Test: `internal/planner/physical/broadcast_hazard_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/planner/physical/broadcast_hazard_test.go`:
+
+```go
+package physical
+
+import "testing"
+
+func stagesByID(stages []Stage) map[string]Stage {
+	m := make(map[string]Stage, len(stages))
+	for _, s := range stages {
+		m[s.ID] = s
+	}
+	return m
+}
+
+func TestComputeBuildBytes_RawScanBuild(t *testing.T) {
+	stages := []Stage{
+		{ID: "scan-l", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 6_000_000_000},
+		{ID: "scan-o", Type: "scan", ScanAlias: "orders", EstimatedBytes: 1_500_000_000},
+		{ID: "join-0", Type: "hash_join",
+			LeftDepStage:  "scan-l", // probe
+			RightDepStage: "scan-o", // build
+			JoinLeftKeys:  []string{"l_orderkey"},
+			JoinRightKeys: []string{"o_orderkey"},
+		},
+	}
+	byID := stagesByID(stages)
+
+	got := computeBuildBytes(byID, byID["join-0"])
+	if got != 1_500_000_000 {
+		t.Errorf("got %d, want 1_500_000_000", got)
+	}
+}
+
+func TestComputeBuildBytes_AggregateOverScanBuild(t *testing.T) {
+	stages := []Stage{
+		{ID: "scan-l", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 1_000_000},
+		{ID: "scan-l2", Type: "scan", ScanAlias: "lineitem:1", EstimatedBytes: 6_000_000_000},
+		{ID: "agg-0", Type: "aggregate",
+			Dependencies: []string{"scan-l2"},
+			GroupByCols:  []string{"l_partkey"},
+			AggSpecs:     []AggSpec{{Func: "avg", InputCol: "l_quantity", OutputCol: "__scalar_0"}},
+		},
+		{ID: "join-0", Type: "hash_join",
+			LeftDepStage:  "scan-l",
+			RightDepStage: "agg-0",
+			JoinLeftKeys:  []string{"l_partkey"},
+			JoinRightKeys: []string{"l_partkey"},
+		},
+	}
+	byID := stagesByID(stages)
+
+	got := computeBuildBytes(byID, byID["join-0"])
+	if got != 6_000_000_000 {
+		t.Errorf("got %d (want 6_000_000_000 — aggregate must report INPUT scan bytes, not output)", got)
+	}
+}
+
+func TestComputeBuildBytes_NoBuild(t *testing.T) {
+	stages := []Stage{
+		{ID: "scan-l", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 1_000_000},
+	}
+	byID := stagesByID(stages)
+	got := computeBuildBytes(byID, byID["scan-l"])
+	if got != 0 {
+		t.Errorf("got %d, want 0 (non-join stage has no build)", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run TestComputeBuildBytes ./internal/planner/physical/`
+Expected: build error `undefined: computeBuildBytes`
+
+- [ ] **Step 3: Implement `computeBuildBytes`**
+
+Append to `internal/planner/physical/broadcast_hazard.go`:
+
+```go
+// computeBuildBytes returns the per-worker bytes a join's build side would
+// occupy if broadcast. For RawScan builds, this is the build scan's
+// EstimatedBytes. For AggregateOverScan builds, this is the INPUT scan's
+// EstimatedBytes — matching PR #43's gating semantics, since the aggregate's
+// memory cost during execution scales with input volume even though its
+// output may be small. Returns 0 for non-join stages.
+func computeBuildBytes(byID map[string]Stage, join Stage) int64 {
+	if join.Type != "hash_join" && join.Type != "broadcast_join" {
+		return 0
+	}
+	if join.RightDepStage == "" {
+		return 0
+	}
+	build, ok := byID[join.RightDepStage]
+	if !ok {
+		return 0
+	}
+	if build.Type == "scan" {
+		return build.EstimatedBytes
+	}
+	// Walk through aggregate/shuffle/merge transparents to the rooted scan.
+	if agg, ok := followToAggregate(byID, build.ID); ok {
+		if scan, ok := followToScan(byID, agg); ok {
+			return scan.EstimatedBytes
+		}
+	}
+	return 0
+}
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `go test -run TestComputeBuildBytes ./internal/planner/physical/ -v`
+Expected: `--- PASS: TestComputeBuildBytes_RawScanBuild`, `_AggregateOverScanBuild`, `_NoBuild`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/planner/physical/broadcast_hazard.go internal/planner/physical/broadcast_hazard_test.go
+git commit -m "feat(planner): computeBuildBytes resolves per-worker broadcast cost"
+```
+
+---
+
+### Task 3: `classifyBuildShape` helper
+
+**Files:**
+- Modify: `internal/planner/physical/broadcast_hazard.go`
+- Modify: `internal/planner/physical/broadcast_hazard_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `broadcast_hazard_test.go`:
+
+```go
+func TestClassifyBuildShape_RawScan(t *testing.T) {
+	stages := []Stage{
+		{ID: "scan-l", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 6_000_000_000},
+		{ID: "scan-o", Type: "scan", ScanAlias: "orders", EstimatedBytes: 1_500_000_000},
+		{ID: "join-0", Type: "hash_join", LeftDepStage: "scan-l", RightDepStage: "scan-o",
+			JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"}},
+	}
+	byID := stagesByID(stages)
+	if got := classifyBuildShape(byID, byID["join-0"]); got != BuildShapeRawScan {
+		t.Errorf("got %v, want RawScan", got)
+	}
+}
+
+func TestClassifyBuildShape_RawScanWithPushedFilter(t *testing.T) {
+	stages := []Stage{
+		{ID: "scan-l", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 6_000_000_000},
+		{ID: "scan-l3", Type: "scan", ScanAlias: "lineitem:2", EstimatedBytes: 6_000_000_000,
+			FilterExprs: []string{"l_receiptdate > l_commitdate"}},
+		{ID: "join-anti", Type: "hash_join", JoinType: "anti",
+			LeftDepStage: "scan-l", RightDepStage: "scan-l3",
+			JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"l_orderkey"}},
+	}
+	byID := stagesByID(stages)
+	if got := classifyBuildShape(byID, byID["join-anti"]); got != BuildShapeRawScan {
+		t.Errorf("got %v, want RawScan (pushed filters do not change shape)", got)
+	}
+}
+
+func TestClassifyBuildShape_AggregateOverScan(t *testing.T) {
+	stages := []Stage{
+		{ID: "scan-l", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 1_000_000},
+		{ID: "scan-l2", Type: "scan", ScanAlias: "lineitem:1", EstimatedBytes: 6_000_000_000},
+		{ID: "agg-0", Type: "aggregate", Dependencies: []string{"scan-l2"},
+			GroupByCols: []string{"l_partkey"},
+			AggSpecs:    []AggSpec{{Func: "avg", InputCol: "l_quantity", OutputCol: "__scalar_0"}}},
+		{ID: "join-0", Type: "hash_join",
+			LeftDepStage: "scan-l", RightDepStage: "agg-0",
+			JoinLeftKeys: []string{"l_partkey"}, JoinRightKeys: []string{"l_partkey"}},
+	}
+	byID := stagesByID(stages)
+	if got := classifyBuildShape(byID, byID["join-0"]); got != BuildShapeAggregateOverScan {
+		t.Errorf("got %v, want AggregateOverScan", got)
+	}
+}
+
+func TestClassifyBuildShape_Unsupported_JoinAsBuild(t *testing.T) {
+	stages := []Stage{
+		{ID: "scan-c", Type: "scan", ScanAlias: "customer", EstimatedBytes: 100_000},
+		{ID: "scan-o", Type: "scan", ScanAlias: "orders", EstimatedBytes: 200_000},
+		{ID: "scan-l", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 6_000_000_000},
+		{ID: "join-inner", Type: "hash_join", LeftDepStage: "scan-c", RightDepStage: "scan-o"},
+		{ID: "join-outer", Type: "hash_join", LeftDepStage: "scan-l", RightDepStage: "join-inner"},
+	}
+	byID := stagesByID(stages)
+	if got := classifyBuildShape(byID, byID["join-outer"]); got != BuildShapeUnsupported {
+		t.Errorf("got %v, want Unsupported (build is a join, not a scan or aggregate-over-scan)", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -run TestClassifyBuildShape ./internal/planner/physical/`
+Expected: build error `undefined: classifyBuildShape`
+
+- [ ] **Step 3: Implement `classifyBuildShape`**
+
+Append to `broadcast_hazard.go`:
+
+```go
+// classifyBuildShape inspects a join's build subplan and returns the shape
+// the remedy selector keys off of. Returns BuildShapeUnsupported (not
+// BuildShapeUnknown) when the build doesn't match any current remedy — the
+// distinction is important for telemetry: Unsupported means "we recognize a
+// hazard but have no remedy," not "we couldn't tell."
+func classifyBuildShape(byID map[string]Stage, join Stage) BuildShape {
+	if join.Type != "hash_join" && join.Type != "broadcast_join" {
+		return BuildShapeUnknown
+	}
+	build, ok := byID[join.RightDepStage]
+	if !ok {
+		return BuildShapeUnknown
+	}
+	if build.Type == "scan" {
+		return BuildShapeRawScan
+	}
+	if agg, ok := followToAggregate(byID, build.ID); ok {
+		if _, ok := followToScan(byID, agg); ok {
+			return BuildShapeAggregateOverScan
+		}
+	}
+	return BuildShapeUnsupported
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `go test -run TestClassifyBuildShape ./internal/planner/physical/ -v`
+Expected: all four subtests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/planner/physical/broadcast_hazard.go internal/planner/physical/broadcast_hazard_test.go
+git commit -m "feat(planner): classifyBuildShape distinguishes RawScan, AggregateOverScan, Unsupported"
+```
+
+---
+
+### Task 4: Per-shape remedy candidates
+
+**Files:**
+- Modify: `internal/planner/physical/broadcast_hazard.go`
+- Modify: `internal/planner/physical/broadcast_hazard_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `broadcast_hazard_test.go`:
+
+```go
+func TestRemedyCandidatesForShape_RawScan(t *testing.T) {
+	cands := remedyCandidatesForShape(BuildShapeRawScan, 4_000_000_000, 4 /* workers */)
+	if len(cands) != 1 {
+		t.Fatalf("got %d candidates, want 1", len(cands))
+	}
+	if cands[0].Kind != RemedyShuffleScan {
+		t.Errorf("got remedy %v, want RemedyShuffleScan", cands[0].Kind)
+	}
+	if cands[0].EstCost != 1_000_000_000 {
+		t.Errorf("got cost %d, want 1_000_000_000 (4GB / 4 workers)", cands[0].EstCost)
+	}
+}
+
+func TestRemedyCandidatesForShape_AggregateOverScan(t *testing.T) {
+	cands := remedyCandidatesForShape(BuildShapeAggregateOverScan, 6_000_000_000, 4)
+	if len(cands) != 1 {
+		t.Fatalf("got %d candidates, want 1", len(cands))
+	}
+	if cands[0].Kind != RemedyPreComputeAggregate {
+		t.Errorf("got remedy %v, want RemedyPreComputeAggregate", cands[0].Kind)
+	}
+	// Conservative output-size heuristic: buildBytes / 100.
+	if cands[0].EstCost != 60_000_000 {
+		t.Errorf("got cost %d, want 60_000_000 (6GB / 100 conservative agg-output estimate)", cands[0].EstCost)
+	}
+}
+
+func TestRemedyCandidatesForShape_Unsupported(t *testing.T) {
+	cands := remedyCandidatesForShape(BuildShapeUnsupported, 1_000_000, 4)
+	if len(cands) != 0 {
+		t.Errorf("got %d candidates, want 0 (Unsupported has no applicable remedy)", len(cands))
+	}
+}
+
+func TestRemedyCandidatesForShape_DivByZeroGuard(t *testing.T) {
+	cands := remedyCandidatesForShape(BuildShapeRawScan, 4_000_000_000, 0)
+	if len(cands) != 1 {
+		t.Fatalf("got %d candidates, want 1", len(cands))
+	}
+	if cands[0].EstCost != 4_000_000_000 {
+		t.Errorf("got cost %d, want 4_000_000_000 (workerCount=0 falls back to broadcast cost)", cands[0].EstCost)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -run TestRemedyCandidatesForShape ./internal/planner/physical/`
+Expected: build error `undefined: remedyCandidatesForShape`
+
+- [ ] **Step 3: Implement `remedyCandidatesForShape`**
+
+Append to `broadcast_hazard.go`:
+
+```go
+// remedyCandidatesForShape returns the remedies applicable to a build shape
+// with their estimated per-worker post-remedy cost. The caller picks the
+// lowest-cost candidate that also passes key-alignment validation.
+//
+// Cost estimation:
+//   RemedyShuffleScan:         buildBytes / workerCount (partitioned)
+//   RemedyPreComputeAggregate: buildBytes / 100 (conservative output heuristic;
+//                              future replacement: NDV-driven from column stats)
+//
+// workerCount=0 is treated as "no partitioning benefit" — the cost reduces to
+// the original broadcast cost, which causes the selector to often pick
+// RemedyNone over a no-op shuffle. This matches standalone-mode no-op
+// semantics from the spec.
+func remedyCandidatesForShape(shape BuildShape, buildBytes int64, workerCount int) []Remedy {
+	switch shape {
+	case BuildShapeRawScan:
+		cost := buildBytes
+		if workerCount > 0 {
+			cost = buildBytes / int64(workerCount)
+		}
+		return []Remedy{{Kind: RemedyShuffleScan, EstCost: cost}}
+	case BuildShapeAggregateOverScan:
+		// Conservative: assume aggregate output is 1% of input bytes when no
+		// stats are available. Wrong-direction errors here only hurt remedy
+		// SELECTION (might pick a slightly more expensive remedy), never
+		// correctness — the substituted plan is correct regardless of cost.
+		return []Remedy{{Kind: RemedyPreComputeAggregate, EstCost: buildBytes / 100}}
+	case BuildShapeUnsupported, BuildShapeUnknown:
+		return nil
+	default:
+		return nil
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `go test -run TestRemedyCandidatesForShape ./internal/planner/physical/ -v`
+Expected: all four subtests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/planner/physical/broadcast_hazard.go internal/planner/physical/broadcast_hazard_test.go
+git commit -m "feat(planner): remedyCandidatesForShape lists per-shape remedies with cost estimates"
+```
+
+---
+
+### Task 5: Remedy selection with key-alignment validation
+
+**Files:**
+- Modify: `internal/planner/physical/broadcast_hazard.go`
+- Modify: `internal/planner/physical/broadcast_hazard_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `broadcast_hazard_test.go`:
+
+```go
+func TestPickRemedy_ShuffleSucceeds_KeysAligned(t *testing.T) {
+	stages := []Stage{
+		{ID: "scan-l", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 6_000_000_000,
+			Columns: []string{"l_orderkey", "l_suppkey", "l_quantity"}},
+		{ID: "scan-l2", Type: "scan", ScanAlias: "lineitem:1", EstimatedBytes: 6_000_000_000,
+			Columns: []string{"l_orderkey", "l_suppkey"}},
+		{ID: "join-semi", Type: "hash_join", JoinType: "semi",
+			LeftDepStage: "scan-l", RightDepStage: "scan-l2",
+			JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"l_orderkey"}},
+	}
+	byID := stagesByID(stages)
+	hazard := pickRemedy(byID, byID["join-semi"], BuildShapeRawScan, 6_000_000_000, 4)
+	if hazard.Kind != RemedyShuffleScan {
+		t.Errorf("got remedy %v, want RemedyShuffleScan", hazard.Kind)
+	}
+}
+
+func TestPickRemedy_ShuffleDemoted_BuildKeysNotInScanCols(t *testing.T) {
+	// Synthetic: the join's build-side key is c_nationkey but the build scan
+	// (orders) doesn't expose it — it comes from a fused customer join. Shuffle
+	// would partition by a key the scan can't read; demote to RemedyNone.
+	stages := []Stage{
+		{ID: "scan-l", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 6_000_000_000,
+			Columns: []string{"l_orderkey"}},
+		{ID: "scan-o", Type: "scan", ScanAlias: "orders", EstimatedBytes: 1_500_000_000,
+			Columns: []string{"o_orderkey", "o_custkey"}},
+		{ID: "join-bad", Type: "hash_join",
+			LeftDepStage: "scan-l", RightDepStage: "scan-o",
+			JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"c_nationkey"}},
+	}
+	byID := stagesByID(stages)
+	hazard := pickRemedy(byID, byID["join-bad"], BuildShapeRawScan, 1_500_000_000, 4)
+	if hazard.Kind != RemedyNone {
+		t.Errorf("got remedy %v, want RemedyNone (build keys not in scan columns)", hazard.Kind)
+	}
+}
+
+func TestPickRemedy_AggregateSucceeds_GroupByCoversJoinKeys(t *testing.T) {
+	stages := []Stage{
+		{ID: "scan-l", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 1_000_000,
+			Columns: []string{"l_partkey", "l_quantity"}},
+		{ID: "scan-l2", Type: "scan", ScanAlias: "lineitem:1", EstimatedBytes: 6_000_000_000,
+			Columns: []string{"l_partkey", "l_quantity"}},
+		{ID: "agg-0", Type: "aggregate", Dependencies: []string{"scan-l2"},
+			GroupByCols: []string{"l_partkey"},
+			AggSpecs:    []AggSpec{{Func: "avg", InputCol: "l_quantity", OutputCol: "__scalar_0"}}},
+		{ID: "join-0", Type: "hash_join",
+			LeftDepStage: "scan-l", RightDepStage: "agg-0",
+			JoinLeftKeys: []string{"l_partkey"}, JoinRightKeys: []string{"l_partkey"}},
+	}
+	byID := stagesByID(stages)
+	hazard := pickRemedy(byID, byID["join-0"], BuildShapeAggregateOverScan, 6_000_000_000, 4)
+	if hazard.Kind != RemedyPreComputeAggregate {
+		t.Errorf("got remedy %v, want RemedyPreComputeAggregate", hazard.Kind)
+	}
+}
+
+func TestPickRemedy_AggregateDemoted_GroupByMissesJoinKey(t *testing.T) {
+	stages := []Stage{
+		{ID: "scan-l", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 1_000_000,
+			Columns: []string{"l_partkey", "l_suppkey"}},
+		{ID: "scan-l2", Type: "scan", ScanAlias: "lineitem:1", EstimatedBytes: 6_000_000_000,
+			Columns: []string{"l_partkey"}},
+		// GROUP BY does NOT include l_suppkey, but the join needs both keys.
+		{ID: "agg-0", Type: "aggregate", Dependencies: []string{"scan-l2"},
+			GroupByCols: []string{"l_partkey"},
+			AggSpecs:    []AggSpec{{Func: "sum", InputCol: "l_quantity", OutputCol: "__scalar_0"}}},
+		{ID: "join-0", Type: "hash_join",
+			LeftDepStage: "scan-l", RightDepStage: "agg-0",
+			JoinLeftKeys: []string{"l_partkey", "l_suppkey"},
+			JoinRightKeys: []string{"l_partkey", "l_suppkey"}},
+	}
+	byID := stagesByID(stages)
+	hazard := pickRemedy(byID, byID["join-0"], BuildShapeAggregateOverScan, 6_000_000_000, 4)
+	if hazard.Kind != RemedyNone {
+		t.Errorf("got remedy %v, want RemedyNone (GROUP BY missing l_suppkey breaks shuffle alignment)", hazard.Kind)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -run TestPickRemedy ./internal/planner/physical/`
+Expected: build error `undefined: pickRemedy`
+
+- [ ] **Step 3: Implement `pickRemedy`**
+
+Append to `broadcast_hazard.go`:
+
+```go
+// pickRemedy returns the lowest-cost applicable remedy for a hazard, after
+// validating that the chosen remedy's key requirements line up with the
+// build subplan's exposed columns. On any validation failure the function
+// demotes through the candidate list; if none pass it returns RemedyNone.
+//
+// Validation rules:
+//   RemedyShuffleScan         → join's right keys must all appear in the build
+//                               scan's Columns (when Columns is annotated).
+//                               Skipped when Columns is empty (no annotation
+//                               available, conservatively allow).
+//   RemedyPreComputeAggregate → aggregate's GroupByCols must cover the join's
+//                               right keys (keysCovered helper from
+//                               aggregate_shuffle.go).
+func pickRemedy(byID map[string]Stage, join Stage, shape BuildShape, buildBytes int64, workerCount int) Remedy {
+	cands := remedyCandidatesForShape(shape, buildBytes, workerCount)
+	// Sort ascending by cost so the first valid candidate wins. Stable order
+	// matters for determinism in tests: candidates with equal cost retain
+	// their list order (which mirrors the per-shape priority).
+	sortRemediesByCost(cands)
+
+	for _, c := range cands {
+		switch c.Kind {
+		case RemedyShuffleScan:
+			if !shuffleKeysAligned(byID, join) {
+				continue
+			}
+			return c
+		case RemedyPreComputeAggregate:
+			if !aggregateKeysAligned(byID, join) {
+				continue
+			}
+			return c
+		}
+	}
+	return Remedy{Kind: RemedyNone, EstCost: buildBytes}
+}
+
+// shuffleKeysAligned returns true when the join's right keys (build side)
+// are all present in the build scan's exposed columns. When the build scan
+// has no Columns annotation, returns true conservatively so the caller can
+// proceed (matches the existing PickShuffleCandidate behavior).
+func shuffleKeysAligned(byID map[string]Stage, join Stage) bool {
+	build, ok := byID[join.RightDepStage]
+	if !ok || build.Type != "scan" {
+		return false
+	}
+	if len(build.Columns) == 0 {
+		return true
+	}
+	cols := make(map[string]bool, len(build.Columns))
+	for _, c := range build.Columns {
+		cols[c] = true
+	}
+	if len(join.JoinRightKeys) == 0 {
+		return false
+	}
+	for _, k := range join.JoinRightKeys {
+		if !cols[k] {
+			return false
+		}
+	}
+	return true
+}
+
+// aggregateKeysAligned returns true when the build's aggregate GroupByCols
+// cover the join's right keys. Reuses the keysCovered helper from
+// aggregate_shuffle.go.
+func aggregateKeysAligned(byID map[string]Stage, join Stage) bool {
+	build, ok := byID[join.RightDepStage]
+	if !ok {
+		return false
+	}
+	agg, ok := followToAggregate(byID, build.ID)
+	if !ok {
+		return false
+	}
+	return keysCovered(join.JoinRightKeys, agg.GroupByCols)
+}
+
+// sortRemediesByCost sorts in place ascending by EstCost. Stable.
+func sortRemediesByCost(rs []Remedy) {
+	for i := 1; i < len(rs); i++ {
+		for j := i; j > 0 && rs[j-1].EstCost > rs[j].EstCost; j-- {
+			rs[j-1], rs[j] = rs[j], rs[j-1]
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `go test -run TestPickRemedy ./internal/planner/physical/ -v`
+Expected: all four subtests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/planner/physical/broadcast_hazard.go internal/planner/physical/broadcast_hazard_test.go
+git commit -m "feat(planner): pickRemedy selects lowest-cost remedy with key-alignment validation"
+```
+
+---
+
+### Task 6: `IdentifyBroadcastHazards` — top-level pass
+
+**Files:**
+- Modify: `internal/planner/physical/broadcast_hazard.go`
+- Modify: `internal/planner/physical/broadcast_hazard_test.go`
+
+- [ ] **Step 1: Write the failing tests (Q21, Q17, sub-budget cases)**
+
+Append to `broadcast_hazard_test.go`:
+
+```go
+// Q21 shape: two semi/anti raw-scan builds on lineitem, both above budget.
+// Expect TWO BroadcastHazards both with RemedyShuffleScan.
+func TestIdentifyBroadcastHazards_Q21Shape(t *testing.T) {
+	stages := []Stage{
+		{ID: "scan-l1", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 3_700_000_000,
+			Columns: []string{"l_orderkey", "l_suppkey", "l_receiptdate", "l_commitdate"}},
+		{ID: "scan-l2", Type: "scan", ScanAlias: "lineitem:1", EstimatedBytes: 3_700_000_000,
+			Columns: []string{"l_orderkey", "l_suppkey"}},
+		{ID: "scan-l3", Type: "scan", ScanAlias: "lineitem:2", EstimatedBytes: 3_700_000_000,
+			Columns:     []string{"l_orderkey", "l_suppkey", "l_receiptdate", "l_commitdate"},
+			FilterExprs: []string{"l_receiptdate > l_commitdate"}},
+		{ID: "join-semi", Type: "hash_join", JoinType: "semi",
+			LeftDepStage: "scan-l1", RightDepStage: "scan-l2",
+			JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"l_orderkey"}},
+		{ID: "join-anti", Type: "hash_join", JoinType: "anti",
+			LeftDepStage: "join-semi", RightDepStage: "scan-l3",
+			JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"l_orderkey"}},
+	}
+	hazards := IdentifyBroadcastHazards(stages, 1_000_000_000, 4 /* workers */)
+	if len(hazards) != 2 {
+		t.Fatalf("got %d hazards, want 2 (l2 semi + l3 anti)", len(hazards))
+	}
+	for i, h := range hazards {
+		if h.Remedy.Kind != RemedyShuffleScan {
+			t.Errorf("hazard[%d] remedy=%v, want RemedyShuffleScan", i, h.Remedy.Kind)
+		}
+		if h.BuildShape != BuildShapeRawScan {
+			t.Errorf("hazard[%d] shape=%v, want RawScan", i, h.BuildShape)
+		}
+	}
+	if hazards[0].JoinStageID != "join-semi" || hazards[1].JoinStageID != "join-anti" {
+		t.Errorf("hazards must be in plan order, got [%s, %s]", hazards[0].JoinStageID, hazards[1].JoinStageID)
+	}
+}
+
+// Q17 shape: aggregate-over-scan build, single hazard, RemedyPreComputeAggregate.
+func TestIdentifyBroadcastHazards_Q17Shape(t *testing.T) {
+	stages := []Stage{
+		{ID: "scan-p", Type: "scan", ScanAlias: "part", EstimatedBytes: 50_000_000,
+			Columns: []string{"p_partkey"}},
+		{ID: "scan-l", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 1_000_000,
+			Columns: []string{"l_partkey", "l_quantity"}},
+		{ID: "scan-l2", Type: "scan", ScanAlias: "lineitem:1", EstimatedBytes: 6_000_000_000,
+			Columns: []string{"l_partkey", "l_quantity"}},
+		{ID: "agg-0", Type: "aggregate", Dependencies: []string{"scan-l2"},
+			GroupByCols: []string{"l_partkey"},
+			AggSpecs:    []AggSpec{{Func: "avg", InputCol: "l_quantity", OutputCol: "__scalar_0"}}},
+		{ID: "join-inner", Type: "hash_join", LeftDepStage: "scan-l", RightDepStage: "scan-p"},
+		{ID: "join-scalar", Type: "hash_join",
+			LeftDepStage: "join-inner", RightDepStage: "agg-0",
+			JoinLeftKeys: []string{"l_partkey"}, JoinRightKeys: []string{"l_partkey"}},
+	}
+	hazards := IdentifyBroadcastHazards(stages, 1_000_000_000, 4)
+	if len(hazards) != 1 {
+		t.Fatalf("got %d hazards, want 1", len(hazards))
+	}
+	if hazards[0].Remedy.Kind != RemedyPreComputeAggregate {
+		t.Errorf("got %v, want RemedyPreComputeAggregate", hazards[0].Remedy.Kind)
+	}
+}
+
+func TestIdentifyBroadcastHazards_AllBuildsBelowBudget(t *testing.T) {
+	stages := []Stage{
+		{ID: "scan-l", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 100_000_000,
+			Columns: []string{"l_orderkey"}},
+		{ID: "scan-o", Type: "scan", ScanAlias: "orders", EstimatedBytes: 100_000_000,
+			Columns: []string{"o_orderkey"}},
+		{ID: "join-0", Type: "hash_join",
+			LeftDepStage: "scan-l", RightDepStage: "scan-o",
+			JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"}},
+	}
+	hazards := IdentifyBroadcastHazards(stages, 1_000_000_000, 4)
+	if len(hazards) != 0 {
+		t.Errorf("got %d hazards, want 0 (all builds under budget)", len(hazards))
+	}
+}
+
+func TestIdentifyBroadcastHazards_UnsupportedShapeRecorded(t *testing.T) {
+	// Build is a join (composite subplan) — Unsupported shape, no remedy,
+	// but still surfaced as a hazard so the caller can log it.
+	stages := []Stage{
+		{ID: "scan-c", Type: "scan", ScanAlias: "customer", EstimatedBytes: 100_000},
+		{ID: "scan-o", Type: "scan", ScanAlias: "orders", EstimatedBytes: 200_000},
+		{ID: "scan-l", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 6_000_000_000,
+			Columns: []string{"l_orderkey"}},
+		{ID: "join-inner", Type: "hash_join", LeftDepStage: "scan-c", RightDepStage: "scan-o"},
+		{ID: "join-outer", Type: "hash_join", LeftDepStage: "scan-l", RightDepStage: "join-inner"},
+	}
+	hazards := IdentifyBroadcastHazards(stages, 1_000, 4)
+	// join-outer's build (join-inner) is not a hazard because it's small. The
+	// only hazard is — wait, scan-l is the probe of join-outer, no hazard there.
+	// In this synthetic, no joins have a build above budget. Adjust to make
+	// join-outer's build the large one:
+	stages = []Stage{
+		{ID: "scan-c", Type: "scan", ScanAlias: "customer", EstimatedBytes: 100_000},
+		{ID: "scan-o", Type: "scan", ScanAlias: "orders", EstimatedBytes: 200_000},
+		{ID: "scan-l", Type: "scan", ScanAlias: "lineitem", EstimatedBytes: 6_000_000_000,
+			Columns: []string{"l_orderkey"}},
+		{ID: "join-inner", Type: "hash_join", LeftDepStage: "scan-c", RightDepStage: "scan-o"},
+		// Build (RightDep) is a JOIN — Unsupported.
+		{ID: "join-outer", Type: "hash_join", LeftDepStage: "scan-l", RightDepStage: "join-inner",
+			// Make join-inner appear large enough to be a hazard. (Tests insert a
+			// fake EstimatedBytes via the stage; computeBuildBytes returns 0 for
+			// non-scan builds, so we need a different test setup. Skip this case:
+			// computeBuildBytes correctly returns 0 for join builds, so join-outer
+			// is not a hazard. The Unsupported branch fires when an aggregate or
+			// scan-rooted subplan is found but no remedy applies — covered by
+			// TestRemedyCandidatesForShape_Unsupported and
+			// TestPickRemedy_AggregateDemoted_GroupByMissesJoinKey.)
+		},
+	}
+	hazards = IdentifyBroadcastHazards(stages, 1_000, 4)
+	if len(hazards) != 0 {
+		t.Errorf("got %d hazards; expected 0 because computeBuildBytes returns 0 for join-rooted builds", len(hazards))
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -run TestIdentifyBroadcastHazards ./internal/planner/physical/`
+Expected: build error `undefined: IdentifyBroadcastHazards`
+
+- [ ] **Step 3: Implement `IdentifyBroadcastHazards`**
+
+Append to `broadcast_hazard.go`:
+
+```go
+// IdentifyBroadcastHazards walks every hash_join / broadcast_join stage in
+// the plan and returns one BroadcastHazard per join whose build's per-worker
+// bytes exceed budget. Returns the empty slice when no hazards are present.
+//
+// Hazards are returned in plan order (the order joins appear in the input
+// stages slice) for deterministic downstream orchestration. Joins whose
+// build computeBuildBytes() returns 0 (composite subplans, missing deps) are
+// not hazards in this pass — they may become hazards in a future remedy
+// extension that handles those shapes.
+//
+// Per the spec invariant: this pass is total. Every join either passes
+// (build ≤ budget, no hazard), is hazardous with an applicable remedy, or
+// is hazardous with shape Unsupported / Remedy.Kind RemedyNone (still
+// returned so the caller can log it).
+func IdentifyBroadcastHazards(stages []Stage, budget int64, workerCount int) []BroadcastHazard {
+	byID := stagesByIDInternal(stages)
+	hazards := make([]BroadcastHazard, 0)
+
+	for _, j := range stages {
+		if j.Type != "hash_join" && j.Type != "broadcast_join" {
+			continue
+		}
+		buildBytes := computeBuildBytes(byID, j)
+		if buildBytes <= budget {
+			continue
+		}
+
+		shape := classifyBuildShape(byID, j)
+		remedy := pickRemedy(byID, j, shape, buildBytes, workerCount)
+
+		h := BroadcastHazard{
+			JoinStageID: j.ID,
+			BuildBytes:  buildBytes,
+			BuildShape:  shape,
+			Remedy:      remedy,
+		}
+
+		// Populate the remedy-specific candidate payload so downstream
+		// orchestration has everything it needs without re-walking the plan.
+		switch remedy.Kind {
+		case RemedyShuffleScan:
+			h.ShuffleCand = buildShuffleCandFromHazard(byID, j)
+		case RemedyPreComputeAggregate:
+			h.AggregateCand = buildAggregateCandFromHazard(byID, j)
+		}
+
+		hazards = append(hazards, h)
+	}
+	return hazards
+}
+
+func stagesByIDInternal(stages []Stage) map[string]Stage {
+	m := make(map[string]Stage, len(stages))
+	for _, s := range stages {
+		m[s.ID] = s
+	}
+	return m
+}
+
+// buildShuffleCandFromHazard constructs the ShuffleCandidate payload for a
+// RemedyShuffleScan hazard. Mirrors what the deleted PickShuffleCandidate
+// would have returned for this single join.
+func buildShuffleCandFromHazard(byID map[string]Stage, j Stage) ShuffleCandidate {
+	build := byID[j.RightDepStage]
+	probe := byID[j.LeftDepStage]
+	return ShuffleCandidate{
+		JoinStageID: j.ID,
+		BuildAlias:  build.ScanAlias,
+		ProbeAlias:  probe.ScanAlias,
+		BuildKeys:   append([]string(nil), j.JoinRightKeys...),
+		ProbeKeys:   append([]string(nil), j.JoinLeftKeys...),
+		JoinKeys:    append([]string(nil), j.JoinRightKeys...),
+		BuildBytes:  build.EstimatedBytes,
+	}
+}
+
+// buildAggregateCandFromHazard constructs the AggregateShuffleCandidate
+// payload for a RemedyPreComputeAggregate hazard. Mirrors what the deleted
+// PickAggregateShuffleCandidate would have returned.
+func buildAggregateCandFromHazard(byID map[string]Stage, j Stage) AggregateShuffleCandidate {
+	build := byID[j.RightDepStage]
+	agg, _ := followToAggregate(byID, build.ID)
+	scan, _ := followToScan(byID, agg)
+	return AggregateShuffleCandidate{
+		JoinStageID:      j.ID,
+		AggregateStageID: agg.ID,
+		InputScanID:      scan.ID,
+		InputScanAlias:   scan.ScanAlias,
+		InputScanBytes:   scan.EstimatedBytes,
+		GroupByKeys:      append([]string(nil), agg.GroupByCols...),
+		JoinBuildKeys:    append([]string(nil), j.JoinRightKeys...),
+		JoinProbeKeys:    append([]string(nil), j.JoinLeftKeys...),
+	}
+}
+```
+
+Also remove the test helper `stagesByID` from the test file if it's now redundant (the test file calls `stagesByID`, the production code has `stagesByIDInternal` — keep both: the test helper avoids exporting the production one).
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `go test -run TestIdentifyBroadcastHazards ./internal/planner/physical/ -v`
+Expected: all subtests PASS, including the Q21 two-hazard case and Q17 single-aggregate case
+
+- [ ] **Step 5: Run full broadcast_hazard test file**
+
+Run: `go test -v ./internal/planner/physical/ -run "BroadcastHazard|RemedyCandidates|PickRemedy|ClassifyBuildShape|ComputeBuildBytes|IdentifyBroadcastHazards"`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/planner/physical/broadcast_hazard.go internal/planner/physical/broadcast_hazard_test.go
+git commit -m "feat(planner): IdentifyBroadcastHazards — per-join hazard pass returning all hazards"
+```
+
+---
+
+## Phase 2 — Coordinator infrastructure (budget, multi-build shuffle, dispatch)
+
+### Task 7: `broadcastBudget()` config primitive
+
+**Files:**
+- Create: `internal/coordinator/budget.go`
+- Test: `internal/coordinator/budget_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/coordinator/budget_test.go`:
+
+```go
+package coordinator
+
+import "testing"
+
+func TestBroadcastBudget_NormalCase(t *testing.T) {
+	prev := bcastBudgetFraction
+	bcastBudgetFraction = 0.25
+	t.Cleanup(func() { bcastBudgetFraction = prev })
+
+	got := computeBroadcastBudget(8<<30 /* 8 GB */, 4 /* workers */)
+	want := int64(0.25 * (8 << 30) / 4) // 512 MB
+	if got != want {
+		t.Errorf("got %d, want %d", got, want)
+	}
+}
+
+func TestBroadcastBudget_WorkerCountZero(t *testing.T) {
+	got := computeBroadcastBudget(8<<30, 0)
+	want := int64(0.25 * (8 << 30)) // workerCount=0 treated as 1 (single-worker)
+	if got != want {
+		t.Errorf("got %d, want %d", got, want)
+	}
+}
+
+func TestBroadcastBudget_MemLimitZero_FallsBackToConfig(t *testing.T) {
+	prev := broadcastBudgetFallbackBytes
+	broadcastBudgetFallbackBytes = 1 << 30
+	t.Cleanup(func() { broadcastBudgetFallbackBytes = prev })
+
+	got := computeBroadcastBudget(0 /* GOMEMLIMIT unset */, 4)
+	if got != 1<<30 {
+		t.Errorf("got %d, want %d (fallback)", got, int64(1<<30))
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run TestBroadcastBudget ./internal/coordinator/`
+Expected: build errors for `bcastBudgetFraction`, `computeBroadcastBudget`, `broadcastBudgetFallbackBytes`
+
+- [ ] **Step 3: Implement budget.go**
+
+Create `internal/coordinator/budget.go`:
+
+```go
+package coordinator
+
+import "runtime/debug"
+
+// bcastBudgetFraction is the fraction of per-worker GOMEMLIMIT that any single
+// broadcast hazard's build is allowed to occupy. Default 0.25 means a single
+// broadcast can use at most 25% of per-worker heap; the remaining 75% covers
+// the executor's hash tables, sort buffers, scan readers, etc. Tunable via
+// var-override in tests; production change requires re-validating the
+// invariant test under the new fraction.
+var bcastBudgetFraction = 0.25
+
+// broadcastBudgetFallbackBytes is the budget value used when GOMEMLIMIT is
+// unset (e.g., local development without the env var). Conservative default
+// of 1 GB — small enough to surface hazards in dev, large enough not to
+// reroute small queries through shuffle unnecessarily.
+var broadcastBudgetFallbackBytes int64 = 1 << 30
+
+// computeBroadcastBudget derives the per-hazard budget from per-worker memory
+// and worker count. Pure function for testability; the Coordinator method
+// broadcastBudget() wraps this with runtime sources.
+func computeBroadcastBudget(memLimit int64, workerCount int) int64 {
+	if memLimit <= 0 {
+		return broadcastBudgetFallbackBytes
+	}
+	wc := workerCount
+	if wc < 1 {
+		wc = 1
+	}
+	return int64(bcastBudgetFraction * float64(memLimit) / float64(wc))
+}
+
+// broadcastBudget returns the per-hazard budget for the current Coordinator's
+// cluster. Uses runtime/debug.SetMemoryLimit's read-only variant via
+// debug.SetGCPercent indirection — Go 1.22 exposes GOMEMLIMIT as
+// debug.SetMemoryLimit(-1).
+func (c *Coordinator) broadcastBudget() int64 {
+	memLimit := readGoMemLimit()
+	return computeBroadcastBudget(memLimit, c.workers.Count())
+}
+
+// readGoMemLimit returns the runtime's GOMEMLIMIT value, or 0 if unset.
+// Uses debug.SetMemoryLimit(-1) which returns the current limit without
+// changing it (as documented in the runtime/debug package).
+func readGoMemLimit() int64 {
+	current := debug.SetMemoryLimit(-1)
+	// SetMemoryLimit returns math.MaxInt64 when no limit is set. Treat that
+	// as "unset" so callers fall back to the configured default.
+	if current == 1<<63-1 {
+		return 0
+	}
+	return current
+}
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `go test -run TestBroadcastBudget ./internal/coordinator/ -v`
+Expected: all three subtests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/coordinator/budget.go internal/coordinator/budget_test.go
+git commit -m "feat(coordinator): broadcastBudget derived from GOMEMLIMIT × fraction / workerCount"
+```
+
+---
+
+### Task 8: Group hazards into multi-build shuffle groups
+
+**Files:**
+- Create: `internal/coordinator/broadcast_remedies.go`
+- Test: `internal/coordinator/broadcast_remedies_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/coordinator/broadcast_remedies_test.go`:
+
+```go
+package coordinator
+
+import (
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/planner/physical"
+)
+
+func TestGroupShuffleHazards_Q21Shape_AlignedKeys(t *testing.T) {
+	// Two semi/anti hazards sharing the same probe alias and join key.
+	// Expected: ONE group with two builds.
+	hazards := []physical.BroadcastHazard{
+		{
+			JoinStageID: "join-semi",
+			Remedy:      physical.Remedy{Kind: physical.RemedyShuffleScan},
+			ShuffleCand: physical.ShuffleCandidate{
+				BuildAlias: "lineitem:1", ProbeAlias: "lineitem",
+				BuildKeys: []string{"l_orderkey"}, ProbeKeys: []string{"l_orderkey"},
+			},
+		},
+		{
+			JoinStageID: "join-anti",
+			Remedy:      physical.Remedy{Kind: physical.RemedyShuffleScan},
+			ShuffleCand: physical.ShuffleCandidate{
+				BuildAlias: "lineitem:2", ProbeAlias: "lineitem",
+				BuildKeys: []string{"l_orderkey"}, ProbeKeys: []string{"l_orderkey"},
+			},
+		},
+	}
+	groups, demoted := groupShuffleHazards(hazards)
+
+	if len(groups) != 1 {
+		t.Fatalf("got %d groups, want 1 (both hazards share probe+key)", len(groups))
+	}
+	if len(groups[0].Builds) != 2 {
+		t.Errorf("got %d builds in group, want 2", len(groups[0].Builds))
+	}
+	if groups[0].ProbeAlias != "lineitem" {
+		t.Errorf("got probe %q, want lineitem", groups[0].ProbeAlias)
+	}
+	if len(demoted) != 0 {
+		t.Errorf("got %d demoted, want 0", len(demoted))
+	}
+}
+
+func TestGroupShuffleHazards_DifferentKeys_SecondDemoted(t *testing.T) {
+	hazards := []physical.BroadcastHazard{
+		{
+			JoinStageID: "join-a",
+			Remedy:      physical.Remedy{Kind: physical.RemedyShuffleScan},
+			ShuffleCand: physical.ShuffleCandidate{
+				BuildAlias: "orders", ProbeAlias: "lineitem",
+				BuildKeys: []string{"o_orderkey"}, ProbeKeys: []string{"l_orderkey"},
+			},
+		},
+		{
+			JoinStageID: "join-b",
+			Remedy:      physical.Remedy{Kind: physical.RemedyShuffleScan},
+			ShuffleCand: physical.ShuffleCandidate{
+				BuildAlias: "supplier", ProbeAlias: "lineitem",
+				BuildKeys: []string{"s_suppkey"}, ProbeKeys: []string{"l_suppkey"}, // different probe key
+			},
+		},
+	}
+	groups, demoted := groupShuffleHazards(hazards)
+
+	if len(groups) != 1 {
+		t.Fatalf("got %d groups, want 1 (only first key dispatched)", len(groups))
+	}
+	if len(demoted) != 1 || demoted[0].JoinStageID != "join-b" {
+		t.Errorf("expected join-b demoted, got %v", demoted)
+	}
+}
+
+func TestGroupShuffleHazards_NonShuffleHazards_Ignored(t *testing.T) {
+	hazards := []physical.BroadcastHazard{
+		{JoinStageID: "j1", Remedy: physical.Remedy{Kind: physical.RemedyPreComputeAggregate}},
+		{JoinStageID: "j2", Remedy: physical.Remedy{Kind: physical.RemedyNone}},
+	}
+	groups, demoted := groupShuffleHazards(hazards)
+	if len(groups) != 0 || len(demoted) != 0 {
+		t.Errorf("got %d groups, %d demoted; want 0,0 (neither hazard is RemedyShuffleScan)", len(groups), len(demoted))
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run TestGroupShuffleHazards ./internal/coordinator/`
+Expected: build error `undefined: groupShuffleHazards`, `shuffleGroup` types
+
+- [ ] **Step 3: Implement grouping logic in `broadcast_remedies.go`**
+
+Create `internal/coordinator/broadcast_remedies.go`:
+
+```go
+package coordinator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/planner/physical"
+)
+
+// shuffleGroup bundles RemedyShuffleScan hazards that share a probe alias
+// and probe keys, so they can be dispatched as one multi-build shuffle stage:
+// one probe-side shuffle + N build-side shuffles, all writing into the same
+// partition layout.
+type shuffleGroup struct {
+	ProbeAlias string
+	ProbeKeys  []string
+	Builds     []shuffleBuildSide
+	// JoinStageIDs lists every join this group remediates (used for
+	// telemetry and downstream stage replacement).
+	JoinStageIDs []string
+}
+
+type shuffleBuildSide struct {
+	JoinStageID string
+	Alias       string
+	Keys        []string
+	Bytes       int64
+}
+
+// groupShuffleHazards partitions a list of hazards into:
+//   - shuffle groups (each group can be dispatched as one multi-sided shuffle)
+//   - demoted hazards (hazards that wanted RemedyShuffleScan but couldn't be
+//     grouped — usually because their probe key conflicts with an
+//     already-claimed probe). Demoted hazards revert to broadcast at runtime
+//     with a telemetry log line.
+//
+// Hazards with non-shuffle remedies (RemedyPreComputeAggregate, RemedyNone)
+// are ignored here; they're dispatched separately by applyBroadcastRemedies.
+func groupShuffleHazards(hazards []physical.BroadcastHazard) (groups []shuffleGroup, demoted []physical.BroadcastHazard) {
+	// Key the groups by (probeAlias, probeKeys-joined). Iteration is in
+	// hazard order so the first hazard wins the probe slot.
+	byKey := make(map[string]int) // map key → index into groups
+	for _, h := range hazards {
+		if h.Remedy.Kind != physical.RemedyShuffleScan {
+			continue
+		}
+		probeKey := h.ShuffleCand.ProbeAlias + "|" + joinStrings(h.ShuffleCand.ProbeKeys)
+		if _, occupied := byKey[probeKey]; !occupied {
+			// Check for probe-alias conflict with an already-claimed group on
+			// a different key (e.g. "lineitem|l_orderkey" exists, this is
+			// "lineitem|l_suppkey" — second is demoted because the same
+			// scan can only be shuffled by one key set per pipeline).
+			for existingKey := range byKey {
+				if splitProbe(existingKey) == h.ShuffleCand.ProbeAlias {
+					demoted = append(demoted, h)
+					goto nextHazard
+				}
+			}
+			byKey[probeKey] = len(groups)
+			groups = append(groups, shuffleGroup{
+				ProbeAlias:   h.ShuffleCand.ProbeAlias,
+				ProbeKeys:    append([]string(nil), h.ShuffleCand.ProbeKeys...),
+				Builds:       nil,
+				JoinStageIDs: nil,
+			})
+		}
+		idx := byKey[probeKey]
+		groups[idx].Builds = append(groups[idx].Builds, shuffleBuildSide{
+			JoinStageID: h.JoinStageID,
+			Alias:       h.ShuffleCand.BuildAlias,
+			Keys:        append([]string(nil), h.ShuffleCand.BuildKeys...),
+			Bytes:       h.ShuffleCand.BuildBytes,
+		})
+		groups[idx].JoinStageIDs = append(groups[idx].JoinStageIDs, h.JoinStageID)
+	nextHazard:
+	}
+	return groups, demoted
+}
+
+func joinStrings(parts []string) string {
+	out := ""
+	for i, p := range parts {
+		if i > 0 {
+			out += ","
+		}
+		out += p
+	}
+	return out
+}
+
+func splitProbe(key string) string {
+	for i, c := range key {
+		if c == '|' {
+			return key[:i]
+		}
+	}
+	return key
+}
+
+// applyBroadcastRemedies is implemented in Task 10. Stubbed here so the file
+// compiles incrementally and Task 8's tests can run against the rest of this
+// file's helpers without depending on Task 10's full implementation.
+func (c *Coordinator) applyBroadcastRemedies(
+	_ context.Context, _ string, _ string, stages []physical.Stage, _ []physical.BroadcastHazard,
+) (revisedStages []physical.Stage, shuffleTasks map[string][]distributed.Task, preAggregates []physical.PreComputedAggregateMeta, err error) {
+	return stages, nil, nil, fmt.Errorf("applyBroadcastRemedies: not implemented yet")
+}
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `go test -run TestGroupShuffleHazards ./internal/coordinator/ -v`
+Expected: all three subtests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/coordinator/broadcast_remedies.go internal/coordinator/broadcast_remedies_test.go
+git commit -m "feat(coordinator): groupShuffleHazards bundles shuffle hazards sharing probe+key"
+```
+
+---
+
+### Task 9: Multi-build `ShuffleLayout` + `orchestrateMultiBuildShuffle`
+
+**Files:**
+- Modify: `internal/coordinator/shuffle_orchestrator.go`
+- Test: `internal/coordinator/shuffle_orchestrator_test.go` (existing or new)
+
+- [ ] **Step 1: Update `ShuffleLayout` struct to support multiple builds**
+
+Edit `internal/coordinator/shuffle_orchestrator.go`, replace the existing `ShuffleLayout` struct with:
+
+```go
+// ShuffleLayout describes the shard file layout produced by an N-sided shuffle
+// (1 probe + M builds). The probe is shuffled by the group's probe keys; each
+// build is shuffled by its own keys (which the planner has validated are
+// equivalent to the probe keys via PickRemedy's key-alignment check).
+//
+// BuildAliases is the ordered list of build-side scan aliases. BuildShardFiles
+// is keyed by the same aliases — BuildShardFiles[alias][p] returns the S3 keys
+// for that build's partition p.
+type ShuffleLayout struct {
+	ProbeAlias       string
+	NumPartitions    int
+	BuildAliases     []string
+	BuildShardFiles  map[string][][]string // alias → partition → files
+	ProbeShardFiles  [][]string
+}
+```
+
+- [ ] **Step 2: Update `buildShufflePipelineTasks` to populate multi-build PreScannedInputs**
+
+Replace the function body (around line 328 in `shuffle_orchestrator.go`):
+
+```go
+func buildShufflePipelineTasks(
+	queryID, sql, resultBucket string,
+	layout *ShuffleLayout,
+	workerCount int,
+) []distributed.Task {
+	resultPrefix := fmt.Sprintf("queries/%s/pipeline-0/", queryID)
+	tasks := make([]distributed.Task, 0, workerCount)
+	for w := 0; w < workerCount; w++ {
+		parts := assignPartitionsToWorker(w, workerCount, layout.NumPartitions)
+		if len(parts) == 0 {
+			continue
+		}
+		var probeFiles []string
+		for _, p := range parts {
+			probeFiles = append(probeFiles, layout.ProbeShardFiles[p]...)
+		}
+		preScanned := map[string][]string{
+			layout.ProbeAlias: probeFiles,
+		}
+		for _, alias := range layout.BuildAliases {
+			var buildFiles []string
+			for _, p := range parts {
+				buildFiles = append(buildFiles, layout.BuildShardFiles[alias][p]...)
+			}
+			preScanned[alias] = buildFiles
+		}
+		tasks = append(tasks, distributed.Task{
+			ID:               uuid.New().String()[:8],
+			QueryID:          queryID,
+			StageID:          "pipeline-0",
+			Type:             distributed.TaskTypePipeline,
+			SQLText:          sql,
+			DataBucket:       resultBucket,
+			ResultBucket:     resultBucket,
+			ResultPrefix:     resultPrefix,
+			PartialAggregate: true,
+			PreScannedInputs: preScanned,
+			CreatedAt:        time.Now(),
+		})
+	}
+	return tasks
+}
+```
+
+- [ ] **Step 3: Replace `orchestrateShuffleStages` with `orchestrateMultiBuildShuffle`**
+
+Replace the function (currently single-build) at the top of `shuffle_orchestrator.go`:
+
+```go
+// orchestrateMultiBuildShuffle runs N+1 shuffle stages (M builds + 1 probe)
+// in parallel and returns the resulting shard layout. M=1 is the original
+// PR #40 case; M=2 is Q21. Failure of any side cancels all.
+func (c *Coordinator) orchestrateMultiBuildShuffle(
+	ctx context.Context,
+	queryID string,
+	group shuffleGroup,
+	stages []physical.Stage,
+	workerCount int,
+) (*ShuffleLayout, error) {
+	numParts := workerCount * shufflePartitionMultiplier
+
+	// Locate the probe scan and each build scan stage.
+	probeStage, err := findScanStageByAlias(stages, group.ProbeAlias)
+	if err != nil {
+		return nil, fmt.Errorf("probe scan %q: %w", group.ProbeAlias, err)
+	}
+	buildStages := make(map[string]physical.Stage, len(group.Builds))
+	for _, b := range group.Builds {
+		s, err := findScanStageByAlias(stages, b.Alias)
+		if err != nil {
+			return nil, fmt.Errorf("build scan %q: %w", b.Alias, err)
+		}
+		buildStages[b.Alias] = s
+	}
+
+	c.logger.Info("multi-build shuffle: starting",
+		"query_id", queryID,
+		"probe_alias", group.ProbeAlias,
+		"build_aliases", group.JoinStageIDs,
+		"num_partitions", numParts,
+		"worker_count", workerCount,
+		"build_count", len(group.Builds),
+	)
+
+	g, gctx := errgroup.WithContext(ctx)
+	buildShards := make(map[string][][]string, len(group.Builds))
+	var buildShardsMu sync.Mutex
+	var probeShards [][]string
+
+	for _, b := range group.Builds {
+		b := b
+		bs := buildStages[b.Alias]
+		g.Go(func() error {
+			shards, err := c.runShuffleSide(gctx, queryID, "build-"+b.Alias, bs, b.Keys, numParts, workerCount)
+			if err != nil {
+				return fmt.Errorf("build-side shuffle for %s: %w", b.Alias, err)
+			}
+			buildShardsMu.Lock()
+			buildShards[b.Alias] = shards
+			buildShardsMu.Unlock()
+			return nil
+		})
+	}
+	g.Go(func() error {
+		shards, err := c.runShuffleSide(gctx, queryID, "probe", probeStage, group.ProbeKeys, numParts, workerCount)
+		if err != nil {
+			return fmt.Errorf("probe-side shuffle for %s: %w", group.ProbeAlias, err)
+		}
+		probeShards = shards
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("orchestrateMultiBuildShuffle: %w", err)
+	}
+
+	c.logger.Info("multi-build shuffle: complete",
+		"query_id", queryID,
+		"num_partitions", numParts,
+		"build_count", len(buildShards),
+	)
+
+	aliases := make([]string, 0, len(group.Builds))
+	for _, b := range group.Builds {
+		aliases = append(aliases, b.Alias)
+	}
+	return &ShuffleLayout{
+		ProbeAlias:      group.ProbeAlias,
+		NumPartitions:   numParts,
+		BuildAliases:    aliases,
+		BuildShardFiles: buildShards,
+		ProbeShardFiles: probeShards,
+	}, nil
+}
+
+// findScanStageByAlias locates a scan stage by its ScanAlias. Returns an
+// error when no scan with that alias exists.
+func findScanStageByAlias(stages []physical.Stage, alias string) (physical.Stage, error) {
+	for _, s := range stages {
+		if s.Type == "scan" && s.ScanAlias == alias {
+			return s, nil
+		}
+	}
+	return physical.Stage{}, fmt.Errorf("no scan stage with alias %q", alias)
+}
+```
+
+Delete the old `orchestrateShuffleStages` and `findShuffleScanStages` functions (the latter superseded by `findScanStageByAlias`).
+
+- [ ] **Step 4: Verify the file still compiles**
+
+Run: `go build ./internal/coordinator/`
+Expected: failure — `coordinator.go` still references the old `orchestrateShuffleStages` signature. We'll fix this in Task 11.
+
+For now, run a more targeted check that the new code compiles in isolation:
+
+Run: `go vet ./internal/coordinator/shuffle_orchestrator.go ./internal/coordinator/shuffle_orchestrator_test.go ./internal/coordinator/broadcast_remedies.go ./internal/coordinator/broadcast_remedies_test.go ./internal/coordinator/budget.go ./internal/coordinator/budget_test.go 2>&1 | head -20`
+Expected: errors confined to symbols `coordinator.go` consumes from this file (resolved in Task 11)
+
+- [ ] **Step 5: Commit (with build-broken note)**
+
+```bash
+git add internal/coordinator/shuffle_orchestrator.go
+git commit -m "refactor(coordinator): ShuffleLayout + orchestrateMultiBuildShuffle support N builds
+
+Build-broken until Task 11 wires the new orchestrator into coordinator.go.
+Done as a separate commit so the multi-build shape is reviewable in isolation."
+```
+
+---
+
+### Task 10: `applyBroadcastRemedies` — full implementation
+
+**Files:**
+- Modify: `internal/coordinator/broadcast_remedies.go`
+- Modify: `internal/coordinator/broadcast_remedies_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `broadcast_remedies_test.go`:
+
+```go
+func TestApplyBroadcastRemedies_NoHazards_Passthrough(t *testing.T) {
+	c := newTestCoordinatorMinimal(t)
+	stages := []physical.Stage{
+		{ID: "pipeline-0", Type: "pipeline"},
+	}
+	revised, shuffleTasks, preAgg, err := c.applyBroadcastRemedies(context.Background(), "q1", stages, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(revised) != len(stages) {
+		t.Errorf("revised stages length differs (got %d, want %d) for no-hazard case", len(revised), len(stages))
+	}
+	if shuffleTasks != nil || preAgg != nil {
+		t.Errorf("expected nil artifacts when no hazards present")
+	}
+}
+
+func TestApplyBroadcastRemedies_AggregateHazardOnly_DispatchesPreCompute(t *testing.T) {
+	// Use a low aggregateShuffleThreshold-equivalent (broadcastBudget) and
+	// real coordinator setup with a synthetic stage list. The pre-compute
+	// produces no rows because the test scan files are empty; that's
+	// expected and the artifact list reflects it.
+	c, cleanup := newTestCoordinatorWithCatalog(t)
+	t.Cleanup(cleanup)
+
+	hazards := []physical.BroadcastHazard{
+		{
+			JoinStageID: "join-scalar",
+			Remedy:      physical.Remedy{Kind: physical.RemedyPreComputeAggregate},
+			AggregateCand: physical.AggregateShuffleCandidate{
+				JoinStageID:      "join-scalar",
+				AggregateStageID: "agg-0",
+				InputScanID:      "scan-l2",
+				InputScanAlias:   "lineitem:1",
+				GroupByKeys:      []string{"l_partkey"},
+				JoinBuildKeys:    []string{"l_partkey"},
+				JoinProbeKeys:    []string{"l_partkey"},
+			},
+		},
+	}
+	// Stages list mirrors the hazard's AggregateCand references.
+	stages := buildSyntheticAggregateHazardStages()
+
+	_, _, preAgg, err := c.applyBroadcastRemedies(context.Background(), "q-test-agg", stages, hazards)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Pre-compute may produce zero result files when synthetic data is empty.
+	// The success criterion is that dispatch did not error AND the artifact
+	// slice (possibly empty) was returned without panic.
+	_ = preAgg
+}
+```
+
+(`newTestCoordinatorMinimal`, `newTestCoordinatorWithCatalog`, and `buildSyntheticAggregateHazardStages` may already exist in the test package; if not, add them as small helpers in `broadcast_remedies_test.go` mirroring the patterns in `distributed_tpch_test.go`. If creating new helpers would be substantial scaffolding, implement only `TestApplyBroadcastRemedies_NoHazards_Passthrough` here and exercise the dispatch paths via the existing distributed TPC-H tests after Task 11.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -run TestApplyBroadcastRemedies ./internal/coordinator/`
+Expected: failure — current stub returns `not implemented`.
+
+- [ ] **Step 3: Replace the stub with the real implementation**
+
+Replace the stubbed `applyBroadcastRemedies` in `broadcast_remedies.go`:
+
+```go
+// applyBroadcastRemedies dispatches each hazard's chosen remedy and returns
+// the artifacts the coordinator routing path needs to assemble final pipeline
+// tasks. Shuffle remedies sharing a probe alias + keys are bundled into a
+// single multi-build shuffle stage. Aggregate remedies are dispatched as
+// independent pre-compute tasks. Hazards with RemedyNone or shape
+// Unsupported are logged but do not transform the plan.
+//
+// `sql` is the original query SQL text; multi-build shuffle pipeline tasks
+// receive it directly so the caller doesn't need to inject it post-dispatch.
+//
+// Returns:
+//   revisedStages: the input stages with shuffle-remediated joins replaced
+//                  by a single "pipeline-0" stage when shuffle dispatched
+//                  successfully (matching PR #40's existing convention).
+//                  When ONLY aggregate remedies fired, the input stages are
+//                  returned unchanged (the pre-compute artifacts attach to
+//                  per-task inputs in the downstream probe-split path).
+//   shuffleTasks: keyed by stage ID, the probe-pipeline tasks built from the
+//                 shuffle layout. Empty when no shuffle remedy fired.
+//   preAggregates: one PreComputedAggregateMeta per dispatched aggregate
+//                  remedy. The downstream probe-split task assembly attaches
+//                  these to each pipeline task so worker-side substitution
+//                  finds the cache files.
+func (c *Coordinator) applyBroadcastRemedies(
+	ctx context.Context,
+	queryID string,
+	sql string,
+	stages []physical.Stage,
+	hazards []physical.BroadcastHazard,
+) (revisedStages []physical.Stage, shuffleTasks map[string][]distributed.Task, preAggregates []physical.PreComputedAggregateMeta, err error) {
+	if len(hazards) == 0 {
+		return stages, nil, nil, nil
+	}
+
+	// Dispatch aggregate remedies first (independent of shuffle, can run in
+	// parallel with shuffle if needed; here sequentially for simplicity —
+	// future work can parallelize).
+	for _, h := range hazards {
+		switch h.Remedy.Kind {
+		case physical.RemedyPreComputeAggregate:
+			cacheFiles, preErr := c.preComputeDerivedAggregate(ctx, queryID, h.AggregateCand, stages)
+			if preErr != nil {
+				c.logger.Warn("aggregate pre-compute failed in remedy dispatch; falling back to broadcast",
+					"query", queryID, "join", h.JoinStageID, "err", preErr)
+				continue
+			}
+			if len(cacheFiles) == 0 {
+				continue
+			}
+			meta, metaErr := buildPreComputedAggregateMeta(h.AggregateCand, stages, cacheFiles)
+			if metaErr != nil {
+				c.logger.Warn("aggregate metadata build failed; falling back to broadcast",
+					"query", queryID, "join", h.JoinStageID, "err", metaErr)
+				continue
+			}
+			preAggregates = append(preAggregates, meta)
+		case physical.RemedyNone:
+			c.logger.Info("broadcast hazard has no applicable remedy; broadcast retained",
+				"query", queryID, "join", h.JoinStageID, "build_bytes", h.BuildBytes, "shape", h.BuildShape.String())
+		}
+	}
+
+	// Group shuffle remedies. Multiple shuffle hazards sharing probe + key go
+	// into one multi-build orchestration; mismatched keys produce demoted
+	// hazards which fall back to broadcast.
+	groups, demoted := groupShuffleHazards(hazards)
+	for _, d := range demoted {
+		c.logger.Warn("shuffle hazard demoted (probe-key conflict with earlier hazard); broadcast retained",
+			"query", queryID, "join", d.JoinStageID, "probe_alias", d.ShuffleCand.ProbeAlias)
+	}
+
+	if len(groups) == 0 {
+		// Only aggregate remedies (or none) fired; stages unchanged.
+		return stages, nil, preAggregates, nil
+	}
+
+	// Dispatch the first shuffle group. Multiple non-overlapping groups in a
+	// single query are not produced by any current TPC-H query; the
+	// invariant test will catch a future query that does. Spec: future work
+	// for chained shuffles.
+	if len(groups) > 1 {
+		c.logger.Warn("multiple non-overlapping shuffle groups in one query — only first dispatched",
+			"query", queryID, "group_count", len(groups))
+	}
+	group := groups[0]
+
+	layout, layoutErr := c.orchestrateMultiBuildShuffle(ctx, queryID, group, stages, c.workers.Count())
+	if layoutErr != nil {
+		return nil, nil, nil, fmt.Errorf("orchestrateMultiBuildShuffle: %w", layoutErr)
+	}
+
+	// Replace the remediated joins' stages with a single pipeline-0 stage
+	// (matches PR #40's coordinator.go convention).
+	probeTasks := buildShufflePipelineTasks(queryID, sql, c.config.ResultBucket, layout, c.workers.Count())
+	revisedStages = []physical.Stage{{
+		ID:    "pipeline-0",
+		Type:  "pipeline",
+		Tasks: len(probeTasks),
+	}}
+	shuffleTasks = map[string][]distributed.Task{"pipeline-0": probeTasks}
+	return revisedStages, shuffleTasks, preAggregates, nil
+}
+```
+
+Also update the imports in `broadcast_remedies.go`:
+
+```go
+import (
+	"context"
+	"fmt"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/planner/physical"
+)
+```
+
+(The original stub already had these imports; verify no extras are needed.)
+
+- [ ] **Step 4: Run the no-hazard test to verify pass**
+
+Run: `go test -run TestApplyBroadcastRemedies_NoHazards ./internal/coordinator/ -v`
+Expected: PASS
+
+The aggregate-hazard test depends on Task 11 (full coordinator wiring) and the existing distributed test harness; deferring to integration verification in Task 15.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/coordinator/broadcast_remedies.go internal/coordinator/broadcast_remedies_test.go
+git commit -m "feat(coordinator): applyBroadcastRemedies dispatches aggregate + multi-build shuffle remedies"
+```
+
+---
+
+## Phase 3 — Coordinator integration
+
+### Task 11: Wire the new pass into `coordinator.go` routing block
+
+**Files:**
+- Modify: `internal/coordinator/coordinator.go`
+
+- [ ] **Step 1: Read the current routing block to understand its structure**
+
+Read `internal/coordinator/coordinator.go` lines 470 through 600 (the section starting with `// Route all queries through pipeline execution.` through the `switch` statement). You'll be replacing the `PickShuffleCandidate` / `PickAggregateShuffleCandidateDiag` block and updating the `case shuffleApplicable` branch to consume the new artifacts.
+
+- [ ] **Step 2: Replace the routing block**
+
+In `coordinator.go`, replace the section from `var probeSplitMergeInfo *logical.MergeInfo` through (but not including) the `switch {` statement with:
+
+```go
+// Route all queries through pipeline execution. The broadcast-hazard pass
+// runs first to apply any plan-level remedies (shuffle large builds,
+// pre-compute derived aggregates). After remedies, the routing modes are:
+//   1. Shuffle layout produced — stages were replaced with pipeline-0,
+//      probe tasks already built; just dispatch them.
+//   2. Probe-split — partition probe table files across workers; pre-computed
+//      aggregate caches (if any) attach as probe-task PreComputedAggregates.
+//   3. Single-worker — fallback when neither shuffle nor probe-split applies.
+var probeSplitMergeInfo *logical.MergeInfo
+var shuffleTasks map[string][]distributed.Task
+var preComputedAggregates []physical.PreComputedAggregateMeta
+
+probeAlias, probeFiles, canProbeSplit := physical.CanProbeSplit(physStages, c.workers.Count())
+mergeInfo := logical.ExtractMergeInfo(logicalPlan)
+
+budget := c.broadcastBudget()
+hazards := physical.IdentifyBroadcastHazards(physStages, budget, c.workers.Count())
+for _, h := range hazards {
+	c.logger.Info("broadcast hazard identified",
+		"query", queryID,
+		"join", h.JoinStageID,
+		"build_bytes", h.BuildBytes,
+		"shape", h.BuildShape.String(),
+		"remedy", h.Remedy.Kind.String(),
+		"remedy_cost", h.Remedy.EstCost,
+	)
+}
+
+revisedStages, dispatchedShuffleTasks, dispatchedPreAggs, remedyErr := c.applyBroadcastRemedies(ctx, queryID, sql, physStages, hazards)
+if remedyErr != nil {
+	return nil, fmt.Errorf("apply broadcast remedies: %w", remedyErr)
+}
+physStages = revisedStages
+shuffleTasks = dispatchedShuffleTasks
+preComputedAggregates = dispatchedPreAggs
+
+shuffleApplicable := len(shuffleTasks) > 0
+```
+
+Then update the `switch { case shuffleApplicable && mergeInfo != nil: ...` branch. The body that previously called `c.orchestrateShuffleStages(...)` and built `probeTasks` is now replaced with: just use `shuffleTasks` directly (it was built by `applyBroadcastRemedies`). Replace that case body with:
+
+```go
+case shuffleApplicable && mergeInfo != nil:
+	probeSplitMergeInfo = mergeInfo
+	c.logger.Info("routing to shuffle-distributed (multi-build)",
+		"query", queryID,
+		"workers", c.workers.Count(),
+		"shuffle_task_count", len(shuffleTasks["pipeline-0"]))
+```
+
+The `case canProbeSplit && mergeInfo != nil:` branch needs no changes — it already attaches `preComputedAggregates` to its tasks.
+
+- [ ] **Step 3: Build and run distributed tests**
+
+Run: `go build ./internal/coordinator/`
+Expected: success.
+
+Run: `go test -run TestDistributedTPCH -count=1 ./internal/coordinator/ -timeout 5m`
+Expected: existing distributed tests pass. Some may fail because their threshold overrides (`shuffleBuildThreshold = 1`) no longer apply — those will be migrated in Task 13.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/coordinator/coordinator.go
+git commit -m "refactor(coordinator): route through IdentifyBroadcastHazards + applyBroadcastRemedies"
+```
+
+---
+
+## Phase 4 — Cleanup of old primitives
+
+### Task 12: Delete `PickShuffleCandidate` and its tests
+
+**Files:**
+- Modify: `internal/planner/physical/plan.go`
+- Modify: `internal/planner/physical/shuffle_insertion_test.go`
+
+- [ ] **Step 1: Verify no remaining callers**
+
+Run: `grep -rn "PickShuffleCandidate" internal/ docs/`
+Expected output: only references in `internal/planner/physical/plan.go` (definition + helpers) and possibly the deleted spec docs.
+
+If any production callers remain (besides the function definition), stop and address them — `PickShuffleCandidate` should be unreferenced after Task 11.
+
+- [ ] **Step 2: Delete the function and its helper types**
+
+In `internal/planner/physical/plan.go`, delete:
+- The `PickShuffleCandidate` function (lines ~1099 through ~1310 in current code)
+- Any `ShuffleCandidate` type definition that's no longer referenced — *but verify first*: it's referenced by `BroadcastHazard.ShuffleCand`, so KEEP the type. Only delete the function.
+
+In `internal/planner/physical/shuffle_insertion_test.go`, delete the entire file (its tests are superseded by `broadcast_hazard_test.go`).
+
+- [ ] **Step 3: Build to verify nothing else broke**
+
+Run: `go build ./internal/planner/... ./internal/coordinator/...`
+Expected: success.
+
+Run: `go test -count=1 ./internal/planner/physical/ -timeout 2m`
+Expected: PASS — `broadcast_hazard_test.go` tests cover the deleted functionality.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/planner/physical/plan.go internal/planner/physical/shuffle_insertion_test.go
+git commit -m "refactor(planner): delete PickShuffleCandidate (subsumed by IdentifyBroadcastHazards)"
+```
+
+---
+
+### Task 13: Delete `PickAggregateShuffleCandidate*` and threshold vars
+
+**Files:**
+- Modify: `internal/planner/physical/aggregate_shuffle.go`
+- Modify: `internal/coordinator/aggregate_shuffle.go`
+- Modify: `internal/coordinator/shuffle_orchestrator.go`
+- Modify: `internal/planner/physical/aggregate_shuffle_test.go`
+- Modify: `internal/coordinator/aggregate_shuffle_test.go`
+- Modify: `internal/coordinator/distributed_tpch_test.go`
+
+- [ ] **Step 1: Verify no production callers of the deleted functions**
+
+Run: `grep -n "PickAggregateShuffleCandidate\|PickAggregateShuffleCandidateDiag\|AggregateShuffleRejectReason\|AggregateShuffleDiag\|aggregateShuffleThreshold\|shuffleBuildThreshold" internal/ --include="*.go" -r`
+Expected: only references in the function definitions, the test files, and the deleted-target call sites in `coordinator.go` (already removed in Task 11).
+
+- [ ] **Step 2: Delete the symbols from `aggregate_shuffle.go`**
+
+In `internal/planner/physical/aggregate_shuffle.go`, delete:
+- `PickAggregateShuffleCandidate` function
+- `PickAggregateShuffleCandidateDiag` function
+- `AggregateShuffleRejectReason` type and its constants (`AggShuffleRejectNoJoin`, etc.)
+- `AggregateShuffleDiag` struct
+- The `String()` method on `AggregateShuffleRejectReason`
+
+KEEP: `AggregateShuffleCandidate` type (used by `BroadcastHazard.AggregateCand`), `BuildAggregateShuffleSQL`, `formatAggExpr`, `keysCovered`, `followToAggregate`, `followToScan`, `PreComputedAggregateMeta`.
+
+In `internal/coordinator/aggregate_shuffle.go`, delete:
+- `var aggregateShuffleThreshold` (line ~55)
+
+KEEP: `buildPreComputedAggregateMeta`, `preComputeDerivedAggregate`, `aggregateShuffleTimeout`.
+
+In `internal/coordinator/shuffle_orchestrator.go`, delete:
+- `var shuffleBuildThreshold` (line ~21)
+
+- [ ] **Step 3: Delete the now-orphaned tests**
+
+Delete `internal/planner/physical/aggregate_shuffle_test.go` (its detection-pass tests are superseded by `broadcast_hazard_test.go`). KEEP any tests for `BuildAggregateShuffleSQL` if they exist in this file — extract them into a new file `aggregate_shuffle_sql_test.go` first, then delete the original.
+
+Delete `internal/coordinator/aggregate_shuffle_test.go` (its candidate-detection assertions move to `broadcast_hazard_test.go`).
+
+- [ ] **Step 4: Migrate threshold overrides in `distributed_tpch_test.go`**
+
+Open `internal/coordinator/distributed_tpch_test.go`. Find every block matching:
+
+```go
+origAggShuffle := aggregateShuffleThreshold
+aggregateShuffleThreshold = 1
+t.Cleanup(func() { aggregateShuffleThreshold = origAggShuffle })
+```
+
+Replace with:
+
+```go
+prev := broadcastBudgetFallbackBytes
+broadcastBudgetFallbackBytes = 1
+t.Cleanup(func() { broadcastBudgetFallbackBytes = prev })
+```
+
+Find every block matching:
+
+```go
+origShuffle := shuffleBuildThreshold
+shuffleBuildThreshold = 1
+t.Cleanup(func() { shuffleBuildThreshold = origShuffle })
+```
+
+Replace with the same `broadcastBudgetFallbackBytes = 1` block (same hook). When both blocks appear in the same test, collapse into one.
+
+Replace any `aggregateShuffleThreshold = 1<<62` (the "infinite" override) with `broadcastBudgetFallbackBytes = 1 << 62`.
+
+- [ ] **Step 5: Build and test**
+
+Run: `go build ./internal/...`
+Expected: success.
+
+Run: `go test -count=1 ./internal/planner/physical/ ./internal/coordinator/ -timeout 10m`
+Expected: PASS. If any distributed test fails, inspect whether its expectations were tied to the old single-candidate semantics; if so, update assertions to reflect multi-hazard outcomes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/planner/physical/aggregate_shuffle.go internal/coordinator/aggregate_shuffle.go internal/coordinator/shuffle_orchestrator.go internal/planner/physical/aggregate_shuffle_test.go internal/coordinator/aggregate_shuffle_test.go internal/coordinator/distributed_tpch_test.go internal/planner/physical/aggregate_shuffle_sql_test.go 2>/dev/null
+git commit -m "refactor(planner,coordinator): delete PickAggregateShuffleCandidate + threshold vars"
+```
+
+(Use `git status` to confirm only the intended files are staged before committing.)
+
+---
+
+## Phase 5 — Architectural invariant test + correctness gate
+
+### Task 14: `TestBroadcastHazardInvariant_AllTPCHQueries`
+
+**Files:**
+- Modify: `internal/planner/physical/plan_tpch_test.go` (or a new `broadcast_hazard_invariant_test.go` in the same package)
+
+- [ ] **Step 1: Write the invariant test**
+
+Append to `internal/planner/physical/plan_tpch_test.go`:
+
+```go
+// TestBroadcastHazardInvariant_AllTPCHQueries asserts the architectural
+// invariant from the broadcast-hazard mitigation pass spec: for every
+// TPC-H query, after IdentifyBroadcastHazards walks the plan with a
+// deliberately low budget, every returned hazard either has a non-None
+// remedy or is BuildShapeUnsupported. A new query introducing a build
+// shape with no remedy fails this test loudly, pointing at exactly which
+// shape needs a new remedy.
+//
+// This test does NOT execute queries — it only inspects the planner's
+// classification. It runs in milliseconds against the TPC-H plan harness.
+func TestBroadcastHazardInvariant_AllTPCHQueries(t *testing.T) {
+	cat, ctx := setupTPCHCatalog(t)
+	const lowBudget int64 = 100 * 1024 * 1024 // 100 MB — forces hazards on most join queries
+	const workerCount = 4
+
+	for name, sql := range tpchPlanQueries {
+		t.Run(name, func(t *testing.T) {
+			stages := sqlToStages(t, cat, ctx, sql, workerCount)
+			if len(stages) == 0 {
+				t.Fatal("no stages generated")
+			}
+			hazards := IdentifyBroadcastHazards(stages, lowBudget, workerCount)
+			for _, h := range hazards {
+				if h.BuildShape == BuildShapeUnsupported {
+					t.Errorf("query %s: hazard at join %q has Unsupported build shape — needs a new remedy",
+						name, h.JoinStageID)
+				}
+				if h.Remedy.Kind == RemedyNone && h.BuildShape != BuildShapeUnsupported {
+					t.Logf("query %s: hazard at join %q demoted to RemedyNone (build_bytes=%d, shape=%s) — likely key-alignment failure, may indicate a planner shape that needs a richer remedy",
+						name, h.JoinStageID, h.BuildBytes, h.BuildShape.String())
+				}
+			}
+		})
+	}
+}
+
+// TestBroadcastHazardInvariant_Q21_ProducesTwoShuffleHazards is a focused
+// witness test for Q21: the multi-build query that motivated the spec.
+// Failure means the per-join hazard pass regressed on the case it was
+// designed for. NOT a benchmark — asserts plan structure only.
+func TestBroadcastHazardInvariant_Q21_ProducesTwoShuffleHazards(t *testing.T) {
+	cat, ctx := setupTPCHCatalog(t)
+	stages := sqlToStages(t, cat, ctx, tpchPlanQueries["Q21"], 4)
+
+	const lowBudget int64 = 100 * 1024 * 1024
+	hazards := IdentifyBroadcastHazards(stages, lowBudget, 4)
+
+	shuffleHazards := 0
+	for _, h := range hazards {
+		if h.Remedy.Kind == RemedyShuffleScan {
+			shuffleHazards++
+		}
+	}
+	if shuffleHazards < 2 {
+		t.Errorf("Q21 must produce at least 2 RemedyShuffleScan hazards (l2 semi-build + l3 anti-build); got %d. Hazards: %+v",
+			shuffleHazards, hazards)
+	}
+}
+```
+
+- [ ] **Step 2: Run the invariant test**
+
+Run: `go test -v -run TestBroadcastHazardInvariant ./internal/planner/physical/ -timeout 2m`
+Expected: PASS. If `TestBroadcastHazardInvariant_AllTPCHQueries` fails on a subtest with `Unsupported build shape`, that's a real architectural finding — investigate what shape the failing query has and either extend the classifier to recognize it, add a remedy that handles it, or document why it's intentionally Unsupported.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/planner/physical/plan_tpch_test.go
+git commit -m "test(planner): broadcast-hazard invariant test over all TPC-H queries + Q21 witness"
+```
+
+---
+
+### Task 15: SF0.01 correctness gate with forced-low budget
+
+**Files:**
+- Modify: `internal/coordinator/distributed_tpch_test.go`
+
+- [ ] **Step 1: Add the forced-budget all-queries correctness test**
+
+Append to `internal/coordinator/distributed_tpch_test.go`:
+
+```go
+// TestDistributedTPCH_BroadcastBudget1_AllQueries runs every TPC-H query at
+// SF0.01 with broadcastBudget forced to 1 byte — i.e. every join with any
+// build size becomes a hazard, and applyBroadcastRemedies dispatches a
+// remedy for each (or demotes to RemedyNone). The success criterion is
+// that all 22 queries complete and return correct row counts. Any
+// regression in the multi-hazard dispatch surfaces here.
+//
+// Result row checksums are NOT compared in this test (the existing
+// TestDistributedTPCH_AllQueries already covers that with the production
+// budget). This test isolates the "forced through the remedy path"
+// codepath and asserts only correctness-of-execution at the row-count
+// level.
+func TestDistributedTPCH_BroadcastBudget1_AllQueries(t *testing.T) {
+	prev := broadcastBudgetFallbackBytes
+	broadcastBudgetFallbackBytes = 1
+	t.Cleanup(func() { broadcastBudgetFallbackBytes = prev })
+
+	coord, cleanup := setupDistributedTestCluster(t, 3 /* workers */)
+	t.Cleanup(cleanup)
+
+	for qNum := 1; qNum <= 22; qNum++ {
+		t.Run(fmt.Sprintf("Q%02d", qNum), func(t *testing.T) {
+			q := tpch.GetQuery(qNum, tpch.SF001)
+			rows, err := coord.Execute(context.Background(), q.SQL)
+			if err != nil {
+				t.Fatalf("Q%02d failed: %v", qNum, err)
+			}
+			if len(rows) == 0 && qNum != 11 /* Q11 may legitimately return 0 at SF0.01 */ {
+				t.Errorf("Q%02d returned 0 rows under broadcastBudget=1 — likely remedy-path bug", qNum)
+			}
+		})
+	}
+}
+```
+
+If `setupDistributedTestCluster`, `tpch.GetQuery`, and `tpch.SF001` already exist with different names, adapt to match. Check existing distributed test setup helpers in `distributed_tpch_test.go` for the established pattern.
+
+- [ ] **Step 2: Run the new test**
+
+Run: `go test -v -run TestDistributedTPCH_BroadcastBudget1_AllQueries ./internal/coordinator/ -timeout 10m`
+Expected: all 22 subtests PASS.
+
+If any query fails:
+- `RemedyNone` demotions causing legitimate broadcast at budget=1 byte: those queries fall through to broadcast (no error, just non-optimal) — the test should still see correct results.
+- Multi-hazard dispatch panics or empty result rows: indicates a real bug in `applyBroadcastRemedies` or `orchestrateMultiBuildShuffle` — investigate based on the failing query's stage list.
+- Pre-compute aggregate dispatch failure: check the AggregateCand payload populated in Task 6 matches what `preComputeDerivedAggregate` expects.
+
+- [ ] **Step 3: Run the full distributed test suite to catch regressions**
+
+Run: `go test -count=1 ./internal/coordinator/ -timeout 15m`
+Expected: all distributed tests pass. The migrated tests from Task 13 (now using `broadcastBudgetFallbackBytes`) should pass under the new budget machinery.
+
+- [ ] **Step 4: Run the full project test suite**
+
+Run: `go test ./internal/... -timeout 20m`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/coordinator/distributed_tpch_test.go
+git commit -m "test(coordinator): SF0.01 correctness gate with broadcastBudget=1 force-path"
+```
+
+---
+
+### Task 16: TPC-H SF0.01 correctness suite (existing) — verify clean
+
+**Files:**
+- (no file changes — verification only)
+
+- [ ] **Step 1: Run the TPC-H correctness suite at SF0.01**
+
+Run: `go test -v -run TestTPCHQueries ./benchmarks/tpch/ -timeout 5m`
+Expected: all 22 queries pass. Row checksums must match the existing baseline.
+
+- [ ] **Step 2: If any checksum mismatch occurs**
+
+A row-checksum mismatch means a remedy is producing semantically different output. Likely causes:
+- `applyBroadcastRemedies` wired into the wrong branch of the routing switch
+- `orchestrateMultiBuildShuffle` is producing per-partition layouts that double-count rows
+- The aggregate pre-compute `AggregateCand` payload's keys don't match the original join's keys
+
+Investigate per-query: enable coordinator debug logs (`WADJET_LOG=debug go test ...`), inspect the printed hazard list and remedy dispatch lines, compare the resulting plan to the pre-change plan.
+
+- [ ] **Step 3: Final commit (none expected)**
+
+If the suite passes clean, no further commits needed. The implementation is complete.
+
+If a fix is required, commit it with a clear message describing the corrective change:
+
+```bash
+git add <files>
+git commit -m "fix(<scope>): <root-cause description>"
+```
+
+Then re-run Step 1 to confirm clean.
+
+---
+
+## Self-review checklist (run after writing the plan)
+
+- [x] Spec coverage:
+  - `IdentifyBroadcastHazards` — Task 6
+  - `BroadcastHazard`, `BuildShape`, `Remedy` types — Task 1
+  - Per-shape remedy candidates with cost — Task 4
+  - Key-alignment validation, demotion to RemedyNone — Task 5
+  - `broadcastBudget` from GOMEMLIMIT × fraction / workers — Task 7
+  - Multi-build shuffle orchestrator — Task 9
+  - `applyBroadcastRemedies` dispatch loop — Tasks 8 + 10
+  - Coordinator routing rewritten — Task 11
+  - Old primitives + thresholds deleted — Tasks 12 + 13
+  - Test migration + invariant test — Tasks 13 + 14
+  - SF0.01 correctness gate forced through remedy path — Task 15
+  - TPC-H result-checksum gate — Task 16
+- [x] Type names consistent across tasks (`BroadcastHazard.ShuffleCand`, `groupShuffleHazards`, `orchestrateMultiBuildShuffle`)
+- [x] Code blocks contain real implementation, not placeholders
+- [x] Each task ends with a commit
+- [x] Build-broken commits explicitly noted (Task 9)

--- a/docs/superpowers/plans/2026-04-20-distribution-property-phase-1.md
+++ b/docs/superpowers/plans/2026-04-20-distribution-property-phase-1.md
@@ -1,0 +1,1658 @@
+# Distribution-Property Pass — Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire up the existing 58-line `internal/planner/physical/distribution.go` scaffolding into a populated, queried planner property — `Distribution.Satisfies(RequiredDistribution)` — and assert exchange consistency for every stage emitted by `PlanDistributed`. Phase 1 is purely additive and behavior-preserving; the heuristic switch in `coordinator.go:541-605` continues to make every routing decision.
+
+**Architecture:** Extend `internal/planner/physical/distribution.go` with `RequiredKind` enum, `RequiredDistribution` struct, `Distribution.Satisfies` predicate, `RequiredChildDistribution`, `OutputDistribution`, `assignStageDistributions`, `AssertExchangeConsistency`, and a `BehaviorPreservingMode` package var. Wire the assignment + assertion into `PlanDistributed` after `enforceQueryLimits`. Add `TestTPCHDistributionConsistency` as the acceptance gate that runs every Q1-Q22 through the new pass with hard assertions. Preserve `SatisfiesJoinKeys` as a thin wrapper over `Satisfies` for existing callers. No coordinator, worker, or executor changes.
+
+**Tech Stack:** Go 1.22+, existing `internal/planner/physical` package (Stage / Distribution / DistKind), existing TPC-H test harness in `plan_tpch_test.go` (`tpchPlanQueryMap`, `setupTPCHCatalog`, `sqlToStages`), `testing` package with table-driven tests, `benchmarks/tpch/` `TestTPCHQueries` for SF0.01 correctness verification.
+
+**Spec:** `docs/superpowers/specs/2026-04-20-distribution-property-phase-1.md`
+
+**Worktree:** `/home/dwright/Projects/caelum/.worktrees/distribution-phase-1` on branch `feat/distribution-property-phase-1`, parent commit `0b78c4e`.
+
+---
+
+## File Structure
+
+| File | Change |
+|---|---|
+| `internal/planner/physical/distribution.go` | **Extend.** Add `RequiredKind` enum, `RequiredDistribution` struct, `Satisfies`, `RequiredChildDistribution`, `OutputDistribution`, `assignStageDistributions`, `AssertExchangeConsistency`, `BehaviorPreservingMode`. Refactor `SatisfiesJoinKeys` to delegate to `Satisfies`. |
+| `internal/planner/physical/distribution_test.go` | **Extend.** Add `TestDistributionSatisfies` table-driven test, `TestRequiredChildDistribution` per-type tests, `TestOutputDistribution` per-type tests, `TestAssignStageDistributions`, `TestAssertExchangeConsistency`. |
+| `internal/planner/physical/plan.go` | **Three-line wire-up.** Inside `PlanDistributed`, after `enforceQueryLimits`, call `assignStageDistributions(stages, p.WorkerCount)` and `AssertExchangeConsistency(stages)`. |
+| `internal/planner/physical/plan_tpch_test.go` | **Add `TestTPCHDistributionConsistency`** — runs every Q1-Q22 through `PlanDistributed` with `WorkerCount=4` and `BehaviorPreservingMode=false`, asserting every stage's `Distribution` is populated and `AssertExchangeConsistency(stages) == nil`. |
+| `internal/coordinator/`, `internal/worker/`, executor packages | **No changes.** |
+
+Total churn: ~400 added lines, ~3 modified lines. No file deletions.
+
+---
+
+## Task 1: Add `RequiredKind` enum and `RequiredDistribution` struct
+
+**Files:**
+- Modify: `internal/planner/physical/distribution.go`
+
+- [ ] **Step 1: Append the `RequiredKind` enum, `RequiredDistribution` struct, and a `String()` method on `RequiredKind` to the end of `distribution.go`**
+
+```go
+// RequiredKind enumerates the partitioning a consumer needs from each input.
+// Mirrors Spark's Distribution trait subclasses; see the Phase 1 spec
+// (docs/superpowers/specs/2026-04-20-distribution-property-phase-1.md) §"The
+// property algebra" for the satisfaction truth table.
+type RequiredKind int
+
+const (
+	RequiredAny               RequiredKind = iota // no constraint
+	RequiredSingleton                             // exactly one partition (final result, coordinator merge)
+	RequiredBroadcast                             // every worker has every row
+	RequiredClusteredOn                           // co-partitioned on Keys, any partition count
+	RequiredHashPartitionedOn                     // hash-partitioned on Keys with exactly Count partitions
+)
+
+// String renders a RequiredKind for log lines and assertion error messages.
+// Stable text identifiers — do not change without checking telemetry consumers.
+func (r RequiredKind) String() string {
+	switch r {
+	case RequiredAny:
+		return "any"
+	case RequiredSingleton:
+		return "singleton"
+	case RequiredBroadcast:
+		return "broadcast"
+	case RequiredClusteredOn:
+		return "clustered_on"
+	case RequiredHashPartitionedOn:
+		return "hash_partitioned_on"
+	default:
+		return "unknown"
+	}
+}
+
+// RequiredDistribution describes what a consumer stage requires of each input.
+// Derived from existing stage fields (JoinLeftKeys, JoinRightKeys, GroupByCols,
+// ShuffleKeys) by RequiredChildDistribution; never stored on Stage.
+type RequiredDistribution struct {
+	Kind  RequiredKind
+	Keys  []string
+	Count int
+}
+```
+
+- [ ] **Step 2: Verify the file compiles**
+
+Run: `go build ./internal/planner/physical/`
+Expected: success (no output, exit 0)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/planner/physical/distribution.go
+git commit -m "$(cat <<'EOF'
+feat(planner): add RequiredKind enum and RequiredDistribution struct
+
+Phase 1 of the distribution-property pass. Adds the consumer-side type that
+mirrors Spark's Distribution trait subclasses. Pure type additions; no
+behavior change. Truth table for the predicate is documented in the spec.
+
+Spec: docs/superpowers/specs/2026-04-20-distribution-property-phase-1.md
+EOF
+)"
+```
+
+---
+
+## Task 2: Add `Distribution.Satisfies(req RequiredDistribution) bool` with full truth table
+
+**Files:**
+- Modify: `internal/planner/physical/distribution_test.go`
+- Modify: `internal/planner/physical/distribution.go`
+
+- [ ] **Step 1: Append the failing table-driven test to `distribution_test.go`**
+
+```go
+func TestDistributionSatisfies(t *testing.T) {
+	hashOrderkey := Distribution{Kind: DistHashPartitioned, Keys: []string{"orderkey"}, Count: 12}
+	hashCustkey := Distribution{Kind: DistHashPartitioned, Keys: []string{"custkey"}, Count: 12}
+	hashOrderkey24 := Distribution{Kind: DistHashPartitioned, Keys: []string{"orderkey"}, Count: 24}
+	singleton := Distribution{Kind: DistSingleton}
+	bcast := Distribution{Kind: DistBroadcast}
+
+	reqAny := RequiredDistribution{Kind: RequiredAny}
+	reqSingleton := RequiredDistribution{Kind: RequiredSingleton}
+	reqBcast := RequiredDistribution{Kind: RequiredBroadcast}
+	reqClusterOrderkey := RequiredDistribution{Kind: RequiredClusteredOn, Keys: []string{"orderkey"}}
+	reqClusterCustkey := RequiredDistribution{Kind: RequiredClusteredOn, Keys: []string{"custkey"}}
+	reqHashOrderkey12 := RequiredDistribution{Kind: RequiredHashPartitionedOn, Keys: []string{"orderkey"}, Count: 12}
+	reqHashOrderkey24 := RequiredDistribution{Kind: RequiredHashPartitionedOn, Keys: []string{"orderkey"}, Count: 24}
+
+	tests := []struct {
+		name string
+		dist Distribution
+		req  RequiredDistribution
+		want bool
+	}{
+		// RequiredAny is satisfied by everything
+		{"singleton sat any", singleton, reqAny, true},
+		{"broadcast sat any", bcast, reqAny, true},
+		{"hash sat any", hashOrderkey, reqAny, true},
+
+		// RequiredSingleton: only DistSingleton
+		{"singleton sat singleton", singleton, reqSingleton, true},
+		{"broadcast not sat singleton", bcast, reqSingleton, false},
+		{"hash not sat singleton", hashOrderkey, reqSingleton, false},
+
+		// RequiredBroadcast: only DistBroadcast
+		{"broadcast sat broadcast", bcast, reqBcast, true},
+		{"singleton not sat broadcast", singleton, reqBcast, false},
+		{"hash not sat broadcast", hashOrderkey, reqBcast, false},
+
+		// RequiredClusteredOn(K): broadcast yes, singleton yes, hash iff Keys==K
+		{"broadcast sat clustered", bcast, reqClusterOrderkey, true},
+		{"singleton sat clustered", singleton, reqClusterOrderkey, true},
+		{"hash on K sat clustered K", hashOrderkey, reqClusterOrderkey, true},
+		{"hash on K not sat clustered K2", hashOrderkey, reqClusterCustkey, false},
+		{"hash on K2 not sat clustered K", hashCustkey, reqClusterOrderkey, false},
+
+		// RequiredHashPartitionedOn(K, N): only hash with same K and N
+		{"hash K N sat hash K N", hashOrderkey, reqHashOrderkey12, true},
+		{"hash K N' not sat hash K N", hashOrderkey24, reqHashOrderkey12, false},
+		{"hash K N sat hash K N'", hashOrderkey, reqHashOrderkey24, false},
+		{"hash K not sat hash K2 N", hashCustkey, reqHashOrderkey12, false},
+		{"singleton not sat hash K N", singleton, reqHashOrderkey12, false},
+		{"broadcast not sat hash K N", bcast, reqHashOrderkey12, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.dist.Satisfies(tt.req)
+			if got != tt.want {
+				t.Errorf("(%v).Satisfies(%v) = %v, want %v", tt.dist, tt.req, got, tt.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails (Satisfies not yet defined)**
+
+Run: `go test -run TestDistributionSatisfies ./internal/planner/physical/`
+Expected: build failure with `tt.dist.Satisfies undefined (type Distribution has no field or method Satisfies)`
+
+- [ ] **Step 3: Add the `Satisfies` method to `distribution.go`**
+
+Append after the `RequiredDistribution` struct added in Task 1:
+
+```go
+// Satisfies reports whether this distribution meets a consumer's required
+// distribution. Single mechanical predicate that mirrors Spark's
+// Partitioning.satisfies(Distribution). The truth table is documented in
+// the Phase 1 spec §"The property algebra".
+//
+//   RequiredAny:                    always true.
+//   RequiredSingleton:              only DistSingleton.
+//   RequiredBroadcast:              only DistBroadcast.
+//   RequiredClusteredOn(K):         DistBroadcast yes; DistSingleton yes;
+//                                   DistHashPartitioned iff Keys==K.
+//   RequiredHashPartitionedOn(K, N): only DistHashPartitioned with Keys==K
+//                                   and Count==N.
+func (d Distribution) Satisfies(req RequiredDistribution) bool {
+	switch req.Kind {
+	case RequiredAny:
+		return true
+	case RequiredSingleton:
+		return d.Kind == DistSingleton
+	case RequiredBroadcast:
+		return d.Kind == DistBroadcast
+	case RequiredClusteredOn:
+		switch d.Kind {
+		case DistBroadcast, DistSingleton:
+			return true
+		case DistHashPartitioned:
+			return keysEqual(d.Keys, req.Keys)
+		default:
+			return false
+		}
+	case RequiredHashPartitionedOn:
+		if d.Kind != DistHashPartitioned {
+			return false
+		}
+		if d.Count != req.Count {
+			return false
+		}
+		return keysEqual(d.Keys, req.Keys)
+	default:
+		return false
+	}
+}
+
+// keysEqual reports whether two ordered key slices are identical.
+func keysEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test -run TestDistributionSatisfies ./internal/planner/physical/`
+Expected: `PASS` with all 19 subtests passing, `ok  github.com/citc-tech/wadjet/internal/planner/physical`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/planner/physical/distribution.go internal/planner/physical/distribution_test.go
+git commit -m "$(cat <<'EOF'
+feat(planner): add Distribution.Satisfies predicate
+
+The single mechanical predicate that drives the property algebra.
+Implements all five RequiredKind cases per the Phase 1 spec truth table.
+Table-driven test covers the full DistKind × RequiredKind matrix (19 cases).
+
+Spec: docs/superpowers/specs/2026-04-20-distribution-property-phase-1.md
+EOF
+)"
+```
+
+---
+
+## Task 3: Refactor `SatisfiesJoinKeys` to delegate to `Satisfies`
+
+**Files:**
+- Modify: `internal/planner/physical/distribution.go`
+
+- [ ] **Step 1: Verify the existing `TestDistributionSatisfiesJoin` test still exists and passes (baseline)**
+
+Run: `go test -run TestDistributionSatisfiesJoin ./internal/planner/physical/`
+Expected: `PASS`, `ok  github.com/citc-tech/wadjet/internal/planner/physical`
+
+- [ ] **Step 2: Replace the body of `SatisfiesJoinKeys` to delegate to `Satisfies`**
+
+Replace the existing function (currently lines ~38-58 of `distribution.go`):
+
+```go
+// SatisfiesJoinKeys reports whether this distribution allows a co-located
+// join on the given keys without re-shuffling. Preserved as a thin wrapper
+// over Satisfies for existing callers.
+func (d Distribution) SatisfiesJoinKeys(joinKeys []string) bool {
+	return d.Satisfies(RequiredDistribution{Kind: RequiredClusteredOn, Keys: joinKeys})
+}
+```
+
+- [ ] **Step 3: Run the existing test to verify behavior is preserved**
+
+Run: `go test -run TestDistributionSatisfiesJoin ./internal/planner/physical/`
+Expected: `PASS` — same outcome as before refactor
+
+- [ ] **Step 4: Run full distribution test file to verify nothing else broke**
+
+Run: `go test -run 'TestDistribution' ./internal/planner/physical/`
+Expected: `PASS` for `TestDistributionEquals`, `TestDistributionSatisfiesJoin`, `TestDistributionSatisfies`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/planner/physical/distribution.go
+git commit -m "$(cat <<'EOF'
+refactor(planner): SatisfiesJoinKeys delegates to Satisfies
+
+Preserve the existing API for callers (no signature change) while
+collapsing its semantics into the new mechanical predicate. The wrapper
+is the RequiredClusteredOn projection of Satisfies.
+EOF
+)"
+```
+
+---
+
+## Task 4: Add `RequiredChildDistribution(stage Stage, slot int)` returning per-slot requirements
+
+**Files:**
+- Modify: `internal/planner/physical/distribution_test.go`
+- Modify: `internal/planner/physical/distribution.go`
+
+- [ ] **Step 1: Append the failing test to `distribution_test.go`**
+
+```go
+func TestRequiredChildDistribution(t *testing.T) {
+	tests := []struct {
+		name  string
+		stage Stage
+		slot  int
+		want  RequiredDistribution
+	}{
+		{
+			name:  "scan has no inputs returns any",
+			stage: Stage{ID: "scan-0", Type: "scan"},
+			slot:  0,
+			want:  RequiredDistribution{Kind: RequiredAny},
+		},
+		{
+			name:  "dual has no inputs returns any",
+			stage: Stage{ID: "dual-0", Type: "dual"},
+			slot:  0,
+			want:  RequiredDistribution{Kind: RequiredAny},
+		},
+		{
+			name:  "shuffle accepts any input",
+			stage: Stage{ID: "shuffle-0", Type: "shuffle", ShuffleKeys: []string{"k"}, NumPartitions: 16},
+			slot:  0,
+			want:  RequiredDistribution{Kind: RequiredAny},
+		},
+		{
+			name: "hash_join probe slot requires clustered on left keys",
+			stage: Stage{
+				ID: "join-0", Type: "hash_join",
+				JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"},
+				LeftDepStage: "shuffle-l", RightDepStage: "shuffle-r",
+				Dependencies: []string{"shuffle-l", "shuffle-r"},
+			},
+			slot: 0,
+			want: RequiredDistribution{Kind: RequiredClusteredOn, Keys: []string{"l_orderkey"}},
+		},
+		{
+			name: "hash_join build slot requires clustered on right keys",
+			stage: Stage{
+				ID: "join-0", Type: "hash_join",
+				JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"},
+				LeftDepStage: "shuffle-l", RightDepStage: "shuffle-r",
+				Dependencies: []string{"shuffle-l", "shuffle-r"},
+			},
+			slot: 1,
+			want: RequiredDistribution{Kind: RequiredClusteredOn, Keys: []string{"o_orderkey"}},
+		},
+		{
+			name: "broadcast_join probe slot requires any (Phase 1)",
+			stage: Stage{
+				ID: "join-0", Type: "broadcast_join",
+				JoinLeftKeys: []string{"l_partkey"}, JoinRightKeys: []string{"p_partkey"},
+				LeftDepStage: "scan-l", RightDepStage: "scan-r",
+				Dependencies: []string{"scan-l", "scan-r"},
+			},
+			slot: 0,
+			want: RequiredDistribution{Kind: RequiredAny},
+		},
+		{
+			name: "broadcast_join build slot requires any (Phase 1)",
+			stage: Stage{
+				ID: "join-0", Type: "broadcast_join",
+				JoinLeftKeys: []string{"l_partkey"}, JoinRightKeys: []string{"p_partkey"},
+				LeftDepStage: "scan-l", RightDepStage: "scan-r",
+				Dependencies: []string{"scan-l", "scan-r"},
+			},
+			slot: 1,
+			want: RequiredDistribution{Kind: RequiredAny},
+		},
+		{
+			name:  "aggregate requires any (Phase 1 conservative — see Risk #1)",
+			stage: Stage{ID: "aggregate-0", Type: "aggregate", GroupByCols: []string{"l_returnflag"}},
+			slot:  0,
+			want:  RequiredDistribution{Kind: RequiredAny},
+		},
+		{
+			name:  "final_aggregate requires any",
+			stage: Stage{ID: "final_aggregate-0", Type: "final_aggregate", GroupByCols: []string{"l_returnflag"}},
+			slot:  0,
+			want:  RequiredDistribution{Kind: RequiredAny},
+		},
+		{
+			name:  "sort requires any",
+			stage: Stage{ID: "sort-0", Type: "sort"},
+			slot:  0,
+			want:  RequiredDistribution{Kind: RequiredAny},
+		},
+		{
+			name:  "merge_sort requires any",
+			stage: Stage{ID: "merge_sort-0", Type: "merge_sort"},
+			slot:  0,
+			want:  RequiredDistribution{Kind: RequiredAny},
+		},
+		{
+			name: "window with PartitionBy requires clustered on partition keys",
+			stage: Stage{
+				ID: "window-0", Type: "window",
+				WindowCols: []WindowColSpec{{Func: "row_number", PartitionBy: []string{"o_custkey"}}},
+			},
+			slot: 0,
+			want: RequiredDistribution{Kind: RequiredClusteredOn, Keys: []string{"o_custkey"}},
+		},
+		{
+			name: "window without PartitionBy requires any",
+			stage: Stage{
+				ID: "window-0", Type: "window",
+				WindowCols: []WindowColSpec{{Func: "row_number"}},
+			},
+			slot: 0,
+			want: RequiredDistribution{Kind: RequiredAny},
+		},
+		{
+			name:  "pipeline requires any",
+			stage: Stage{ID: "pipeline-0", Type: "pipeline"},
+			slot:  0,
+			want:  RequiredDistribution{Kind: RequiredAny},
+		},
+		{
+			name:  "table_func requires any",
+			stage: Stage{ID: "tf-0", Type: "table_func"},
+			slot:  0,
+			want:  RequiredDistribution{Kind: RequiredAny},
+		},
+		{
+			name:  "unknown stage type requires any",
+			stage: Stage{ID: "?-0", Type: "mystery"},
+			slot:  0,
+			want:  RequiredDistribution{Kind: RequiredAny},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RequiredChildDistribution(tt.stage, tt.slot)
+			if got.Kind != tt.want.Kind {
+				t.Fatalf("Kind = %v, want %v", got.Kind, tt.want.Kind)
+			}
+			if !keysEqual(got.Keys, tt.want.Keys) {
+				t.Fatalf("Keys = %v, want %v", got.Keys, tt.want.Keys)
+			}
+			if got.Count != tt.want.Count {
+				t.Fatalf("Count = %v, want %v", got.Count, tt.want.Count)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails (function not yet defined)**
+
+Run: `go test -run TestRequiredChildDistribution ./internal/planner/physical/`
+Expected: build failure with `undefined: RequiredChildDistribution`
+
+- [ ] **Step 3: Add `RequiredChildDistribution` to `distribution.go`**
+
+Append after the `Satisfies` method:
+
+```go
+// RequiredChildDistribution returns the per-slot required distribution for a
+// stage's input. `slot` indexes into the stage's logical input list:
+//   - For joins: slot 0 is the probe (LeftDepStage), slot 1 is the build (RightDepStage).
+//   - For unary stages: slot 0 is the sole input.
+//   - For stages with no inputs (scan, dual): RequiredAny is returned for any slot.
+//
+// Never stored on Stage; recomputed by AssertExchangeConsistency. Rules are
+// derived from how walkStages already implicitly constructs the plan; see
+// the Phase 1 spec §"RequiredChildDistribution" for the per-stage table.
+//
+// Unknown stage types return RequiredAny (no constraint asserted). New stage
+// types added to the planner must add their rule here or accept the no-op
+// default.
+func RequiredChildDistribution(stage Stage, slot int) RequiredDistribution {
+	switch stage.Type {
+	case "scan", "dual":
+		// No inputs — any slot is RequiredAny by definition.
+		return RequiredDistribution{Kind: RequiredAny}
+	case "shuffle":
+		// Shuffle accepts any input and re-partitions.
+		return RequiredDistribution{Kind: RequiredAny}
+	case "hash_join":
+		switch slot {
+		case 0:
+			return RequiredDistribution{Kind: RequiredClusteredOn, Keys: stage.JoinLeftKeys}
+		case 1:
+			return RequiredDistribution{Kind: RequiredClusteredOn, Keys: stage.JoinRightKeys}
+		default:
+			return RequiredDistribution{Kind: RequiredAny}
+		}
+	case "broadcast_join":
+		// Phase 1 leaves both slots at RequiredAny — the executor handles
+		// broadcast in-process today (no explicit broadcast Exchange stage).
+		// Phase 2 inserts Exchange{Type: Replicate} between scan and the
+		// build slot, at which point the build requirement strengthens to
+		// RequiredBroadcast. See spec Risk #4.
+		return RequiredDistribution{Kind: RequiredAny}
+	case "aggregate":
+		// Phase 1 conservative: today's two-phase distributed aggregate
+		// runs the partial stage on RequiredAny inputs (the partial does
+		// not require pre-clustering — it produces partials that the final
+		// stage merges). See spec Risk #1.
+		return RequiredDistribution{Kind: RequiredAny}
+	case "final_aggregate", "merge_aggregate":
+		return RequiredDistribution{Kind: RequiredAny}
+	case "sort", "merge_sort":
+		return RequiredDistribution{Kind: RequiredAny}
+	case "window":
+		// If any window column declares a PartitionBy, the input must be
+		// clustered on those keys. Take the first PartitionBy as the
+		// requirement (today's planner emits a single window stage per
+		// partition spec; multiple PartitionBy clauses become separate
+		// window stages).
+		for _, wc := range stage.WindowCols {
+			if len(wc.PartitionBy) > 0 {
+				return RequiredDistribution{Kind: RequiredClusteredOn, Keys: wc.PartitionBy}
+			}
+		}
+		return RequiredDistribution{Kind: RequiredAny}
+	case "pipeline", "table_func":
+		return RequiredDistribution{Kind: RequiredAny}
+	default:
+		return RequiredDistribution{Kind: RequiredAny}
+	}
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test -run TestRequiredChildDistribution ./internal/planner/physical/`
+Expected: `PASS` with all 16 subtests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/planner/physical/distribution.go internal/planner/physical/distribution_test.go
+git commit -m "$(cat <<'EOF'
+feat(planner): add RequiredChildDistribution per stage type
+
+Derives a consumer's per-slot required distribution from existing Stage
+fields (JoinLeftKeys, JoinRightKeys, WindowCols.PartitionBy). Pure
+function; never stored. Per-stage rules track how walkStages already
+implicitly constructs the plan. Phase 1 conservative defaults for
+broadcast_join build slot (RequiredAny) and aggregate input (RequiredAny)
+documented inline; spec Risks #1 and #4 explain Phase 2 evolution.
+EOF
+)"
+```
+
+---
+
+## Task 5: Add `OutputDistribution(stage Stage, deps map[string]Distribution)` returning per-stage outputs
+
+**Files:**
+- Modify: `internal/planner/physical/distribution_test.go`
+- Modify: `internal/planner/physical/distribution.go`
+
+- [ ] **Step 1: Append the failing test to `distribution_test.go`**
+
+```go
+func TestOutputDistribution(t *testing.T) {
+	tests := []struct {
+		name  string
+		stage Stage
+		deps  map[string]Distribution
+		want  Distribution
+	}{
+		{
+			name:  "scan emits singleton",
+			stage: Stage{ID: "scan-0", Type: "scan", ScanAlias: "lineitem"},
+			deps:  nil,
+			want:  Distribution{Kind: DistSingleton},
+		},
+		{
+			name:  "dual emits singleton",
+			stage: Stage{ID: "dual-0", Type: "dual"},
+			deps:  nil,
+			want:  Distribution{Kind: DistSingleton},
+		},
+		{
+			name: "shuffle emits hash partitioned",
+			stage: Stage{
+				ID: "shuffle-0", Type: "shuffle",
+				ShuffleKeys: []string{"l_orderkey"}, NumPartitions: 16,
+			},
+			deps: nil,
+			want: Distribution{Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 16},
+		},
+		{
+			name: "hash_join inherits probe distribution",
+			stage: Stage{
+				ID: "join-0", Type: "hash_join",
+				LeftDepStage: "shuffle-l", RightDepStage: "shuffle-r",
+				Dependencies: []string{"shuffle-l", "shuffle-r"},
+			},
+			deps: map[string]Distribution{
+				"shuffle-l": {Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 16},
+				"shuffle-r": {Kind: DistHashPartitioned, Keys: []string{"o_orderkey"}, Count: 16},
+			},
+			want: Distribution{Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 16},
+		},
+		{
+			name: "broadcast_join inherits probe distribution",
+			stage: Stage{
+				ID: "join-0", Type: "broadcast_join",
+				LeftDepStage: "scan-l", RightDepStage: "scan-r",
+				Dependencies: []string{"scan-l", "scan-r"},
+			},
+			deps: map[string]Distribution{
+				"scan-l": {Kind: DistSingleton},
+				"scan-r": {Kind: DistSingleton},
+			},
+			want: Distribution{Kind: DistSingleton},
+		},
+		{
+			name:  "aggregate emits singleton",
+			stage: Stage{ID: "aggregate-0", Type: "aggregate", GroupByCols: []string{"l_returnflag"}},
+			deps:  nil,
+			want:  Distribution{Kind: DistSingleton},
+		},
+		{
+			name: "final_aggregate lone reducer emits singleton",
+			stage: Stage{
+				ID: "final_aggregate-0", Type: "final_aggregate",
+				GroupByCols: []string{"l_returnflag"},
+			},
+			deps: nil,
+			want: Distribution{Kind: DistSingleton},
+		},
+		{
+			name: "final_aggregate merge group emits hash partitioned",
+			stage: Stage{
+				ID: "merge_aggregate-0-0", Type: "final_aggregate",
+				GroupByCols:     []string{"l_returnflag"},
+				MergeGroup:      0,
+				MergeGroupCount: 4,
+			},
+			deps: nil,
+			want: Distribution{Kind: DistHashPartitioned, Keys: []string{"l_returnflag"}, Count: 4},
+		},
+		{
+			name:  "sort emits singleton",
+			stage: Stage{ID: "sort-0", Type: "sort"},
+			deps:  nil,
+			want:  Distribution{Kind: DistSingleton},
+		},
+		{
+			name:  "merge_sort lone emits singleton",
+			stage: Stage{ID: "merge_sort-0", Type: "merge_sort"},
+			deps:  nil,
+			want:  Distribution{Kind: DistSingleton},
+		},
+		{
+			name: "merge_sort merge group emits hash partitioned",
+			stage: Stage{
+				ID: "merge_sort-0-0", Type: "merge_sort",
+				SortKeys:        []SortKeySpec{{Column: "l_orderkey"}},
+				MergeGroup:      0,
+				MergeGroupCount: 4,
+			},
+			deps: nil,
+			want: Distribution{Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 4},
+		},
+		{
+			name:  "window emits singleton",
+			stage: Stage{ID: "window-0", Type: "window"},
+			deps:  nil,
+			want:  Distribution{Kind: DistSingleton},
+		},
+		{
+			name:  "pipeline emits singleton",
+			stage: Stage{ID: "pipeline-0", Type: "pipeline"},
+			deps:  nil,
+			want:  Distribution{Kind: DistSingleton},
+		},
+		{
+			name:  "table_func emits singleton",
+			stage: Stage{ID: "tf-0", Type: "table_func"},
+			deps:  nil,
+			want:  Distribution{Kind: DistSingleton},
+		},
+		{
+			name:  "unknown stage type emits singleton",
+			stage: Stage{ID: "?-0", Type: "mystery"},
+			deps:  nil,
+			want:  Distribution{Kind: DistSingleton},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := OutputDistribution(tt.stage, tt.deps)
+			if !got.Equals(tt.want) {
+				t.Fatalf("OutputDistribution = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test -run TestOutputDistribution ./internal/planner/physical/`
+Expected: build failure with `undefined: OutputDistribution`
+
+- [ ] **Step 3: Add `OutputDistribution` to `distribution.go`**
+
+Append after `RequiredChildDistribution`:
+
+```go
+// OutputDistribution computes the partitioning a stage's output has, given
+// the resolved distributions of its dependencies. Pure function over
+// stage fields + dep map. Rules track how today's planner emits stages;
+// see the Phase 1 spec §"OutputDistribution" for the per-stage table.
+//
+// Phase 1 deliberately labels probe-split scans (Tasks > 1) as DistSingleton
+// because the per-worker file-list is opaque to the property algebra.
+// Phase 2 adds a richer label (e.g. DistRoundRobin) when the executor wires
+// scan partitioning into the property graph. See spec Risk #2.
+func OutputDistribution(stage Stage, deps map[string]Distribution) Distribution {
+	switch stage.Type {
+	case "scan":
+		return Distribution{Kind: DistSingleton}
+	case "dual":
+		return Distribution{Kind: DistSingleton}
+	case "shuffle":
+		return Distribution{
+			Kind:  DistHashPartitioned,
+			Keys:  stage.ShuffleKeys,
+			Count: stage.NumPartitions,
+		}
+	case "hash_join", "broadcast_join":
+		// The join inherits the probe (left) input's distribution — the
+		// join itself does not re-partition the joined output, it just
+		// pairs probe rows with matching build rows.
+		if probe, ok := deps[stage.LeftDepStage]; ok {
+			return probe
+		}
+		return Distribution{Kind: DistSingleton}
+	case "aggregate":
+		return Distribution{Kind: DistSingleton}
+	case "final_aggregate", "merge_aggregate":
+		// Per spec §"OutputDistribution": merge-grouped finals are labeled
+		// hash-partitioned on group-by cols with Count=MergeGroupCount for
+		// symmetry with Trino/Spark. Lone reducers (MergeGroupCount == 0)
+		// are singleton. See spec Risk #1.
+		if stage.MergeGroupCount > 0 {
+			return Distribution{
+				Kind:  DistHashPartitioned,
+				Keys:  stage.GroupByCols,
+				Count: stage.MergeGroupCount,
+			}
+		}
+		return Distribution{Kind: DistSingleton}
+	case "sort":
+		return Distribution{Kind: DistSingleton}
+	case "merge_sort":
+		// Merge-grouped intermediate merges are labeled hash-partitioned on
+		// the sort keys (column names) for symmetry. Final merge of
+		// intermediates (MergeGroupCount == 0) is singleton.
+		if stage.MergeGroupCount > 0 {
+			keys := make([]string, len(stage.SortKeys))
+			for i, sk := range stage.SortKeys {
+				keys[i] = sk.Column
+			}
+			return Distribution{
+				Kind:  DistHashPartitioned,
+				Keys:  keys,
+				Count: stage.MergeGroupCount,
+			}
+		}
+		return Distribution{Kind: DistSingleton}
+	case "window", "pipeline", "table_func":
+		return Distribution{Kind: DistSingleton}
+	default:
+		return Distribution{Kind: DistSingleton}
+	}
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test -run TestOutputDistribution ./internal/planner/physical/`
+Expected: `PASS` with all 15 subtests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/planner/physical/distribution.go internal/planner/physical/distribution_test.go
+git commit -m "$(cat <<'EOF'
+feat(planner): add OutputDistribution per stage type
+
+Computes per-stage output partitioning from stage fields and resolved
+dependency distributions. Joins inherit the probe input distribution
+(no re-partition by the join itself). Shuffle stages emit hash-partitioned
+on ShuffleKeys × NumPartitions. Merge-grouped finals/sorts are labeled
+hash-partitioned (symmetry with Trino/Spark; spec Risk #1).
+
+Phase 1 conservatively labels probe-split scans as DistSingleton; spec
+Risk #2 explains Phase 2 evolution.
+EOF
+)"
+```
+
+---
+
+## Task 6: Add `assignStageDistributions` to populate `Stage.Distribution` for every stage
+
+**Files:**
+- Modify: `internal/planner/physical/distribution_test.go`
+- Modify: `internal/planner/physical/distribution.go`
+
+- [ ] **Step 1: Append the failing test to `distribution_test.go`**
+
+```go
+func TestAssignStageDistributions(t *testing.T) {
+	// Synthetic 3-stage plan: scan -> shuffle -> join (with another scan + shuffle as build)
+	stages := []Stage{
+		{ID: "scan-0", Type: "scan", ScanAlias: "lineitem"},
+		{ID: "scan-1", Type: "scan", ScanAlias: "orders"},
+		{
+			ID: "shuffle-2", Type: "shuffle",
+			ShuffleKeys: []string{"l_orderkey"}, NumPartitions: 16,
+			Dependencies: []string{"scan-0"},
+		},
+		{
+			ID: "shuffle-3", Type: "shuffle",
+			ShuffleKeys: []string{"o_orderkey"}, NumPartitions: 16,
+			Dependencies: []string{"scan-1"},
+		},
+		{
+			ID: "join-4", Type: "hash_join",
+			JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"},
+			LeftDepStage: "shuffle-2", RightDepStage: "shuffle-3",
+			Dependencies: []string{"shuffle-2", "shuffle-3"},
+		},
+	}
+
+	assignStageDistributions(stages, 4)
+
+	want := map[string]Distribution{
+		"scan-0":    {Kind: DistSingleton},
+		"scan-1":    {Kind: DistSingleton},
+		"shuffle-2": {Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 16},
+		"shuffle-3": {Kind: DistHashPartitioned, Keys: []string{"o_orderkey"}, Count: 16},
+		// Hash join inherits probe-side distribution (shuffle-2)
+		"join-4": {Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 16},
+	}
+	for _, s := range stages {
+		got := s.Distribution
+		w := want[s.ID]
+		if !got.Equals(w) {
+			t.Errorf("stage %s: Distribution = %+v, want %+v", s.ID, got, w)
+		}
+	}
+}
+
+func TestAssignStageDistributions_OutOfOrderInput(t *testing.T) {
+	// Stages provided out of topological order. The pass must still resolve
+	// dependencies (e.g. join-4 declared before its shuffle deps).
+	stages := []Stage{
+		{
+			ID: "join-4", Type: "hash_join",
+			JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"},
+			LeftDepStage: "shuffle-2", RightDepStage: "shuffle-3",
+			Dependencies: []string{"shuffle-2", "shuffle-3"},
+		},
+		{
+			ID: "shuffle-2", Type: "shuffle",
+			ShuffleKeys: []string{"l_orderkey"}, NumPartitions: 16,
+			Dependencies: []string{"scan-0"},
+		},
+		{
+			ID: "shuffle-3", Type: "shuffle",
+			ShuffleKeys: []string{"o_orderkey"}, NumPartitions: 16,
+			Dependencies: []string{"scan-1"},
+		},
+		{ID: "scan-0", Type: "scan", ScanAlias: "lineitem"},
+		{ID: "scan-1", Type: "scan", ScanAlias: "orders"},
+	}
+
+	assignStageDistributions(stages, 4)
+
+	for _, s := range stages {
+		if s.ID == "join-4" {
+			want := Distribution{Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 16}
+			if !s.Distribution.Equals(want) {
+				t.Errorf("join-4 Distribution = %+v, want %+v (dep resolution should not depend on input order)", s.Distribution, want)
+			}
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test -run TestAssignStageDistributions ./internal/planner/physical/`
+Expected: build failure with `undefined: assignStageDistributions`
+
+- [ ] **Step 3: Add `assignStageDistributions` to `distribution.go`**
+
+Append after `OutputDistribution`:
+
+```go
+// assignStageDistributions walks the stages slice in dependency order and
+// populates Stage.Distribution per the OutputDistribution rules. The walk
+// is by-ID so stages provided out of topological order are still resolved
+// correctly (matters because fuseJoinStages rewires deps after walkStages).
+//
+// workerCount is reserved for future rules (e.g. probe-split scan
+// distribution) — Phase 1 ignores it but threads it through to keep the
+// signature stable for Phase 2.
+func assignStageDistributions(stages []Stage, workerCount int) {
+	_ = workerCount // reserved for Phase 2 probe-split distribution rules
+
+	// Build an ID → index lookup so we can mutate stages in place.
+	idx := make(map[string]int, len(stages))
+	for i, s := range stages {
+		idx[s.ID] = i
+	}
+
+	// Track resolved distributions by stage ID. A stage is resolvable once
+	// all its dependencies have been resolved.
+	resolved := make(map[string]Distribution, len(stages))
+
+	// Iterate until every stage has a resolved distribution. The loop runs
+	// at most len(stages) times because each pass resolves at least one
+	// stage (the dependency graph is a DAG validated by walkStages).
+	for pass := 0; pass < len(stages) && len(resolved) < len(stages); pass++ {
+		for i := range stages {
+			s := &stages[i]
+			if _, done := resolved[s.ID]; done {
+				continue
+			}
+			// Check that every dependency has been resolved.
+			ready := true
+			for _, dep := range s.Dependencies {
+				if _, ok := resolved[dep]; !ok {
+					ready = false
+					break
+				}
+			}
+			if !ready {
+				continue
+			}
+			// Build the per-dep distribution map for OutputDistribution.
+			depMap := make(map[string]Distribution, len(s.Dependencies))
+			for _, dep := range s.Dependencies {
+				depMap[dep] = resolved[dep]
+			}
+			d := OutputDistribution(*s, depMap)
+			s.Distribution = d
+			resolved[s.ID] = d
+			_ = idx // idx kept for Phase 2 stages that need cross-references
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Run the tests to verify both pass**
+
+Run: `go test -run TestAssignStageDistributions ./internal/planner/physical/`
+Expected: `PASS` with both subtests passing (`TestAssignStageDistributions` and `TestAssignStageDistributions_OutOfOrderInput`)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/planner/physical/distribution.go internal/planner/physical/distribution_test.go
+git commit -m "$(cat <<'EOF'
+feat(planner): add assignStageDistributions
+
+Walks the stages slice and populates Stage.Distribution per the
+OutputDistribution rules. Dependency resolution is by-ID so stages
+provided out of topological order are still resolved correctly —
+fuseJoinStages rewires deps after walkStages, and the assignment must
+not assume slice order matches dependency order.
+
+workerCount reserved for Phase 2 probe-split distribution rules.
+EOF
+)"
+```
+
+---
+
+## Task 7: Add `BehaviorPreservingMode` package var and `AssertExchangeConsistency` walker
+
+**Files:**
+- Modify: `internal/planner/physical/distribution_test.go`
+- Modify: `internal/planner/physical/distribution.go`
+
+- [ ] **Step 1: Append the failing tests to `distribution_test.go`**
+
+```go
+func TestAssertExchangeConsistency_ConsistentPlan(t *testing.T) {
+	// scan -> shuffle (on l_orderkey) -> join.probe (RequiredClusteredOn l_orderkey)
+	// scan -> shuffle (on o_orderkey) -> join.build (RequiredClusteredOn o_orderkey)
+	// All edges satisfy: hash-partitioned-on-K satisfies clustered-on-K.
+	stages := []Stage{
+		{ID: "scan-0", Type: "scan", Distribution: Distribution{Kind: DistSingleton}},
+		{ID: "scan-1", Type: "scan", Distribution: Distribution{Kind: DistSingleton}},
+		{
+			ID: "shuffle-2", Type: "shuffle",
+			ShuffleKeys: []string{"l_orderkey"}, NumPartitions: 16,
+			Dependencies: []string{"scan-0"},
+			Distribution: Distribution{Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 16},
+		},
+		{
+			ID: "shuffle-3", Type: "shuffle",
+			ShuffleKeys: []string{"o_orderkey"}, NumPartitions: 16,
+			Dependencies: []string{"scan-1"},
+			Distribution: Distribution{Kind: DistHashPartitioned, Keys: []string{"o_orderkey"}, Count: 16},
+		},
+		{
+			ID: "join-4", Type: "hash_join",
+			JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"},
+			LeftDepStage: "shuffle-2", RightDepStage: "shuffle-3",
+			Dependencies: []string{"shuffle-2", "shuffle-3"},
+			Distribution: Distribution{Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 16},
+		},
+	}
+
+	if err := AssertExchangeConsistency(stages); err != nil {
+		t.Fatalf("expected no error on consistent plan, got: %v", err)
+	}
+}
+
+func TestAssertExchangeConsistency_BrokenPlan_StrictMode(t *testing.T) {
+	// Save and restore the package var.
+	prev := BehaviorPreservingMode
+	BehaviorPreservingMode = false
+	defer func() { BehaviorPreservingMode = prev }()
+
+	// join requires its build slot clustered on o_orderkey, but the build
+	// dependency is hash-partitioned on c_custkey — violation.
+	stages := []Stage{
+		{ID: "scan-0", Type: "scan", Distribution: Distribution{Kind: DistSingleton}},
+		{
+			ID: "shuffle-1", Type: "shuffle",
+			ShuffleKeys: []string{"l_orderkey"}, NumPartitions: 16,
+			Dependencies: []string{"scan-0"},
+			Distribution: Distribution{Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 16},
+		},
+		{ID: "scan-2", Type: "scan", Distribution: Distribution{Kind: DistSingleton}},
+		{
+			ID: "shuffle-3", Type: "shuffle",
+			ShuffleKeys: []string{"c_custkey"}, NumPartitions: 16,
+			Dependencies: []string{"scan-2"},
+			Distribution: Distribution{Kind: DistHashPartitioned, Keys: []string{"c_custkey"}, Count: 16},
+		},
+		{
+			ID: "join-4", Type: "hash_join",
+			JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"},
+			LeftDepStage: "shuffle-1", RightDepStage: "shuffle-3",
+			Dependencies: []string{"shuffle-1", "shuffle-3"},
+			Distribution: Distribution{Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 16},
+		},
+	}
+
+	err := AssertExchangeConsistency(stages)
+	if err == nil {
+		t.Fatal("expected error on broken plan in strict mode, got nil")
+	}
+	if !strings.Contains(err.Error(), "join-4") {
+		t.Errorf("error should mention violating consumer stage join-4, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "shuffle-3") {
+		t.Errorf("error should mention violating producer stage shuffle-3, got: %v", err)
+	}
+}
+
+func TestAssertExchangeConsistency_BrokenPlan_BehaviorPreservingMode(t *testing.T) {
+	prev := BehaviorPreservingMode
+	BehaviorPreservingMode = true
+	defer func() { BehaviorPreservingMode = prev }()
+
+	// Same broken plan as the strict-mode test.
+	stages := []Stage{
+		{ID: "scan-0", Type: "scan", Distribution: Distribution{Kind: DistSingleton}},
+		{
+			ID: "shuffle-1", Type: "shuffle",
+			ShuffleKeys: []string{"l_orderkey"}, NumPartitions: 16,
+			Dependencies: []string{"scan-0"},
+			Distribution: Distribution{Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 16},
+		},
+		{ID: "scan-2", Type: "scan", Distribution: Distribution{Kind: DistSingleton}},
+		{
+			ID: "shuffle-3", Type: "shuffle",
+			ShuffleKeys: []string{"c_custkey"}, NumPartitions: 16,
+			Dependencies: []string{"scan-2"},
+			Distribution: Distribution{Kind: DistHashPartitioned, Keys: []string{"c_custkey"}, Count: 16},
+		},
+		{
+			ID: "join-4", Type: "hash_join",
+			JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"},
+			LeftDepStage: "shuffle-1", RightDepStage: "shuffle-3",
+			Dependencies: []string{"shuffle-1", "shuffle-3"},
+			Distribution: Distribution{Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 16},
+		},
+	}
+
+	// In BehaviorPreservingMode, AssertExchangeConsistency returns nil —
+	// the violation is logged at WARN but does not bubble up as an error.
+	if err := AssertExchangeConsistency(stages); err != nil {
+		t.Fatalf("expected nil in BehaviorPreservingMode (warn-only), got: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Add the `strings` import to `distribution_test.go` if not already present**
+
+Run: `go test -run TestAssertExchangeConsistency ./internal/planner/physical/`
+Expected: build failure mentioning `undefined: AssertExchangeConsistency`, `undefined: BehaviorPreservingMode`, and possibly `undefined: strings`
+
+If `strings` is not already imported, add it. Open `internal/planner/physical/distribution_test.go` and ensure the import block includes `"strings"`:
+
+```go
+import (
+	"strings"
+	"testing"
+)
+```
+
+- [ ] **Step 3: Add `BehaviorPreservingMode`, `AssertExchangeConsistency`, and supporting types to `distribution.go`**
+
+First, add the `log` import. At the top of `distribution.go`, change the package declaration to include imports:
+
+```go
+package physical
+
+import (
+	"fmt"
+	"log"
+)
+```
+
+Then append after `assignStageDistributions`:
+
+```go
+// BehaviorPreservingMode controls assertion hardness. When true (Phase 1
+// default), AssertExchangeConsistency logs violations at WARN and returns
+// nil — every existing distributed plan continues to execute unchanged
+// even if the property algebra rules in this file are wrong. When false
+// (tests, and Phase 2 onward), violations are returned as errors and
+// callers must handle them.
+//
+// Phase 2 deletes this var and makes the assertion always strict — the
+// EnsureDistribution rule guarantees no violation can survive into the
+// emitted plan.
+var BehaviorPreservingMode = true
+
+// joinSlot derives the per-dependency slot index for a join stage by
+// matching dependency IDs against LeftDepStage / RightDepStage. Returns
+// 0 for the probe (left), 1 for the build (right), -1 if dep matches
+// neither (which means the dep is auxiliary, e.g. a fused-join build).
+func joinSlot(stage Stage, depID string) int {
+	if depID == stage.LeftDepStage {
+		return 0
+	}
+	if depID == stage.RightDepStage {
+		return 1
+	}
+	return -1
+}
+
+// AssertExchangeConsistency walks every (producer, consumer, slot) edge in
+// the stages slice and asserts that producer.Distribution.Satisfies(
+// RequiredChildDistribution(consumer, slot)). Returns the first violation
+// as an error, or nil if all edges are consistent.
+//
+// In BehaviorPreservingMode, violations are logged at WARN and nil is
+// returned — Phase 1 is purely additive and must not block any plan that
+// the heuristic switch would otherwise accept.
+//
+// Phase 2 promotes this to the satisfaction check that drives Exchange
+// insertion: a violation triggers an Exchange stage being added, not a
+// plan rejection.
+func AssertExchangeConsistency(stages []Stage) error {
+	byID := make(map[string]Stage, len(stages))
+	for _, s := range stages {
+		byID[s.ID] = s
+	}
+
+	for _, consumer := range stages {
+		for _, depID := range consumer.Dependencies {
+			producer, ok := byID[depID]
+			if !ok {
+				// Dangling dep — not a Phase 1 concern (validateStageGraph
+				// already covers this). Skip silently.
+				continue
+			}
+
+			// Determine the slot. For join stages, derive from
+			// LeftDepStage / RightDepStage. For non-join consumers, slot 0
+			// (single-input) is the only meaningful index — Phase 1 does
+			// not assert non-join multi-input requirements.
+			slot := 0
+			if consumer.Type == "hash_join" || consumer.Type == "broadcast_join" {
+				s := joinSlot(consumer, depID)
+				if s < 0 {
+					// Auxiliary dep (e.g. fused-join build). Skip — no
+					// Phase 1 rule constrains it.
+					continue
+				}
+				slot = s
+			}
+
+			req := RequiredChildDistribution(consumer, slot)
+			if !producer.Distribution.Satisfies(req) {
+				violation := fmt.Errorf(
+					"exchange consistency violation: consumer=%s (type=%s, slot=%d) requires %s%v "+
+						"but producer=%s emits Distribution{Kind=%v, Keys=%v, Count=%d}",
+					consumer.ID, consumer.Type, slot,
+					req.Kind, req.Keys,
+					producer.ID, producer.Distribution.Kind, producer.Distribution.Keys, producer.Distribution.Count,
+				)
+				if BehaviorPreservingMode {
+					log.Printf("WARN: %v", violation)
+					continue
+				}
+				return violation
+			}
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run the tests to verify all three pass**
+
+Run: `go test -run TestAssertExchangeConsistency ./internal/planner/physical/`
+Expected: `PASS` with three subtests passing (`_ConsistentPlan`, `_BrokenPlan_StrictMode`, `_BrokenPlan_BehaviorPreservingMode`)
+
+- [ ] **Step 5: Run the full distribution test file to verify nothing else broke**
+
+Run: `go test -run 'TestDistribution|TestRequired|TestOutput|TestAssign|TestAssert' ./internal/planner/physical/`
+Expected: all tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/planner/physical/distribution.go internal/planner/physical/distribution_test.go
+git commit -m "$(cat <<'EOF'
+feat(planner): add AssertExchangeConsistency + BehaviorPreservingMode
+
+Walks every (producer, consumer, slot) edge and asserts the producer's
+Distribution satisfies the consumer's RequiredChildDistribution. Phase 1
+ships in BehaviorPreservingMode=true: violations are logged at WARN and
+nil is returned, preserving every plan the heuristic switch produces
+today even if the property algebra rules are wrong. Tests flip the var
+to assert hard.
+
+Phase 2 deletes BehaviorPreservingMode; the EnsureDistribution rule
+guarantees no violation can survive into the emitted plan.
+EOF
+)"
+```
+
+---
+
+## Task 8: Wire `assignStageDistributions` + `AssertExchangeConsistency` into `PlanDistributed`
+
+**Files:**
+- Modify: `internal/planner/physical/distribution_test.go`
+- Modify: `internal/planner/physical/plan.go:975-988` (add three lines after `enforceQueryLimits`)
+
+- [ ] **Step 1: Append the failing integration test to `distribution_test.go`**
+
+```go
+func TestPlanDistributed_PopulatesStageDistribution(t *testing.T) {
+	// Confirm PlanDistributed populates Stage.Distribution on every stage
+	// it emits. Uses the TPC-H test catalog from plan_tpch_test.go (same
+	// package) and a synthetic 2-table join.
+	cat, ctx := setupTPCHCatalog(t)
+	sql := `SELECT l_orderkey, o_orderdate
+		FROM lineitem JOIN orders ON l_orderkey = o_orderkey
+		WHERE o_orderdate >= '1995-01-01'`
+
+	stages := sqlToStages(t, cat, ctx, sql, 4)
+
+	for _, s := range stages {
+		// Every stage must have a populated Distribution. The zero value
+		// is {Kind: DistSingleton, Keys: nil, Count: 0} which is a valid
+		// "populated" value for stages that emit singleton output. We
+		// detect "unpopulated" by checking that the wire-up actually ran
+		// — for shuffle stages, the non-zero Count is a reliable proof.
+		if s.Type == "shuffle" {
+			if s.Distribution.Kind != DistHashPartitioned {
+				t.Errorf("shuffle stage %s: Distribution.Kind = %v, want DistHashPartitioned", s.ID, s.Distribution.Kind)
+			}
+			if s.Distribution.Count == 0 {
+				t.Errorf("shuffle stage %s: Distribution.Count = 0 (assignStageDistributions not wired in)", s.ID)
+			}
+			if len(s.Distribution.Keys) == 0 {
+				t.Errorf("shuffle stage %s: Distribution.Keys empty (assignStageDistributions not wired in)", s.ID)
+			}
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails (wire-up not yet in place)**
+
+Run: `go test -run TestPlanDistributed_PopulatesStageDistribution ./internal/planner/physical/`
+Expected: `FAIL` — at least one shuffle stage has `Distribution.Kind = 0` (DistSingleton, the zero value) and `Count = 0`
+
+- [ ] **Step 3: Wire the calls into `PlanDistributed`**
+
+Open `internal/planner/physical/plan.go`. Find the existing `PlanDistributed` (around line 975):
+
+```go
+func (p *Planner) PlanDistributed(ctx context.Context, node *logical.Node) ([]Stage, error) {
+	p.planCtx = ctx // store for scalar subquery evaluation during stage generation
+	if len(node.CTEs) > 0 {
+		p.ctes = node.CTEs
+	}
+	// Ensure scan nodes have column metadata — needed by fixJoinKeyOrder
+	// to assign shuffle keys to the correct child side.
+	p.AnnotateScanColumns(ctx, node)
+	stages := p.generateStages(node)
+	if err := p.enforceQueryLimits(stages, node); err != nil {
+		return nil, err
+	}
+	return stages, nil
+}
+```
+
+Replace the body so the final lines become:
+
+```go
+func (p *Planner) PlanDistributed(ctx context.Context, node *logical.Node) ([]Stage, error) {
+	p.planCtx = ctx // store for scalar subquery evaluation during stage generation
+	if len(node.CTEs) > 0 {
+		p.ctes = node.CTEs
+	}
+	// Ensure scan nodes have column metadata — needed by fixJoinKeyOrder
+	// to assign shuffle keys to the correct child side.
+	p.AnnotateScanColumns(ctx, node)
+	stages := p.generateStages(node)
+	if err := p.enforceQueryLimits(stages, node); err != nil {
+		return nil, err
+	}
+	// Phase 1 distribution-property pass: populate Stage.Distribution for
+	// every stage and assert exchange consistency. In BehaviorPreservingMode
+	// (default), violations are logged but do not fail planning. See
+	// docs/superpowers/specs/2026-04-20-distribution-property-phase-1.md.
+	assignStageDistributions(stages, p.WorkerCount)
+	if err := AssertExchangeConsistency(stages); err != nil {
+		// In strict mode (Phase 2 onward, or test override) this is a
+		// hard failure. BehaviorPreservingMode swallows the error inside
+		// AssertExchangeConsistency, so reaching this branch implies the
+		// caller flipped the var.
+		return nil, fmt.Errorf("exchange consistency: %w", err)
+	}
+	return stages, nil
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test -run TestPlanDistributed_PopulatesStageDistribution ./internal/planner/physical/`
+Expected: `PASS`
+
+- [ ] **Step 5: Run the full distribution test file again**
+
+Run: `go test -run 'TestDistribution|TestRequired|TestOutput|TestAssign|TestAssert|TestPlanDistributed_Populates' ./internal/planner/physical/`
+Expected: all tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/planner/physical/distribution.go internal/planner/physical/distribution_test.go internal/planner/physical/plan.go
+git commit -m "$(cat <<'EOF'
+feat(planner): wire distribution-property pass into PlanDistributed
+
+After enforceQueryLimits, call assignStageDistributions to populate
+Stage.Distribution on every stage and AssertExchangeConsistency to
+verify producer/consumer edges are consistent. In BehaviorPreservingMode
+(Phase 1 default), violations are logged at WARN and PlanDistributed
+returns the stages unchanged — the existing heuristic switch in
+coordinator.go continues to drive every routing decision.
+
+Integration test confirms shuffle stages carry populated DistHashPartitioned.
+EOF
+)"
+```
+
+---
+
+## Task 9: Add `TestTPCHDistributionConsistency` — the Phase 1 acceptance gate
+
+**Files:**
+- Modify: `internal/planner/physical/plan_tpch_test.go`
+
+- [ ] **Step 1: Append the acceptance-gate test to `plan_tpch_test.go`**
+
+```go
+// TestTPCHDistributionConsistency is the Phase 1 acceptance gate for the
+// distribution-property pass. For every Q1-Q22, runs PlanDistributed with
+// WorkerCount=4 in strict mode (BehaviorPreservingMode=false) and asserts:
+//   1. Every stage has a populated Distribution (shuffle stages explicitly
+//      DistHashPartitioned with non-zero Count).
+//   2. AssertExchangeConsistency(stages) == nil.
+//
+// Failure on any query means either the OutputDistribution /
+// RequiredChildDistribution rules are wrong or PlanDistributed emits an
+// inconsistent plan. Either way, the spec's load-bearing invariant is
+// broken and Phase 2 cannot proceed safely.
+//
+// Spec: docs/superpowers/specs/2026-04-20-distribution-property-phase-1.md
+func TestTPCHDistributionConsistency(t *testing.T) {
+	cat, ctx := setupTPCHCatalog(t)
+
+	// Strict mode: any consistency violation must surface as an error.
+	prev := BehaviorPreservingMode
+	BehaviorPreservingMode = false
+	defer func() { BehaviorPreservingMode = prev }()
+
+	for qNum := 1; qNum <= 22; qNum++ {
+		sql, ok := tpchPlanQueryMap[qNum]
+		if !ok {
+			t.Logf("Q%02d not in plan query map; skipping", qNum)
+			continue
+		}
+		name := fmt.Sprintf("Q%02d", qNum)
+		t.Run(name, func(t *testing.T) {
+			parsed, err := plansql.Parse(sql)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			selectInfo, err := plansql.ExtractSelect(parsed)
+			if err != nil {
+				t.Fatalf("extract: %v", err)
+			}
+			logicalPlan, err := logical.BuildFromSelect(selectInfo)
+			if err != nil {
+				t.Fatalf("logical plan: %v", err)
+			}
+			scanAnnotator := func(plan *logical.Node) {
+				NewPlanner(cat).AnnotateScanColumns(ctx, plan)
+			}
+			scanAnnotator(logicalPlan)
+			logicalPlan = logical.Optimize(logicalPlan, scanAnnotator)
+
+			planner := NewPlanner(cat)
+			planner.WorkerCount = 4
+			stages, err := planner.PlanDistributed(ctx, logicalPlan)
+			if err != nil {
+				// In strict mode, exchange-consistency violations come back
+				// as errors prefixed "exchange consistency: ...".
+				t.Fatalf("PlanDistributed failed: %v", err)
+			}
+
+			// Assertion 1: every stage has a populated Distribution. The
+			// zero value DistSingleton is "populated" for stages that emit
+			// singleton output, but shuffle stages must carry the
+			// hash-partitioned label with non-zero Count and non-empty Keys.
+			for _, s := range stages {
+				if s.Type == "shuffle" {
+					if s.Distribution.Kind != DistHashPartitioned {
+						t.Errorf("%s shuffle stage %s: Distribution.Kind = %v, want DistHashPartitioned",
+							name, s.ID, s.Distribution.Kind)
+					}
+					if s.Distribution.Count == 0 {
+						t.Errorf("%s shuffle stage %s: Distribution.Count = 0 (not populated)",
+							name, s.ID)
+					}
+					if len(s.Distribution.Keys) == 0 {
+						t.Errorf("%s shuffle stage %s: Distribution.Keys empty (not populated)",
+							name, s.ID)
+					}
+				}
+			}
+
+			// Assertion 2: in strict mode, AssertExchangeConsistency
+			// already ran inside PlanDistributed — if it returned an
+			// error it would have aborted above. Re-run defensively to
+			// log per-stage detail on failure.
+			if err := AssertExchangeConsistency(stages); err != nil {
+				for _, s := range stages {
+					t.Logf("  %-24s type=%-16s dist=%+v",
+						s.ID, s.Type, s.Distribution)
+				}
+				t.Fatalf("%s: %v", name, err)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run the acceptance gate**
+
+Run: `go test -v -run TestTPCHDistributionConsistency ./internal/planner/physical/`
+Expected: `PASS` for every Q01-Q22 subtest. If any subtest fails, the failure log shows the per-stage Distribution detail — read it carefully. Likely root causes (in priority order):
+  - **Merge-group label mismatch (spec Risk #1):** if a merge-grouped `final_aggregate` consumer flags a violation against its `final_aggregate-i-g` producer, the rule in `OutputDistribution` (currently `DistHashPartitioned`) needs to flip to `DistSingleton` for merge-grouped finals. Update the rule, re-run the test.
+  - **Probe-split scan label opaqueness (spec Risk #2):** unlikely to fire because `RequiredAny` is the default consumer requirement for scans; passes by default.
+  - **Fused-join dep skipped incorrectly:** if `joinSlot` returns -1 for a fused-join build dep that should be checked, the assertion is over-skipping. Phase 1 deliberately skips these (auxiliary deps); document any false negatives in the test log but do not fail.
+
+- [ ] **Step 3: If a violation surfaces, choose remediation and re-run**
+
+If the failure is the merge-group label (Risk #1), edit `OutputDistribution` in `distribution.go`. Replace the `final_aggregate, merge_aggregate` arm:
+
+```go
+	case "final_aggregate", "merge_aggregate":
+		// Merge-grouped finals: today's coordinator routes results by
+		// MergeGroup index, not by hash partitioning. Phase 1 labels
+		// them DistSingleton per group — the routing scheme makes the
+		// "partition" concept inapplicable to the property algebra.
+		// (Spec Risk #1 documented Phase 1's symmetry-with-Trino label
+		// as a fallback; the test above is the authoritative source.)
+		return Distribution{Kind: DistSingleton}
+```
+
+Then re-run `go test -v -run TestTPCHDistributionConsistency ./internal/planner/physical/`. Expected: `PASS` for every Q01-Q22 subtest.
+
+- [ ] **Step 4: Commit (commit the test even if you also had to amend OutputDistribution)**
+
+```bash
+git add internal/planner/physical/plan_tpch_test.go internal/planner/physical/distribution.go
+git commit -m "$(cat <<'EOF'
+test(planner): TPC-H distribution-consistency acceptance gate
+
+For every Q1-Q22, runs PlanDistributed with WorkerCount=4 in strict
+mode (BehaviorPreservingMode=false) and asserts every stage has a
+populated Distribution and AssertExchangeConsistency returns nil.
+This is the Phase 1 acceptance gate — Phase 2 cannot proceed if this
+fails.
+
+If the merge-group rule from spec §"OutputDistribution" needed
+adjustment, the OutputDistribution change is included here too with
+the updated Risk #1 documentation inline.
+EOF
+)"
+```
+
+---
+
+## Task 10: Verify TPC-H SF0.01 row-checksum correctness (no behavior change)
+
+**Files:** None modified. Verification step only.
+
+- [ ] **Step 1: Run TPC-H SF0.01 correctness suite**
+
+Run: `go test -v -run TestTPCHQueries ./benchmarks/tpch/ 2>&1 | tee /tmp/tpch-sf001-after.txt`
+Expected: every query passes — same row counts and (where checked) checksums as on the parent commit (`0b78c4e`). Total runtime ~5-15 seconds.
+
+- [ ] **Step 2: Verify the test summary line**
+
+Run: `grep -E '^(--- FAIL|FAIL|PASS|ok)' /tmp/tpch-sf001-after.txt | head -5`
+Expected output ends with `PASS` and `ok  github.com/citc-tech/wadjet/benchmarks/tpch`. No `FAIL` lines.
+
+- [ ] **Step 3: If any failure, halt and report**
+
+If any TPC-H SF0.01 query fails, **stop immediately**. The Phase 1 plan is purely additive and the only added work is one O(stages) walk plus one O(edges) assertion. A behavioral change indicates either:
+  - The wire-up in `PlanDistributed` accidentally mutated something other than `Stage.Distribution` (audit `assignStageDistributions` for unintended writes).
+  - `AssertExchangeConsistency` returned a non-nil error in BehaviorPreservingMode (it should never — verify the code path).
+
+Open an issue or report back with the failure detail; do not commit further.
+
+- [ ] **Step 4: No commit — verification step only**
+
+This task records the verification artifact at `/tmp/tpch-sf001-after.txt`. No file changes; nothing to commit.
+
+---
+
+## Task 11: Run the full project test suite to confirm no regressions
+
+**Files:** None modified. Verification step only.
+
+- [ ] **Step 1: Run the full internal test suite**
+
+Run: `go test ./internal/... 2>&1 | tee /tmp/internal-tests-after.txt`
+Expected: `ok` for every package. Total runtime 1-3 minutes.
+
+- [ ] **Step 2: Inspect for any FAIL lines**
+
+Run: `grep -E '^(FAIL|--- FAIL)' /tmp/internal-tests-after.txt`
+Expected: empty output. Any FAIL line indicates a regression.
+
+- [ ] **Step 3: If any failure, isolate and fix**
+
+If a non-physical-package test failed, the most likely cause is a callsite that depended on the old `SatisfiesJoinKeys` behavior. Open the failing test, inspect the assertion, and verify the new `Satisfies` delegation produces the same boolean. The truth table in Task 2's `TestDistributionSatisfies` is authoritative.
+
+If a physical-package test failed that wasn't covered above (e.g. a `plan_coverage_test.go` test), inspect the failure: the new pass populates `Stage.Distribution` on every stage, which previously was always the zero value. If the test asserts `s.Distribution.Equals(Distribution{})` or similar zero-value checks, the test needs updating to reflect populated distributions — make the change, re-run, commit with `test(planner): update Distribution zero-value assertions for Phase 1`.
+
+- [ ] **Step 4: Run `go vet` for static analysis cleanliness**
+
+Run: `go vet ./internal/planner/physical/...`
+Expected: empty output (no warnings).
+
+- [ ] **Step 5: No commit — verification step only (unless a test was updated in Step 3)**
+
+If Step 3 required test updates, commit them as their own `test(planner): ...` commit. Otherwise no commit.
+
+---
+
+## Task 12: Final summary check — confirm Phase 1 acceptance criteria
+
+**Files:** None modified. Audit step only.
+
+- [ ] **Step 1: Audit the spec's acceptance criteria against the implementation**
+
+Re-read `docs/superpowers/specs/2026-04-20-distribution-property-phase-1.md` §"Goals" (numbered 1-6). Confirm each is satisfied:
+
+| Goal | Verification |
+|---|---|
+| 1. Promote Distribution to populated property | Task 8 wire-up + Task 9 acceptance gate |
+| 2. RequiredDistribution as derived view | Task 4 `RequiredChildDistribution` |
+| 3. `Satisfies` predicate generalising `SatisfiesJoinKeys` | Tasks 2 + 3 |
+| 4. Planner-layer assertion runs after `PlanDistributed` | Tasks 7 + 8 + 9 |
+| 5. SF0.01 identical row checksums | Task 10 |
+| 6. SF1 wall-time within ±5% | Out-of-scope for this plan; spec calls out as a release-gate, not a per-PR gate. Operator may defer to CI. |
+
+- [ ] **Step 2: Verify branch state**
+
+Run: `git log --oneline 0b78c4e..HEAD`
+Expected: 8-10 commits all prefixed `feat(planner)`, `refactor(planner)`, or `test(planner)` per the Conventional Commits convention.
+
+Run: `git status`
+Expected: `nothing to commit, working tree clean`.
+
+- [ ] **Step 3: Verify no out-of-scope changes**
+
+Run: `git diff --stat 0b78c4e..HEAD`
+Expected: changes only under `internal/planner/physical/`. No changes to `internal/coordinator/`, `internal/worker/`, `internal/engine/`, or any other package.
+
+If any out-of-scope file appears in the diff, **stop and revert that change**: Phase 1 is planner-only by spec.
+
+- [ ] **Step 4: Phase 1 complete**
+
+The branch `feat/distribution-property-phase-1` is ready for PR. PR title: `feat(planner): distribution-property pass phase 1 — wire up scaffolding`. PR body should reference the spec and the acceptance gate (`TestTPCHDistributionConsistency`).
+
+No commit for this audit step.
+
+---
+
+## Summary
+
+12 tasks, ~50 steps total (TDD-disciplined: each new function gets a failing test → run-fail → implement → run-pass → commit). The acceptance gate is `TestTPCHDistributionConsistency` (Task 9) which runs every Q01-Q22 through `PlanDistributed` in strict mode. The behavior-preservation gate is `TestTPCHQueries` at SF0.01 (Task 10) — every query must produce identical results to the parent commit `0b78c4e`.
+
+Out of scope (per spec §"Non-Goals"): coordinator changes, worker changes, executor changes, cost-based decisions, Exchange stage type, adaptive runtime re-planning. These are Phase 2-4 and explicitly forbidden in this PR.

--- a/docs/superpowers/specs/2026-04-19-broadcast-hazard-mitigation-pass.md
+++ b/docs/superpowers/specs/2026-04-19-broadcast-hazard-mitigation-pass.md
@@ -1,0 +1,247 @@
+# Broadcast-Hazard Mitigation Pass — unifying PR #40 + PR #43 into a per-join planner pass
+
+**Status:** Draft
+**Date:** 2026-04-19
+**Author:** Derek Wright (with Claude)
+**Subsumes:** `2026-04-18-shuffle-based-build-partitioning-design.md` (PR #40), `2026-04-18-shuffle-distributed-aggregate.md` (PR #43)
+**Architectural invariant established:** *No query in the optimized plan broadcast-duplicates a join build whose per-worker bytes exceed the configured budget.*
+
+## Problem
+
+The planner today reasons about broadcast-duplication hazards through **two parallel primitives**, each with the same Phase-1 limitations:
+
+| Primitive | Detects | Cap | Threshold |
+|---|---|---|---|
+| `physical.PickShuffleCandidate` (PR #40) | Joins whose build is a base-table scan above `shuffleBuildThreshold` | One candidate per query | `var shuffleBuildThreshold = 4 GB` |
+| `physical.PickAggregateShuffleCandidate` (PR #43) | Joins whose build is `aggregate(GROUP BY K, scan(T))` above `aggregateShuffleThreshold` | One candidate per query | `var aggregateShuffleThreshold = 1 GB` |
+
+Both primitives express the same underlying concept — *"this join's build will broadcast-duplicate to every worker; rewrite the plan to avoid it"* — but each is shape-specific, single-candidate, and gated by its own constant. The duplicate-primitive smell is the architectural symptom. Q21's poor performance at SF10 is the loudest visible consequence: it has **two** raw-scan builds (decorrelated EXISTS and NOT EXISTS over `lineitem`), each just below the 4 GB threshold, neither of which the existing primitives handle. A future query with three large builds would expose the same gap again. Lowering thresholds, adding a third primitive for semi/anti shapes, or capping at "Phase 2 multi-candidate" all preserve the wrong abstraction.
+
+The right abstraction: **broadcast-hazard mitigation is a per-join planner pass, not a per-query coordinator branch.** Every join's build cost is evaluated against a memory budget; every hazard gets a remedy chosen by build shape; the choice between remedies is a cost comparison, not a hard-coded rule. The two existing primitives become specific remedies the new pass selects between; the constants become a single budget derived from cluster config.
+
+## Goals
+
+1. Replace `PickShuffleCandidate` and `PickAggregateShuffleCandidate` with a single primitive that walks every join in the plan and returns every broadcast-duplication hazard.
+2. Establish and enforce the architectural invariant in planner-layer tests, independent of any specific TPC-H query.
+3. Make the threshold a budget derived from per-worker memory, not a hand-tuned constant per shape.
+4. Preserve the executable behavior of PR #40 and PR #43 unchanged — they become remedies the new pass selects, not new code paths.
+5. Leave a clear extension point for additional remedies (distinct-key pre-compute for key-only semi/anti builds; runtime-adaptive partition counts; etc.) without growing the primitive count.
+
+## Non-Goals
+
+- New remedy types beyond the two PR #40 / PR #43 already provide. The distinct-key pre-compute remedy that would further reduce Q21's broadcast volume is a *future* slot the framework exposes; this spec does not implement it.
+- Cost-based join-order changes. The pass operates after logical optimization; build/probe assignment is taken as given.
+- Skew handling beyond the 4N partition count PR #40 ships with.
+- Replacing or modifying the executor's hash-join, semi/anti probe, or aggregate paths. The pass only rewrites the *plan*; execution code is untouched.
+- Standalone (single-process) mode. Standalone has no broadcast hazard because there's only one worker; the pass is a no-op when worker count is 1.
+- The build-cache primitive (`internal/coordinator/build_cache.go`, using `LargeBuildScans`). Build cache addresses *I/O* hazard (every worker re-reads the same Parquet) by materializing the scan once to S3 and sharing it; the new pass addresses *memory* hazard (every worker holds the same hash table). Both can apply to the same join. Unifying the two is a worthwhile follow-up but is not in this spec — neither pass currently changes the other's behavior.
+
+## Design
+
+### Approach summary
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Primitive shape | Single function `IdentifyBroadcastHazards(stages, budget) []BroadcastHazard` returning all hazards | Plan-wide visibility instead of per-call iteration; eliminates the "what if there are two" failure mode by construction |
+| Hazard granularity | Per-join, not per-query | Multi-build queries (Q21, Q07, Q09) are expressed as N hazards naturally; no special multi-candidate code |
+| Remedy selection | Per-hazard cost comparison among applicable remedies for that build's shape | Future remedies extend the choice set without rewriting the dispatcher |
+| Threshold model | One `broadcastBudget int64` derived from `GOMEMLIMIT × bcastBudgetFraction / workerCount` (config) | Replaces two magic-byte constants with a derived value tied to the actual constraint (per-worker memory) |
+| Execution wiring | Each remedy maps 1:1 to an existing orchestrator helper (`orchestrateShuffleStages`, `preComputeDerivedAggregate`) | Zero change to the orchestrators; the new pass picks which to invoke and the coordinator iterates |
+| Migration | Old primitives deleted in the same change that introduces the new one | No "Phase 1 / Phase 2" or feature-flag bridge — the architectural simplification is the *point* of the change |
+
+### The primitive
+
+```go
+// In internal/planner/physical/broadcast_hazard.go (new file).
+
+// BroadcastHazard records a join whose build side, if left as a broadcast,
+// would exceed the per-worker memory budget. The pass returns one of these
+// for every such join in the plan.
+type BroadcastHazard struct {
+    JoinStageID    string         // the join whose build poses the hazard
+    BuildBytes     int64          // estimated per-worker bytes if broadcast (full build size)
+    BuildShape     BuildShape     // RawScan | AggregateOverScan | Unsupported
+    Remedy         Remedy         // chosen remedy (see RemedyKind)
+    // Remedy-specific payloads (one populated, others zero):
+    ShuffleCand    ShuffleCandidate          // when Remedy.Kind == RemedyShuffleScan
+    AggregateCand  AggregateShuffleCandidate // when Remedy.Kind == RemedyPreComputeAggregate
+}
+
+type BuildShape int
+const (
+    BuildShapeRawScan           BuildShape = iota // build is a single base-table scan (possibly with filters)
+    BuildShapeAggregateOverScan                    // build is aggregate(GROUP BY K, scan(T))
+    BuildShapeUnsupported                          // shape doesn't match any current remedy
+)
+
+type Remedy struct {
+    Kind     RemedyKind
+    EstCost  int64 // per-worker bytes after remedy applies; for cost comparison if multiple remedies are applicable to a shape
+}
+
+type RemedyKind int
+const (
+    RemedyNone                  RemedyKind = iota // hazard recognized but no remedy available; broadcast remains
+    RemedyShuffleScan                              // PR #40 mechanism: partition the build's scan by join keys
+    RemedyPreComputeAggregate                      // PR #43 mechanism: pre-compute aggregate centrally, broadcast cache paths
+    // Future: RemedyPreComputeDistinctKeys, RemedyShuffleAggregate, etc.
+)
+
+// IdentifyBroadcastHazards walks every hash_join / broadcast_join stage in the
+// plan and returns one BroadcastHazard per join whose build's per-worker bytes
+// exceed budget. Returns the empty slice when no hazards are present.
+//
+// Hazards are returned in plan order (deterministic for downstream orchestration).
+//
+// The function is total: every join is either classified into a known
+// BuildShape with a chosen Remedy, or returned with BuildShape=Unsupported and
+// Remedy.Kind=RemedyNone so the caller can log/observe it. Unsupported hazards
+// are never silently dropped — telemetry is the spec's main feedback loop for
+// finding new remedy needs on production workloads.
+func IdentifyBroadcastHazards(stages []Stage, budget int64) []BroadcastHazard
+```
+
+### Per-join classification
+
+For each join stage:
+
+1. **Compute build bytes.** Walk the build sub-DAG to its root scan(s); sum `EstimatedBytes`. (For aggregate-over-scan builds, this is the *input scan* bytes — matches PR #43's gating.) If `buildBytes ≤ budget`, the join is not a hazard; skip.
+
+2. **Classify build shape.** Apply existing helpers (`followToAggregate`, `followToScan` — already in `aggregate_shuffle.go`) plus a simple "is the build a single scan with optional filters" check.
+
+3. **Select remedy.** For each applicable remedy, compute estimated per-worker bytes after remedy:
+   - `RemedyShuffleScan`: `buildBytes / workerCount` (partitioned).
+   - `RemedyPreComputeAggregate`: `aggregate output bytes` (estimated from NDV statistics if available; conservatively `buildBytes / 100` as a first-pass heuristic when stats are missing — telemetry will inform tuning).
+   Pick the lowest-cost applicable remedy. If none apply, set `RemedyNone`.
+
+4. **Validate join-key alignment.** If the chosen remedy needs the join keys to be partitionable by the remedy's partition keys (shuffle: build scan's columns must include join keys; aggregate: GROUP BY keys must cover join keys), confirm it. On failure, demote to next-best remedy or `RemedyNone`. Reuse `keysCovered` and the existing column-anchored fallback logic.
+
+5. **Emit hazard.** Append `BroadcastHazard{...}` to the result.
+
+### Coordinator integration
+
+In `internal/coordinator/coordinator.go`, the existing two-branch routing block — the back-to-back `PickShuffleCandidate` + `PickAggregateShuffleCandidateDiag` calls plus the suppression logic between them — is replaced by a single block:
+
+```go
+hazards := physical.IdentifyBroadcastHazards(physStages, c.broadcastBudget())
+for _, h := range hazards {
+    c.logger.Info("broadcast hazard identified",
+        "query", queryID, "join", h.JoinStageID,
+        "build_bytes", h.BuildBytes, "shape", h.BuildShape,
+        "remedy", h.Remedy.Kind, "remedy_cost", h.Remedy.EstCost)
+}
+revisedStages, preExecArtifacts, err := c.applyBroadcastRemedies(ctx, queryID, physStages, hazards)
+if err != nil {
+    return nil, fmt.Errorf("apply broadcast remedies: %w", err)
+}
+physStages = revisedStages
+preComputedAggregates = preExecArtifacts.Aggregates
+shuffleTasks = preExecArtifacts.ShuffleTasks
+```
+
+`applyBroadcastRemedies` is a thin coordinator method that iterates hazards and dispatches:
+
+- `RemedyShuffleScan` → `c.orchestrateShuffleStages(...)` (existing function, unchanged), populating a `ShuffleTasks` map keyed by the resulting probe stage ID.
+- `RemedyPreComputeAggregate` → `c.preComputeDerivedAggregate(...)` (existing function, unchanged), appending to `Aggregates`.
+- `RemedyNone` → no plan transformation; the join continues to broadcast, the hazard remains in telemetry.
+
+The shuffle and pre-compute helpers themselves remain identical to today. The architectural simplification is purely at the planner/coordinator boundary: one identification pass, one dispatch loop, no per-shape branching.
+
+When multiple hazards reference the same upstream scan (e.g. a scan that feeds two joins), the dispatch loop deduplicates with a concrete rule: hazards are processed in plan order; for each hazard, before dispatching, check whether an already-applied remedy upstream of this join already reduces its build to ≤ budget. If so, skip. If not, dispatch this hazard's remedy. Two hazards needing *different* shuffle keys on the same scan is the only conflicting case: the loop dispatches the first and demotes the second to `RemedyNone` with a telemetry line. None of the 22 TPC-H queries exhibit this conflict; if a future query does, the invariant test fails and points at the join that needs a richer remedy (e.g. shuffle-by-multiple-keys or a re-shuffle stage).
+
+### Budget model
+
+`broadcastBudget()` returns `bcastBudgetFraction × goMemLimit / max(1, workerCount)`, with:
+
+- `bcastBudgetFraction` defaulting to `0.25` (a single broadcast hazard should not consume more than a quarter of per-worker heap).
+- `goMemLimit` read from runtime; fallback to a `BroadcastBudgetBytes` config value when GOMEMLIMIT is unset (e.g. local dev).
+
+This ties the threshold to the actual constraint (per-worker memory pressure) instead of a magic byte count. Tests can override the fraction or set the budget directly via the same `var` pattern PR #40 / PR #43 use today. The constants `shuffleBuildThreshold` and `aggregateShuffleThreshold` are deleted in this change; their existing test overrides migrate to setting `broadcastBudget` directly.
+
+### Q21 walkthrough (correctness check, not goal)
+
+After the pass, Q21's plan at SF10 with workerCount=4 should produce:
+
+- Hazard A: join between l1 (probe) and l2 (semi-build), `buildBytes ≈ 3.7 GB`, `BuildShape=RawScan`, `Remedy=RemedyShuffleScan` partitioning l2 by `l_orderkey`.
+- Hazard B: join between l1 (probe) and l3 (anti-build), `buildBytes ≈ filtered_lineitem_bytes`, `BuildShape=RawScan`, `Remedy=RemedyShuffleScan` partitioning l3 by `l_orderkey`.
+
+Both hazards' shuffle keys align (`l_orderkey`), so the coordinator dispatches one shuffle layout per hazard with a shared key. Per-worker build state for each is `buildBytes / 4`.
+
+Q21 is *not* a goal of the spec — it's a witness that the architectural fix produces the right plan transformation. The goal is the invariant: no broadcast hazard above budget remains in any query's plan. Q21's wall-time delta is downstream evidence, not the success criterion.
+
+## Architectural invariant
+
+After this change, the following property holds for every distributed query at planning time:
+
+> For every `hash_join` or `broadcast_join` stage `J` in the optimized physical plan, either (a) `J.buildBytes ≤ broadcastBudget`, or (b) the plan contains a remedy stage upstream of `J` whose effect is to reduce per-worker build bytes for `J` to ≤ `broadcastBudget`.
+
+This invariant is asserted by a planner-layer test (`TestBroadcastHazardInvariant_AllTPCHQueries`) that runs every TPC-H query through the planner with a deliberately small budget, identifies all hazards, applies the pass, and re-checks: no remaining hazards above budget. If a future query introduces a build shape no remedy handles, the test fails on `BuildShapeUnsupported` — the failure points exactly at the missing remedy.
+
+## Files
+
+| File | Change |
+|---|---|
+| `internal/planner/physical/broadcast_hazard.go` | **New.** `BroadcastHazard`, `BuildShape`, `Remedy`, `IdentifyBroadcastHazards` and helpers. |
+| `internal/planner/physical/broadcast_hazard_test.go` | **New.** Unit tests for shape classification, remedy selection, key-alignment validation. |
+| `internal/planner/physical/plan.go` | **Delete** `PickShuffleCandidate`. Keep `LargeBuildScans` (still used by `internal/coordinator/build_cache.go` for the orthogonal build-cache I/O remedy — not in this spec's scope). Move shared scan-walk helpers into `broadcast_hazard.go` if reused there. |
+| `internal/planner/physical/aggregate_shuffle.go` | **Delete** `PickAggregateShuffleCandidate`, `PickAggregateShuffleCandidateDiag`, `AggregateShuffleRejectReason`, `AggregateShuffleDiag`. Keep `BuildAggregateShuffleSQL`, `AggregateShuffleCandidate`, `followToAggregate`, `followToScan`, `keysCovered` — these become helpers for the new pass and the existing orchestrator. |
+| `internal/coordinator/coordinator.go` | Replace the two-branch routing block with `IdentifyBroadcastHazards` + `applyBroadcastRemedies` loop. |
+| `internal/coordinator/broadcast_remedies.go` | **New.** `applyBroadcastRemedies` method dispatching hazards to existing orchestrators. |
+| `internal/coordinator/shuffle_orchestrator.go` | **Delete** `var shuffleBuildThreshold`. Existing `orchestrateShuffleStages` unchanged. |
+| `internal/coordinator/aggregate_shuffle.go` | **Delete** `var aggregateShuffleThreshold`. Existing `preComputeDerivedAggregate` unchanged. |
+| `internal/coordinator/budget.go` | **New.** `broadcastBudget()`, `var bcastBudgetFraction = 0.25`. |
+| `internal/coordinator/distributed_tpch_test.go` | Migrate threshold overrides to `broadcastBudget` overrides. Add `TestBroadcastHazardInvariant_AllTPCHQueries`. |
+| `internal/planner/physical/shuffle_insertion_test.go`, `aggregate_shuffle_test.go` | Delete tests bound to old primitives; tests for shape classification and remedy selection move to `broadcast_hazard_test.go`. Tests for the underlying mechanism (orchestrator behavior, shuffle SQL generation) stay. |
+
+## Testing strategy
+
+**Planner-layer (the invariant).**
+
+- `TestBroadcastHazardInvariant_AllTPCHQueries` — for every Q1-Q22 at SF1 catalog stats with `workerCount=4` and a deliberately low budget (e.g. 100 MB to force hazards on most join-heavy queries): identify hazards, apply, re-identify, assert zero hazards above budget remain. Any `BuildShapeUnsupported` causes failure with a clear message.
+- `TestIdentifyBroadcastHazards_MultiBuildQueries` — synthetic stages mirroring Q21 (two raw-scan builds), Q09 (multiple builds), Q17 (aggregate build + raw probe). Asserts the right hazards are returned, in the right order, with the right remedy per hazard.
+- `TestIdentifyBroadcastHazards_KeyAlignmentFallback` — synthetic stages where shuffle keys don't align; assert the pass falls back to the next-best remedy (or `RemedyNone`) instead of producing an incorrect plan.
+- `TestRemedyCostComparison` — synthetic stages where both `RemedyShuffleScan` and `RemedyPreComputeAggregate` are applicable to the same hazard; assert the lower-cost one is chosen.
+
+**Coordinator-layer (the dispatch loop).**
+
+- Existing `TestDistributedTPCHForcedShuffle_*` tests migrate to set `broadcastBudget = 1`. They should pass unchanged in result content because the underlying orchestrators are not modified.
+- New `TestApplyBroadcastRemedies_NoHazards` — when `IdentifyBroadcastHazards` returns empty, the coordinator's plan and stages are unchanged.
+- New `TestApplyBroadcastRemedies_TwoShufflesOneAggregate` — hazards mixing remedy types are dispatched correctly.
+
+**Correctness gate.**
+
+- All 22 TPC-H queries pass at SF0.01 with `broadcastBudget = 1` (forces every join through the remedy path). Result row checksums match the SF0.01 baselines stored in `benchmarks/tpch/baseline-sf100.json` and equivalents.
+
+**No new EC2 deploys are required to land this change.** The architectural invariant is verified at the planner layer; the orchestrator code paths it dispatches to are already deploy-validated by PR #40 and PR #43.
+
+## Migration plan
+
+This is a single-PR change. There is no feature flag and no parallel old/new code path. The PR contains:
+
+1. New `broadcast_hazard.go` with the primitive and remedy types.
+2. New `applyBroadcastRemedies` and `broadcastBudget` in coordinator.
+3. Deletion of `PickShuffleCandidate`, `PickAggregateShuffleCandidate*`, `shuffleBuildThreshold`, `aggregateShuffleThreshold`.
+4. Coordinator routing block rewritten to the single-loop form.
+5. Test migration (existing tests setting old thresholds → set new budget).
+6. New invariant test at the planner layer.
+
+All-in-one is appropriate because the new primitive *is* the replacement; shipping them side-by-side would re-introduce the duplicate-primitive smell the spec exists to eliminate.
+
+## Risks and open questions
+
+1. **Cost estimation accuracy for `RemedyPreComputeAggregate`.** The conservative `buildBytes / 100` heuristic when stats are missing may pick the wrong remedy on some shapes. Mitigation: telemetry on the chosen remedy + actual post-execution build bytes; revisit with stats-driven estimation once we have data. Wrong choice still produces a *correct* plan, just a less efficient one.
+
+2. **Multi-hazard remedy interaction.** Two hazards on the same scan (e.g. a scan feeding two joins) could pick conflicting remedies. The dispatch loop's documented dedup behavior handles the common cases (TPC-H), but a synthetic adversarial query could expose a gap. The invariant test on all 22 queries gives a baseline; new shapes appearing in production would surface as `BuildShapeUnsupported` or invariant violations in CI.
+
+3. **Budget vs. existing per-task memory budget.** The `broadcastBudget` and the executor's per-task memory budget interact: budget should be ≤ per-task budget × bcastBudgetFraction. The spec defaults to 0.25, leaving 0.75 for non-build state. Operationally, both numbers should derive from the same root config (per-worker memory + worker count). The first version of this spec uses GOMEMLIMIT directly; refining to a single config root is a follow-up.
+
+4. **Standalone mode no-op.** `workerCount = 1` makes the budget per-worker = full GOMEMLIMIT; no hazards trigger. This is correct (broadcast is free in single-worker), but the test suite must explicitly cover the path to prevent a regression where a future change accidentally reads `workerCount` before it's populated and triggers spurious shuffles.
+
+5. **Future remedy interaction.** When `RemedyPreComputeDistinctKeys` is added (a likely follow-up for key-only semi/anti builds), it must slot into the existing per-hazard cost comparison without changing the dispatch loop. The spec deliberately leaves the cost-comparison API open-ended (any number of applicable remedies) to make this trivial.
+
+## Out of scope (future remedies, separate specs)
+
+- **`RemedyPreComputeDistinctKeys`.** For key-only semi/anti joins where DISTINCT join-key cardinality ≪ row count, pre-compute `SELECT DISTINCT k FROM T [WHERE filter]` centrally and broadcast the small key set instead of partitioning the full scan. Would further reduce Q21's per-worker build bytes; complements rather than replaces shuffle.
+- **Stats-driven remedy cost estimation.** Replace the conservative output-bytes heuristic with NDV-driven estimates from the column-stats catalog landed earlier.
+- **Runtime-adaptive partition counts.** Currently 4N; could derive from observed key skew at planning time using sketch statistics.
+- **Logical-plan EXISTS-with-inequality decorrelation.** A separate optimizer rewrite that transforms certain EXISTS shapes into aggregate forms before this pass runs. Independent change at the logical layer; would let `RemedyPreComputeAggregate` cover queries the rewrite touches.

--- a/docs/superpowers/specs/2026-04-20-distribution-property-phase-1.md
+++ b/docs/superpowers/specs/2026-04-20-distribution-property-phase-1.md
@@ -1,0 +1,251 @@
+# Distribution-Property Pass — Phase 1: wire up the existing scaffolding
+
+**Status:** Draft
+**Date:** 2026-04-20
+**Author:** Derek Wright (with Claude)
+**Branch:** `feat/distribution-property-phase-1`
+**Companion research brief:** `docs/superpowers/research/2026-04-19-distribution-model-trino-spark.md`
+**Origin context:** `feat/broadcast-hazard-mitigation` (parked at `67ba055`) — five SF10 iterations confirmed the whack-a-mole pattern is an architectural mismatch, not a bug.
+**Architectural invariant established:** *Every stage in a distributed plan declares the actual partitioning of its output, and every consuming stage's required input distribution is checkable against the producer's actual distribution via a single `Satisfies` predicate. Phase 1 establishes this property + assertion infrastructure with zero behavior change.*
+
+## Problem
+
+Wadjet's coordinator currently picks one of three distributed routing modes per query via a hand-written switch in `internal/coordinator/coordinator.go:541-605`:
+
+```go
+switch {
+case shuffleApplicable && mergeInfo != nil:   // shuffle-distributed
+case canProbeSplit && mergeInfo != nil:       // probe-split + optional pre-computed-aggregates
+default:                                       // single worker
+}
+```
+
+Each mode is decided by a separate detection helper (`PickShuffleCandidate`, `CanProbeSplit`, `PickAggregateShuffleCandidate`) that re-inspects stage shape independently. The detectors interact through a shared `[]Stage` graph: PR #43 had to add `if len(preComputedAggregates) > 0 { shuffleApplicable = false }` (`coordinator.go:537-539`) precisely because two detectors disagreed. Across five EC2 SF10 iterations on the parked `feat/broadcast-hazard-mitigation` branch (`project_q21_broadcast_hazard_iteration_2026-04-19.md`), every fix to one detector broke another. The whack-a-mole was the symptom of an architectural mismatch — the research brief identifies that **Trino and Spark express the same set of routing decisions as a single property algebra (`Partitioning.satisfies(Distribution)`) over operator inputs and outputs**, and the four-mode coordinator switch is the wrong substrate for the same decisions.
+
+The research brief's load-bearing primitive (sections 1-2): *child produces Partitioning P; parent requires Distribution D; insert exchange iff `!P.satisfies(D)`*. The brief also flags that Wadjet already has a 58-line beachhead — `internal/planner/physical/distribution.go` (commits `d5c2bf3` + `cc92345`) — with `DistKind`, `Distribution`, `Equals`, `SatisfiesJoinKeys`, plus a `Stage.Distribution Distribution` field on `Stage` (`plan.go:115-120`). The scaffolding is **never written to** anywhere in production code (verified by `grep -n "Distribution:" internal/planner/physical/`). Per `feedback_context_loss_architectural_shortcuts.md`, the next session shipped a heuristic shortcut and the abstraction was abandoned.
+
+Phase 1 wires up the existing scaffolding behind a single mechanical predicate (`Distribution.Satisfies(RequiredDistribution)`) and a single assertion that every stage's actual distribution is consistent with what its consumer requires. Phase 1 makes no execution changes — the heuristic switch keeps making the same decisions. Phase 1 only proves that the *new model can describe the existing plans* — and adds a planner-level safety net so future work cannot silently desync the property algebra from reality.
+
+## Goals
+
+1. **Promote `Distribution` from a detected-but-unused property to a populated, queried property** on every stage emitted by `physical.PlanDistributed`.
+2. **Add `RequiredDistribution`** as a derived view on consumer stages — what each stage requires of each input — computed from existing stage fields (`JoinLeftKeys`, `JoinRightKeys`, `GroupByCols`, `ShuffleKeys`). Not stored; recomputed.
+3. **Add `Satisfies(req RequiredDistribution) bool`** on `Distribution`, generalising `SatisfiesJoinKeys` to cover all required-distribution kinds (Singleton, Any, ClusteredOn, HashPartitionedOn, Broadcast).
+4. **Add a planner-layer "exchange consistency" assertion** that runs after `PlanDistributed`: for every stage, for every dependency, assert `dep.Distribution.Satisfies(stage.RequiredChildDistribution(slot))`. **The assertion must hold for every TPC-H query at SF0.01 today.** If it fires, the population rules in this spec are wrong.
+5. **Every TPC-H query at SF0.01 produces identical row checksums** before and after Phase 1 lands. Verified by existing `TestTPCHQueries`.
+6. **Every TPC-H query at SF1 produces identical wall-time within ±5%** before and after. Verified by `TestTPCHQueriesLarge`. The only added work is one O(stages) walk during planning.
+
+## Non-Goals (the "Phase 1 does NOT do" list)
+
+Phase 1 is **purely additive**. Out of scope:
+
+- **No coordinator changes.** The four-mode switch at `coordinator.go:541-605` keeps making the same decisions. Phase 2 retires it.
+- **No modifications to `CanProbeSplit`, `PickShuffleCandidate`, `PickAggregateShuffleCandidate`.** Phase 2 deletes them.
+- **No changes to `build_cache.go`, `shuffle_orchestrator.go`, `aggregate_shuffle.go`.** Phase 2 re-targets the dispatch backends.
+- **No reference to `IdentifyBroadcastHazards` or code from `feat/broadcast-hazard-mitigation`.** That branch is parked; its multi-build orchestrator is a Phase 2 reference, not a Phase 1 input.
+- **No new exchange stages.** Stages are read-only in Phase 1's pass; only the `Distribution` field is written.
+- **No cost-based decisions, no stats infrastructure.** Phase 3.
+- **No `Exchange` stage type.** Phase 2 unifies today's `shuffle` / build-cache / coordinator-merge under `Exchange{Type: Repartition|Replicate|Gather}`.
+- **No worker changes.** The worker does not see `Stage.Distribution`; it remains a planner-internal property.
+- **No changes to the stages emitted by `PlanDistributed`.** `walkStages` (`plan.go:1713`), `emitMergeAggregateTree`, `emitMergeSortTree`, `fuseJoinStages` are unchanged. The only new output is the `Distribution` field per stage.
+- **No standalone-mode change.** Standalone plans don't emit stages; the pass is gated on `len(stages) > 0`.
+- **No adaptive runtime re-planning.** Phase 4.
+
+## Design
+
+### The property algebra (Phase 1 nucleus)
+
+Extend `internal/planner/physical/distribution.go`:
+
+```go
+// Existing struct; no field changes.
+type Distribution struct {
+    Kind  DistKind
+    Keys  []string
+    Count int
+}
+
+// NEW: enumerates the partitioning a consumer needs from each input.
+// Mirrors Spark's Distribution trait subclasses (research brief §1).
+type RequiredKind int
+
+const (
+    RequiredAny               RequiredKind = iota // no constraint
+    RequiredSingleton                              // exactly one partition (final result, coordinator merge)
+    RequiredBroadcast                              // every worker has every row
+    RequiredClusteredOn                            // co-partitioned on Keys, any partition count
+    RequiredHashPartitionedOn                      // hash-partitioned on Keys with exactly Count partitions
+)
+
+type RequiredDistribution struct {
+    Kind  RequiredKind
+    Keys  []string
+    Count int
+}
+
+// NEW: the single mechanical predicate. Mirrors Spark's
+// Partitioning.satisfies(Distribution).
+//
+//   RequiredAny:                always true.
+//   RequiredSingleton:          only DistSingleton.
+//   RequiredBroadcast:          only DistBroadcast.
+//   RequiredClusteredOn(K):     DistBroadcast yes; DistSingleton yes;
+//                               DistHashPartitioned iff Keys==K.
+//   RequiredHashPartitionedOn(K, N): only DistHashPartitioned with Keys==K
+//                               and Count==N.
+func (d Distribution) Satisfies(req RequiredDistribution) bool
+
+// SatisfiesJoinKeys preserved as a thin wrapper:
+//   d.Satisfies(RequiredDistribution{Kind: RequiredClusteredOn, Keys: joinKeys})
+// Existing callers and tests continue compiling unchanged.
+```
+
+The Phase 1 design splits Spark's single `Partitioning.satisfies(Distribution)` across two Go types because Go lacks the trait inheritance Spark uses; the predicate `actual.Satisfies(required)` carries identical semantics.
+
+### `RequiredChildDistribution` — what each stage needs from each input
+
+```go
+// NEW: derives a per-input requirement from existing stage fields.
+// `slot` indexes into Stage.Dependencies. Never stored; recomputed.
+func RequiredChildDistribution(stage Stage, slot int) RequiredDistribution
+```
+
+Rules per `Stage.Type`, derived from how `walkStages` already implicitly constructs the plan:
+
+| Stage.Type | Requirement per input slot |
+|---|---|
+| `scan`, `dual` | No inputs. |
+| `shuffle` | `RequiredAny` (shuffle accepts any input and re-partitions). |
+| `hash_join` | Probe slot (`LeftDepStage`): `RequiredClusteredOn(JoinLeftKeys)`. Build slot (`RightDepStage`): `RequiredClusteredOn(JoinRightKeys)`. |
+| `broadcast_join` | Probe: `RequiredAny`. Build: `RequiredAny` (Phase 1 does not strengthen this — see Risk #4). |
+| `aggregate` | `RequiredClusteredOn(GroupByCols)` when `WorkerCount > 1`; `RequiredAny` otherwise. |
+| `final_aggregate`, `merge_aggregate` | `RequiredAny` for partial-merge groups (`MergeGroupCount > 0` — see Risk #1); `RequiredAny` for the lone final reducer (today's plans gather to a single task implicitly). |
+| `sort`, `merge_sort` | `RequiredAny`. |
+| `window` | `RequiredClusteredOn(PartitionBy)` if any `WindowCol` partitions; `RequiredAny` otherwise. |
+| `pipeline` | All slots `RequiredAny`. |
+| `table_func` | Per-function; default `RequiredAny`. |
+
+Unknown stage types return `RequiredAny` — no constraint asserted, so the consistency check passes by default. New stage types added later must add their rule here.
+
+### `OutputDistribution` — what each stage produces
+
+```go
+// NEW: computes the per-stage output distribution given resolved dependency
+// distributions. Pure function over stage fields + dep map.
+func OutputDistribution(stage Stage, deps map[string]Distribution) Distribution
+```
+
+Rules derived directly from how today's planner emits stages:
+
+| Stage.Type | Output Distribution |
+|---|---|
+| `scan` | `DistSingleton` (Phase 1 conservatively labels even multi-task probe-split scans as `Singleton` because the per-worker file-list is opaque to the property algebra — see Risk #2). |
+| `shuffle` | `DistHashPartitioned{Keys: ShuffleKeys, Count: NumPartitions}`. |
+| `hash_join`, `broadcast_join` | Inherits the probe input's distribution (the join doesn't re-partition the joined output). |
+| `aggregate` (partial, single-task) | `DistSingleton`. |
+| `final_aggregate` (lone reducer) | `DistSingleton`. |
+| `final_aggregate` (merge group, `MergeGroupCount > 0`) | `DistHashPartitioned{Keys: GroupByCols, Count: MergeGroupCount}`. See Risk #1. |
+| `sort`, `merge_sort` (lone) | `DistSingleton`. |
+| `merge_sort` (merge group) | `DistHashPartitioned{Keys: SortKeys-derived, Count: MergeGroupCount}`. |
+| `window`, `pipeline`, `dual`, `table_func` | `DistSingleton`. |
+
+### The wire-up: `assignStageDistributions` + the assertion
+
+```go
+// NEW: walks stages in dependency order and populates Stage.Distribution
+// per the OutputDistribution rules above.
+func assignStageDistributions(stages []Stage, workerCount int)
+
+// NEW: walks every (producer, consumer, slot) edge and asserts
+// producer.Distribution.Satisfies(RequiredChildDistribution(consumer, slot)).
+// Returns the first violation, or nil.
+//
+// Phase 1: must pass for every TPC-H query at SF0.01. Phase 2 promotes this
+// to the satisfaction check that drives Exchange insertion.
+func AssertExchangeConsistency(stages []Stage) error
+```
+
+Both are called once at the end of `PlanDistributed` (after `enforceQueryLimits`). A package-level `BehaviorPreservingMode bool` (default `true`) controls assertion hardness — in `BehaviorPreservingMode`, a non-nil error is logged at WARN; tests flip the var to assert hard. Phase 2 deletes the var.
+
+The walk-order issue: today's `[]Stage` slice from `walkStages` is topological *except* for the late `fuseJoinStages` rewire. `assignStageDistributions` resolves dependencies by ID lookup at run time, after all rewiring is complete, so fusion is invisible to it.
+
+### Architectural invariant established by Phase 1
+
+> For every stage `S` in the output of `PlanDistributed(...)`, `S.Distribution` is a populated `Distribution` value reflecting the actual per-worker partitioning of `S`'s output. For every dependency edge `(producer, consumer, slot)`, `producer.Distribution.Satisfies(RequiredChildDistribution(consumer, slot))` holds.
+
+This is the load-bearing property the entire phased redesign rests on. Phase 2 (Exchange insertion) trusts the invariant when deciding where to insert exchanges. Phase 3 (cost model) trusts it when picking among satisfying alternatives. If a future change to `PlanDistributed` (new stage type, new fusion pass) breaks the invariant, the planner-layer test fires immediately — long before EC2 gets involved.
+
+## Files
+
+| File | Change |
+|---|---|
+| `internal/planner/physical/distribution.go` | **Extend.** Add `RequiredKind` enum, `RequiredDistribution` struct, `Satisfies(req RequiredDistribution) bool` method on `Distribution`, `RequiredChildDistribution(stage Stage, slot int) RequiredDistribution`, `OutputDistribution(stage Stage, deps map[string]Distribution) Distribution`, `assignStageDistributions(stages []Stage, workerCount int)`, `AssertExchangeConsistency(stages []Stage) error`, `BehaviorPreservingMode bool`. Keep `DistKind`, `Distribution`, `Equals`, `SatisfiesJoinKeys` unchanged (the latter delegates to `Satisfies`). Net additions ~250 lines. |
+| `internal/planner/physical/distribution_test.go` | **Extend.** Table-driven `TestDistributionSatisfies` covering every `(DistKind × RequiredKind)` cell. Per-stage-type tests for `RequiredChildDistribution` and `OutputDistribution`. Sanity test for `assignStageDistributions` over a synthetic 3-join plan. ~150 lines. |
+| `internal/planner/physical/plan.go` | **Three-line change in `PlanDistributed`.** After `enforceQueryLimits`, call `assignStageDistributions(stages, p.WorkerCount)` then `if err := AssertExchangeConsistency(stages); err != nil { /* log; do not fail in BehaviorPreservingMode */ }`. No other changes to `walkStages` or its helpers. |
+| `internal/planner/physical/plan_tpch_test.go` | **Add `TestTPCHDistributionConsistency`.** For every Q1-Q22, run `PlanDistributed` with `WorkerCount=4`, assert every stage's `Distribution` is populated, then assert `AssertExchangeConsistency(stages) == nil`. The acceptance gate. |
+| `internal/coordinator/coordinator.go` | **No changes.** The four-mode switch is untouched. The coordinator does not read `Stage.Distribution` in Phase 1. |
+
+Total churn: ~400 added lines, ~3 modified. No file deletions, no coordinator changes, no worker changes.
+
+## Testing strategy
+
+**Unit tests on the property algebra.** Table-driven `TestDistributionSatisfies` exhaustively covers `(DistKind × RequiredKind)`:
+
+| Distribution | Required | Satisfies? |
+|---|---|---|
+| Singleton | Any, Singleton, ClusteredOn(K) | true |
+| Singleton | Broadcast, HashPartitionedOn(K, N) | false |
+| Broadcast | Any, Broadcast, ClusteredOn(K) | true |
+| Broadcast | Singleton, HashPartitionedOn(K, N) | false |
+| HashPartitioned(K, N) | Any, ClusteredOn(K), HashPartitionedOn(K, N) | true |
+| HashPartitioned(K, N) | ClusteredOn(K'), HashPartitionedOn(K', N), HashPartitionedOn(K, N') | false |
+
+Plus per-stage-type tests on `RequiredChildDistribution` and `OutputDistribution` (one synthetic stage per type).
+
+**Planner-layer consistency test.** `TestTPCHDistributionConsistency` iterates `tpchPlanQueryMap`, runs each through `physical.PlanDistributed` with `WorkerCount=4`, and asserts: every stage's `Distribution` is populated; `AssertExchangeConsistency(stages) == nil`. **This is the Phase 1 acceptance gate.** Failure on any of Q1-Q22 means either the rules in this spec are wrong or `PlanDistributed` emits an inconsistent plan.
+
+**Correctness gate (no-behavior-change verification).**
+
+- `go test -v -run TestTPCHQueries ./benchmarks/tpch/` (SF0.01, ~5s) — every query produces identical row checksums to baseline. **Load-bearing test for Goal #5.**
+- `TPCH_SCALE=1 go test -v -run TestTPCHQueriesLarge -timeout 30m ./benchmarks/tpch/` (SF1, ~66s) — within ±5% of pre-Phase-1 wall-time. The only new work is one O(stages) walk plus one O(edges) assertion, both microsecond-scale.
+
+**No EC2 deploys are required for Phase 1.** The change is planner-internal; SF0.01 + SF1 local runs are sufficient.
+
+## Migration plan
+
+Single PR. No public feature flag. The internal `BehaviorPreservingMode` bool gates assertion hardness — defaulting to `true` keeps Phase 1 strictly additive.
+
+PR contents:
+1. Extended `distribution.go` (new types, `Satisfies`, `RequiredChildDistribution`, `OutputDistribution`, `assignStageDistributions`, `AssertExchangeConsistency`, `BehaviorPreservingMode`).
+2. Extended `distribution_test.go`.
+3. Three-line wire-up in `plan.go`'s `PlanDistributed`.
+4. New `TestTPCHDistributionConsistency` in `plan_tpch_test.go`.
+5. Pass `go test ./...`, the SF0.01 correctness gate, and SF1 wall-time within ±5%.
+
+The PR is small (~400 added lines, ~3 modified) and reviewable in one sitting.
+
+## Risks and open questions
+
+1. **Merge-group output distribution may need refinement.** Today's `emitMergeAggregateTree` (`plan.go:5460-5505`) emits per-merge-group `final_aggregate` stages with `MergeGroup`/`MergeGroupCount` fields, but the worker doesn't actually receive a hash-partitioned input — the coordinator routes results by `MergeGroup` index. Phase 1's rule labels these as `DistHashPartitioned{GroupByCols, MergeGroupCount}` for symmetry with Trino/Spark. **Resolution:** if `TestTPCHDistributionConsistency` fires on a merge-grouped query, the rule moves to `DistSingleton` per group with a comment documenting index-based routing.
+
+2. **Probe-split per-worker scan distribution is opaque.** `scan` stages with `Tasks > 1` are partitioned at the file level, not by row key. Phase 1 conservatively labels these `DistSingleton`. The risk is `TestTPCHDistributionConsistency` passing for trivially wrong reasons (`DistSingleton` satisfies `RequiredAny`). **Mitigation:** the test logs the per-stage distribution; PR reviewer confirms the labels make sense for at least Q01, Q03, Q05, Q17, Q21. Phase 2 adds `DistRoundRobin` (or `DistFilePartitioned`) to model probe-split correctly.
+
+3. **`fuseJoinStages` rewires `LeftDepStage` / `RightDepStage` after `walkStages`.** `assignStageDistributions` resolves dependencies by ID lookup at run time, so fusion is invisible to it. Verified by the consistency test on Q05 (which has fused joins).
+
+4. **Broadcast-build distribution is not strengthened in Phase 1.** Today's planner has no broadcast stage between scan and `broadcast_join` (the executor handles broadcast in-process). Phase 1 leaves the broadcast-join build slot at `RequiredAny`, so the assertion does not check broadcast-build distributions. Phase 2 inserts an explicit `Exchange{Type: Replicate}` between scan and `broadcast_join`, at which point the requirement strengthens to `RequiredBroadcast`.
+
+5. **`pipeline-0` collapse is opaque.** When the coordinator collapses the entire query to a `pipeline-0` stage (probe-split or single-worker mode), `Stage.Distribution` is `DistSingleton` and `RequiredChildDistribution` is `RequiredAny` — the algebra reduces to a no-op. **This is fine for Phase 1.** Phase 2 retires the collapse and emits individual stages back through the coordinator dispatch loop. Note that Phase 1's `assignStageDistributions` runs inside `PlanDistributed`, *before* the coordinator's switch collapses to `pipeline-0` — so the consistency assertion sees the full pre-collapse plan.
+
+6. **The "DO NOT EXTEND THE HEURISTIC" connection.** Per `feedback_context_loss_architectural_shortcuts.md`: the prior architectural-shortcut incident left `distribution.go` orphaned because the next session shipped a heuristic instead. **If a future session sees the heuristic switch in `coordinator.go:541-605` and tries to extend it (add a fourth case, tweak `PickShuffleCandidate`, etc.) instead of completing Phase 2, that is a repeat of the prior mistake.** The switch remaining in place after Phase 1 is *expected and temporary*; do not extend it.
+
+## Out of scope (mapped to research-brief Phase boundaries)
+
+- **Phase 2 — Exchange insertion + retire the heuristic switch.** Add `Exchange` stage type with `Type ∈ {Repartition, Replicate, Gather}`. Implement `EnsureDistribution` rule that walks the stage graph and inserts `Exchange` stages where `producer.Distribution.Satisfies(RequiredChildDistribution(consumer, slot))` would fail. Replace `coordinator.go:541-605`'s switch with a stage-DAG dispatcher that maps `Exchange{Type: Repartition}` → `orchestrateShuffleStages`, `Exchange{Type: Replicate}` → `preScanBuildTables`, `Exchange{Type: Gather}` → coordinator merge. Delete `CanProbeSplit`, `PickShuffleCandidate`, `PickAggregateShuffleCandidate`, `MergeInfo`. Multi-build queries (Q21) emerge naturally as multiple `Exchange{Type: Repartition}` stages with shared partitioning schemes — no special multi-candidate handling. Effort estimate (research brief §6): ~3 weeks.
+- **Phase 3 — Cost model + stats integration.** Wire `Stage.EstimatedBytes` / `EstimatedRows` into a cost-aware `EnsureDistribution` that picks among equally-satisfying alternatives (broadcast vs. shuffle) per join. Replicate Trino's `useParentPreferredPartitioning` heuristic. The threshold variables `shuffleBuildThreshold`, `aggregateShuffleThreshold` get a principled home as inputs to the cost function. ~2 weeks.
+- **Phase 4 — AQE-style adaptive re-planning.** Split the stage DAG into query stages at `Exchange` boundaries. After each `Exchange` materialises, collect partition-size stats, re-run `EnsureDistribution` on the unexecuted remainder. Highest-ROI item but largest lift. ~4-6 weeks.
+
+## Connection to prior work
+
+This spec is the *foundation* the parked `feat/broadcast-hazard-mitigation` branch (`67ba055`) needed. The branch's `IdentifyBroadcastHazards`, multi-build shuffle orchestrator, and shape-budget cost model are reusable in Phase 2/3 — but only on top of the property algebra Phase 1 establishes. Attempting to land that branch's logic *without* the algebra is what produced the five-iteration whack-a-mole at SF10.
+
+When a future session revives the broadcast-hazard work, the order is: Phase 1 (this spec) → Phase 2 (Exchange insertion + EnsureDistribution rule, retire the switch) → port hazard detection into Phase 3's cost model. The branch's code is a reference, not a starting point.

--- a/internal/planner/physical/distribution.go
+++ b/internal/planner/physical/distribution.go
@@ -204,3 +204,72 @@ func RequiredChildDistribution(stage Stage, slot int) RequiredDistribution {
 		return RequiredDistribution{Kind: RequiredAny}
 	}
 }
+
+// OutputDistribution computes the partitioning a stage's output has, given
+// the resolved distributions of its dependencies. Pure function over
+// stage fields + dep map. Rules track how today's planner emits stages;
+// see the Phase 1 spec §"OutputDistribution" for the per-stage table.
+//
+// Phase 1 deliberately labels probe-split scans (Tasks > 1) as DistSingleton
+// because the per-worker file-list is opaque to the property algebra.
+// Phase 2 adds a richer label (e.g. DistRoundRobin) when the executor wires
+// scan partitioning into the property graph. See spec Risk #2.
+func OutputDistribution(stage Stage, deps map[string]Distribution) Distribution {
+	switch stage.Type {
+	case "scan":
+		return Distribution{Kind: DistSingleton}
+	case "dual":
+		return Distribution{Kind: DistSingleton}
+	case "shuffle":
+		return Distribution{
+			Kind:  DistHashPartitioned,
+			Keys:  stage.ShuffleKeys,
+			Count: stage.NumPartitions,
+		}
+	case "hash_join", "broadcast_join":
+		// The join inherits the probe (left) input's distribution — the
+		// join itself does not re-partition the joined output, it just
+		// pairs probe rows with matching build rows.
+		if probe, ok := deps[stage.LeftDepStage]; ok {
+			return probe
+		}
+		return Distribution{Kind: DistSingleton}
+	case "aggregate":
+		return Distribution{Kind: DistSingleton}
+	case "final_aggregate", "merge_aggregate":
+		// Per spec §"OutputDistribution": merge-grouped finals are labeled
+		// hash-partitioned on group-by cols with Count=MergeGroupCount for
+		// symmetry with Trino/Spark. Lone reducers (MergeGroupCount == 0)
+		// are singleton. See spec Risk #1.
+		if stage.MergeGroupCount > 0 {
+			return Distribution{
+				Kind:  DistHashPartitioned,
+				Keys:  stage.GroupByCols,
+				Count: stage.MergeGroupCount,
+			}
+		}
+		return Distribution{Kind: DistSingleton}
+	case "sort":
+		return Distribution{Kind: DistSingleton}
+	case "merge_sort":
+		// Merge-grouped intermediate merges are labeled hash-partitioned on
+		// the sort keys (column names) for symmetry. Final merge of
+		// intermediates (MergeGroupCount == 0) is singleton.
+		if stage.MergeGroupCount > 0 {
+			keys := make([]string, len(stage.SortKeys))
+			for i, sk := range stage.SortKeys {
+				keys[i] = sk.Column
+			}
+			return Distribution{
+				Kind:  DistHashPartitioned,
+				Keys:  keys,
+				Count: stage.MergeGroupCount,
+			}
+		}
+		return Distribution{Kind: DistSingleton}
+	case "window", "pipeline", "table_func":
+		return Distribution{Kind: DistSingleton}
+	default:
+		return Distribution{Kind: DistSingleton}
+	}
+}

--- a/internal/planner/physical/distribution.go
+++ b/internal/planner/physical/distribution.go
@@ -56,3 +56,45 @@ func (d Distribution) SatisfiesJoinKeys(joinKeys []string) bool {
 		return false
 	}
 }
+
+// RequiredKind enumerates the partitioning a consumer needs from each input.
+// Mirrors Spark's Distribution trait subclasses; see the Phase 1 spec
+// (docs/superpowers/specs/2026-04-20-distribution-property-phase-1.md) §"The
+// property algebra" for the satisfaction truth table.
+type RequiredKind int
+
+const (
+	RequiredAny               RequiredKind = iota // no constraint
+	RequiredSingleton                             // exactly one partition (final result, coordinator merge)
+	RequiredBroadcast                             // every worker has every row
+	RequiredClusteredOn                           // co-partitioned on Keys, any partition count
+	RequiredHashPartitionedOn                     // hash-partitioned on Keys with exactly Count partitions
+)
+
+// String renders a RequiredKind for log lines and assertion error messages.
+// Stable text identifiers — do not change without checking telemetry consumers.
+func (r RequiredKind) String() string {
+	switch r {
+	case RequiredAny:
+		return "any"
+	case RequiredSingleton:
+		return "singleton"
+	case RequiredBroadcast:
+		return "broadcast"
+	case RequiredClusteredOn:
+		return "clustered_on"
+	case RequiredHashPartitionedOn:
+		return "hash_partitioned_on"
+	default:
+		return "unknown"
+	}
+}
+
+// RequiredDistribution describes what a consumer stage requires of each input.
+// Derived from existing stage fields (JoinLeftKeys, JoinRightKeys, GroupByCols,
+// ShuffleKeys) by RequiredChildDistribution; never stored on Stage.
+type RequiredDistribution struct {
+	Kind  RequiredKind
+	Keys  []string
+	Count int
+}

--- a/internal/planner/physical/distribution.go
+++ b/internal/planner/physical/distribution.go
@@ -138,3 +138,69 @@ func keysEqual(a, b []string) bool {
 	}
 	return true
 }
+
+// RequiredChildDistribution returns the per-slot required distribution for a
+// stage's input. `slot` indexes into the stage's logical input list:
+//   - For joins: slot 0 is the probe (LeftDepStage), slot 1 is the build (RightDepStage).
+//   - For unary stages: slot 0 is the sole input.
+//   - For stages with no inputs (scan, dual): RequiredAny is returned for any slot.
+//
+// Never stored on Stage; recomputed by AssertExchangeConsistency. Rules are
+// derived from how walkStages already implicitly constructs the plan; see
+// the Phase 1 spec §"RequiredChildDistribution" for the per-stage table.
+//
+// Unknown stage types return RequiredAny (no constraint asserted). New stage
+// types added to the planner must add their rule here or accept the no-op
+// default.
+func RequiredChildDistribution(stage Stage, slot int) RequiredDistribution {
+	switch stage.Type {
+	case "scan", "dual":
+		// No inputs — any slot is RequiredAny by definition.
+		return RequiredDistribution{Kind: RequiredAny}
+	case "shuffle":
+		// Shuffle accepts any input and re-partitions.
+		return RequiredDistribution{Kind: RequiredAny}
+	case "hash_join":
+		switch slot {
+		case 0:
+			return RequiredDistribution{Kind: RequiredClusteredOn, Keys: stage.JoinLeftKeys}
+		case 1:
+			return RequiredDistribution{Kind: RequiredClusteredOn, Keys: stage.JoinRightKeys}
+		default:
+			return RequiredDistribution{Kind: RequiredAny}
+		}
+	case "broadcast_join":
+		// Phase 1 leaves both slots at RequiredAny — the executor handles
+		// broadcast in-process today (no explicit broadcast Exchange stage).
+		// Phase 2 inserts Exchange{Type: Replicate} between scan and the
+		// build slot, at which point the build requirement strengthens to
+		// RequiredBroadcast. See spec Risk #4.
+		return RequiredDistribution{Kind: RequiredAny}
+	case "aggregate":
+		// Phase 1 conservative: today's two-phase distributed aggregate
+		// runs the partial stage on RequiredAny inputs (the partial does
+		// not require pre-clustering — it produces partials that the final
+		// stage merges). See spec Risk #1.
+		return RequiredDistribution{Kind: RequiredAny}
+	case "final_aggregate", "merge_aggregate":
+		return RequiredDistribution{Kind: RequiredAny}
+	case "sort", "merge_sort":
+		return RequiredDistribution{Kind: RequiredAny}
+	case "window":
+		// If any window column declares a PartitionBy, the input must be
+		// clustered on those keys. Take the first PartitionBy as the
+		// requirement (today's planner emits a single window stage per
+		// partition spec; multiple PartitionBy clauses become separate
+		// window stages).
+		for _, wc := range stage.WindowCols {
+			if len(wc.PartitionBy) > 0 {
+				return RequiredDistribution{Kind: RequiredClusteredOn, Keys: wc.PartitionBy}
+			}
+		}
+		return RequiredDistribution{Kind: RequiredAny}
+	case "pipeline", "table_func":
+		return RequiredDistribution{Kind: RequiredAny}
+	default:
+		return RequiredDistribution{Kind: RequiredAny}
+	}
+}

--- a/internal/planner/physical/distribution.go
+++ b/internal/planner/physical/distribution.go
@@ -98,3 +98,58 @@ type RequiredDistribution struct {
 	Keys  []string
 	Count int
 }
+
+// Satisfies reports whether this distribution meets a consumer's required
+// distribution. Single mechanical predicate that mirrors Spark's
+// Partitioning.satisfies(Distribution). The truth table is documented in
+// the Phase 1 spec §"The property algebra".
+//
+//   RequiredAny:                    always true.
+//   RequiredSingleton:              only DistSingleton.
+//   RequiredBroadcast:              only DistBroadcast.
+//   RequiredClusteredOn(K):         DistBroadcast yes; DistSingleton yes;
+//                                   DistHashPartitioned iff Keys==K.
+//   RequiredHashPartitionedOn(K, N): only DistHashPartitioned with Keys==K
+//                                   and Count==N.
+func (d Distribution) Satisfies(req RequiredDistribution) bool {
+	switch req.Kind {
+	case RequiredAny:
+		return true
+	case RequiredSingleton:
+		return d.Kind == DistSingleton
+	case RequiredBroadcast:
+		return d.Kind == DistBroadcast
+	case RequiredClusteredOn:
+		switch d.Kind {
+		case DistBroadcast, DistSingleton:
+			return true
+		case DistHashPartitioned:
+			return keysEqual(d.Keys, req.Keys)
+		default:
+			return false
+		}
+	case RequiredHashPartitionedOn:
+		if d.Kind != DistHashPartitioned {
+			return false
+		}
+		if d.Count != req.Count {
+			return false
+		}
+		return keysEqual(d.Keys, req.Keys)
+	default:
+		return false
+	}
+}
+
+// keysEqual reports whether two ordered key slices are identical.
+func keysEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/planner/physical/distribution.go
+++ b/internal/planner/physical/distribution.go
@@ -273,3 +273,57 @@ func OutputDistribution(stage Stage, deps map[string]Distribution) Distribution 
 		return Distribution{Kind: DistSingleton}
 	}
 }
+
+// assignStageDistributions walks the stages slice in dependency order and
+// populates Stage.Distribution per the OutputDistribution rules. The walk
+// is by-ID so stages provided out of topological order are still resolved
+// correctly (matters because fuseJoinStages rewires deps after walkStages).
+//
+// workerCount is reserved for future rules (e.g. probe-split scan
+// distribution) — Phase 1 ignores it but threads it through to keep the
+// signature stable for Phase 2.
+func assignStageDistributions(stages []Stage, workerCount int) {
+	_ = workerCount // reserved for Phase 2 probe-split distribution rules
+
+	// Build an ID → index lookup so we can mutate stages in place.
+	idx := make(map[string]int, len(stages))
+	for i, s := range stages {
+		idx[s.ID] = i
+	}
+
+	// Track resolved distributions by stage ID. A stage is resolvable once
+	// all its dependencies have been resolved.
+	resolved := make(map[string]Distribution, len(stages))
+
+	// Iterate until every stage has a resolved distribution. The loop runs
+	// at most len(stages) times because each pass resolves at least one
+	// stage (the dependency graph is a DAG validated by walkStages).
+	for pass := 0; pass < len(stages) && len(resolved) < len(stages); pass++ {
+		for i := range stages {
+			s := &stages[i]
+			if _, done := resolved[s.ID]; done {
+				continue
+			}
+			// Check that every dependency has been resolved.
+			ready := true
+			for _, dep := range s.Dependencies {
+				if _, ok := resolved[dep]; !ok {
+					ready = false
+					break
+				}
+			}
+			if !ready {
+				continue
+			}
+			// Build the per-dep distribution map for OutputDistribution.
+			depMap := make(map[string]Distribution, len(s.Dependencies))
+			for _, dep := range s.Dependencies {
+				depMap[dep] = resolved[dep]
+			}
+			d := OutputDistribution(*s, depMap)
+			s.Distribution = d
+			resolved[s.ID] = d
+			_ = idx // idx kept for Phase 2 stages that need cross-references
+		}
+	}
+}

--- a/internal/planner/physical/distribution.go
+++ b/internal/planner/physical/distribution.go
@@ -36,25 +36,10 @@ func (d Distribution) Equals(other Distribution) bool {
 }
 
 // SatisfiesJoinKeys reports whether this distribution allows a co-located
-// join on the given keys without re-shuffling. Broadcast always satisfies;
-// hash-partitioned satisfies iff the keys match exactly (in order).
+// join on the given keys without re-shuffling. Preserved as a thin wrapper
+// over Satisfies for existing callers.
 func (d Distribution) SatisfiesJoinKeys(joinKeys []string) bool {
-	switch d.Kind {
-	case DistBroadcast:
-		return true
-	case DistHashPartitioned:
-		if len(d.Keys) != len(joinKeys) {
-			return false
-		}
-		for i := range d.Keys {
-			if d.Keys[i] != joinKeys[i] {
-				return false
-			}
-		}
-		return true
-	default:
-		return false
-	}
+	return d.Satisfies(RequiredDistribution{Kind: RequiredClusteredOn, Keys: joinKeys})
 }
 
 // RequiredKind enumerates the partitioning a consumer needs from each input.

--- a/internal/planner/physical/distribution.go
+++ b/internal/planner/physical/distribution.go
@@ -1,5 +1,10 @@
 package physical
 
+import (
+	"fmt"
+	"log"
+)
+
 // DistKind is the kind of partitioning a stage's output has.
 type DistKind int
 
@@ -326,4 +331,92 @@ func assignStageDistributions(stages []Stage, workerCount int) {
 			_ = idx // idx kept for Phase 2 stages that need cross-references
 		}
 	}
+}
+
+// BehaviorPreservingMode controls assertion hardness. When true (Phase 1
+// default), AssertExchangeConsistency logs violations at WARN and returns
+// nil — every existing distributed plan continues to execute unchanged
+// even if the property algebra rules in this file are wrong. When false
+// (tests, and Phase 2 onward), violations are returned as errors and
+// callers must handle them.
+//
+// Phase 2 deletes this var and makes the assertion always strict — the
+// EnsureDistribution rule guarantees no violation can survive into the
+// emitted plan.
+var BehaviorPreservingMode = true
+
+// joinSlot derives the per-dependency slot index for a join stage by
+// matching dependency IDs against LeftDepStage / RightDepStage. Returns
+// 0 for the probe (left), 1 for the build (right), -1 if dep matches
+// neither (which means the dep is auxiliary, e.g. a fused-join build).
+func joinSlot(stage Stage, depID string) int {
+	if depID == stage.LeftDepStage {
+		return 0
+	}
+	if depID == stage.RightDepStage {
+		return 1
+	}
+	return -1
+}
+
+// AssertExchangeConsistency walks every (producer, consumer, slot) edge in
+// the stages slice and asserts that producer.Distribution.Satisfies(
+// RequiredChildDistribution(consumer, slot)). Returns the first violation
+// as an error, or nil if all edges are consistent.
+//
+// In BehaviorPreservingMode, violations are logged at WARN and nil is
+// returned — Phase 1 is purely additive and must not block any plan that
+// the heuristic switch would otherwise accept.
+//
+// Phase 2 promotes this to the satisfaction check that drives Exchange
+// insertion: a violation triggers an Exchange stage being added, not a
+// plan rejection.
+func AssertExchangeConsistency(stages []Stage) error {
+	byID := make(map[string]Stage, len(stages))
+	for _, s := range stages {
+		byID[s.ID] = s
+	}
+
+	for _, consumer := range stages {
+		for _, depID := range consumer.Dependencies {
+			producer, ok := byID[depID]
+			if !ok {
+				// Dangling dep — not a Phase 1 concern (validateStageGraph
+				// already covers this). Skip silently.
+				continue
+			}
+
+			// Determine the slot. For join stages, derive from
+			// LeftDepStage / RightDepStage. For non-join consumers, slot 0
+			// (single-input) is the only meaningful index — Phase 1 does
+			// not assert non-join multi-input requirements.
+			slot := 0
+			if consumer.Type == "hash_join" || consumer.Type == "broadcast_join" {
+				s := joinSlot(consumer, depID)
+				if s < 0 {
+					// Auxiliary dep (e.g. fused-join build). Skip — no
+					// Phase 1 rule constrains it.
+					continue
+				}
+				slot = s
+			}
+
+			req := RequiredChildDistribution(consumer, slot)
+			if !producer.Distribution.Satisfies(req) {
+				violation := fmt.Errorf(
+					"exchange consistency violation: consumer=%s (type=%s, slot=%d) requires %s%v "+
+						"but producer=%s emits Distribution{Kind=%v, Keys=%v, Count=%d}",
+					consumer.ID, consumer.Type, slot,
+					req.Kind, req.Keys,
+					producer.ID, producer.Distribution.Kind, producer.Distribution.Keys, producer.Distribution.Count,
+				)
+				if BehaviorPreservingMode {
+					log.Printf("WARN: %v", violation)
+					continue
+				}
+				return violation
+			}
+		}
+	}
+	return nil
 }

--- a/internal/planner/physical/distribution_test.go
+++ b/internal/planner/physical/distribution_test.go
@@ -97,3 +97,149 @@ func TestDistributionSatisfies(t *testing.T) {
 		})
 	}
 }
+
+func TestRequiredChildDistribution(t *testing.T) {
+	tests := []struct {
+		name  string
+		stage Stage
+		slot  int
+		want  RequiredDistribution
+	}{
+		{
+			name:  "scan has no inputs returns any",
+			stage: Stage{ID: "scan-0", Type: "scan"},
+			slot:  0,
+			want:  RequiredDistribution{Kind: RequiredAny},
+		},
+		{
+			name:  "dual has no inputs returns any",
+			stage: Stage{ID: "dual-0", Type: "dual"},
+			slot:  0,
+			want:  RequiredDistribution{Kind: RequiredAny},
+		},
+		{
+			name:  "shuffle accepts any input",
+			stage: Stage{ID: "shuffle-0", Type: "shuffle", ShuffleKeys: []string{"k"}, NumPartitions: 16},
+			slot:  0,
+			want:  RequiredDistribution{Kind: RequiredAny},
+		},
+		{
+			name: "hash_join probe slot requires clustered on left keys",
+			stage: Stage{
+				ID: "join-0", Type: "hash_join",
+				JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"},
+				LeftDepStage: "shuffle-l", RightDepStage: "shuffle-r",
+				Dependencies: []string{"shuffle-l", "shuffle-r"},
+			},
+			slot: 0,
+			want: RequiredDistribution{Kind: RequiredClusteredOn, Keys: []string{"l_orderkey"}},
+		},
+		{
+			name: "hash_join build slot requires clustered on right keys",
+			stage: Stage{
+				ID: "join-0", Type: "hash_join",
+				JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"},
+				LeftDepStage: "shuffle-l", RightDepStage: "shuffle-r",
+				Dependencies: []string{"shuffle-l", "shuffle-r"},
+			},
+			slot: 1,
+			want: RequiredDistribution{Kind: RequiredClusteredOn, Keys: []string{"o_orderkey"}},
+		},
+		{
+			name: "broadcast_join probe slot requires any (Phase 1)",
+			stage: Stage{
+				ID: "join-0", Type: "broadcast_join",
+				JoinLeftKeys: []string{"l_partkey"}, JoinRightKeys: []string{"p_partkey"},
+				LeftDepStage: "scan-l", RightDepStage: "scan-r",
+				Dependencies: []string{"scan-l", "scan-r"},
+			},
+			slot: 0,
+			want: RequiredDistribution{Kind: RequiredAny},
+		},
+		{
+			name: "broadcast_join build slot requires any (Phase 1)",
+			stage: Stage{
+				ID: "join-0", Type: "broadcast_join",
+				JoinLeftKeys: []string{"l_partkey"}, JoinRightKeys: []string{"p_partkey"},
+				LeftDepStage: "scan-l", RightDepStage: "scan-r",
+				Dependencies: []string{"scan-l", "scan-r"},
+			},
+			slot: 1,
+			want: RequiredDistribution{Kind: RequiredAny},
+		},
+		{
+			name:  "aggregate requires any (Phase 1 conservative — see Risk #1)",
+			stage: Stage{ID: "aggregate-0", Type: "aggregate", GroupByCols: []string{"l_returnflag"}},
+			slot:  0,
+			want:  RequiredDistribution{Kind: RequiredAny},
+		},
+		{
+			name:  "final_aggregate requires any",
+			stage: Stage{ID: "final_aggregate-0", Type: "final_aggregate", GroupByCols: []string{"l_returnflag"}},
+			slot:  0,
+			want:  RequiredDistribution{Kind: RequiredAny},
+		},
+		{
+			name:  "sort requires any",
+			stage: Stage{ID: "sort-0", Type: "sort"},
+			slot:  0,
+			want:  RequiredDistribution{Kind: RequiredAny},
+		},
+		{
+			name:  "merge_sort requires any",
+			stage: Stage{ID: "merge_sort-0", Type: "merge_sort"},
+			slot:  0,
+			want:  RequiredDistribution{Kind: RequiredAny},
+		},
+		{
+			name: "window with PartitionBy requires clustered on partition keys",
+			stage: Stage{
+				ID: "window-0", Type: "window",
+				WindowCols: []WindowColSpec{{Func: "row_number", PartitionBy: []string{"o_custkey"}}},
+			},
+			slot: 0,
+			want: RequiredDistribution{Kind: RequiredClusteredOn, Keys: []string{"o_custkey"}},
+		},
+		{
+			name: "window without PartitionBy requires any",
+			stage: Stage{
+				ID: "window-0", Type: "window",
+				WindowCols: []WindowColSpec{{Func: "row_number"}},
+			},
+			slot: 0,
+			want: RequiredDistribution{Kind: RequiredAny},
+		},
+		{
+			name:  "pipeline requires any",
+			stage: Stage{ID: "pipeline-0", Type: "pipeline"},
+			slot:  0,
+			want:  RequiredDistribution{Kind: RequiredAny},
+		},
+		{
+			name:  "table_func requires any",
+			stage: Stage{ID: "tf-0", Type: "table_func"},
+			slot:  0,
+			want:  RequiredDistribution{Kind: RequiredAny},
+		},
+		{
+			name:  "unknown stage type requires any",
+			stage: Stage{ID: "?-0", Type: "mystery"},
+			slot:  0,
+			want:  RequiredDistribution{Kind: RequiredAny},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RequiredChildDistribution(tt.stage, tt.slot)
+			if got.Kind != tt.want.Kind {
+				t.Fatalf("Kind = %v, want %v", got.Kind, tt.want.Kind)
+			}
+			if !keysEqual(got.Keys, tt.want.Keys) {
+				t.Fatalf("Keys = %v, want %v", got.Keys, tt.want.Keys)
+			}
+			if got.Count != tt.want.Count {
+				t.Fatalf("Count = %v, want %v", got.Count, tt.want.Count)
+			}
+		})
+	}
+}

--- a/internal/planner/physical/distribution_test.go
+++ b/internal/planner/physical/distribution_test.go
@@ -381,3 +381,81 @@ func TestOutputDistribution(t *testing.T) {
 		})
 	}
 }
+
+func TestAssignStageDistributions(t *testing.T) {
+	// Synthetic 3-stage plan: scan -> shuffle -> join (with another scan + shuffle as build)
+	stages := []Stage{
+		{ID: "scan-0", Type: "scan", ScanAlias: "lineitem"},
+		{ID: "scan-1", Type: "scan", ScanAlias: "orders"},
+		{
+			ID: "shuffle-2", Type: "shuffle",
+			ShuffleKeys: []string{"l_orderkey"}, NumPartitions: 16,
+			Dependencies: []string{"scan-0"},
+		},
+		{
+			ID: "shuffle-3", Type: "shuffle",
+			ShuffleKeys: []string{"o_orderkey"}, NumPartitions: 16,
+			Dependencies: []string{"scan-1"},
+		},
+		{
+			ID: "join-4", Type: "hash_join",
+			JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"},
+			LeftDepStage: "shuffle-2", RightDepStage: "shuffle-3",
+			Dependencies: []string{"shuffle-2", "shuffle-3"},
+		},
+	}
+
+	assignStageDistributions(stages, 4)
+
+	want := map[string]Distribution{
+		"scan-0":    {Kind: DistSingleton},
+		"scan-1":    {Kind: DistSingleton},
+		"shuffle-2": {Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 16},
+		"shuffle-3": {Kind: DistHashPartitioned, Keys: []string{"o_orderkey"}, Count: 16},
+		// Hash join inherits probe-side distribution (shuffle-2)
+		"join-4": {Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 16},
+	}
+	for _, s := range stages {
+		got := s.Distribution
+		w := want[s.ID]
+		if !got.Equals(w) {
+			t.Errorf("stage %s: Distribution = %+v, want %+v", s.ID, got, w)
+		}
+	}
+}
+
+func TestAssignStageDistributions_OutOfOrderInput(t *testing.T) {
+	// Stages provided out of topological order. The pass must still resolve
+	// dependencies (e.g. join-4 declared before its shuffle deps).
+	stages := []Stage{
+		{
+			ID: "join-4", Type: "hash_join",
+			JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"},
+			LeftDepStage: "shuffle-2", RightDepStage: "shuffle-3",
+			Dependencies: []string{"shuffle-2", "shuffle-3"},
+		},
+		{
+			ID: "shuffle-2", Type: "shuffle",
+			ShuffleKeys: []string{"l_orderkey"}, NumPartitions: 16,
+			Dependencies: []string{"scan-0"},
+		},
+		{
+			ID: "shuffle-3", Type: "shuffle",
+			ShuffleKeys: []string{"o_orderkey"}, NumPartitions: 16,
+			Dependencies: []string{"scan-1"},
+		},
+		{ID: "scan-0", Type: "scan", ScanAlias: "lineitem"},
+		{ID: "scan-1", Type: "scan", ScanAlias: "orders"},
+	}
+
+	assignStageDistributions(stages, 4)
+
+	for _, s := range stages {
+		if s.ID == "join-4" {
+			want := Distribution{Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 16}
+			if !s.Distribution.Equals(want) {
+				t.Errorf("join-4 Distribution = %+v, want %+v (dep resolution should not depend on input order)", s.Distribution, want)
+			}
+		}
+	}
+}

--- a/internal/planner/physical/distribution_test.go
+++ b/internal/planner/physical/distribution_test.go
@@ -243,3 +243,141 @@ func TestRequiredChildDistribution(t *testing.T) {
 		})
 	}
 }
+
+func TestOutputDistribution(t *testing.T) {
+	tests := []struct {
+		name  string
+		stage Stage
+		deps  map[string]Distribution
+		want  Distribution
+	}{
+		{
+			name:  "scan emits singleton",
+			stage: Stage{ID: "scan-0", Type: "scan", ScanAlias: "lineitem"},
+			deps:  nil,
+			want:  Distribution{Kind: DistSingleton},
+		},
+		{
+			name:  "dual emits singleton",
+			stage: Stage{ID: "dual-0", Type: "dual"},
+			deps:  nil,
+			want:  Distribution{Kind: DistSingleton},
+		},
+		{
+			name: "shuffle emits hash partitioned",
+			stage: Stage{
+				ID: "shuffle-0", Type: "shuffle",
+				ShuffleKeys: []string{"l_orderkey"}, NumPartitions: 16,
+			},
+			deps: nil,
+			want: Distribution{Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 16},
+		},
+		{
+			name: "hash_join inherits probe distribution",
+			stage: Stage{
+				ID: "join-0", Type: "hash_join",
+				LeftDepStage: "shuffle-l", RightDepStage: "shuffle-r",
+				Dependencies: []string{"shuffle-l", "shuffle-r"},
+			},
+			deps: map[string]Distribution{
+				"shuffle-l": {Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 16},
+				"shuffle-r": {Kind: DistHashPartitioned, Keys: []string{"o_orderkey"}, Count: 16},
+			},
+			want: Distribution{Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 16},
+		},
+		{
+			name: "broadcast_join inherits probe distribution",
+			stage: Stage{
+				ID: "join-0", Type: "broadcast_join",
+				LeftDepStage: "scan-l", RightDepStage: "scan-r",
+				Dependencies: []string{"scan-l", "scan-r"},
+			},
+			deps: map[string]Distribution{
+				"scan-l": {Kind: DistSingleton},
+				"scan-r": {Kind: DistSingleton},
+			},
+			want: Distribution{Kind: DistSingleton},
+		},
+		{
+			name:  "aggregate emits singleton",
+			stage: Stage{ID: "aggregate-0", Type: "aggregate", GroupByCols: []string{"l_returnflag"}},
+			deps:  nil,
+			want:  Distribution{Kind: DistSingleton},
+		},
+		{
+			name: "final_aggregate lone reducer emits singleton",
+			stage: Stage{
+				ID: "final_aggregate-0", Type: "final_aggregate",
+				GroupByCols: []string{"l_returnflag"},
+			},
+			deps: nil,
+			want: Distribution{Kind: DistSingleton},
+		},
+		{
+			name: "final_aggregate merge group emits hash partitioned",
+			stage: Stage{
+				ID: "merge_aggregate-0-0", Type: "final_aggregate",
+				GroupByCols:     []string{"l_returnflag"},
+				MergeGroup:      0,
+				MergeGroupCount: 4,
+			},
+			deps: nil,
+			want: Distribution{Kind: DistHashPartitioned, Keys: []string{"l_returnflag"}, Count: 4},
+		},
+		{
+			name:  "sort emits singleton",
+			stage: Stage{ID: "sort-0", Type: "sort"},
+			deps:  nil,
+			want:  Distribution{Kind: DistSingleton},
+		},
+		{
+			name:  "merge_sort lone emits singleton",
+			stage: Stage{ID: "merge_sort-0", Type: "merge_sort"},
+			deps:  nil,
+			want:  Distribution{Kind: DistSingleton},
+		},
+		{
+			name: "merge_sort merge group emits hash partitioned",
+			stage: Stage{
+				ID: "merge_sort-0-0", Type: "merge_sort",
+				SortKeys:        []SortKeySpec{{Column: "l_orderkey"}},
+				MergeGroup:      0,
+				MergeGroupCount: 4,
+			},
+			deps: nil,
+			want: Distribution{Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 4},
+		},
+		{
+			name:  "window emits singleton",
+			stage: Stage{ID: "window-0", Type: "window"},
+			deps:  nil,
+			want:  Distribution{Kind: DistSingleton},
+		},
+		{
+			name:  "pipeline emits singleton",
+			stage: Stage{ID: "pipeline-0", Type: "pipeline"},
+			deps:  nil,
+			want:  Distribution{Kind: DistSingleton},
+		},
+		{
+			name:  "table_func emits singleton",
+			stage: Stage{ID: "tf-0", Type: "table_func"},
+			deps:  nil,
+			want:  Distribution{Kind: DistSingleton},
+		},
+		{
+			name:  "unknown stage type emits singleton",
+			stage: Stage{ID: "?-0", Type: "mystery"},
+			deps:  nil,
+			want:  Distribution{Kind: DistSingleton},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := OutputDistribution(tt.stage, tt.deps)
+			if !got.Equals(tt.want) {
+				t.Fatalf("OutputDistribution = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/planner/physical/distribution_test.go
+++ b/internal/planner/physical/distribution_test.go
@@ -576,3 +576,34 @@ func TestAssertExchangeConsistency_BrokenPlan_BehaviorPreservingMode(t *testing.
 		t.Fatalf("expected nil in BehaviorPreservingMode (warn-only), got: %v", err)
 	}
 }
+
+func TestPlanDistributed_PopulatesStageDistribution(t *testing.T) {
+	// Confirm PlanDistributed populates Stage.Distribution on every stage
+	// it emits. Uses the TPC-H test catalog from plan_tpch_test.go (same
+	// package) and a synthetic 2-table join.
+	cat, ctx := setupTPCHCatalog(t)
+	sql := `SELECT l_orderkey, o_orderdate
+		FROM lineitem JOIN orders ON l_orderkey = o_orderkey
+		WHERE o_orderdate >= '1995-01-01'`
+
+	stages := sqlToStages(t, cat, ctx, sql, 4)
+
+	for _, s := range stages {
+		// Every stage must have a populated Distribution. The zero value
+		// is {Kind: DistSingleton, Keys: nil, Count: 0} which is a valid
+		// "populated" value for stages that emit singleton output. We
+		// detect "unpopulated" by checking that the wire-up actually ran
+		// — for shuffle stages, the non-zero Count is a reliable proof.
+		if s.Type == "shuffle" {
+			if s.Distribution.Kind != DistHashPartitioned {
+				t.Errorf("shuffle stage %s: Distribution.Kind = %v, want DistHashPartitioned", s.ID, s.Distribution.Kind)
+			}
+			if s.Distribution.Count == 0 {
+				t.Errorf("shuffle stage %s: Distribution.Count = 0 (assignStageDistributions not wired in)", s.ID)
+			}
+			if len(s.Distribution.Keys) == 0 {
+				t.Errorf("shuffle stage %s: Distribution.Keys empty (assignStageDistributions not wired in)", s.ID)
+			}
+		}
+	}
+}

--- a/internal/planner/physical/distribution_test.go
+++ b/internal/planner/physical/distribution_test.go
@@ -36,3 +36,64 @@ func TestDistributionSatisfiesJoin(t *testing.T) {
 		t.Error("broadcast should always satisfy join")
 	}
 }
+
+func TestDistributionSatisfies(t *testing.T) {
+	hashOrderkey := Distribution{Kind: DistHashPartitioned, Keys: []string{"orderkey"}, Count: 12}
+	hashCustkey := Distribution{Kind: DistHashPartitioned, Keys: []string{"custkey"}, Count: 12}
+	hashOrderkey24 := Distribution{Kind: DistHashPartitioned, Keys: []string{"orderkey"}, Count: 24}
+	singleton := Distribution{Kind: DistSingleton}
+	bcast := Distribution{Kind: DistBroadcast}
+
+	reqAny := RequiredDistribution{Kind: RequiredAny}
+	reqSingleton := RequiredDistribution{Kind: RequiredSingleton}
+	reqBcast := RequiredDistribution{Kind: RequiredBroadcast}
+	reqClusterOrderkey := RequiredDistribution{Kind: RequiredClusteredOn, Keys: []string{"orderkey"}}
+	reqClusterCustkey := RequiredDistribution{Kind: RequiredClusteredOn, Keys: []string{"custkey"}}
+	reqHashOrderkey12 := RequiredDistribution{Kind: RequiredHashPartitionedOn, Keys: []string{"orderkey"}, Count: 12}
+	reqHashOrderkey24 := RequiredDistribution{Kind: RequiredHashPartitionedOn, Keys: []string{"orderkey"}, Count: 24}
+
+	tests := []struct {
+		name string
+		dist Distribution
+		req  RequiredDistribution
+		want bool
+	}{
+		// RequiredAny is satisfied by everything
+		{"singleton sat any", singleton, reqAny, true},
+		{"broadcast sat any", bcast, reqAny, true},
+		{"hash sat any", hashOrderkey, reqAny, true},
+
+		// RequiredSingleton: only DistSingleton
+		{"singleton sat singleton", singleton, reqSingleton, true},
+		{"broadcast not sat singleton", bcast, reqSingleton, false},
+		{"hash not sat singleton", hashOrderkey, reqSingleton, false},
+
+		// RequiredBroadcast: only DistBroadcast
+		{"broadcast sat broadcast", bcast, reqBcast, true},
+		{"singleton not sat broadcast", singleton, reqBcast, false},
+		{"hash not sat broadcast", hashOrderkey, reqBcast, false},
+
+		// RequiredClusteredOn(K): broadcast yes, singleton yes, hash iff Keys==K
+		{"broadcast sat clustered", bcast, reqClusterOrderkey, true},
+		{"singleton sat clustered", singleton, reqClusterOrderkey, true},
+		{"hash on K sat clustered K", hashOrderkey, reqClusterOrderkey, true},
+		{"hash on K not sat clustered K2", hashOrderkey, reqClusterCustkey, false},
+		{"hash on K2 not sat clustered K", hashCustkey, reqClusterOrderkey, false},
+
+		// RequiredHashPartitionedOn(K, N): only hash with same K and N
+		{"hash K N sat hash K N", hashOrderkey, reqHashOrderkey12, true},
+		{"hash K N' not sat hash K N", hashOrderkey24, reqHashOrderkey12, false},
+		{"hash K N sat hash K N'", hashOrderkey, reqHashOrderkey24, false},
+		{"hash K not sat hash K2 N", hashCustkey, reqHashOrderkey12, false},
+		{"singleton not sat hash K N", singleton, reqHashOrderkey12, false},
+		{"broadcast not sat hash K N", bcast, reqHashOrderkey12, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.dist.Satisfies(tt.req)
+			if got != tt.want {
+				t.Errorf("(%v).Satisfies(%v) = %v, want %v", tt.dist, tt.req, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/planner/physical/distribution_test.go
+++ b/internal/planner/physical/distribution_test.go
@@ -1,6 +1,9 @@
 package physical
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestDistributionEquals(t *testing.T) {
 	tests := []struct {
@@ -457,5 +460,119 @@ func TestAssignStageDistributions_OutOfOrderInput(t *testing.T) {
 				t.Errorf("join-4 Distribution = %+v, want %+v (dep resolution should not depend on input order)", s.Distribution, want)
 			}
 		}
+	}
+}
+
+func TestAssertExchangeConsistency_ConsistentPlan(t *testing.T) {
+	// scan -> shuffle (on l_orderkey) -> join.probe (RequiredClusteredOn l_orderkey)
+	// scan -> shuffle (on o_orderkey) -> join.build (RequiredClusteredOn o_orderkey)
+	// All edges satisfy: hash-partitioned-on-K satisfies clustered-on-K.
+	stages := []Stage{
+		{ID: "scan-0", Type: "scan", Distribution: Distribution{Kind: DistSingleton}},
+		{ID: "scan-1", Type: "scan", Distribution: Distribution{Kind: DistSingleton}},
+		{
+			ID: "shuffle-2", Type: "shuffle",
+			ShuffleKeys: []string{"l_orderkey"}, NumPartitions: 16,
+			Dependencies: []string{"scan-0"},
+			Distribution: Distribution{Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 16},
+		},
+		{
+			ID: "shuffle-3", Type: "shuffle",
+			ShuffleKeys: []string{"o_orderkey"}, NumPartitions: 16,
+			Dependencies: []string{"scan-1"},
+			Distribution: Distribution{Kind: DistHashPartitioned, Keys: []string{"o_orderkey"}, Count: 16},
+		},
+		{
+			ID: "join-4", Type: "hash_join",
+			JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"},
+			LeftDepStage: "shuffle-2", RightDepStage: "shuffle-3",
+			Dependencies: []string{"shuffle-2", "shuffle-3"},
+			Distribution: Distribution{Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 16},
+		},
+	}
+
+	if err := AssertExchangeConsistency(stages); err != nil {
+		t.Fatalf("expected no error on consistent plan, got: %v", err)
+	}
+}
+
+func TestAssertExchangeConsistency_BrokenPlan_StrictMode(t *testing.T) {
+	// Save and restore the package var.
+	prev := BehaviorPreservingMode
+	BehaviorPreservingMode = false
+	defer func() { BehaviorPreservingMode = prev }()
+
+	// join requires its build slot clustered on o_orderkey, but the build
+	// dependency is hash-partitioned on c_custkey — violation.
+	stages := []Stage{
+		{ID: "scan-0", Type: "scan", Distribution: Distribution{Kind: DistSingleton}},
+		{
+			ID: "shuffle-1", Type: "shuffle",
+			ShuffleKeys: []string{"l_orderkey"}, NumPartitions: 16,
+			Dependencies: []string{"scan-0"},
+			Distribution: Distribution{Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 16},
+		},
+		{ID: "scan-2", Type: "scan", Distribution: Distribution{Kind: DistSingleton}},
+		{
+			ID: "shuffle-3", Type: "shuffle",
+			ShuffleKeys: []string{"c_custkey"}, NumPartitions: 16,
+			Dependencies: []string{"scan-2"},
+			Distribution: Distribution{Kind: DistHashPartitioned, Keys: []string{"c_custkey"}, Count: 16},
+		},
+		{
+			ID: "join-4", Type: "hash_join",
+			JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"},
+			LeftDepStage: "shuffle-1", RightDepStage: "shuffle-3",
+			Dependencies: []string{"shuffle-1", "shuffle-3"},
+			Distribution: Distribution{Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 16},
+		},
+	}
+
+	err := AssertExchangeConsistency(stages)
+	if err == nil {
+		t.Fatal("expected error on broken plan in strict mode, got nil")
+	}
+	if !strings.Contains(err.Error(), "join-4") {
+		t.Errorf("error should mention violating consumer stage join-4, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "shuffle-3") {
+		t.Errorf("error should mention violating producer stage shuffle-3, got: %v", err)
+	}
+}
+
+func TestAssertExchangeConsistency_BrokenPlan_BehaviorPreservingMode(t *testing.T) {
+	prev := BehaviorPreservingMode
+	BehaviorPreservingMode = true
+	defer func() { BehaviorPreservingMode = prev }()
+
+	// Same broken plan as the strict-mode test.
+	stages := []Stage{
+		{ID: "scan-0", Type: "scan", Distribution: Distribution{Kind: DistSingleton}},
+		{
+			ID: "shuffle-1", Type: "shuffle",
+			ShuffleKeys: []string{"l_orderkey"}, NumPartitions: 16,
+			Dependencies: []string{"scan-0"},
+			Distribution: Distribution{Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 16},
+		},
+		{ID: "scan-2", Type: "scan", Distribution: Distribution{Kind: DistSingleton}},
+		{
+			ID: "shuffle-3", Type: "shuffle",
+			ShuffleKeys: []string{"c_custkey"}, NumPartitions: 16,
+			Dependencies: []string{"scan-2"},
+			Distribution: Distribution{Kind: DistHashPartitioned, Keys: []string{"c_custkey"}, Count: 16},
+		},
+		{
+			ID: "join-4", Type: "hash_join",
+			JoinLeftKeys: []string{"l_orderkey"}, JoinRightKeys: []string{"o_orderkey"},
+			LeftDepStage: "shuffle-1", RightDepStage: "shuffle-3",
+			Dependencies: []string{"shuffle-1", "shuffle-3"},
+			Distribution: Distribution{Kind: DistHashPartitioned, Keys: []string{"l_orderkey"}, Count: 16},
+		},
+	}
+
+	// In BehaviorPreservingMode, AssertExchangeConsistency returns nil —
+	// the violation is logged at WARN but does not bubble up as an error.
+	if err := AssertExchangeConsistency(stages); err != nil {
+		t.Fatalf("expected nil in BehaviorPreservingMode (warn-only), got: %v", err)
 	}
 }

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -984,6 +984,18 @@ func (p *Planner) PlanDistributed(ctx context.Context, node *logical.Node) ([]St
 	if err := p.enforceQueryLimits(stages, node); err != nil {
 		return nil, err
 	}
+	// Phase 1 distribution-property pass: populate Stage.Distribution for
+	// every stage and assert exchange consistency. In BehaviorPreservingMode
+	// (default), violations are logged but do not fail planning. See
+	// docs/superpowers/specs/2026-04-20-distribution-property-phase-1.md.
+	assignStageDistributions(stages, p.WorkerCount)
+	if err := AssertExchangeConsistency(stages); err != nil {
+		// In strict mode (Phase 2 onward, or test override) this is a
+		// hard failure. BehaviorPreservingMode swallows the error inside
+		// AssertExchangeConsistency, so reaching this branch implies the
+		// caller flipped the var.
+		return nil, fmt.Errorf("exchange consistency: %w", err)
+	}
 	return stages, nil
 }
 

--- a/internal/planner/physical/plan_tpch_test.go
+++ b/internal/planner/physical/plan_tpch_test.go
@@ -629,3 +629,95 @@ func TestTPCHShuffleKeysResolvable(t *testing.T) {
 		})
 	}
 }
+
+// TestTPCHDistributionConsistency is the Phase 1 acceptance gate for the
+// distribution-property pass. For every Q1-Q22, runs PlanDistributed with
+// WorkerCount=4 in strict mode (BehaviorPreservingMode=false) and asserts:
+//  1. Every stage has a populated Distribution (shuffle stages explicitly
+//     DistHashPartitioned with non-zero Count).
+//  2. AssertExchangeConsistency(stages) == nil.
+//
+// Failure on any query means either the OutputDistribution /
+// RequiredChildDistribution rules are wrong or PlanDistributed emits an
+// inconsistent plan. Either way, the spec's load-bearing invariant is
+// broken and Phase 2 cannot proceed safely.
+//
+// Spec: docs/superpowers/specs/2026-04-20-distribution-property-phase-1.md
+func TestTPCHDistributionConsistency(t *testing.T) {
+	cat, ctx := setupTPCHCatalog(t)
+
+	// Strict mode: any consistency violation must surface as an error.
+	prev := BehaviorPreservingMode
+	BehaviorPreservingMode = false
+	defer func() { BehaviorPreservingMode = prev }()
+
+	for qNum := 1; qNum <= 22; qNum++ {
+		sql, ok := tpchPlanQueryMap[qNum]
+		if !ok {
+			t.Logf("Q%02d not in plan query map; skipping", qNum)
+			continue
+		}
+		name := fmt.Sprintf("Q%02d", qNum)
+		t.Run(name, func(t *testing.T) {
+			parsed, err := plansql.Parse(sql)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			selectInfo, err := plansql.ExtractSelect(parsed)
+			if err != nil {
+				t.Fatalf("extract: %v", err)
+			}
+			logicalPlan, err := logical.BuildFromSelect(selectInfo)
+			if err != nil {
+				t.Fatalf("logical plan: %v", err)
+			}
+			scanAnnotator := func(plan *logical.Node) {
+				NewPlanner(cat).AnnotateScanColumns(ctx, plan)
+			}
+			scanAnnotator(logicalPlan)
+			logicalPlan = logical.Optimize(logicalPlan, scanAnnotator)
+
+			planner := NewPlanner(cat)
+			planner.WorkerCount = 4
+			stages, err := planner.PlanDistributed(ctx, logicalPlan)
+			if err != nil {
+				// In strict mode, exchange-consistency violations come back
+				// as errors prefixed "exchange consistency: ...".
+				t.Fatalf("PlanDistributed failed: %v", err)
+			}
+
+			// Assertion 1: every stage has a populated Distribution. The
+			// zero value DistSingleton is "populated" for stages that emit
+			// singleton output, but shuffle stages must carry the
+			// hash-partitioned label with non-zero Count and non-empty Keys.
+			for _, s := range stages {
+				if s.Type == "shuffle" {
+					if s.Distribution.Kind != DistHashPartitioned {
+						t.Errorf("%s shuffle stage %s: Distribution.Kind = %v, want DistHashPartitioned",
+							name, s.ID, s.Distribution.Kind)
+					}
+					if s.Distribution.Count == 0 {
+						t.Errorf("%s shuffle stage %s: Distribution.Count = 0 (not populated)",
+							name, s.ID)
+					}
+					if len(s.Distribution.Keys) == 0 {
+						t.Errorf("%s shuffle stage %s: Distribution.Keys empty (not populated)",
+							name, s.ID)
+					}
+				}
+			}
+
+			// Assertion 2: in strict mode, AssertExchangeConsistency
+			// already ran inside PlanDistributed — if it returned an
+			// error it would have aborted above. Re-run defensively to
+			// log per-stage detail on failure.
+			if err := AssertExchangeConsistency(stages); err != nil {
+				for _, s := range stages {
+					t.Logf("  %-24s type=%-16s dist=%+v",
+						s.ID, s.Type, s.Distribution)
+				}
+				t.Fatalf("%s: %v", name, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 of the distribution-property pass (spec on branch at
`docs/superpowers/specs/2026-04-20-distribution-property-phase-1.md`).

Adds the type algebra for treating distribution as a first-class
operator property, modelled on Spark's `Distribution` / `Partitioning` /
`satisfies` triad. No behaviour change — `AssertExchangeConsistency`
runs as a no-op in `BehaviorPreservingMode` (default `true`).

This unblocks Phase 2 (`docs/superpowers/specs/2026-04-20-distribution-property-phase-2-design.md`
on main), which replaces the coordinator's four-mode routing switch
with property-based Exchange insertion.

## What's added (planner-only)

- `RequiredKind` enum (`RequiredAny`, `RequiredSingleton`,
  `RequiredBroadcast`, `RequiredClusteredOn`, `RequiredHashPartitionedOn`)
- `RequiredDistribution` struct — consumer-side partitioning requirement
- `Distribution.Satisfies(RequiredDistribution) bool` — truth-table predicate
- `SatisfiesJoinKeys` refactored to delegate to `Satisfies` (no behaviour change)
- `RequiredChildDistribution(stage, side)` — per-child required distribution
- `OutputDistribution(stage, workerCount)` — per-stage output distribution
- `assignStageDistributions` — populates `Stage.Distribution` for a plan
- `AssertExchangeConsistency` — strict/no-op consistency validator
- `BehaviorPreservingMode` package var (default `true`; `AssertExchangeConsistency` is a no-op when set)
- Wire-up in `PlanDistributed`

## Test plan

- [x] `TestDistributionSatisfies` truth-table coverage
- [x] `TestRequiredChildDistribution` per stage type
- [x] `TestOutputDistribution` per stage type
- [x] `TestAssignStageDistributions` end-to-end
- [x] `TestAssertExchangeConsistency` pass/fail scenarios
- [x] `TestTPCHDistributionConsistency` — all Q01–Q22 through `PlanDistributed` with `WorkerCount=4` and `BehaviorPreservingMode=false`; asserts every stage's Distribution populated and `AssertExchangeConsistency == nil`

## Diff summary

- `internal/planner/physical/distribution.go`: +386 lines
- `internal/planner/physical/distribution_test.go`: +573 lines
- `internal/planner/physical/plan.go`: +12 lines wire-up
- `internal/planner/physical/plan_tpch_test.go`: +92 lines

Scope: planner-only. No coordinator, worker, or executor changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)