### PR TITLE
fix(coordinator): bump stageIdleTimeout 10m → 30m for slow shuffle stages

### DIFF
--- a/internal/coordinator/orchestrate_repartition.go
+++ b/internal/coordinator/orchestrate_repartition.go
@@ -39,7 +39,16 @@ const shuffleStageTimeout = 60 * time.Minute
 // reporting completions every few minutes is fine; one that has gone silent
 // for stageIdleTimeout is broken (worker crashed, deadlock, lost result
 // publish).
-const stageIdleTimeout = 10 * time.Minute
+//
+// 30 min is sized for SF10 shuffle stages where each task uploads many
+// partitions sequentially over a contended network. Observed wall time
+// per task: 10–20 min for lineitem shuffle output. The previous 10 min
+// fired before any task could complete on legitimately-long shuffles
+// and surfaced as confusing "S3 PUT context deadline exceeded" errors —
+// what actually happened was coord cancelling the query out from under
+// the in-flight upload. shuffleStageTimeout (60 min absolute) still
+// catches pathological cases where progress signals leak entirely.
+const stageIdleTimeout = 30 * time.Minute
 
 // ShuffleLayout describes the shard file layout produced by the two-sided
 // shuffle stages. The caller (coordinator routing path) constructs probe


### PR DESCRIPTION
## Summary
`stageIdleTimeout` 10m → 30m. Shuffle stages have long per-task wall time (24 partitions × ~30s each = 12+ min) so the previous 10m fired before any task could complete and the query was cancelled mid-upload.

## Root cause
SF10 `38b004f` deploy: Q03 failed at exactly 10m31s with `S3 PUT context deadline exceeded`. The error message is misleading — the actual cause is coord cancelling the query when stage idle fires, which propagates as ctx-canceled to the worker's in-flight S3 PUT.

`awaitStageProgress` (PR #56) only counts task replies as progress signals. The worker's 2 min in-flight NATS heartbeat keeps JetStream's AckWait alive but doesn't reach the stage's progress channel, so a slow-but-healthy shuffle stage looks identical to a stuck one.

## Why 30m
- Sized for SF10 lineitem shuffle (10–20 min observed per task).
- 60m absolute `shuffleStageTimeout` still catches genuinely stuck stages where progress signals leak entirely.
- For compute stages with many small fast tasks, the 30m idle never fires anyway.

## Test plan
- [x] `TestShuffleCorrectness` (3 workers × all 22 TPC-H SF0.01): PASS
- [x] `go build ./...` clean
- [ ] SF10 redeploy after merge — confirm Q03/Q04 clear

## Follow-up
Per-partition progress reporting from worker → coord so the idle detector sees fine-grained progress regardless of task wall time. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)