### PR TITLE
perf(coordinator): size scan fan-out from cluster capacity

### DIFF
--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -779,6 +779,32 @@ func (c *Coordinator) dispatchPipelineStage(
 	return c.dispatchComputeStage(ctx, queryID, stage, inputs, workerCount)
 }
 
+// scanFanOutTaskCount picks the number of scan-side tasks for stage fan-out.
+// Returns max(workerCount, capacity), capped at fileCount and floored at 1.
+//
+// Prefers cluster capacity (sum of each worker's auto-tuned MaxConcurrent
+// reported in heartbeats) over the raw worker count because workers
+// downscale concurrency under memory pressure. With 3 workers each running
+// MaxConcurrent=2 the cluster can run 6 tasks at once; sizing scan fan-out
+// to 3 leaves half the cluster idle AND doubles per-task memory pressure
+// (each task reads twice as many files).
+//
+// Falls back to workerCount when capacity == 0 — typical for the first
+// query post-cluster-startup, before any heartbeat has reported MaxConcurrent.
+func scanFanOutTaskCount(workerCount, capacity, fileCount int) int {
+	n := workerCount
+	if capacity > n {
+		n = capacity
+	}
+	if n > fileCount {
+		n = fileCount
+	}
+	if n < 1 {
+		n = 1
+	}
+	return n
+}
+
 // dispatchScanAggregateStage dispatches N partial-aggregate tasks, one
 // per worker, each reading a disjoint slice of stage.ScanFiles. Each task
 // runs a HashAggregate on its file slice and emits a partial result as
