### PR TITLE
feat(harness): S3 mode for SF10 regression reproduction

### DIFF
--- a/cmd/tpch-harness/main.go
+++ b/cmd/tpch-harness/main.go
@@ -26,12 +26,22 @@ func main() {
 		noCompare      = flag.Bool("no-compare", false, "skip baseline comparison, just emit measurements")
 		wadjetBin      = flag.String("wadjet-bin", "", "path to wadjet binary (default: $WADJET_BIN or ./wadjet)")
 		pgAddr         = flag.String("pg-addr", ":15433", "pgwire listen address for the spawned coordinator")
+		source         = flag.String("source", "local", "data source: local (files under --data-dir) or s3 (coordinator reads from --bucket)")
+		bucket         = flag.String("bucket", "wadjet-bench-sf10-use2", "S3 bucket name (source=s3)")
+		region         = flag.String("region", "us-east-2", "S3 region (source=s3)")
+		endpoint       = flag.String("endpoint", "s3.us-east-2.amazonaws.com", "S3 endpoint (source=s3)")
+		ssl            = flag.Bool("ssl", true, "use SSL for S3 (source=s3)")
+		dataPrefix     = flag.String("data-prefix", "tables/", "S3 prefix under --bucket containing table data (source=s3)")
 	)
 	flag.Parse()
 
 	if *mode == "" {
 		fmt.Fprintln(os.Stderr, "ERROR: --mode is required (local or golden)")
 		flag.Usage()
+		os.Exit(harness.ExitSetup)
+	}
+	if *source != "local" && *source != "s3" {
+		fmt.Fprintln(os.Stderr, "ERROR: --source must be 'local' or 's3'")
 		os.Exit(harness.ExitSetup)
 	}
 
