### PR TITLE
feat(harness): add --workers flag for local mode

### DIFF
--- a/cmd/tpch-harness/main.go
+++ b/cmd/tpch-harness/main.go
@@ -32,6 +32,7 @@ func main() {
 		endpoint       = flag.String("endpoint", "s3.us-east-2.amazonaws.com", "S3 endpoint (source=s3)")
 		ssl            = flag.Bool("ssl", true, "use SSL for S3 (source=s3)")
 		dataPrefix     = flag.String("data-prefix", "tables/", "S3 prefix under --bucket containing table data (source=s3)")
+		numWorkers     = flag.Int("workers", 0, "number of worker processes to spawn (local mode); 0 = default of 2. Set to 1 to avoid 2-process memory overcommit on small dev boxes when measuring SF10+.")
 	)
 	flag.Parse()
 
@@ -56,6 +57,7 @@ func main() {
 		NoCompare:      *noCompare,
 		WadjetBin:      *wadjetBin,
 		PgAddr:         *pgAddr,
+		NumWorkers:     *numWorkers,
 		Source:         *source,
 		Bucket:         *bucket,
 		Region:         *region,

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -58,7 +58,10 @@ func Run(ctx context.Context, cfg Config, logger *slog.Logger) (RunResult, error
 	switch cfg.Mode {
 	case ModeLocal:
 		sliceCfg := SliceConfigs[cfg.Slice]
-		const numWorkers = 2
+		numWorkers := cfg.NumWorkers
+		if numWorkers <= 0 {
+			numWorkers = 2 // historical default — preserves prior behavior
+		}
 		pf := CheckPreflight(sliceCfg, runDir, numWorkers)
 		if !pf.OK {
 			return result, fmt.Errorf("preflight failed:\n  - %s", pf.Error())

--- a/internal/harness/types.go
+++ b/internal/harness/types.go
@@ -42,6 +42,7 @@ type Config struct {
 	NoCompare      bool
 	WadjetBin      string // path to wadjet binary; auto-built if empty
 	PgAddr         string // local only; override for coordinator pgwire listen addr
+	NumWorkers     int    // local only; cluster size to spawn (0 = default of 2)
 
 	// S3 source (Source=="s3" only)
 	Source     string // "local" (default) or "s3"


### PR DESCRIPTION
Replaces hardcoded `const numWorkers = 2` in `internal/harness/harness.go` with a `Config.NumWorkers` field plus a `--workers` CLI flag.

Default stays 2 (preserves prior behavior). Setting `--workers=1` lets SF10+ measurements run on memory-constrained dev boxes (32 GB host, 2 worker processes × ~23 GB GOMEMLIMIT each = overcommit) without the 2-process OS-OOM artifact that doesn't reflect AWS deployment reality (one worker per c7g.4xlarge has the full host to itself).

Local harness is a cheap regression / correctness gate, not a performance proxy for AWS — this flag lets us match the deployment topology when that matters.

## Test plan

- [x] `go test ./internal/harness/` — pkg green
- [x] `go test -run TestTPCHQueries ./benchmarks/tpch/` — SF0.01 22-query
- [x] `go test -run 'TestTPCHNativeDAG_SF001|TestTPCHNativeDAG_SF01|TestDistributedTPCH' ./internal/coordinator/` — distributed SF0.01/SF0.1
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)