### PR TITLE
perf(worker): shared memory pool + multi-worker per node

### DIFF
--- a/cmd/wadjet/main.go
+++ b/cmd/wadjet/main.go
@@ -60,6 +60,7 @@ var (
 	leafRemotes      []string
 	grpcAddr         string
 	memoryBudget     int64
+	sharedPoolBudget int64
 	spillDir         string
 	resultStoreBytes int64
 	pgAddr           string
@@ -114,6 +115,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&otelEndpoint, "otel-endpoint", "", "OTLP gRPC endpoint for tracing (e.g., localhost:4317)")
 	rootCmd.PersistentFlags().BoolVar(&otelInsecure, "otel-insecure", false, "Use plaintext gRPC for OTLP exporter")
 	rootCmd.PersistentFlags().Int64Var(&memoryBudget, "memory-budget", 0, "Per-task memory budget in bytes (0 = auto-detect from cgroup, or unlimited)")
+	rootCmd.PersistentFlags().Int64Var(&sharedPoolBudget, "shared-pool-budget", 0, "Worker-wide shared memory pool in bytes (0 = auto-detect: envelope minus cache). All concurrent tasks Reserve against this pool.")
 	rootCmd.PersistentFlags().StringVar(&spillDir, "spill-dir", "", "Directory for spill files (default: OS temp dir)")
 	rootCmd.PersistentFlags().Int64Var(&cacheBytes, "cache-bytes", 0, "LRU file cache size in bytes (0 = auto-detect: 20% of memory)")
 
@@ -221,6 +223,13 @@ func serveCmd() *cobra.Command {
 					// and spill threshold lowered to 60%, enabling tighter budgets
 					// without OOM risk on multi-join queries.
 					// Formula: (envelope - cache) / (4 * maxConcurrent)
+					//
+					// Note: with the shared worker memory pool (Trino MemoryPool /
+					// Spark ExecutionMemoryPool model), the per-task budget is only
+					// consulted by the planner for operator sizing — actual
+					// allocation tracking flows through `sharedPoolBudget` below.
+					// We keep this calculation for planner sizing and as a fallback
+					// for legacy callers, but spill triggers are pool-driven.
 					memoryBudget = (goMemLimit - cacheBytes) / (4 * maxConc)
 
 					// Auto-tune maxConc DOWN when the per-task budget would be
@@ -254,6 +263,21 @@ func serveCmd() *cobra.Command {
 					}
 
 					logger.Info("auto-detected memory budget", "budget_bytes", memoryBudget, "max_concurrent", maxConc)
+				}
+				if sharedPoolBudget == 0 {
+					// Pool is the full envelope minus the file cache. All
+					// concurrent tasks Reserve from it; operators
+					// cooperatively spill when the pool fills. NOT divided
+					// by maxConc — the pool's whole point is to share a
+					// single budget across tasks instead of statically
+					// carving N slices.
+					sharedPoolBudget = goMemLimit - cacheBytes
+					if sharedPoolBudget < 256*1024*1024 {
+						sharedPoolBudget = 256 * 1024 * 1024
+					}
+					logger.Info("auto-detected shared pool budget",
+						"pool_bytes", sharedPoolBudget,
+						"go_mem_limit", goMemLimit, "cache_bytes", cacheBytes)
 				}
 			}
 
@@ -742,6 +766,7 @@ func runStandalone(ctx context.Context, store objstore.Store, logger *slog.Logge
 		MaxConcurrent:    maxConcurrent,
 		CacheBytes:       cacheBytes,
 		MemoryBudget:     memoryBudget,
+		SharedPoolBudget: sharedPoolBudget,
 		SpillDir:         spillDir,
 		ResultStoreBytes: resultStoreBytes,
 	}, store, nc, js, logger)
@@ -1212,6 +1237,7 @@ func runWorker(ctx context.Context, store objstore.Store, logger *slog.Logger) e
 		MaxConcurrent:    maxConcurrent,
 		CacheBytes:       cacheBytes,
 		MemoryBudget:     memoryBudget,
+		SharedPoolBudget: sharedPoolBudget,
 		SpillDir:         spillDir,
 		ResultStoreBytes: resultStoreBytes,
 	}, store, nc, js, logger)