@@ -46,6 +56,12 @@ func main() {
 		NoCompare:      *noCompare,
 		WadjetBin:      *wadjetBin,
 		PgAddr:         *pgAddr,
+		Source:         *source,
+		Bucket:         *bucket,
+		Region:         *region,
+		Endpoint:       *endpoint,
+		SSL:            *ssl,
+		DataPrefix:     *dataPrefix,
 	}
 	if *queries != "" {
 		cfg.Queries = strings.Split(*queries, ",")

--- a/cmd/tpch-harness/main.go
+++ b/cmd/tpch-harness/main.go
@@ -25,6 +25,7 @@ func main() {
 		updateBaseline = flag.Bool("update-baseline", false, "(golden only) write the result directly to --baseline")
 		noCompare      = flag.Bool("no-compare", false, "skip baseline comparison, just emit measurements")
 		wadjetBin      = flag.String("wadjet-bin", "", "path to wadjet binary (default: $WADJET_BIN or ./wadjet)")
+		pgAddr         = flag.String("pg-addr", ":15433", "pgwire listen address for the spawned coordinator")
 	)
 	flag.Parse()
 
@@ -44,6 +45,7 @@ func main() {
 		UpdateBaseline: *updateBaseline,
 		NoCompare:      *noCompare,
 		WadjetBin:      *wadjetBin,
+		PgAddr:         *pgAddr,
 	}
 	if *queries != "" {
 		cfg.Queries = strings.Split(*queries, ",")

--- a/internal/harness/cluster.go
+++ b/internal/harness/cluster.go
@@ -25,8 +25,18 @@ type ClusterConfig struct {
 	NumWorkers int
 	GoMemLimit int64
 	PgAddr     string // pgwire listen address for coordinator (default ":15433")
-	DataDir    string // local data dir (FileStore) for storage-type=file
-	Logger     *slog.Logger
+	DataDir    string // local data dir (FileStore) for StorageType=="file"
+
+	// StorageType selects the coordinator/worker storage backend.
+	// "" or "file" -> FileStore at DataDir (default)
+	// "s3"         -> MinIO/S3 at Endpoint/Region/Bucket
+	StorageType string
+	Bucket      string
+	Region      string
+	Endpoint    string
+	SSL         bool
+
+	Logger *slog.Logger
 }
 
 // Cluster is a process supervisor for one coordinator + N workers.
@@ -117,9 +127,7 @@ func (c *Cluster) StartCoordinator(ctx context.Context) error {
 		"--spill-dir=" + filepath.Join(c.cfg.RunDir, "spill", "coord"),
 		"--nats-store-dir=" + filepath.Join(c.cfg.RunDir, "nats"),
 	}
-	if c.cfg.DataDir != "" {
-		coordArgs = append(coordArgs, "--storage-type=file", "--data-dir="+c.cfg.DataDir)
-	}
+	coordArgs = append(coordArgs, storageArgs(c.cfg)...)
 	coord, err := c.spawn("coord", coordArgs)
 	if err != nil {
 		return fmt.Errorf("spawning coordinator: %w", err)
@@ -164,9 +172,7 @@ func (c *Cluster) StartWorkers(ctx context.Context) error {
 			"--spill-dir=" + filepath.Join(c.cfg.RunDir, "spill", role),
 			"--metrics-addr=:" + strconv.Itoa(metricsPort),
 		}
-		if c.cfg.DataDir != "" {
-			workerArgs = append(workerArgs, "--storage-type=file", "--data-dir="+c.cfg.DataDir)
-		}
+		workerArgs = append(workerArgs, storageArgs(c.cfg)...)
 		w, err := c.spawn(role, workerArgs)
 		if err != nil {
 			return fmt.Errorf("spawning %s: %w", role, err)
@@ -354,6 +360,30 @@ func (c *Cluster) shutdown(_ context.Context) error {
 		return fmt.Errorf("post-shutdown orphan check: %w", err)
 	}
 	return nil
+}
+
+// storageArgs returns the --storage-type/--bucket/... flags to pass to both
+// coordinator and worker based on the cluster's configured backend. Empty
+// StorageType falls back to the FileStore (DataDir) path used by local mode.
+func storageArgs(cfg ClusterConfig) []string {
+	switch cfg.StorageType {
+	case "s3":
+		args := []string{
+			"--storage-type=s3",
+			"--bucket=" + cfg.Bucket,
+			"--region=" + cfg.Region,
+			"--endpoint=" + cfg.Endpoint,
+		}
+		if cfg.SSL {
+			args = append(args, "--ssl")
+		}
+		return args
+	default: // "" or "file"
+		if cfg.DataDir != "" {
+			return []string{"--storage-type=file", "--data-dir=" + cfg.DataDir}
+		}
+		return nil
+	}
 }
 
 // freePort asks the kernel for an available TCP port.

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -69,6 +69,7 @@ func Run(ctx context.Context, cfg Config, logger *slog.Logger) (RunResult, error
 			RunDir:     runDir,
 			NumWorkers: numWorkers,
 			GoMemLimit: sliceCfg.GoMemLimit,
+			PgAddr:     cfg.PgAddr,
 			DataDir:    cfg.DataDir,
 			Logger:     logger,
 		})

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -64,7 +64,7 @@ func Run(ctx context.Context, cfg Config, logger *slog.Logger) (RunResult, error
 			return result, fmt.Errorf("preflight failed:\n  - %s", pf.Error())
 		}
 
-		cluster = NewCluster(ClusterConfig{
+		clusterCfg := ClusterConfig{
 			WadjetBin:  cfg.WadjetBin,
 			RunDir:     runDir,
 			NumWorkers: numWorkers,
@@ -72,7 +72,16 @@ func Run(ctx context.Context, cfg Config, logger *slog.Logger) (RunResult, error
 			PgAddr:     cfg.PgAddr,
 			DataDir:    cfg.DataDir,
 			Logger:     logger,
-		})
+		}
+		if cfg.Source == "s3" {
+			clusterCfg.StorageType = "s3"
+			clusterCfg.Bucket = cfg.Bucket
+			clusterCfg.Region = cfg.Region
+			clusterCfg.Endpoint = cfg.Endpoint
+			clusterCfg.SSL = cfg.SSL
+			clusterCfg.DataDir = "" // ignore — S3 is the source
+		}
+		cluster = NewCluster(clusterCfg)
 
 		// Two-phase startup: coordinator (owns NATS) first, seed data, then workers.
 		if err := cluster.StartCoordinator(ctx); err != nil {
@@ -80,8 +89,15 @@ func Run(ctx context.Context, cfg Config, logger *slog.Logger) (RunResult, error
 		}
 		defer cluster.Shutdown(context.Background())
 
-		if err := loadSampleData(ctx, cluster, cfg.DataDir, sliceCfg, logger); err != nil {
-			return result, fmt.Errorf("loading sample data: %w", err)
+		switch cfg.Source {
+		case "s3":
+			if err := primeS3Catalog(ctx, cluster, cfg.Endpoint, cfg.Region, cfg.Bucket, cfg.SSL, cfg.DataPrefix, logger); err != nil {
+				return result, fmt.Errorf("priming S3 catalog: %w", err)
+			}
+		default: // "local" or empty
+			if err := loadSampleData(ctx, cluster, cfg.DataDir, sliceCfg, logger); err != nil {
+				return result, fmt.Errorf("loading sample data: %w", err)
+			}
 		}
 
 		if err := cluster.StartWorkers(ctx); err != nil {

--- a/internal/harness/s3_catalog.go
+++ b/internal/harness/s3_catalog.go
@@ -1,0 +1,180 @@
+package harness
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+
+	"github.com/citc-tech/wadjet/benchmarks/tpch"
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/storage/catalog"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// primeS3Catalog lists parquet files under bucket/dataPrefix/<table>/ for each
+// of the 8 TPC-H tables, probes the first file for its real schema, and
+// registers the files in the NATS KV catalog via CreateTable + AddFiles.
+//
+// Mirrors cmd/tpch-bench's discoverData pattern but writes to the catalog
+// directly through NATS (like loadSampleData) rather than through a
+// *wadjet.DB handle — the coordinator is a subprocess, so we'd otherwise
+// have to go over pgwire to reach its in-process DB.
+//
+// This path assumes data is already staged in S3. It does not write sample
+// parquet files; use loadSampleData for the FileStore path.
+func primeS3Catalog(
+	ctx context.Context,
+	cluster *Cluster,
+	endpoint, region, bucket string,
+	ssl bool,
+	dataPrefix string,
+	logger *slog.Logger,
+) error {
+	if dataPrefix != "" && !strings.HasSuffix(dataPrefix, "/") {
+		dataPrefix += "/"
+	}
+
+	store, err := objstore.NewMinIOStore(objstore.MinIOConfig{
+		Endpoint: endpoint,
+		UseSSL:   ssl,
+		Region:   region,
+	})
+	if err != nil {
+		return fmt.Errorf("s3 store: %w", err)
+	}
+
+	nc, err := cluster.ConnectNATS()
+	if err != nil {
+		return fmt.Errorf("connecting to NATS for catalog: %w", err)
+	}
+	defer nc.Close()
+
+	js, err := distributed.NewJetStream(nc)
+	if err != nil {
+		return fmt.Errorf("creating JetStream: %w", err)
+	}
+	kv, err := catalog.NewNATSKV(js)
+	if err != nil {
+		return fmt.Errorf("creating NATS KV: %w", err)
+	}
+	cat := catalog.New(kv, store, bucket)
+	if err := cat.Init(ctx); err != nil {
+		return fmt.Errorf("catalog init: %w", err)
+	}
+
+	for name := range tpch.AllTables {
+		prefix := dataPrefix + name + "/"
+		objects, err := store.List(ctx, bucket, objstore.ListOptions{Prefix: prefix})
+		if err != nil {
+			return fmt.Errorf("listing s3://%s/%s: %w", bucket, prefix, err)
+		}
+		var pqObjects []objstore.ObjectInfo
+		for _, obj := range objects {
+			if strings.HasSuffix(obj.Key, ".parquet") {
+				pqObjects = append(pqObjects, obj)
+			}
+		}
+		if len(pqObjects) == 0 {
+			return fmt.Errorf("no parquet files under s3://%s/%s", bucket, prefix)
+		}
+
+		// Probe the first file for the real schema. SF10/SF100 Polars-generated
+		// parquet uses INT64/DATE rather than the hardcoded INT32/STRING
+		// tpch.AllTables schemas; registering the hardcoded schema causes
+		// silent type truncation in join keys. See cmd/tpch-bench/main.go
+		// discoverData for the original motivation.
+		schema, err := probeS3Schema(ctx, store, bucket, pqObjects[0].Key)
+		if err != nil {
+			logger.Warn("schema probe failed, falling back to hardcoded schema",
+				"table", name, "key", pqObjects[0].Key, "err", err)
+			schema = tpch.AllTables[name]
+		}
+
+		if err := cat.CreateTable(ctx, name, schema, nil); err != nil && !strings.Contains(err.Error(), "already exists") {
+			return fmt.Errorf("create table %s: %w", name, err)
+		}
+
+		files := make([]catalog.FileEntry, 0, len(pqObjects))
+		var totalRows int64
+		for _, obj := range pqObjects {
+			numRows, perr := probeS3RowCount(ctx, store, bucket, obj.Key)
+			if perr != nil {
+				logger.Warn("row-count probe failed", "table", name, "key", obj.Key, "err", perr)
+				numRows = 0
+			}
+			totalRows += numRows
+			files = append(files, catalog.FileEntry{
+				Path:      obj.Key,
+				SizeBytes: obj.Size,
+				NumRows:   numRows,
+				CreatedAt: obj.LastModified,
+			})
+		}
+		if err := cat.AddFiles(ctx, name, nil, "", files); err != nil {
+			return fmt.Errorf("registering files for %s: %w", name, err)
+		}
+		logger.Info("primed table from S3", "table", name, "files", len(files), "rows", totalRows)
+	}
+	return nil
+}
+
+func probeS3Schema(ctx context.Context, store objstore.Store, bucket, key string) (parquet.Schema, error) {
+	if ras, ok := store.(objstore.ReaderAtStore); ok {
+		ra, sz, err := ras.GetReaderAt(ctx, bucket, key)
+		if err != nil {
+			return parquet.Schema{}, fmt.Errorf("opening reader-at: %w", err)
+		}
+		defer ra.Close()
+		r, err := parquet.NewReader(ra, sz)
+		if err != nil {
+			return parquet.Schema{}, fmt.Errorf("parquet reader: %w", err)
+		}
+		return r.Schema(), nil
+	}
+	rc, _, err := store.Get(ctx, bucket, key)
+	if err != nil {
+		return parquet.Schema{}, fmt.Errorf("get: %w", err)
+	}
+	defer rc.Close()
+	buf, err := io.ReadAll(rc)
+	if err != nil {
+		return parquet.Schema{}, fmt.Errorf("read: %w", err)
+	}
+	r, err := parquet.NewReaderFromBytes(buf)
+	if err != nil {
+		return parquet.Schema{}, fmt.Errorf("parquet reader: %w", err)
+	}
+	return r.Schema(), nil
+}
+
+func probeS3RowCount(ctx context.Context, store objstore.Store, bucket, key string) (int64, error) {
+	if ras, ok := store.(objstore.ReaderAtStore); ok {
+		ra, sz, err := ras.GetReaderAt(ctx, bucket, key)
+		if err != nil {
+			return 0, fmt.Errorf("opening reader-at: %w", err)
+		}
+		defer ra.Close()
+		r, err := parquet.NewReader(ra, sz)
+		if err != nil {
+			return 0, fmt.Errorf("parquet reader: %w", err)
+		}
+		return r.NumRows(), nil
+	}
+	rc, _, err := store.Get(ctx, bucket, key)
+	if err != nil {
+		return 0, fmt.Errorf("get: %w", err)
+	}
+	defer rc.Close()
+	buf, err := io.ReadAll(rc)
+	if err != nil {
+		return 0, fmt.Errorf("read: %w", err)
+	}
+	r, err := parquet.NewReaderFromBytes(buf)
+	if err != nil {
+		return 0, fmt.Errorf("parquet reader: %w", err)
+	}
+	return r.NumRows(), nil
+}

--- a/internal/harness/types.go
+++ b/internal/harness/types.go
@@ -42,6 +42,14 @@ type Config struct {
 	NoCompare      bool
 	WadjetBin      string // path to wadjet binary; auto-built if empty
 	PgAddr         string // local only; override for coordinator pgwire listen addr
+
+	// S3 source (Source=="s3" only)
+	Source     string // "local" (default) or "s3"
+	Bucket     string
+	Region     string
+	Endpoint   string
+	SSL        bool
+	DataPrefix string // prefix under Bucket containing table data (e.g. "tables/")
 }
 
 // QueryMeasurement is the result of running one query (or micro).

--- a/internal/harness/types.go
+++ b/internal/harness/types.go
@@ -41,6 +41,7 @@ type Config struct {
 	UpdateBaseline bool
 	NoCompare      bool
 	WadjetBin      string // path to wadjet binary; auto-built if empty
+	PgAddr         string // local only; override for coordinator pgwire listen addr
 }
 
 // QueryMeasurement is the result of running one query (or micro).


### PR DESCRIPTION
## Summary

Adds S3-mode to `cmd/tpch-harness` so it can drive a local coordinator + workers cluster against the real SF10 TPC-H bucket (`wadjet-bench-sf10-use2`). Closes the gap flagged in `feedback_tpch_harness_local_gate.md`: the existing `--slice=small` path runs against 22 MB of SF100 samples, which is too small to exercise multi-step shuffle code paths at scale.

Five commits:

1. **b1fbe60** `feat(harness): add --pg-addr flag` — small ergonomic fix; default `:15433` collides with common dev postgres containers
2. **6e4d158** `feat(harness): add --source/--bucket/--region/--endpoint/--ssl/--data-prefix flags` — plumb S3 config through `Config`
3. **96d56c9** `feat(harness): branch coordinator/worker args on StorageType` — extract `storageArgs()` helper; FileStore path unchanged
4. **cdf3c84** `feat(harness): add primeS3Catalog for S3-source mode` — lists parquet under `s3://<bucket>/<dataPrefix>/<table>/`, probes schema + row counts, registers via catalog (through NATS, matching `loadSampleData` pattern)
5. **6a77e76** `feat(harness): route S3 source through primeS3Catalog` — `Run()` branches on `cfg.Source`

## Motivation

The 2026-04-21 Phase 2b runtime change passed all local gates (SF0.01 22/22, SF1 local within 2%, `--slice=small` harness clean) but failed catastrophically on EC2 SF10: Q18 timed out at 10 min, Q15/Q18/Q20/Q21/Q22 returned wrong rows, total elapsed 3.24× slower. EC2 discovery cost ~$1.20 per A/B — and the root cause (empty-BuildAlias skip guard silently discarding multi-step shuffles) is a class of bug that only manifests when the coordinator actually dispatches real distributed stages at scale.

This PR makes that repro local.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -run TestTPCHQueries ./benchmarks/tpch/` — 22/22 pass
- [x] Local FileStore path unchanged: `./tpch-harness --mode=local --slice=small` produces same output as before (Q03's known `invalid length for int8: 4` preserved)
- [x] S3 path works: primes all 8 TPC-H tables from `wadjet-bench-sf10-use2` in ~8 min (600 lineitem files × footer probe)
- [x] Reproduces the Phase 2b SF10 regression locally: Q18 timed out at 5 min, Q20 killed the coordinator, Q21 collateral-failed — exactly the class EC2 caught

## Usage

```bash
AWS_PROFILE=citc ./tpch-harness --mode=local --source=s3 \
  --bucket=wadjet-bench-sf10-use2 --region=us-east-2 \
  --endpoint=s3.us-east-2.amazonaws.com --ssl --data-prefix=tables/ \
  --pg-addr=:15499 --wadjet-bin=./wadjet_bin --no-compare \
  --queries=q18,q20,q21
```

Becomes the pre-deploy gate for any coordinator/distribution change. Follow-up PR (Phase 3 native-DAG execution) depends on this.

## Spec

`docs/superpowers/specs/2026-04-22-distribution-native-dag-execution-design.md` (already on `feat/distribution-property-phase-2`, will migrate in the Phase 3 PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)