@@ -810,15 +836,24 @@ func (c *Coordinator) dispatchScanAggregateStage(
 	// whole aggregate runs on one worker and the merge step is a
 	// pass-through. Loses parallelism for AVG queries (Q01 is the
 	// notable one) but preserves correctness.
+	avgFallback := false
 	for _, a := range stage.FusedAggSpecs {
 		if strings.EqualFold(strings.TrimSpace(a.Func), "avg") {
 			c.logger.Info("scan-aggregate AVG fallback: single-task",
 				"stage_id", stage.ID, "func", a.Func)
 			workerCount = 1
+			avgFallback = true
 			break
 		}
 	}
-	fileSets := splitFilesEvenly(stage.ScanFiles, workerCount)
+	// Same fan-out widening as dispatchScanFilterStage: prefer cluster capacity
+	// over raw worker count so each task stays inside the per-worker memory
+	// budget. AVG fallback intentionally stays at 1 task.
+	taskCount := workerCount
+	if !avgFallback {
+		taskCount = scanFanOutTaskCount(workerCount, c.workers.ClusterCapacity(), len(stage.ScanFiles))
+	}
+	fileSets := splitFilesEvenly(stage.ScanFiles, taskCount)
 	actualTasks := len(fileSets)
 	if actualTasks == 0 {
 		return StageOutput{
@@ -983,7 +1018,14 @@ func (c *Coordinator) dispatchScanFilterStage(
 	if len(stage.ScanFiles) == 0 {
 		return StageOutput{Kind: OutputPartitioned, NumPartitions: 0, Files: nil}, nil
 	}
-	fileSets := splitFilesEvenly(stage.ScanFiles, workerCount)
+	// Task count: prefer cluster capacity (workers × auto-tuned MaxConcurrent)
+	// over raw worker count so each task stays under the per-worker memory
+	// budget. With 3 workers × MaxConcurrent=2, that's 6 tasks instead of 3
+	// — for SF10 lineitem (600 files) that's 100 files/task instead of 200,
+	// which keeps each task's heap below the 32GB worker limit and avoids
+	// the OOM-restart-then-idle-timeout pattern observed on Q04 SF10.
+	taskCount := scanFanOutTaskCount(workerCount, c.workers.ClusterCapacity(), len(stage.ScanFiles))
+	fileSets := splitFilesEvenly(stage.ScanFiles, taskCount)
 	actualTasks := len(fileSets)
 	if actualTasks == 0 {
 		return StageOutput{Kind: OutputPartitioned, NumPartitions: 0, Files: nil}, nil

--- a/internal/coordinator/scan_fanout_test.go
+++ b/internal/coordinator/scan_fanout_test.go
@@ -1,0 +1,45 @@
+package coordinator
+
+import "testing"
+
+func TestScanFanOutTaskCount(t *testing.T) {
+	tests := []struct {
+		name        string
+		workerCount int
+		capacity    int
+		fileCount   int
+		want        int
+	}{
+		// Capacity > workerCount: prefer capacity (auto-tuned concurrency).
+		// Q04 SF10 case: 3 workers × MaxConcurrent=2 = 6 capacity, 600 files.
+		{name: "sf10_q04_lineitem", workerCount: 3, capacity: 6, fileCount: 600, want: 6},
+
+		// Capacity unreported (first-query startup): fall back to workerCount.
+		{name: "capacity_unreported", workerCount: 3, capacity: 0, fileCount: 600, want: 3},
+
+		// Capacity reported lower than workerCount: stick with workerCount
+		// (workers downscaled but we still want at least one task per worker).
+		{name: "capacity_below_workers", workerCount: 4, capacity: 2, fileCount: 600, want: 4},
+
+		// Few files: never produce more tasks than files.
+		{name: "more_capacity_than_files", workerCount: 3, capacity: 6, fileCount: 4, want: 4},
+
+		// Single file: one task.
+		{name: "single_file", workerCount: 3, capacity: 6, fileCount: 1, want: 1},
+
+		// Zero workers (edge case): floor at 1.
+		{name: "zero_workers_zero_capacity", workerCount: 0, capacity: 0, fileCount: 5, want: 1},
+
+		// Equal capacity and workerCount: deterministic.
+		{name: "equal", workerCount: 3, capacity: 3, fileCount: 12, want: 3},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := scanFanOutTaskCount(tc.workerCount, tc.capacity, tc.fileCount)
+			if got != tc.want {
+				t.Errorf("scanFanOutTaskCount(%d, %d, %d) = %d, want %d",
+					tc.workerCount, tc.capacity, tc.fileCount, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
`dispatchScanFilterStage` and `dispatchScanAggregateStage` now size their task counts off `max(workerCount, ClusterCapacity)` instead of raw `workerCount`. Capacity is the sum of each worker's auto-tuned `MaxConcurrent` reported in heartbeats — typically 2× the worker count under memory pressure on SF10's c7g.4xlarge cluster.

## Why
Direct fix for the Q04 SF10 idle-timeout observed in the 2026-04-28 deploy:

- 3-worker cluster, each worker auto-tuned to `MaxConcurrent=2` → 6 effective slots.
- Q04's `scan-filter scan-1` had 600 lineitem files; old code split into `workerCount=3` tasks of **200 files each**.
- Each task pulled enough data that worker heap exceeded the 32GB limit, OOM-restarted mid-stage. Abandoned tasks never reported, coord-side idle timeout fired at 10m, query failed with 0 rows.

With the fix, the same scenario splits into 6 tasks of 100 files each — half the per-task memory pressure and the full cluster engaged.

When `ClusterCapacity()` returns 0 (no heartbeat with `MaxConcurrent` yet — typical for first query post-startup), the helper falls back to `workerCount`, identical to the old behavior.

## Implementation
New helper `scanFanOutTaskCount(workerCount, capacity, fileCount)`:
- Returns `max(workerCount, capacity)`.
- Clamps to `fileCount` (never more tasks than files).
- Floors at 1.

Wired into both leaf-scan dispatch sites. AVG-fallback path in `dispatchScanAggregateStage` stays at 1 task (existing correctness constraint).

## Test plan
- [x] New `TestScanFanOutTaskCount` — 7 cases including SF10 Q04 scenario, capacity-unreported fallback, capacity-below-workerCount, files-fewer-than-capacity clamp, single-file, zero-worker floor.
- [x] `TestShuffleCorrectness` (3 workers × all 22 TPC-H SF0.01): PASS.
- [x] Full coord suite (227s, 198 tests skipping 2 pre-existing local-env SF100-sample tests): PASS.
- [x] `go build ./...`, `go vet ./internal/coordinator/...`: clean.

## Next
After this lands, redeploy SF10 to confirm Q04 passes. Q05's hash-partitioned broadcast_join memory issue is a separate triage (see `project_sf10_deploy_2026-04-28.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)