### PR TITLE
fix(objstore): bump ResponseHeaderTimeout from 120s to 30min

### DIFF
--- a/internal/storage/objstore/minio.go
+++ b/internal/storage/objstore/minio.go
@@ -43,7 +43,20 @@ func s3Transport(secure bool) *http.Transport {
 		TLSHandshakeTimeout: 10 * time.Second,
 		TLSClientConfig:     &tls.Config{MinVersion: tls.VersionTLS12}, //nolint:gosec // TLS always verified
 		ExpectContinueTimeout: 1 * time.Second,
-		ResponseHeaderTimeout: 120 * time.Second,
+		// ResponseHeaderTimeout fires when the server hasn't sent response
+		// headers by the deadline. For PUT, the server only sends headers
+		// AFTER the entire body upload completes, so this is effectively a
+		// per-upload wall-clock limit. With multiple worker processes per
+		// host contending for bandwidth, a 1-2GB shuffle partition can
+		// take >2min just to upload. 30min gives enough headroom for
+		// SF100-class shuffles under heavy contention; the per-task
+		// context still bounds total wall time.
+		//
+		// Observed in SF10 67062a5 deploy: 12 worker processes uploading
+		// shuffle partitions concurrently → 2m36s PUT failed at the
+		// previous 120s threshold despite the upload being legitimately
+		// in flight.
+		ResponseHeaderTimeout: 30 * time.Minute,
 		DisableCompression:    true, // Parquet/object data is already compressed
 	}
 }


### PR DESCRIPTION
## Summary
`s3Transport`'s `ResponseHeaderTimeout` was 120s. For PUT, the response only arrives after the body upload completes — so this was effectively a per-upload wall-clock limit. Bumped to 30 min.

## Root cause
SF10 `67062a5` deploy showed Q03's shuffle task `a4c511fe` failing after exactly 2m36s with `context deadline exceeded` on `Put .../shuffle/.../partition=0022/...wshf`. With 12 worker processes per cluster contending for host bandwidth, 1-2GB shuffle partitions legitimately take longer than 120s to upload. The PUT was in flight, the server just hadn't responded yet because the body wasn't done.

## Why 30 min
- Conservative: way longer than any legitimate PUT should take.
- Per-task context still bounds total wall time (idle stage timeout 10m, query timeout 30m).
- `ResponseHeaderTimeout = 0` (no timeout) is also reasonable but loses the safety net for genuinely stuck connections.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/storage/objstore/`: PASS
- [ ] SF10 redeploy after merge — confirm Q03/Q04 no longer fail with `context deadline exceeded` on S3 PUT

🤖 Generated with [Claude Code](https://claude.com/claude-code)