### PR TITLE
perf(planner): hash-shuffle ahead of grouped final_aggregate

### DIFF
--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -41,6 +41,15 @@ func (c *Coordinator) executeStageDAG(
 	if len(stages) == 0 {
 		return nil, fmt.Errorf("executeStageDAG: empty stage list")
 	}
+	// Clamp to >=1 so dispatchers that key off workerCount (notably
+	// runShuffleSide via splitFilesEvenly) don't silently degrade to a
+	// zero-task no-op when the workers map hasn't yet picked up a
+	// heartbeat. The legacy dispatchers had per-helper clamps; new
+	// shuffle stages spliced by insertHashShuffleBeforeFinalAgg hit the
+	// runShuffleSide path directly and need this enforced upstream.
+	if workerCount < 1 {
+		workerCount = 1
+	}
 
 	// Fail-fast on plan shapes the dispatchers can't consume — see
 	// physical.ValidateNativeDAGShape. The 2026-04-23 SF10 A/B blew 10

--- a/internal/planner/physical/distribution.go
+++ b/internal/planner/physical/distribution.go
@@ -248,12 +248,25 @@ func OutputDistribution(stage Stage, deps map[string]Distribution) Distribution 
 		// Per spec §"OutputDistribution": merge-grouped finals are labeled
 		// hash-partitioned on group-by cols with Count=MergeGroupCount for
 		// symmetry with Trino/Spark. Lone reducers (MergeGroupCount == 0)
-		// are singleton. See spec Risk #1.
+		// are singleton — UNLESS the planner spliced a matching hash-
+		// repartition Exchange directly upstream (insertHashShuffleBeforeFinalAgg
+		// does this for grouped finals), in which case each task computes
+		// disjoint groups and the output is naturally hash-partitioned on
+		// the group keys.
 		if stage.MergeGroupCount > 0 {
 			return Distribution{
 				Kind:  DistHashPartitioned,
 				Keys:  stage.GroupByCols,
 				Count: stage.MergeGroupCount,
+			}
+		}
+		if len(stage.GroupByCols) > 0 && len(stage.Dependencies) == 1 {
+			if dep, ok := deps[stage.Dependencies[0]]; ok && dep.Kind == DistHashPartitioned && keysEqual(dep.Keys, stage.GroupByCols) {
+				return Distribution{
+					Kind:  DistHashPartitioned,
+					Keys:  append([]string(nil), stage.GroupByCols...),
+					Count: dep.Count,
+				}
 			}
 		}
 		return Distribution{Kind: DistSingleton}

--- a/internal/planner/physical/native_dag_rewrite.go
+++ b/internal/planner/physical/native_dag_rewrite.go
@@ -348,3 +348,97 @@ func isMergeTreeFinal(stages []Stage, s *Stage, idIndex map[string]int) bool {
 	}
 	return true
 }
