### PR TITLE
perf(coordinator): size dispatch concurrency from cluster capacity

### DIFF
--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -132,13 +132,29 @@ func (c *Coordinator) executeStageDAG(
 	// The semaphore is acquired AFTER all upstream dependencies are
 	// satisfied, so it can never deadlock waiting on a producer that itself
 	// can't acquire a slot.
-	dispatchSlots := 2 * workerCount
+	// Source the slot count from the actual cluster capacity (sum of each
+	// worker's auto-tuned max_concurrent reported in heartbeats) when
+	// available. Workers downscale max_concurrent under memory pressure
+	// (auto-detected memory budget logic in cmd/wadjet), so this gives the
+	// dispatcher a memory-aware backpressure signal: if every worker has
+	// shrunk to max_concurrent=2 because the box is tight, dispatch only
+	// queues that many stages at a time instead of stampeding 8+ in a wave.
+	// Falls back to 2 * workerCount when no worker has reported
+	// MaxConcurrent yet (cluster startup, legacy workers).
+	dispatchSlots := c.workers.ClusterCapacity()
+	dispatchSource := "cluster_capacity"
+	if dispatchSlots <= 0 {
+		dispatchSlots = 2 * workerCount
+		dispatchSource = "fallback_2x_workerCount"
+	}
 	if dispatchSlots < 2 {
 		dispatchSlots = 2
+		dispatchSource = "floor"
 	}
 	dispatchSem := make(chan struct{}, dispatchSlots)
 	c.logger.Info("stage-DAG dispatch", "query", queryID,
-		"stages", len(pending), "dispatch_concurrency", dispatchSlots)
+		"stages", len(pending), "dispatch_concurrency", dispatchSlots,
+		"dispatch_source", dispatchSource)
 
 	g, gctx := errgroup.WithContext(ctx)
 	for _, s := range pending {

--- a/internal/coordinator/workers.go
+++ b/internal/coordinator/workers.go
@@ -12,12 +12,13 @@ import (
 
 // WorkerInfo tracks the state of a registered worker.
 type WorkerInfo struct {
-	WorkerID    string
-	ClusterID   string
-	MemoryUsed  int64
-	MemoryTotal int64
-	Draining    bool
-	LastSeen    time.Time
+	WorkerID      string
+	ClusterID     string
+	MaxConcurrent int   // effective task-slot count reported in heartbeat; 0 = legacy worker (assume default)
+	MemoryUsed    int64
+	MemoryTotal   int64
+	Draining      bool
+	LastSeen      time.Time
 }
 
 // TaskLiveness tracks when each in-flight task was last reported active.
@@ -127,6 +128,7 @@ func (wr *WorkerRegistry) record(hb distributed.WorkerHeartbeat) {
 		wr.workers[hb.WorkerID] = info
 	}
 	info.ClusterID = hb.ClusterID
+	info.MaxConcurrent = hb.MaxConcurrent
 	info.MemoryUsed = hb.MemoryUsed
 	info.MemoryTotal = hb.MemoryTotal
 	info.Draining = hb.Draining
@@ -163,6 +165,30 @@ func (wr *WorkerRegistry) ActiveWorkers() []*WorkerInfo {
 // Count returns the number of active workers.
 func (wr *WorkerRegistry) Count() int {
 	return len(wr.ActiveWorkers())
+}
+
+// ClusterCapacity returns the sum of effective task-slot counts across
+// active (non-draining, non-stale) workers, taken from the most recent
+// heartbeat each worker reported. Workers running pre-MaxConcurrent-in-
+// heartbeat builds report 0; those are skipped here so the result reflects
+// only workers we have honest capacity data for. Returns 0 when no worker
+// has reported MaxConcurrent yet — callers should fall back to a
+// conservative static cap (e.g. 2 * Count).
+func (wr *WorkerRegistry) ClusterCapacity() int {
+	wr.mu.RLock()
+	defer wr.mu.RUnlock()
+	cutoff := time.Now().Add(-wr.stale)
+	total := 0
+	for _, w := range wr.workers {
+		if !w.LastSeen.After(cutoff) || w.Draining {
+			continue
+		}
+		if w.MaxConcurrent <= 0 {
+			continue
+		}
+		total += w.MaxConcurrent
+	}
+	return total
 }
 
 // ReapStale removes workers that haven't sent a heartbeat recently.

--- a/internal/distributed/messages.go
+++ b/internal/distributed/messages.go
@@ -284,6 +284,7 @@ type TaskStats struct {
 type WorkerHeartbeat struct {
 	WorkerID      string    `json:"worker_id"`
 	ClusterID     string    `json:"cluster_id,omitempty"` // cluster this worker belongs to
+	MaxConcurrent int       `json:"max_concurrent,omitempty"`  // worker's effective task slot count (after auto-tuning); 0 = unknown
 	ActiveTasks   int       `json:"active_tasks"`
 	ActiveTaskIDs []string  `json:"active_task_ids,omitempty"` // task IDs currently executing
 	MemoryUsed    int64     `json:"memory_used"`

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -699,6 +699,7 @@ func (w *Worker) heartbeatLoop(ctx context.Context, sem chan struct{}) {
 			hb := distributed.WorkerHeartbeat{
 				WorkerID:      w.config.WorkerID,
 				ClusterID:     w.config.ClusterID,
+				MaxConcurrent: w.config.MaxConcurrent,
 				ActiveTasks:   len(sem),
 				ActiveTaskIDs: taskIDs,
 				MemoryUsed:    int64(memStats.Alloc),


### PR DESCRIPTION
## Summary

Lever #5 from the SF10 native-DAG handoff. The static throttle from #52 caps concurrent stage dispatches at `2 * workerCount`. That works as a safety floor but doesn't react to workers' auto-tuned memory budgets — a worker that has shrunk its `max_concurrent` from 4 down to 2 because GOMEMLIMIT is tight is still treated as "2 slots wide" by the dispatcher, even though the worker itself only has 2 task slots and any extra in-flight stages just queue in NATS while their result-collection state pins coord memory.

This wires the worker's effective `max_concurrent` through to the dispatcher:

- `WorkerHeartbeat` carries `max_concurrent` (the worker's currently effective slot count, post-auto-tune).
- `WorkerInfo` + `WorkerRegistry` record it per worker.
- `WorkerRegistry.ClusterCapacity()` sums across active, non-draining workers (skipping any that haven't yet reported the field — legacy workers and cluster-startup-before-first-heartbeat).
- `executeStageDAG` sources `dispatchSlots` from `ClusterCapacity`, falling back to `2 * workerCount` when capacity is unknown and clamping to a floor of 2.

Now when workers downscale `max_concurrent` under memory pressure, the dispatcher contracts in lockstep — the per-stage task burst that sank the lever-#2B integration on a 32 GB box (worker cluster reported 4 slots while coord queued 8+ stages) gets bounded honestly instead of relying on a static heuristic.

`dispatch_source` (`cluster_capacity` / `fallback_2x_workerCount` / `floor`) logged alongside `dispatch_concurrency` so post-mortems can tell which path was active.

## Why this is the right shape

Workers already self-tune `max_concurrent` based on physical memory ÷ per-task budget (cmd/wadjet auto-detect). They're the source of truth for "how many tasks I can hold without OOM". The dispatcher previously ignored that signal and used a static cluster-size proxy. This change closes the loop.

Future memory-reactive throttles (V2: gate dispatch on heartbeat-reported live `MemoryUsed` headroom) layer naturally on top of the same heartbeat path; this PR is the prerequisite plumbing.

## Test plan

- [x] `go test ./internal/distributed/` — heartbeat marshal round-trip with the new field
- [x] `go test ./internal/worker/`
- [x] `go test ./benchmarks/tpch/ -run TestTPCHQueries` — SF0.01 22-query
- [x] `go test ./internal/coordinator/` — full suite (228s, all green modulo pre-existing flaky `TestLeaderElection_LeaseRefresh`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)