### PR TITLE
perf(coordinator): probe-split broadcast_join in native-DAG

### DIFF
--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -1024,23 +1024,28 @@ func (c *Coordinator) dispatchComputeStage(
 		// Unknown distribution — fall back to 1 rather than workerCount.
 		numTasks = 1
 	}
-	// NB: stage.Tasks from the legacy planner encodes probe-split intent
-	// (e.g., Tasks=workerCount for broadcast_join means "split probe files
-	// across N workers"). That semantics assumes each task receives a
-	// DIFFERENT slice of probe files — which only works if the coordinator
-	// slices probe input per task. Native-DAG dispatch today hands every
-	// Singleton-stage task the same full probe set (partitionFilesForWorker
-	// on Singleton input returns the full list for every worker), so
-	// honoring stage.Tasks=N duplicates the full scan/join N× and triples
-	// the worker memory pressure. Until native-DAG grows probe-split
-	// semantics, Distribution is the authoritative signal and stage.Tasks
-	// is intentionally ignored here.
+	// Probe-split for broadcast_join: when the planner picks DistSingleton
+	// (because probe upstream is a leaf scan with DistSingleton output), the
+	// join would otherwise run as a single task on one worker — the entire
+	// probe scan + hash probe is serialized. When workerCount > 1 and the
+	// probe upstream is a multi-file OutputSinglePart, fan out to
+	// min(workerCount, len(probeFiles)) tasks each scanning 1/N of probe
+	// files. The build is broadcast (every task reads the same OutputSinglePart
+	// Files[0]), so memory pressure stays bounded — the per-task hash table
+	// is identical to the single-task case. Only the probe scan + probe
+	// compute is parallelized.
+	probeSplit := false
+	if n, ok := broadcastJoinProbeSplit(stage, inputs, workerCount, numTasks); ok {
+		numTasks = n
+		probeSplit = true
+	}
 	resultPrefix := fmt.Sprintf("queries/%s/%s/", queryID, stage.ID)
 	c.logger.Info("dispatchComputeStage",
 		"stage_id", stage.ID, "stage_type", stage.Type,
 		"deps", stage.Dependencies, "num_tasks", numTasks,
 		"distribution_kind", stage.Distribution.Kind,
 		"distribution_count", stage.Distribution.Count,
+		"probe_split", probeSplit,
 		"inputs_aliases", len(inputs))
 
 	// Build one task per output partition. Input slicing uses numTasks as