--- a/deploy/benchmark/terraform/main.tf
+++ b/deploy/benchmark/terraform/main.tf
@@ -505,25 +505,51 @@ resource "aws_instance" "worker" {
       exit 1
     fi
 
-    # Start wadjet worker (retry on failure — coordinator may restart during benchmark)
-    while true; do
-      /usr/local/bin/wadjet serve \
-        --mode=worker \
-        --nats-url="nats://$COORD_IP:4222" \
-        --endpoint="s3.${local.eff_region}.amazonaws.com" \
-        --ssl \
-        --bucket="${local.bucket_name}" \
-        --region="${local.eff_region}" \
-        --storage-type=s3 \
-        --max-concurrent=${var.max_concurrent} \
-        --spill-dir="$SPILL_DIR" \
-        ${var.memory_budget > 0 ? "--memory-budget=${var.memory_budget}" : ""} \
-        ${var.cache_bytes > 0 ? "--cache-bytes=${var.cache_bytes}" : ""} 2>&1
-      EXIT_CODE=$?
-      echo "Worker exited with code $EXIT_CODE, restarting in 5s..."
-      echo "WORKER_STARTED=1" >> /etc/environment
-      sleep 5
+    # Launch ${var.workers_per_node} independent wadjet worker processes.
+    # Each gets its own GOMEMLIMIT slice (envelope/N) so an OOM on one
+    # only kills that process — siblings on the same node keep running.
+    # Each process auto-detects its memory envelope from cgroup, so we
+    # use systemd-style per-process cgroups (created via systemd-run)
+    # to give each worker a hard memory ceiling. When the worker exits
+    # (crash, OOM, etc.) the supervising shell loop restarts it.
+    WORKERS_PER_NODE=${var.workers_per_node}
+    TOTAL_BYTES=$(awk '/MemTotal/ {print $2 * 1024}' /proc/meminfo)
+    PER_PROC_BYTES=$((TOTAL_BYTES * 75 / 100 / WORKERS_PER_NODE))
+    echo "Starting $WORKERS_PER_NODE worker process(es), each with ~$((PER_PROC_BYTES/1024/1024/1024)) GiB envelope"
+
+    start_worker() {
+      local idx=$1
+      local worker_spill="$SPILL_DIR/w$idx"
+      mkdir -p "$worker_spill"
+      while true; do
+        # systemd-run creates a transient unit with MemoryMax so the
+        # cgroup's auto-detected limit reflects the per-process slice,
+        # not the whole-node total.
+        systemd-run --quiet --unit="wadjet-worker-$idx-$$-$(date +%s)" \
+          --scope -p "MemoryMax=$PER_PROC_BYTES" -p "MemoryHigh=$((PER_PROC_BYTES * 9 / 10))" \
+          /usr/local/bin/wadjet serve \
+            --mode=worker \
+            --nats-url="nats://$COORD_IP:4222" \
+            --endpoint="s3.${local.eff_region}.amazonaws.com" \
+            --ssl \
+            --bucket="${local.bucket_name}" \
+            --region="${local.eff_region}" \
+            --storage-type=s3 \
+            --max-concurrent=${var.max_concurrent} \
+            --spill-dir="$worker_spill" \
+            ${var.memory_budget > 0 ? "--memory-budget=${var.memory_budget}" : ""} \
+            ${var.cache_bytes > 0 ? "--cache-bytes=${var.cache_bytes}" : ""} 2>&1 | sed "s/^/[w$idx] /"
+        EXIT_CODE=$?
+        echo "[w$idx] exited code=$EXIT_CODE, restarting in 5s..."
+        sleep 5
+      done
+    }
+
+    echo "WORKER_STARTED=1" >> /etc/environment
+    for i in $(seq 0 $((WORKERS_PER_NODE - 1))); do
+      start_worker $i &
     done
+    wait
   EOF
   )
 

