### PR TITLE
perf(coordinator): throttle concurrent stage dispatch to bound coord state

### DIFF
--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -119,7 +119,26 @@ func (c *Coordinator) executeStageDAG(
 	for id := range pending {
 		done[id] = make(chan struct{})
 	}
-	c.logger.Info("stage-DAG dispatch", "query", queryID, "stages", len(pending))
+	// Cap how many stages can be dispatching concurrently to keep coord-side
+	// result-collection state (NATS subscriptions, in-flight task batches,
+	// per-stage buffers) bounded. Without this, every "ready" stage in a
+	// wave dispatches simultaneously — for Q18 SF10 (17 stages, multiple
+	// fan-outs ready at once) the resulting coord+worker total RSS routinely
+	// overshoots the host's physical memory and the OS OOM-kills a process.
+	//
+	// 2 * workerCount keeps workers saturated (each worker has typically
+	// max_concurrent>=2 tasks) while bounding the number of in-flight stage
+	// pipelines coord must track to a small multiple of the cluster size.
+	// The semaphore is acquired AFTER all upstream dependencies are
+	// satisfied, so it can never deadlock waiting on a producer that itself
+	// can't acquire a slot.
+	dispatchSlots := 2 * workerCount
+	if dispatchSlots < 2 {
+		dispatchSlots = 2
+	}
+	dispatchSem := make(chan struct{}, dispatchSlots)
+	c.logger.Info("stage-DAG dispatch", "query", queryID,
+		"stages", len(pending), "dispatch_concurrency", dispatchSlots)
 
 	g, gctx := errgroup.WithContext(ctx)
 	for _, s := range pending {
@@ -179,6 +198,17 @@ func (c *Coordinator) executeStageDAG(
 			if err != nil {
 				return fmt.Errorf("stage %s collect inputs: %w", s.ID, err)
 			}
+			// Acquire a dispatch slot now that we have inputs and are
+			// about to publish tasks. Held until the stage completes so
+			// concurrent stage count never exceeds dispatchSlots. Released
+			// via defer so it always fires, even on dispatch error.
+			select {
+			case dispatchSem <- struct{}{}:
+			case <-gctx.Done():
+				return gctx.Err()
+			}
+			defer func() { <-dispatchSem }()
+
 			var out StageOutput
 			switch s.Type {
 			case physical.StageExchangeRepartition:


### PR DESCRIPTION
## Summary

Lever #4 from the SF10 native-DAG handoff. Cap how many stages can dispatch concurrently within a single query so coord-side state (NATS subscriptions, in-flight task batches, per-stage result buffers) stays bounded. Without this, every "ready" stage's goroutine in `executeStageDAG` fires immediately, and on Q18 SF10 the resulting coord+worker total RSS reliably overshoots the box's physical memory — OS OOM-kills a process before the query completes.

## Implementation

Per-query semaphore sized `2 * workerCount`, acquired in each stage's goroutine *after* its dependency wait but *before* dispatch, held until the stage's tasks finish. Released via `defer` so it always fires (even on dispatch error).

```
g.Go(func() error {
  // wait for deps...
  // wait for scalar deps...
  // collect inputs...

  select {
  case dispatchSem <- struct{}{}:
  case <-gctx.Done():
    return gctx.Err()
  }
  defer func() { <-dispatchSem }()

  // dispatchPipelineStage / dispatchShuffleStage / etc.
})
```

## Why `2 * workerCount`

Each worker typically runs `max_concurrent >= 2` tasks. `2 * W` saturates the cluster (workers stay busy, none idle) while keeping the number of concurrent stage pipelines coord tracks to a small multiple of cluster size. For W=2 (today's harness default) → 4 slots. For W=3 → 6 slots. Conservative, predictable.

## Why no deadlock

The semaphore is acquired *after* the goroutine has waited on every dep's `done` channel. A producer that needs a slot can never block its consumer that already holds one — by construction the consumer hasn't acquired yet (it's still waiting in the dep loop).

## What this does NOT do

- Doesn't query worker memory state for adaptive throttling. A "real" memory-pressure-aware dispatcher would inspect heartbeat-extended worker status before granting slots. That's a follow-up; the count-based bound already covers the structural overcommit case from SF10 testing.
- Doesn't change worker-side `max_concurrent` or worker memory budgets — those are independent levers (#5).

## Test plan

- [x] `go test ./internal/coordinator/` — full suite (`TestDistributedTPCH` exercises multi-worker dispatch with the throttle active)
- [x] `go test ./benchmarks/tpch/ -run TestTPCHQueries` — SF0.01 22-query
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)