### PR TITLE
perf(coordinator): replace fixed stage timeout with progress-based detection

### DIFF
--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -23,6 +23,41 @@ import (
 // aggregation stages don't falsely time out.
 const gatherReceiveTimeout = 10 * time.Minute
 
+// awaitStageProgress blocks until either every dispatched task has reported
+// a result (signalled via allDone) or progress has stalled for longer than
+// stageIdleTimeout. Each task-completion subscription handler should send
+// (non-blocking) to progress on every result. The absolute wall-clock cap
+// shuffleStageTimeout still applies as a backstop for pathological cases
+// where progress signals leak (lost NATS subscription).
+//
+// Returns nil on completion, ctx.Err() on cancellation, or a stuck/timeout
+// error otherwise.
+func awaitStageProgress(ctx context.Context, allDone <-chan struct{}, progress <-chan struct{}, label string) error {
+	const tickEvery = 30 * time.Second
+	ticker := time.NewTicker(tickEvery)
+	defer ticker.Stop()
+	lastProgress := time.Now()
+	deadline := time.Now().Add(shuffleStageTimeout)
+	for {
+		select {
+		case <-allDone:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-progress:
+			lastProgress = time.Now()
+		case now := <-ticker.C:
+			if now.Sub(lastProgress) > stageIdleTimeout {
+				return fmt.Errorf("stage %s: idle for %s with no task progress (likely worker crash, deadlock, or lost result publish)",
+					label, stageIdleTimeout)
+			}
+			if now.After(deadline) {
+				return fmt.Errorf("stage %s: exceeded absolute timeout %s", label, shuffleStageTimeout)
+			}
+		}
+	}
+}
+
 // executeStageDAG is the native-DAG distributed executor. It walks the
 // Exchange-annotated stage DAG in topological order, dispatches each
 // stage via its Type-specific helper, records outputs in a per-query
@@ -734,6 +769,7 @@ func (c *Coordinator) dispatchScanAggregateStage(
 	collected := make([]taskResult, 0, len(tasks))
 	var mu sync.Mutex
 	done := make(chan struct{}, 1)
+	progress := make(chan struct{}, len(tasks))
 	sub, err := c.nc.Subscribe(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
 		if uerr := distributed.Unmarshal(msg.Data, &r); uerr != nil {
@@ -747,6 +783,10 @@ func (c *Coordinator) dispatchScanAggregateStage(
 		}
 		got := len(collected)
 		mu.Unlock()
+		select {
+		case progress <- struct{}{}:
+		default:
+		}
 		if got >= len(tasks) {
 			select {
 			case done <- struct{}{}:
@@ -762,12 +802,8 @@ func (c *Coordinator) dispatchScanAggregateStage(
 	if err := c.scheduler.PublishTasks(ctx, tasks); err != nil {
 		return StageOutput{}, fmt.Errorf("scan-agg stage %s publish: %w", stage.ID, err)
 	}
-	select {
-	case <-done:
-	case <-ctx.Done():
-		return StageOutput{}, ctx.Err()
-	case <-time.After(shuffleStageTimeout):
-		return StageOutput{}, fmt.Errorf("scan-agg stage %s timeout", stage.ID)
+	if err := awaitStageProgress(ctx, done, progress, "scan-agg "+stage.ID); err != nil {
+		return StageOutput{}, err
 	}
 
 	mu.Lock()
@@ -845,6 +881,7 @@ func (c *Coordinator) dispatchScanFilterStage(
 	var collected []taskResult
 	var mu sync.Mutex
 	done := make(chan struct{}, 1)
+	progress := make(chan struct{}, 1)
 	sub, err := c.nc.Subscribe(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
 		if uerr := distributed.Unmarshal(msg.Data, &r); uerr != nil {
@@ -858,6 +895,10 @@ func (c *Coordinator) dispatchScanFilterStage(
 		}
 		got := len(collected)
 		mu.Unlock()
+		select {
+		case progress <- struct{}{}:
+		default:
+		}
 		if got >= 1 {
 			select {
 			case done <- struct{}{}:
@@ -872,12 +913,8 @@ func (c *Coordinator) dispatchScanFilterStage(
 	if err := c.scheduler.PublishTasks(ctx, []distributed.Task{task}); err != nil {
 		return StageOutput{}, fmt.Errorf("scan-filter stage %s publish: %w", stage.ID, err)
 	}
-	select {
-	case <-done:
-	case <-ctx.Done():
-		return StageOutput{}, ctx.Err()
-	case <-time.After(shuffleStageTimeout):
-		return StageOutput{}, fmt.Errorf("scan-filter stage %s timeout", stage.ID)
+	if err := awaitStageProgress(ctx, done, progress, "scan-filter "+stage.ID); err != nil {
+		return StageOutput{}, err
 	}
 	mu.Lock()
 	defer mu.Unlock()
@@ -1062,6 +1099,7 @@ func (c *Coordinator) dispatchComputeStage(
 	collected := make([]taskResult, 0, len(tasks))
 	var mu sync.Mutex
 	done := make(chan struct{}, 1)
+	progress := make(chan struct{}, len(tasks))
 	sub, err := c.nc.Subscribe(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
 		if err := distributed.Unmarshal(msg.Data, &r); err != nil {
@@ -1075,6 +1113,10 @@ func (c *Coordinator) dispatchComputeStage(
 		}
 		got := len(collected)
 		mu.Unlock()
+		select {
+		case progress <- struct{}{}:
+		default:
+		}
 		if got >= len(tasks) {
 			select {
 			case done <- struct{}{}:
@@ -1094,17 +1136,13 @@ func (c *Coordinator) dispatchComputeStage(
 		return StageOutput{}, fmt.Errorf("stage %s: publish: %w", stage.ID, err)
 	}
 
-	select {
-	case <-done:
-		c.logger.Info("compute stage complete", "stage_id", stage.ID, "tasks", len(tasks))
-	case <-ctx.Done():
+	if err := awaitStageProgress(ctx, done, progress, "compute "+stage.ID); err != nil {
 		mu.Lock()
 		got := len(collected)
 		mu.Unlock()
-		return StageOutput{}, fmt.Errorf("stage %s: ctx done with %d/%d results: %w", stage.ID, got, len(tasks), ctx.Err())
-	case <-time.After(shuffleStageTimeout):
-		return StageOutput{}, fmt.Errorf("stage %s: timed out after %s", stage.ID, shuffleStageTimeout)
+		return StageOutput{}, fmt.Errorf("stage %s with %d/%d results: %w", stage.ID, got, len(tasks), err)
 	}
+	c.logger.Info("compute stage complete", "stage_id", stage.ID, "tasks", len(tasks))
 
 	mu.Lock()
 	results := make([]taskResult, len(collected))
@@ -1353,6 +1391,7 @@ func (c *Coordinator) runStageTasks(
 	collected := make([]taskResult, 0, len(tasks))
 	var mu sync.Mutex
 	done := make(chan struct{}, 1)
+	progress := make(chan struct{}, len(tasks))
 	sub, err := c.nc.Subscribe(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
 		if uerr := distributed.Unmarshal(msg.Data, &r); uerr != nil {
@@ -1366,6 +1405,10 @@ func (c *Coordinator) runStageTasks(
 		}
 		got := len(collected)
 		mu.Unlock()
+		select {
+		case progress <- struct{}{}:
+		default:
+		}
 		if got >= len(tasks) {
 			select {
 			case done <- struct{}{}:
@@ -1381,12 +1424,8 @@ func (c *Coordinator) runStageTasks(
 	if err := c.scheduler.PublishTasks(ctx, tasks); err != nil {
 		return nil, fmt.Errorf("stage %s: publish: %w", stageLabel, err)
 	}
-	select {
-	case <-done:
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-time.After(shuffleStageTimeout):
-		return nil, fmt.Errorf("stage %s: timeout after %s", stageLabel, shuffleStageTimeout)
+	if err := awaitStageProgress(ctx, done, progress, stageLabel); err != nil {
+		return nil, err
 	}
 
 	mu.Lock()

--- a/internal/coordinator/orchestrate_repartition.go
+++ b/internal/coordinator/orchestrate_repartition.go
@@ -24,8 +24,22 @@ var shuffleBuildThreshold int64 = 4 * 1024 * 1024 * 1024 // 4 GB
 // 4 reduces hot-key skew impact while keeping file count bounded.
 const shufflePartitionMultiplier = 4
 
-// shuffleStageTimeout is the per-shuffle-stage timeout. Phase 1: no per-stage retry.
-const shuffleStageTimeout = 10 * time.Minute
+// shuffleStageTimeout is the absolute upper bound a stage is allowed to run.
+// It's intentionally generous because the actual stuck-stage detection is
+// progress-based (see awaitStageProgress in execute_stage_dag.go): a stage is
+// considered stuck only when no task has reported a result in
+// stageIdleTimeout. The wall-clock cap here is the belt-and-suspenders for
+// pathological cases where progress signals leak (lost subscription, NATS
+// partition) and we still need to bail out.
+const shuffleStageTimeout = 60 * time.Minute
+
+// stageIdleTimeout is how long a stage may go without observing any task
+// completion before it's declared stuck. Replaces the old fixed-wall-clock
+// shuffleStageTimeout in the dispatch+collect loops: a stage that's slow but
+// reporting completions every few minutes is fine; one that has gone silent
+// for stageIdleTimeout is broken (worker crashed, deadlock, lost result
+// publish).
+const stageIdleTimeout = 10 * time.Minute
 
 // ShuffleLayout describes the shard file layout produced by the two-sided
 // shuffle stages. The caller (coordinator routing path) constructs probe

--- a/internal/coordinator/workers.go
+++ b/internal/coordinator/workers.go
@@ -82,15 +82,16 @@ func NewWorkerRegistry(nc *nats.Conn, logger *slog.Logger, staleTTL time.Duratio
 		logger = slog.Default()
 	}
 	if staleTTL <= 0 {
-		// Default: 10 minutes. Workers under heavy compute load with
-		// GOGC=off may not schedule their heartbeat goroutine for
-		// 30+ seconds. At SF100, build-cache pre-scans and large hash
-		// table builds can stall heartbeats for minutes. The previous
-		// 5-minute TTL caused stale reaping during build cache scans
-		// of ~8GB tables from S3. 10 minutes provides enough buffer
-		// while still detecting truly dead workers within a reasonable
-		// window.
-		staleTTL = 10 * time.Minute
+		// Default: 30 minutes. Workers under heavy compute load with
+		// GOGC=off may stall their heartbeat goroutine for many minutes
+		// (runtime.ReadMemStats does a stop-the-world; large hash builds
+		// + back-to-back GCs leave little scheduler space). The 26 April
+		// SF10 AWS run reaped workers during 10m+ shuffle stages even
+		// though the workers were alive and progressing — false positives
+		// shut down the cluster mid-query. 30 minutes accommodates the
+		// observed worst-case heartbeat gap on SF10 c7g.4xlarge while
+		// still detecting truly dead workers eventually.
+		staleTTL = 30 * time.Minute
 	}
 
 	wr := &WorkerRegistry{


### PR DESCRIPTION
## Summary

The 10m-wall-clock per-stage cap fired on Q03/Q04/Q05 in the 26 April SF10 AWS run even though stages were genuinely making progress (S3-bound lineitem shuffle reads — heavy but not stuck). The cap was calibrated for SF1; at SF10 it kills legitimately-long stages.

Replace the fixed wall-clock cap with progress-based detection: a stage is \"stuck\" only when no task has reported a result in \`stageIdleTimeout\` (10m). Stages that complete tasks every minute or two — even if total wall time exceeds 10m — keep running. The absolute \`shuffleStageTimeout\` becomes a backstop (60m) for pathological cases where progress signals leak (lost subscription, NATS partition).

## Why this is the right shape

The old fixed cap conflated two failure modes:

1. **Stuck stage** (worker crash, deadlock, lost result publish) — should fail fast
2. **Slow stage** (heavy I/O, large datasets) — should be allowed to complete

Idle-time tracking distinguishes them honestly. SF1's 1-min stages and SF10's 30-min lineitem shuffles both work correctly without query-specific tuning.

## Implementation

- New \`awaitStageProgress(ctx, allDone, progress, label) error\` helper.
- Each dispatch+collect site (\`dispatchScanAggregateStage\`, \`dispatchScanFilterStage\`, \`dispatchComputeStage\`, \`runStageTasks\`) sends a non-blocking progress signal from its NATS result handler and waits via \`awaitStageProgress\` instead of \`time.After(shuffleStageTimeout)\`.
- 4 call sites converted; behavior identical for fast stages, more lenient for slow-but-progressing ones.

## Plus: bump worker stale TTL from 10m to 30m

Workers under SF10 GOGC=off compute can stall heartbeats for 20+ min when \`runtime.ReadMemStats\` (which does stop-the-world) contends with back-to-back GCs. The old 10m TTL caused premature worker reap during legitimate work in the same AWS run. 30m accommodates the observed worst-case heartbeat gap on c7g.4xlarge while still surfacing truly-dead workers eventually.

The deeper fix — decouple liveness from \`ReadMemStats\` STW (e.g., separate \"alive\" heartbeat without memstats) — is bigger and tracked separately.

## Test plan

- [x] \`go test ./internal/planner/... ./internal/worker/\` — green
- [x] \`go test ./benchmarks/tpch/ -run TestTPCHQueries\` — SF0.01 22-query
- [x] \`go test ./internal/coordinator/\` — full suite (modulo two pre-existing env-dependent SF100Sample tests requiring \`/tmp/sf100-sample\` parquet files)
- [ ] CI green
- [ ] AWS SF10 redeploy (this is the actual verification — local SF10 has artifacts that don't reflect AWS reality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)