@@ -1049,7 +1054,13 @@ func (c *Coordinator) dispatchComputeStage(
 	// Hash-partitioned N-task stages each task reads its N-th partition.
 	tasks := make([]distributed.Task, 0, numTasks)
 	for w := 0; w < numTasks; w++ {
-		taskInputs, err := buildTaskInputsForStage(stage, inputs, w, numTasks)
+		var taskInputs map[string][]string
+		var err error
+		if probeSplit {
+			taskInputs, err = buildTaskInputsForBroadcastJoinSplitProbe(stage, inputs, w, numTasks)
+		} else {
+			taskInputs, err = buildTaskInputsForStage(stage, inputs, w, numTasks)
+		}
 		if err != nil {
 			return StageOutput{}, fmt.Errorf("stage %s worker %d: %w", stage.ID, w, err)
 		}
@@ -1201,6 +1212,23 @@ func (c *Coordinator) dispatchComputeStage(
 		kind = OutputPartitioned
 	case physical.DistBroadcast:
 		kind = OutputReplicated
+	}
+	if probeSplit {
+		// Probe-split fan-out keeps the planner's DistSingleton labelling but
+		// produces N physical files (one per probe-slice task). Collapse all
+		// per-task files into Files[0] so OutputSinglePart consumers (which
+		// read only Files[0]) see the full join result. Downstream parallelism
+		// is preserved by finalAggregateFanoutCandidate / flattenStageFiles
+		// callers that iterate every Files[i].
+		flat := make([]string, 0)
+		for _, f := range files {
+			flat = append(flat, f...)
+		}
+		return StageOutput{
+			Kind:          OutputSinglePart,
+			NumPartitions: 1,
+			Files:         [][]string{flat},
+		}, nil
 	}
 	return StageOutput{
 		Kind:          kind,
@@ -1514,6 +1542,88 @@ func buildTaskInputsForStage(stage physical.Stage, upstreams map[string]StageOut
 		inputs[depID] = partitionFilesForWorker(upstreams[depID], workerIdx, workerCount)
 	}
 	return inputs, nil
+}
+
+// broadcastJoinProbeSplit reports whether a broadcast_join stage qualifies
+// for probe-split fan-out. Returns the desired numTasks and ok=true when:
+//   - the stage is a broadcast_join the planner left at numTasks=1 (DistSingleton)
+//   - the cluster has spare workers (workerCount > 1)
+//   - the probe upstream is OutputSinglePart with at least 2 files
+//
+// Triggers only for DistSingleton broadcast_join; the hash-partitioned path
+// is already parallelized by the planner via Exchange{Repartition}.
+func broadcastJoinProbeSplit(
+	stage physical.Stage,
+	inputs map[string]StageOutput,
+	workerCount, currentNumTasks int,
+) (numTasks int, ok bool) {
+	if stage.Type != physical.StageBroadcastJoin {
+		return 0, false
+	}
+	if currentNumTasks != 1 {
+		return 0, false
+	}
+	if workerCount <= 1 {
+		return 0, false
+	}
+	if len(stage.Dependencies) != 2 {
+		return 0, false
+	}
+	probeDep := stage.LeftDepStage
+	if probeDep == "" {
+		probeDep = stage.Dependencies[0]
+	}
+	probeIn, present := inputs[probeDep]
+	if !present || probeIn.Kind != OutputSinglePart {
+		return 0, false
+	}
+	probeFiles := flattenStageFiles(probeIn)
+	if len(probeFiles) < 2 {
+		return 0, false
+	}
+	n := workerCount
+	if n > len(probeFiles) {
+		n = len(probeFiles)
+	}
+	return n, true
+}
+
+// buildTaskInputsForBroadcastJoinSplitProbe is the probe-split variant of
+// buildTaskInputsForStage for broadcast_join. Each task receives:
+//   - build alias → the full broadcast set (every task sees every build row)
+//   - probe alias → its 1/numTasks slice of probe upstream files
+//
+// Caller must verify the stage has 2 deps and probe upstream is single-part
+// with multiple files; this helper assumes the dispatcher already vetted
+// eligibility.
+func buildTaskInputsForBroadcastJoinSplitProbe(stage physical.Stage, upstreams map[string]StageOutput, workerIdx, numTasks int) (map[string][]string, error) {
+	if len(stage.Dependencies) != 2 {
+		return nil, fmt.Errorf("broadcast_join split-probe stage %s expects 2 deps, got %d", stage.ID, len(stage.Dependencies))
+	}
+	probeDep := stage.LeftDepStage
+	buildDep := stage.RightDepStage
+	if probeDep == "" {
+		probeDep = stage.Dependencies[0]
+	}
+	if buildDep == "" {
+		buildDep = stage.Dependencies[1]
+	}
+	buildAlias := stage.BuildTableAlias
+	if buildAlias == "" {
+		buildAlias = "build"
+	}
+	probeAlias := "probe"
+	if probeAlias == buildAlias {
+		probeAlias = "probe_side"
+	}
+	out := make(map[string][]string, 2)
+	out[buildAlias] = flattenStageFiles(upstreams[buildDep])
+	probeFiles := flattenStageFiles(upstreams[probeDep])
+	parts := splitFilesEvenly(probeFiles, numTasks)
+	if workerIdx >= 0 && workerIdx < len(parts) {
+		out[probeAlias] = parts[workerIdx]
+	}
+	return out, nil
 }
 
 // dispatchGatherStage is terminal: dispatches a single Gather task to one

--- a/internal/coordinator/native_dag_test.go
+++ b/internal/coordinator/native_dag_test.go
@@ -248,6 +248,83 @@ func TestNativeDAG_AvgFallback(t *testing.T) {
 	}
 }
 
+// TestNativeDAG_BroadcastJoinProbeSplit exercises the broadcast_join
+// probe-split path: a small build (small dimension table) joined against
+// a multi-chunk probe (4 files). With workerCount > 1 the dispatcher should
+// fan out the broadcast_join to multiple tasks, each scanning a slice of
+// probe files while reading the full build. Verifies that the join produces
+// the expected row count (no duplication from the fan-out, no rows dropped
+// from probe slicing).
+func TestNativeDAG_BroadcastJoinProbeSplit(t *testing.T) {
+	_, coord, store := setupDistributed(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	cat := coord.catalog
+
+	// Small dimension (build, broadcast-eligible).
+	dimSchema := []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "label", Type: parquet.TypeString},
+	}
+	dim := []map[string]any{
+		{"id": int64(1), "label": "A"},
+		{"id": int64(2), "label": "B"},
+		{"id": int64(3), "label": "C"},
+	}
+	ingestTestData(t, ctx, store, cat, "dim", dimSchema, dim)
+
+	// Multi-chunk facts table — 4 chunks × 25 rows = 100 rows. With
+	// MaxConcurrent=4 the cluster reports capacity=4, so the dispatcher
+	// should split the probe across 4 tasks (one chunk per task).
+	factSchema := []parquet.Column{
+		{Name: "fk", Type: parquet.TypeInt64},
+		{Name: "amt", Type: parquet.TypeInt64},
+	}
+	chunks := make([][]map[string]any, 4)
+	for c := 0; c < 4; c++ {
+		rows := make([]map[string]any, 25)
+		for i := 0; i < 25; i++ {
+			rows[i] = map[string]any{
+				"fk":  int64((i % 3) + 1),
+				"amt": int64(c*100 + i),
+			}
+		}
+		chunks[c] = rows
+	}
+	ingestMultiFile(t, ctx, store, cat, "facts", factSchema, chunks)
+
+	sql := "SELECT d.label, COUNT(*) AS n FROM facts f JOIN dim d ON f.fk = d.id GROUP BY d.label"
+
+	res, err := coord.ExecuteSQL(ctx, sql)
+	if err != nil {
+		t.Fatalf("ExecuteSQL: %v", err)
+	}
+	if res.Error != "" {
+		t.Fatalf("query error: %s", res.Error)
+	}
+
+	got := map[string]int64{}
+	for _, r := range res.Rows() {
+		got[r["label"].(string)] = toInt64(r["n"])
+	}
+	// Each chunk has 25 rows with fk values cycling 1,2,3,1,2,3,...
+	// Per chunk: id=1 gets 9, id=2 gets 8, id=3 gets 8. ×4 chunks =
+	// {A:36, B:32, C:32}. Total 100.
+	want := map[string]int64{"A": 36, "B": 32, "C": 32}
+	for k, w := range want {
+		if got[k] != w {
+			t.Errorf("label=%s: got %d, want %d (full result %v)", k, got[k], w, got)
+		}
+	}
+	var total int64
+	for _, n := range got {
+		total += n
+	}
+	if total != 100 {
+		t.Errorf("total joined rows = %d, want 100 (probe-split duplicated or dropped rows)", total)
+	}
+}
+
 // TestNativeDAG_Join exercises a hash_join compute stage end-to-end by
 // running a two-table INNER JOIN through the native DAG executor.
 func TestNativeDAG_Join(t *testing.T) {

--- a/internal/coordinator/probe_split_test.go
+++ b/internal/coordinator/probe_split_test.go
@@ -1,0 +1,210 @@
+package coordinator
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/planner/physical"
+)
+
+// TestBroadcastJoinProbeSplit_Trigger verifies the dispatcher's decision to
+// fan out a Singleton broadcast_join: triggers only when the cluster has
+// spare workers, the planner picked numTasks=1, and the probe upstream is a
+// multi-file OutputSinglePart. Mirrors the conditions enforced in
+// dispatchComputeStage.
+func TestBroadcastJoinProbeSplit_Trigger(t *testing.T) {
+	stage := physical.Stage{
+		Type:          physical.StageBroadcastJoin,
+		Dependencies:  []string{"probe", "build"},
+		LeftDepStage:  "probe",
+		RightDepStage: "build",
+	}
+	multi := map[string]StageOutput{
+		"probe": {Kind: OutputSinglePart, Files: [][]string{{"p0", "p1", "p2", "p3"}}},
+		"build": {Kind: OutputSinglePart, Files: [][]string{{"b0"}}},
+	}
+
+	cases := []struct {
+		name      string
+		stage     physical.Stage
+		inputs    map[string]StageOutput
+		workers   int
+		curTasks  int
+		wantOK    bool
+		wantTasks int
+	}{
+		{name: "happy_path", stage: stage, inputs: multi, workers: 4, curTasks: 1, wantOK: true, wantTasks: 4},
+		{name: "fewer_files_than_workers", stage: stage, inputs: map[string]StageOutput{
+			"probe": {Kind: OutputSinglePart, Files: [][]string{{"p0", "p1"}}},
+			"build": {Kind: OutputSinglePart, Files: [][]string{{"b0"}}},
+		}, workers: 8, curTasks: 1, wantOK: true, wantTasks: 2},
+		{name: "single_probe_file", stage: stage, inputs: map[string]StageOutput{
+			"probe": {Kind: OutputSinglePart, Files: [][]string{{"p0"}}},
+			"build": {Kind: OutputSinglePart, Files: [][]string{{"b0"}}},
+		}, workers: 4, curTasks: 1, wantOK: false},
+		{name: "single_worker", stage: stage, inputs: multi, workers: 1, curTasks: 1, wantOK: false},
+		{name: "already_parallel", stage: stage, inputs: multi, workers: 4, curTasks: 4, wantOK: false},
+		{name: "non_broadcast_stage", stage: physical.Stage{Type: physical.StageHashJoin, Dependencies: []string{"probe", "build"}, LeftDepStage: "probe", RightDepStage: "build"}, inputs: multi, workers: 4, curTasks: 1, wantOK: false},
+		{name: "probe_partitioned", stage: stage, inputs: map[string]StageOutput{
+			"probe": {Kind: OutputPartitioned, NumPartitions: 4, Files: [][]string{{"p0"}, {"p1"}, {"p2"}, {"p3"}}},
+			"build": {Kind: OutputSinglePart, Files: [][]string{{"b0"}}},
+		}, workers: 4, curTasks: 1, wantOK: false},
+		{name: "probe_replicated", stage: stage, inputs: map[string]StageOutput{
+			"probe": {Kind: OutputReplicated, Files: [][]string{{"p0", "p1"}}},
+			"build": {Kind: OutputSinglePart, Files: [][]string{{"b0"}}},
+		}, workers: 4, curTasks: 1, wantOK: false},
+		{name: "missing_probe", stage: stage, inputs: map[string]StageOutput{
+			"build": {Kind: OutputSinglePart, Files: [][]string{{"b0"}}},
+		}, workers: 4, curTasks: 1, wantOK: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			n, ok := broadcastJoinProbeSplit(tc.stage, tc.inputs, tc.workers, tc.curTasks)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && n != tc.wantTasks {
+				t.Errorf("numTasks = %d, want %d", n, tc.wantTasks)
+			}
+		})
+	}
+}
+
+// TestBuildTaskInputsForBroadcastJoinSplitProbe verifies the helper slices
+// probe files across tasks while replicating the build set to every task.
+func TestBuildTaskInputsForBroadcastJoinSplitProbe(t *testing.T) {
+	stage := physical.Stage{
+		ID:              "bj-1",
+		Type:            physical.StageBroadcastJoin,
+		Dependencies:    []string{"probe", "build"},
+		LeftDepStage:    "probe",
+		RightDepStage:   "build",
+		BuildTableAlias: "n",
+	}
+	upstreams := map[string]StageOutput{
+		"probe": {
+			Kind:  OutputSinglePart,
+			Files: [][]string{{"p0.parquet", "p1.parquet", "p2.parquet", "p3.parquet"}},
+		},
+		"build": {
+			Kind:  OutputSinglePart,
+			Files: [][]string{{"b0.wshf", "b1.wshf"}},
+		},
+	}
+
+	const numTasks = 3
+	got := make(map[int]map[string][]string)
+	for w := 0; w < numTasks; w++ {
+		in, err := buildTaskInputsForBroadcastJoinSplitProbe(stage, upstreams, w, numTasks)
+		if err != nil {
+			t.Fatalf("worker %d: %v", w, err)
+		}
+		got[w] = in
+	}
+
+	// Build alias must be present at every task with the full broadcast set.
+	for w := 0; w < numTasks; w++ {
+		if !reflect.DeepEqual(got[w]["n"], []string{"b0.wshf", "b1.wshf"}) {
+			t.Errorf("worker %d build slot = %v, want full broadcast", w, got[w]["n"])
+		}
+	}
+
+	// Probe alias must cover all 4 files exactly once across tasks (a partition).
+	var seen []string
+	for w := 0; w < numTasks; w++ {
+		seen = append(seen, got[w]["probe"]...)
+	}
+	sort.Strings(seen)
+	want := []string{"p0.parquet", "p1.parquet", "p2.parquet", "p3.parquet"}
+	if !reflect.DeepEqual(seen, want) {
+		t.Errorf("probe slices union = %v, want %v (each file exactly once)", seen, want)
+	}
+
+	// No two workers may receive the same probe file.
+	dedup := make(map[string]int)
+	for _, f := range seen {
+		dedup[f]++
+		if dedup[f] > 1 {
+			t.Errorf("probe file %s assigned to multiple workers", f)
+		}
+	}
+}
+
+// TestBuildTaskInputsForBroadcastJoinSplitProbe_FewerFilesThanTasks: when probe
+// has fewer files than numTasks, splitFilesEvenly returns fewer slices, and
+// the helper must not panic for trailing workers.
+func TestBuildTaskInputsForBroadcastJoinSplitProbe_FewerFilesThanTasks(t *testing.T) {
+	stage := physical.Stage{
+		ID:            "bj-1",
+		Type:          physical.StageBroadcastJoin,
+		Dependencies:  []string{"probe", "build"},
+		LeftDepStage:  "probe",
+		RightDepStage: "build",
+	}
+	upstreams := map[string]StageOutput{
+		"probe": {Kind: OutputSinglePart, Files: [][]string{{"p0.parquet"}}},
+		"build": {Kind: OutputSinglePart, Files: [][]string{{"b0.wshf"}}},
+	}
+
+	in0, err := buildTaskInputsForBroadcastJoinSplitProbe(stage, upstreams, 0, 4)
+	if err != nil {
+		t.Fatalf("worker 0: %v", err)
+	}
+	if !reflect.DeepEqual(in0["probe"], []string{"p0.parquet"}) {
+		t.Errorf("worker 0 probe = %v, want [p0.parquet]", in0["probe"])
+	}
+	// Workers 1-3 should get empty probe (no out-of-bounds panic).
+	for w := 1; w < 4; w++ {
+		in, err := buildTaskInputsForBroadcastJoinSplitProbe(stage, upstreams, w, 4)
+		if err != nil {
+			t.Fatalf("worker %d: %v", w, err)
+		}
+		if len(in["probe"]) != 0 {
+			t.Errorf("worker %d probe = %v, want empty", w, in["probe"])
+		}
+		// Build still replicated.
+		if !reflect.DeepEqual(in["build"], []string{"b0.wshf"}) {
+			t.Errorf("worker %d build = %v, want [b0.wshf]", w, in["build"])
+		}
+	}
+}
+
+// TestBuildTaskInputsForBroadcastJoinSplitProbe_MissingDeps: rejects stages
+// without exactly two dependencies.
+func TestBuildTaskInputsForBroadcastJoinSplitProbe_MissingDeps(t *testing.T) {
+	stage := physical.Stage{
+		ID:           "bj-1",
+		Type:         physical.StageBroadcastJoin,
+		Dependencies: []string{"only-one"},
+	}
+	if _, err := buildTaskInputsForBroadcastJoinSplitProbe(stage, nil, 0, 2); err == nil {
+		t.Fatal("expected error for stage with 1 dep, got nil")
+	}
+}
+
+// TestBuildTaskInputsForBroadcastJoinSplitProbe_BuildAliasFallback: when
+// stage.BuildTableAlias is empty, the helper must fall back to "build".
+func TestBuildTaskInputsForBroadcastJoinSplitProbe_BuildAliasFallback(t *testing.T) {
+	stage := physical.Stage{
+		ID:            "bj-1",
+		Type:          physical.StageBroadcastJoin,
+		Dependencies:  []string{"probe", "build"},
+		LeftDepStage:  "probe",
+		RightDepStage: "build",
+	}
+	upstreams := map[string]StageOutput{
+		"probe": {Kind: OutputSinglePart, Files: [][]string{{"p0", "p1"}}},
+		"build": {Kind: OutputSinglePart, Files: [][]string{{"b0"}}},
+	}
+	in, err := buildTaskInputsForBroadcastJoinSplitProbe(stage, upstreams, 0, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := in["build"]; !reflect.DeepEqual(got, []string{"b0"}) {
+		t.Errorf("default build alias missing, got map = %v", in)
+	}
+	if got := in["probe"]; !reflect.DeepEqual(got, []string{"p0"}) {
+		t.Errorf("probe slice 0 = %v, want [p0]", got)
+	}
+}


### PR DESCRIPTION
## Summary
- When the planner picks `DistSingleton` for a `broadcast_join` (probe upstream is a leaf scan), the join would otherwise run as one task on one worker. With `workerCount > 1` and a multi-file probe upstream, fan out to `min(workerCount, len(probeFiles))` tasks. Each task reads 1/N of probe files; build is replicated to every task.
- Triggers only when probe upstream is `OutputSinglePart` with ≥2 files. Hash-partitioned `broadcast_join` is unchanged (planner already parallelizes via `Exchange{Repartition}`).
- Per-task hash table memory matches the single-task case — only probe scan and probe compute are parallelized.

## Why
Addresses Q05's serialization on SF10. broadcast_join over 600+ lineitem files ran on a single worker, dominated wall time, and tripped the new progress-based idle timeout (#56). Every task now reads its slice of the probe in parallel.

This is the smaller of the two architectural levers from `project_native_dag_remaining_levers_2026-04-26-pm.md`. The build-cache port to native-DAG remains a separate, larger lift.

## Implementation
1. `dispatchComputeStage`: after deriving the planner's `numTasks`, call `broadcastJoinProbeSplit(stage, inputs, workerCount, numTasks)`. When it returns ok, override `numTasks` and set the `probeSplit` flag.
2. `buildTaskInputsForBroadcastJoinSplitProbe(stage, upstreams, w, numTasks)`: each task gets the full broadcast build set + `splitFilesEvenly(probeFiles, numTasks)[w]`.
3. Output collapsed to `OutputSinglePart` with all per-task files concatenated into `Files[0]`. Downstream `OutputSinglePart` consumers see the full join result; `final_aggregate` fan-out preserves parallelism via `flattenStageFiles`.

## Test plan
- [x] New unit tests for `broadcastJoinProbeSplit` (9 cases covering happy path, single-file probe, single-worker cluster, partitioned/replicated probe rejection, missing-dep guards) — all pass.
- [x] New unit tests for `buildTaskInputsForBroadcastJoinSplitProbe` (probe slicing, build replication, fewer-files-than-tasks edge case, missing-deps error, build-alias fallback) — all pass.
- [x] New end-to-end test `TestNativeDAG_BroadcastJoinProbeSplit`: small dim build (1 chunk, 3 rows) + multi-chunk facts probe (4 chunks × 25 rows), verifies COUNT(*) per group matches expected (no row duplication, no rows dropped).
- [x] Full coord test suite: 198 PASS / 0 FAIL (`-skip` only the 2 pre-existing local-env SF100 sample tests — passing on CI).
- [x] `TestShuffleCorrectness` (3-worker × all 22 TPC-H queries SF0.01): PASS.
- [x] `internal/planner/physical/...`: PASS (no planner changes).
- [x] `go build ./...`, `go vet ./internal/coordinator/...`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)