### PR TITLE
chore(deploy): bump SF10/SF100 query_timeout from 10m to 30m

### DIFF
--- a/deploy/benchmark/terraform/sf10-distributed.tfvars
+++ b/deploy/benchmark/terraform/sf10-distributed.tfvars
@@ -9,4 +9,4 @@ worker_instance_type      = "c7g.4xlarge"  # 16 vCPU, 32 GB (2xlarge OOM'd Q21)
 worker_count              = 3
 data_bucket              = "wadjet-bench-sf10-use2"
 skip_queries             = ""
-query_timeout            = "10m"
+query_timeout            = "30m"  # SF10 heavy queries (Q03/Q05/Q21 lineitem joins) need >10m; the 26 April AWS run hit the 10m cap on Q03 even though stages were progressing

--- a/deploy/benchmark/terraform/sf100-distributed.tfvars
+++ b/deploy/benchmark/terraform/sf100-distributed.tfvars
@@ -9,3 +9,4 @@ mode                      = "distributed"
 coordinator_instance_type = "c7g.2xlarge"   # 8 vCPU, 16 GB
 worker_instance_type      = "c7gd.4xlarge"  # 16 vCPU, 32 GB, 237 GB NVMe
 worker_count              = 3
+query_timeout             = "30m"           # SF100 heavy queries need >10m default; mirrors sf10-distributed


### PR DESCRIPTION
The 10m cap was calibrated for SF1; at SF10 it cuts off Q03/Q05/Q21 even when stages are genuinely progressing.

In the 26 April AWS run Q03 hit the 10m cap, then with the cap raised to 30m completed in 6m05s. Coord-side stage timeout is now progress-based (#56) but the bench-runner enforces its own outer per-query cap and that's what was firing.

30m gives SF10 actual workloads room without losing the dead-stage detection signal entirely. SF100 inherits the same default for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)