+
+// insertHashShuffleBeforeFinalAgg splices a StageExchangeRepartition (hash by
+// GroupByCols) between every grouped final_aggregate and its sole upstream
+// dep, so the dispatcher can fan the merge across workers. Without this, a
+// Singleton final_aggregate over a fanned-out partial input runs as one task
+// re-aggregating everything serially — the dominant cost for queries like
+// Q18 SF10 where the partial output is large.
+//
+// Why a dedicated pass instead of EnsureDistribution: the property algebra
+// has RequiredClusteredOn satisfied by DistSingleton (a single-worker output
+// is "trivially clustered"), so labeling final_aggregate as
+// RequiredClusteredOn doesn't trigger an exchange when the upstream is a
+// fused-aggregate scan (whose nominal Distribution stays Singleton even
+// though dispatchScanAggregateStage fans it out into N partial files at
+// runtime). Working around that requires either a new DistKind or special-
+// casing scan output, both of which break unrelated callers (notably the
+// merge_aggregate consistency check). A targeted rewrite keeps the property
+// algebra unchanged and only acts on the case that actually benefits.
+//
+// Skips:
+//   - merge_aggregate intermediates (MergeGroupCount > 0): handled by the
+//     existing merge tree shape, output is already labeled hash-partitioned.
+//   - Scalar aggregates (no GROUP BY): nothing to cluster on.
+//   - Multi-dep finals (the dual-level merge tree shape): the upstream is
+//     already a fan-out and the dispatcher's fanout in
+//     dispatchFinalAggregateFanout handles it.
+//   - Stages whose sole dep is already a StageExchangeRepartition with
+//     matching Keys: no-op, exchange already in place.
+func insertHashShuffleBeforeFinalAgg(stages []Stage, workerCount int) []Stage {
+	if workerCount <= 0 {
+		workerCount = 1
+	}
+	idIndex := make(map[string]int, len(stages))
+	for i, s := range stages {
+		idIndex[s.ID] = i
+	}
+
+	out := make([]Stage, 0, len(stages))
+	for _, s := range stages {
+		out = append(out, s)
+	}
+
+	for i := range out {
+		s := &out[i]
+		if s.Type != "final_aggregate" {
+			continue
+		}
+		if s.MergeGroupCount > 0 {
+			continue
+		}
+		if len(s.GroupByCols) == 0 {
+			continue
+		}
+		if len(s.Dependencies) != 1 {
+			continue
+		}
+		// Skip when fuseSortIntoPredecessor has folded sort+limit into
+		// this final_aggregate. Hash-partitioning would let each task
+		// apply Limit independently (e.g., Q10 LIMIT 20 with 3 workers
+		// emits 60 rows) and global sort order can't be reconstructed
+		// from per-partition slices. Both require a Singleton
+		// finalization step that we don't synthesize today.
+		if s.Limit > 0 || len(s.SortKeys) > 0 {
+			continue
+		}
+		depID := s.Dependencies[0]
+		depIdx, ok := idIndex[depID]
+		if !ok {
+			continue
+		}
+		dep := out[depIdx]
+		if dep.Type == StageExchangeRepartition && dep.Exchange != nil &&
+			keysEqual(dep.Exchange.Keys, s.GroupByCols) {
+			continue
+		}
+
+		exchID := fmt.Sprintf("%s-%s", StageExchangeRepartition, s.ID)
+		exch := Stage{
+			ID:           exchID,
+			Type:         StageExchangeRepartition,
+			Dependencies: []string{depID},
+			Exchange: &ExchangeStage{
+				Keys:  append([]string(nil), s.GroupByCols...),
+				Count: workerCount,
+			},
+		}
+		out = append(out, exch)
+		idIndex[exchID] = len(out) - 1
+		// Rewire the final_aggregate by index since &out[i] may now be
+		// invalid after append.
+		out[i].Dependencies = []string{exchID}
+	}
+	return out
+}

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -1193,6 +1193,14 @@ func (p *Planner) PlanDistributed(ctx context.Context, node *logical.Node) ([]St
 		if ensureErr != nil {
 			return nil, fmt.Errorf("ensure distribution: %w", ensureErr)
 		}
+		stages = insertHashShuffleBeforeFinalAgg(stages, p.WorkerCount)
+		// Re-run distribution assignment so stages whose OutputDistribution
+		// depends on (now-spliced) upstream Exchange outputs see the right
+		// inputs. Notably: a grouped final_aggregate whose input is a
+		// freshly-inserted hash-partition Exchange should label its own
+		// output DistHashPartitioned (so the dispatcher fans it out across
+		// workers) instead of the pre-Exchange Singleton.
+		assignStageDistributions(stages, p.WorkerCount)
 		prev := BehaviorPreservingMode
 		BehaviorPreservingMode = false
 		defer func() { BehaviorPreservingMode = prev }()

--- a/internal/planner/physical/testdata/ensure_distribution/q02.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q02.golden
@@ -19,9 +19,10 @@ join-17	broadcast_join	Singleton	deps=join-15,scan-16
 scan-18	scan	Singleton
 join-19	broadcast_join	Singleton	deps=join-17,scan-18
 aggregate-20	aggregate	Singleton	deps=join-19
-final_aggregate-21	final_aggregate	Singleton	deps=aggregate-20
+final_aggregate-21	final_aggregate	Hash(ps_partkey)/4	deps=exchange-repartition-final_aggregate-21
 exchange-repartition-22	exchange-repartition	Hash(p_partkey)/32	deps=join-12
 exchange-repartition-23	exchange-repartition	Hash(ps_partkey)/32	deps=final_aggregate-21
 join-24	hash_join	Hash(p_partkey)/32	deps=exchange-repartition-22,exchange-repartition-23
 sort-25	sort	Singleton	deps=join-24
 exchange-gather-sort-25	exchange-gather	Singleton	deps=sort-25
+exchange-repartition-final_aggregate-21	exchange-repartition	Hash(ps_partkey)/4	deps=aggregate-20

--- a/internal/planner/physical/testdata/ensure_distribution/q15.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q15.golden
@@ -1,12 +1,14 @@
 scan-0	scan	Singleton
 scan-1	scan	Singleton
-final_aggregate-40	final_aggregate	Singleton	deps=scan-1
+final_aggregate-40	final_aggregate	Hash(l_suppkey)/4	deps=exchange-repartition-final_aggregate-40
 exchange-repartition-41	exchange-repartition	Hash(s_suppkey)/32	deps=scan-0
 exchange-repartition-42	exchange-repartition	Hash(l_suppkey)/32	deps=final_aggregate-40
 join-43	hash_join	Hash(s_suppkey)/32	deps=exchange-repartition-41,exchange-repartition-42
 scan-44	scan	Singleton
-final_aggregate-83	final_aggregate	Singleton	deps=scan-44
+final_aggregate-83	final_aggregate	Hash(l_suppkey)/4	deps=exchange-repartition-final_aggregate-83
 aggregate-84	aggregate	Singleton	deps=final_aggregate-83
 final_aggregate-85	final_aggregate	Singleton	deps=aggregate-84
 sort-86	sort	Singleton	deps=join-43
 exchange-gather-sort-86	exchange-gather	Singleton	deps=sort-86
+exchange-repartition-final_aggregate-40	exchange-repartition	Hash(l_suppkey)/4	deps=scan-1
+exchange-repartition-final_aggregate-83	exchange-repartition	Hash(l_suppkey)/4	deps=scan-44

--- a/internal/planner/physical/testdata/ensure_distribution/q17.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q17.golden
@@ -4,10 +4,11 @@ exchange-repartition-2	exchange-repartition	Hash(l_partkey)/32	deps=scan-0
 exchange-repartition-3	exchange-repartition	Hash(p_partkey)/32	deps=scan-1
 join-4	hash_join	Hash(l_partkey)/32	deps=exchange-repartition-2,exchange-repartition-3
 scan-5	scan	Singleton
-final_aggregate-44	final_aggregate	Singleton	deps=scan-5
+final_aggregate-44	final_aggregate	Hash(l_partkey)/4	deps=exchange-repartition-final_aggregate-44
 exchange-repartition-45	exchange-repartition	Hash(p_partkey)/32	deps=join-4
 exchange-repartition-46	exchange-repartition	Hash(l_partkey)/32	deps=final_aggregate-44
 join-47	hash_join	Hash(p_partkey)/32	deps=exchange-repartition-45,exchange-repartition-46
 aggregate-48	aggregate	Singleton	deps=join-47
 final_aggregate-49	final_aggregate	Singleton	deps=aggregate-48
 exchange-gather-final_aggregate-49	exchange-gather	Singleton	deps=final_aggregate-49
+exchange-repartition-final_aggregate-44	exchange-repartition	Hash(l_partkey)/4	deps=scan-5

--- a/internal/planner/physical/testdata/ensure_distribution/q18.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q18.golden
@@ -8,10 +8,11 @@ exchange-repartition-6	exchange-repartition	Hash(o_orderkey)/32	deps=join-4
 exchange-repartition-7	exchange-repartition	Hash(l_orderkey)/32	deps=scan-5
 join-8	hash_join	Hash(o_orderkey)/32	deps=exchange-repartition-6,exchange-repartition-7
 scan-9	scan	Singleton
-final_aggregate-48	final_aggregate	Singleton	deps=scan-9
+final_aggregate-48	final_aggregate	Hash(l_orderkey)/4	deps=exchange-repartition-final_aggregate-48
 exchange-repartition-49	exchange-repartition	Hash(o_orderkey)/32	deps=join-8
 exchange-repartition-50	exchange-repartition	Hash(l_orderkey)/32	deps=final_aggregate-48
 join-51	hash_join	Hash(o_orderkey)/32	deps=exchange-repartition-49,exchange-repartition-50
 aggregate-52	aggregate	Singleton	deps=join-51
 final_aggregate-53	final_aggregate	Singleton	deps=aggregate-52
 exchange-gather-final_aggregate-53	exchange-gather	Singleton	deps=final_aggregate-53
+exchange-repartition-final_aggregate-48	exchange-repartition	Hash(l_orderkey)/4	deps=scan-9

--- a/internal/planner/physical/testdata/ensure_distribution/q20.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q20.golden
@@ -7,7 +7,7 @@ exchange-repartition-5	exchange-repartition	Hash(ps_partkey)/32	deps=scan-3
 exchange-repartition-6	exchange-repartition	Hash(p_partkey)/32	deps=scan-4
 join-7	hash_join	Hash(ps_partkey)/32	deps=exchange-repartition-5,exchange-repartition-6
 scan-8	scan	Singleton
-final_aggregate-47	final_aggregate	Singleton	deps=scan-8
+final_aggregate-47	final_aggregate	Hash(l_partkey,l_suppkey)/4	deps=exchange-repartition-final_aggregate-47
 exchange-repartition-48	exchange-repartition	Hash(ps_partkey,ps_suppkey)/32	deps=join-7
 exchange-repartition-49	exchange-repartition	Hash(l_partkey,l_suppkey)/32	deps=final_aggregate-47
 join-50	hash_join	Hash(ps_partkey,ps_suppkey)/32	deps=exchange-repartition-48,exchange-repartition-49
@@ -16,3 +16,4 @@ exchange-repartition-52	exchange-repartition	Hash(ps_suppkey)/32	deps=join-50
 join-53	hash_join	Hash(s_suppkey)/32	deps=exchange-repartition-51,exchange-repartition-52
 sort-54	sort	Singleton	deps=join-53
 exchange-gather-sort-54	exchange-gather	Singleton	deps=sort-54
+exchange-repartition-final_aggregate-47	exchange-repartition	Hash(l_partkey,l_suppkey)/4	deps=scan-8


### PR DESCRIPTION
## Summary

Lever #2 unlock from the SF10 native-DAG handoff. Today a grouped `final_aggregate` over a Singleton-distributed partial input runs as a single Singleton task that re-aggregates every partial serially — for Q18 SF10 the `scan-9 → final_aggregate-48` hop is the dominant cost and #51's dispatch-time fanout doesn't fire because K = workerCount.

This PR splices a `StageExchangeRepartition` (hash by `GroupByCols`) ahead of every grouped `final_aggregate` so each downstream merge task sees disjoint group keys — the merge fans out across workers with no global re-aggregate needed.

## ⚠️ Integration regression on small boxes — hold for review

CI green, planner+coord unit tests pass, **but** Q18 SF10 integration on a 32 GB box with `numWorkers=2` regresses:

| Config | Wall | Stages done | Peak heap | Outcome |
|---|---|---|---|---|
| cache only (#49) baseline | 28s | 0 | 15 GB | OOM |
| cache + #51 fanout | 115s | 3 (scan-9 done) | 11 GB | OOM |
| cache + #51 + #52 + #53 | 4.5min | 1 | 20 GB | OOM |

The extra exchange stage adds memory pressure under `numWorkers=2` on a 32 GB box (3 wadjet processes overcommitting RAM). #52's dispatch throttle bounds *stage* count but not per-stage *task* burst — scan stages alone stampede before the new exchange ever runs.

**Recommend hold until lever #5 (worker max_concurrent backpressure) lands.** With #5 in place, the per-stage task burst is bounded and the extra-stage memory cost should be tractable. The architectural primitive itself is sound (planner unit tests + golden snapshots + 22-query SF0.01 + coord suite all green); it just trips a separate memory-overcommit issue at SF10 with the current dispatcher.

## Implementation

**Three pieces:**

1. **New rewrite pass `insertHashShuffleBeforeFinalAgg`** in `internal/planner/physical/native_dag_rewrite.go`, runs after `EnsureDistribution`. For every grouped `final_aggregate` with a single dep that isn't already a matching exchange, it splices an `Exchange{Type:Repartition, Keys:GroupByCols, Count:workerCount}` between the dep and the final.

   Why a dedicated pass instead of teaching `RequiredChildDistribution` the new rule: `RequiredClusteredOn` is satisfied by `DistSingleton` (a single-worker output is "trivially clustered"), so a downstream `ClusteredOn(GroupByCols)` check would NOT trigger an exchange when the upstream is a fused-aggregate scan (whose nominal `Distribution` is `Singleton` even though `dispatchScanAggregateStage` fans it out into N partial files at runtime). Working around that requires either a new `DistKind` or special-casing scan output, both of which break unrelated callers (notably the `merge_aggregate` intermediate consistency check on Q01/Q15/Q17/Q18/Q20).

2. **`OutputDistribution`** for grouped non-tree `final_aggregate` now inherits `HashPartitioned` when its (now-spliced) input is `HashPartitioned` with matching keys, so the dispatcher sees `DistHashPartitioned` and fans the stage out to N tasks.

3. **`assignStageDistributions` runs a second time** after `EnsureDistribution` + the new pass so the spliced Exchange's hash-partitioned output propagates to the `final_aggregate`'s own Distribution.

**Plus two corner-case fixes uncovered along the way:**

4. **Skip when `s.Limit > 0 || len(s.SortKeys) > 0`**: `fuseSortIntoPredecessor` folds `Sort + LIMIT` into the `final_aggregate`. With my hash-fanout each partition's task applied LIMIT independently → Q10 `LIMIT 20` × 3 workers = 60 rows. Both LIMIT and global sort require Singleton finalization that we don't synthesize here.

5. **`workerCount = 1` clamp at `executeStageDAG` entry**: `runShuffleSide`'s `splitFilesEvenly(files, 0)` returns 0 tasks → silent zero-output. Test setups that query before the worker registers a heartbeat (e.g., `TestDistributedAggregateQuery`) hit this. Legacy dispatchers had per-helper clamps; the new path needs this enforced upstream.

## Skips (intentional)

- `merge_aggregate` intermediates (`MergeGroupCount > 0`): existing merge tree shape already labels output partitioned.
- Scalar aggregates (no `GROUP BY`): nothing to cluster on.
- Multi-dep finals (dual-level merge tree): `dispatchFinalAggregateFanout` (#51) handles.
- Stages whose sole dep is already a matching `StageExchangeRepartition`: no-op.
- Final aggregate with `Limit > 0` or `SortKeys != ∅`: would break LIMIT / global ORDER.

## Test plan

- [x] `go test ./internal/planner/...` — unit + plan tests + 22 golden snapshots regenerated
- [x] `go test ./benchmarks/tpch/ -run TestTPCHQueries` — SF0.01 22-query
- [x] `go test ./internal/worker/`
- [x] `go test ./internal/coordinator/` — full suite (one flaky pre-existing `TestLeaderElection_LeaseRefresh` passes 3/3 in isolation)
- [x] CI green on this branch
- [ ] **Q18 SF10 integration shows regression** — see warning section above. Hold for lever #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)