--- a/deploy/benchmark/terraform/sf10-distributed.tfvars
+++ b/deploy/benchmark/terraform/sf10-distributed.tfvars
@@ -7,6 +7,8 @@ mode                     = "distributed"
 coordinator_instance_type = "c7g.2xlarge"  # 8 vCPU, 16 GB
 worker_instance_type      = "c7g.4xlarge"  # 16 vCPU, 32 GB (2xlarge OOM'd Q21)
 worker_count              = 3
+workers_per_node         = 4   # 4 wadjet processes per node × 3 nodes = 12 worker processes. Each ~6GB envelope (75% of 32GB / 4). OOM on one process doesn't take down siblings.
+max_concurrent           = 2   # per process; effective cluster concurrency = 4 × 2 × 3 = 24 task slots
 data_bucket              = "wadjet-bench-sf10-use2"
 skip_queries             = ""
 query_timeout            = "30m"  # SF10 heavy queries (Q03/Q05/Q21 lineitem joins) need >10m; the 26 April AWS run hit the 10m cap on Q03 even though stages were progressing

--- a/deploy/benchmark/terraform/variables.tf
+++ b/deploy/benchmark/terraform/variables.tf
@@ -111,9 +111,15 @@ variable "query_timeout" {
 }
 
 variable "max_concurrent" {
-  description = "Maximum concurrent tasks per worker (lower = less memory, slower execution)"
+  description = "Maximum concurrent tasks per worker process (lower = less memory, slower execution). With workers_per_node > 1 the effective cluster concurrency is workers_per_node × max_concurrent × node_count."
   type        = number
   default     = 4
+}
+
+variable "workers_per_node" {
+  description = "Number of independent wadjet worker processes to launch per node. >1 gives crash isolation: when one process OOMs, sibling workers on the same node keep running. Each process gets a per-process memory envelope (auto-derived from /N of total) and registers separately with the coord."
+  type        = number
+  default     = 1
 }
 
 variable "cache_bytes" {

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -249,6 +249,23 @@ func (c *Coordinator) executeStageDAG(
 			if err != nil {
 				return fmt.Errorf("stage %s collect inputs: %w", s.ID, err)
 			}
+			// Memory-pressure backpressure: refuse to dispatch new tasks
+			// when the cluster's shared memory pool is near exhaustion.
+			// Lets in-flight operators spill and free pool memory before
+			// piling on more concurrent work. Re-checks every 500ms so
+			// stages resume admission as soon as pressure drops.
+			//
+			// Returns 0 when no worker has reported pool stats (legacy
+			// workers, missing --shared-pool-budget); in that case the
+			// gate is effectively disabled and dispatch behaves as before.
+			const poolPressureMax = 0.85
+			for c.workers.ClusterPoolPressure() >= poolPressureMax {
+				select {
+				case <-time.After(500 * time.Millisecond):
+				case <-gctx.Done():
+					return gctx.Err()
+				}
+			}
 			// Acquire a dispatch slot now that we have inputs and are
 			// about to publish tasks. Held until the stage completes so
 			// concurrent stage count never exceeds dispatchSlots. Released

--- a/internal/coordinator/workers.go
+++ b/internal/coordinator/workers.go
@@ -17,6 +17,8 @@ type WorkerInfo struct {
 	MaxConcurrent int   // effective task-slot count reported in heartbeat; 0 = legacy worker (assume default)
 	MemoryUsed    int64
 	MemoryTotal   int64
+	PoolUsed      int64 // shared memory pool bytes Reserved
+	PoolBudget    int64 // shared memory pool capacity in bytes; pressure = PoolUsed / PoolBudget
 	Draining      bool
 	LastSeen      time.Time
 }
@@ -132,6 +134,8 @@ func (wr *WorkerRegistry) record(hb distributed.WorkerHeartbeat) {
 	info.MaxConcurrent = hb.MaxConcurrent
 	info.MemoryUsed = hb.MemoryUsed
 	info.MemoryTotal = hb.MemoryTotal
+	info.PoolUsed = hb.PoolUsed
+	info.PoolBudget = hb.PoolBudget
 	info.Draining = hb.Draining
 	// Use coordinator-side time for LastSeen. The heartbeat message
 	// arriving proves the worker is alive — even if the worker's
@@ -166,6 +170,42 @@ func (wr *WorkerRegistry) ActiveWorkers() []*WorkerInfo {
 // Count returns the number of active workers.
 func (wr *WorkerRegistry) Count() int {
 	return len(wr.ActiveWorkers())
+}
+
+// ClusterPoolPressure returns the cluster-wide shared memory pool pressure
+// as a value in [0.0, 1.0], computed from the most recent heartbeat each
+// active worker reported. Returns 0 when no worker has reported pool stats
+// (legacy workers, or worker without --shared-pool-budget).
+//
+// The dispatcher uses this to throttle new task admission when the cluster
+// is near memory exhaustion — refusing to dispatch lets in-flight operators
+// spill and free pool memory before piling on more concurrent work.
+func (wr *WorkerRegistry) ClusterPoolPressure() float64 {
+	wr.mu.RLock()
+	defer wr.mu.RUnlock()
+	cutoff := time.Now().Add(-wr.stale)
+	var totalUsed, totalBudget int64
+	for _, w := range wr.workers {
+		if !w.LastSeen.After(cutoff) || w.Draining {
+			continue
+		}
+		if w.PoolBudget <= 0 {
+			continue
+		}
+		totalUsed += w.PoolUsed
+		totalBudget += w.PoolBudget
+	}
+	if totalBudget == 0 {
+		return 0
+	}
+	p := float64(totalUsed) / float64(totalBudget)
+	if p < 0 {
+		p = 0
+	}
+	if p > 1 {
+		p = 1
+	}
+	return p
 }
 
 // ClusterCapacity returns the sum of effective task-slot counts across

--- a/internal/distributed/messages.go
+++ b/internal/distributed/messages.go
@@ -289,6 +289,8 @@ type WorkerHeartbeat struct {
 	ActiveTaskIDs []string  `json:"active_task_ids,omitempty"` // task IDs currently executing
 	MemoryUsed    int64     `json:"memory_used"`
 	MemoryTotal   int64     `json:"memory_total"`
+	PoolUsed      int64     `json:"pool_used,omitempty"`   // bytes Reserved in the worker's shared memory pool
+	PoolBudget    int64     `json:"pool_budget,omitempty"` // shared memory pool capacity in bytes; pressure = PoolUsed/PoolBudget
 	RSS           int64     `json:"rss,omitempty"`             // process RSS from /proc/self/status
 	NumGoroutines int       `json:"num_goroutines,omitempty"`
 	Mallocs       uint64    `json:"mallocs,omitempty"`         // cumulative allocation count from runtime.MemStats

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -73,27 +73,61 @@ func NewExecutor(store objstore.Store, cache *LRUCache, js jetstream.JetStream) 
 	return &Executor{store: store, js: js, cache: cache, logger: slog.Default()}
 }
 
-// SetMemoryBudget configures the worker-level memory budget and spill
-// directory, and eagerly creates the shared Tracker + SpillManager that
-// all tasks will use. Budget is the TOTAL across concurrent tasks, not
-// per-task — callers should pass ~75% of worker RAM.
+// SetMemoryBudget configures the per-task memory budget and the spill
+// directory. For backward compatibility it also initializes a shared
+// pool of the same size, so existing callers that pass a single budget
+// continue to get cooperative spill across concurrent tasks. Callers
+// that want a different pool size (typically larger than per-task
+// budget) should call SetSharedPoolBudget afterward to override.
 func (e *Executor) SetMemoryBudget(budget int64, spillDir string) {
 	e.memoryBudget = budget
 	e.spillDir = spillDir
 	if budget > 0 {
-		e.sharedTracker = memory.NewTracker("worker", budget)
-		dir := spillDir
-		if dir == "" {
-			dir = os.TempDir()
-		}
-		sm, err := memory.NewSpillManager(dir, e.sharedTracker)
-		if err != nil {
-			e.logger.Warn("failed to create worker spill manager; tasks run without spill governance",
-				"error", err)
-			return
-		}
-		e.sharedSpill = sm
+		e.SetSharedPoolBudget(budget)
 	}
+}
+
+// SharedPoolStats returns (used, budget) bytes for the worker-wide
+// memory pool, or (0, 0) if no pool is configured. Used by the worker
+// heartbeat loop to publish pool pressure for coord-side dispatch
+// backpressure.
+func (e *Executor) SharedPoolStats() (used, budget int64) {
+	if e.sharedTracker == nil {
+		return 0, 0
+	}
+	return e.sharedTracker.Used(), e.sharedTracker.Budget()
+}
+
+// SetSharedPoolBudget creates the worker-wide memory pool that all
+// concurrent tasks Reserve against. Operators (HashJoin build, sort
+// run accumulation, hash aggregate state) cooperatively spill when the
+// pool fills, regardless of which task is holding the bytes. Matches the
+// Trino MemoryPool / Spark ExecutionMemoryPool model.
+//
+// Pool budget should be the FULL worker envelope (after cache reservation),
+// not a per-task slice. With 32GB physical RAM and a 24GB GOMEMLIMIT,
+// pool budget is roughly 21GB (envelope − cache).
+//
+// Calling this with budget<=0 disables the shared pool and falls back to
+// per-task tracking via SetMemoryBudget.
+func (e *Executor) SetSharedPoolBudget(budget int64) {
+	if budget <= 0 {
+		e.sharedTracker = nil
+		e.sharedSpill = nil
+		return
+	}
+	e.sharedTracker = memory.NewTracker("worker", budget)
+	dir := e.spillDir
+	if dir == "" {
+		dir = os.TempDir()
+	}
+	sm, err := memory.NewSpillManager(dir, e.sharedTracker)
+	if err != nil {
+		e.logger.Warn("failed to create worker spill manager; tasks run without spill governance",
+			"error", err)
+		return
+	}
+	e.sharedSpill = sm
 }
 
 // SetResultStore attaches an in-memory result store for inter-stage result passing.
@@ -132,58 +166,70 @@ func (e *Executor) SetLogger(l *slog.Logger) {
 	e.logger = l
 }
 
-// newSpillManager creates a Tracker + SpillManager for a task if memory budget is configured.
-// Returns nil, nil if budget is 0 (unlimited).
+// newSpillManager creates a Tracker + SpillManager for a task.
+//
+// When the worker has a configured shared memory pool (via SetMemoryBudget),
+// the task tracker is a CHILD of the shared pool — its Reserve calls bubble
+// up so spill triggers fire on cumulative worker pressure, not per-task
+// quotas. Matches the Trino MemoryPool / Spark ExecutionMemoryPool model:
+// every concurrent task allocates from one budget, and operators
+// cooperatively spill when the pool fills, regardless of which task is
+// holding the bytes.
+//
+// Without a shared pool (SetMemoryBudget never called or budget==0), returns
+// nil/nil — no tracking, no spill. Same behaviour as the old per-task path.
 func (e *Executor) newSpillManager(taskID string) (*memory.SpillManager, *memory.Tracker) {
+	if e.sharedTracker != nil {
+		return e.sharedSpill, e.sharedTracker.Child(taskID)
+	}
 	if e.memoryBudget <= 0 {
 		return nil, nil
 	}
-
+	// Fallback: legacy per-task pool when SetMemoryBudget wasn't called but
+	// memoryBudget is set directly (test paths, embedded callers).
 	tracker := memory.NewTracker(taskID, e.memoryBudget)
-
 	dir := e.spillDir
 	if dir == "" {
 		dir = os.TempDir()
 	}
-
 	sm, err := memory.NewSpillManager(dir, tracker)
 	if err != nil {
 		e.logger.Warn("failed to create spill manager, running without spill",
 			"task_id", taskID, "error", err)
 		return nil, tracker
 	}
-
 	return sm, tracker
 }
 
-// newSpillManagerScaled creates a Tracker + SpillManager with a budget scaled
-// by the number of concurrent hash tables. Join tasks with N fused joins need
-// N+1 hash tables in memory simultaneously during probing. Without scaling,
-// each table gets 1/(N+1) of the budget, triggering premature spill.
+// newSpillManagerScaled is preserved for the legacy per-task-pool path —
+// when the shared pool is active (the prod path), join scaling has no
+// meaning because the pool is sized for cumulative pressure across all
+// concurrent tasks and operators. Scaling per-task budgets would
+// over-provision against a shared pool that already accounts for them.
+//
+// joinCount is therefore only honoured on the legacy path.
 func (e *Executor) newSpillManagerScaled(taskID string, joinCount int) (*memory.SpillManager, *memory.Tracker) {
+	if e.sharedTracker != nil {
+		return e.sharedSpill, e.sharedTracker.Child(taskID)
+	}
 	if e.memoryBudget <= 0 {
 		return nil, nil
 	}
-
 	budget := e.memoryBudget
 	if joinCount > 1 {
 		budget = e.memoryBudget * int64(joinCount)
 	}
-
 	tracker := memory.NewTracker(taskID, budget)
-
 	dir := e.spillDir
 	if dir == "" {
 		dir = os.TempDir()
 	}
-
 	sm, err := memory.NewSpillManager(dir, tracker)
 	if err != nil {
 		e.logger.Warn("failed to create spill manager, running without spill",
 			"task_id", taskID, "error", err)
 		return nil, tracker
 	}
-
 	return sm, tracker
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -34,7 +34,8 @@ type Config struct {
 	ClusterID        string // cluster this worker belongs to (for federated routing)
 	MaxConcurrent    int    // max concurrent tasks
 	CacheBytes       int64  // local LRU cache size
-	MemoryBudget     int64  // per-task memory budget in bytes (0 = unlimited, no spill)
+	MemoryBudget     int64  // per-task memory budget in bytes (0 = unlimited, no spill); used as legacy fallback when SharedPoolBudget is unset
+	SharedPoolBudget int64  // worker-wide memory pool in bytes (0 = derived as MemoryBudget*MaxConcurrent). All concurrent tasks Reserve against this pool; spill triggers fire on cumulative worker pressure.
 	SpillDir         string // directory for spill files (default: os temp dir)
 	ResultStoreBytes int64  // in-memory result store capacity (0 = disabled, results go to S3)
 }
@@ -93,7 +94,18 @@ func New(cfg Config, store objstore.Store, nc *nats.Conn, js jetstream.JetStream
 
 	cache := NewLRUCache(cfg.CacheBytes)
 	executor := NewExecutor(store, cache, js)
+	pool := cfg.SharedPoolBudget
+	if pool <= 0 && cfg.MemoryBudget > 0 && cfg.MaxConcurrent > 0 {
+		// Legacy callers pass per-task MemoryBudget; reconstruct the
+		// worker-wide pool size as `per-task × MaxConcurrent` so all
+		// concurrent tasks share one budget. This matches what the
+		// per-task budget was originally a slice of.
+		pool = cfg.MemoryBudget * int64(cfg.MaxConcurrent)
+	}
 	executor.SetMemoryBudget(cfg.MemoryBudget, cfg.SpillDir)
+	if pool > 0 {
+		executor.SetSharedPoolBudget(pool)
+	}
 	executor.SetLogger(logger)
 	executor.SetNATSConn(nc)
 	if cfg.ResultStoreBytes > 0 {
@@ -762,6 +774,7 @@ func (w *Worker) heartbeatLoop(ctx context.Context, sem chan struct{}) {
 			}
 			w.activeTasksMu.RUnlock()
 
+			poolUsed, poolBudget := w.executor.SharedPoolStats()
 			hb := distributed.WorkerHeartbeat{
 				WorkerID:      w.config.WorkerID,
 				ClusterID:     w.config.ClusterID,
@@ -770,6 +783,8 @@ func (w *Worker) heartbeatLoop(ctx context.Context, sem chan struct{}) {
 				ActiveTaskIDs: taskIDs,
 				MemoryUsed:    alloc,
 				MemoryTotal:   sys,
+				PoolUsed:      poolUsed,
+				PoolBudget:    poolBudget,
 				RSS:           rss,
 				NumGoroutines: ng,
 				Mallocs:       mallocs,


### PR DESCRIPTION
## Summary

Four changes that remove the per-task memory-budget knob (the bottleneck behind today's SF10 Q04/Q05 idle timeouts) and match the Trino MemoryPool / Spark ExecutionMemoryPool model.

### 1. Shared memory pool with operator accounting
- `worker.Config.SharedPoolBudget` (separate from per-task `MemoryBudget`).
- `executor.SetSharedPoolBudget(budget)` creates the worker-wide `Tracker` + `SpillManager`.
- `newSpillManager{,Scaled}` now route per-task trackers as **children** of the shared pool — `Reserve` calls bubble up, all concurrent tasks share one budget.
- `cmd/wadjet/main.go` auto-detects pool budget as `goMemLimit - cacheBytes` (the full envelope after cache) rather than the per-task slice. Exposed via `--shared-pool-budget`.
- `SetMemoryBudget(budget, dir)` still wires the pool for back-compat with existing tests.

### 2. Spill on pool pressure (free with #1)
The shared `SpillManager` already checks `tracker.Used() > budget * threshold/100`. With the shared tracker, the threshold now fires on cumulative pool used, not per-task quota. Operators consulting `ShouldSpill()` get cooperative pool-pressure spill for free.

### 3. Coord-side dispatch backpressure
- `WorkerHeartbeat.PoolUsed` + `PoolBudget`, populated from `executor.SharedPoolStats()`.
- `WorkerRegistry.ClusterPoolPressure()` returns `sum(used)/sum(budget)` across active workers.
- `executeStageDAG` blocks on `pressure < 0.85` before acquiring a dispatch slot; re-checks every 500ms. Lets in-flight operators spill before piling on more concurrent work.
- Returns 0 when no worker reports pool stats (legacy workers) — gate disabled, behaviour identical to pre-change.

### 4. Multi-worker per node (deploy plumbing)
- `workers_per_node` tfvar (default `1`; `=4` for SF10).
- userdata launches N supervised `wadjet serve` processes via `systemd-run --scope -p MemoryMax=envelope/N`. Each process has its own cgroup hard cap so an OOM on one only kills that process — siblings on the same node keep running.
- For SF10's 32GB c7g.4xlarge: 4 processes × ~6GB envelope × 3 nodes = **12 worker processes**, each independently OOM-isolated. Combined with `max_concurrent=2` per process: 24 cluster task slots.

## Why
Today's SF10 deploys have shown:
- Q04 (scan-filter on 600 lineitem files) hits the 10m idle timeout because a worker OOMs mid-stage and ALL its in-flight tasks die with it — the coord can't distinguish "task crashed" from "task in flight" so it just times out.
- Q05 (broadcast_join 48 hash-partitioned tasks) shows the same pattern: 6 of 48 complete, then the worker dies, the rest never report.

The auto-tune that knocks `MaxConcurrent` 4→2 because per-task budget falls below 2GB is a symptom of the missing pool: with a single shared budget, light tasks borrow nothing extra and heavy tasks get what they need, so the static "every task needs to fit a worst-case SF100 hash table" carve-up goes away. And with multiple worker processes per node, OOM in one doesn't cascade.

## Test plan
- [x] Full coord+worker test sweep (215s + 1s, 200+ tests skipping the two pre-existing local-env SF100-sample tests): **PASS**
- [x] `TestShuffleCorrectness` (3 workers × all 22 TPC-H SF0.01): **PASS**
- [x] `TestSetMemoryBudget_SharedPool` + `TestSharedPool_CumulativeReservations`: **PASS**
- [x] `go build ./...` + `go vet`: clean
- [x] `tofu validate` on terraform: clean
- [ ] Validate on SF10 EC2 (next deploy gated on user approval per `feedback_no_auto_deploy`)

## Risk
- **Cooperative spill correctness**: existing operators already call `ShouldSpill()` — switching the underlying tracker doesn't change their contract. But the threshold now triggers when ANY task's allocation tips the pool over the threshold, which means a heavy task can force a light task to spill. That's by design (Trino does the same) but worth watching at SF100.
- **systemd-run availability**: AL2023 ships systemd by default, but if it's missing we'd lose the cgroup ceiling and rely on the process's own GOMEMLIMIT detection.
- **Process count overhead**: 4 processes per node = 4× catalog state + 4× file-cache memory. Acceptable at the 6GB envelope per process; might need rebalancing at smaller worker types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)