### PR TITLE
fix(objstore): remove per-call timeout from CircuitStore.Put

### DIFF
--- a/internal/storage/objstore/circuit.go
+++ b/internal/storage/objstore/circuit.go
@@ -183,15 +183,21 @@ func (cs *CircuitStore) do(ctx context.Context, fn func(context.Context) error) 
 	return err
 }
 
-// Put implements Store.
+// Put implements Store. PUT operations are not wrapped in a per-call
+// timeout — the inner store's transport-level ResponseHeaderTimeout
+// (30 min) plus the caller's ctx already bound upload time. A short
+// per-call timeout caused multi-process clusters to fail healthy uploads
+// when contended bandwidth dropped per-connection throughput below the
+// previous 20 MB/s sizing assumption.
+//
+// The circuit breaker's failure counting still applies — repeated PUT
+// errors trip the breaker — but a slow-yet-progressing upload no longer
+// triggers a context deadline mid-stream.
 func (cs *CircuitStore) Put(ctx context.Context, bucket, key string, r io.Reader, size int64, contentType string) (string, error) {
-	timeout := cs.putTimeout(size)
 	if err := cs.beforeRequest(); err != nil {
 		return "", err
 	}
-	tctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	etag, err := cs.inner.Put(tctx, bucket, key, r, size, contentType)
+	etag, err := cs.inner.Put(ctx, bucket, key, r, size, contentType)
 	if err != nil {
 		cs.onFailure(err)
 	} else {
@@ -200,15 +206,13 @@ func (cs *CircuitStore) Put(ctx context.Context, bucket, key string, r io.Reader
 	return etag, err
 }
 
-// PutIfMatch implements Store.
+// PutIfMatch implements Store. See Put for why we don't wrap in a
+// per-call timeout.
 func (cs *CircuitStore) PutIfMatch(ctx context.Context, bucket, key string, r io.Reader, size int64, contentType string, expectedETag string) (string, error) {
-	timeout := cs.putTimeout(size)
 	if err := cs.beforeRequest(); err != nil {
 		return "", err
 	}
-	tctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	etag, err := cs.inner.PutIfMatch(tctx, bucket, key, r, size, contentType, expectedETag)
+	etag, err := cs.inner.PutIfMatch(ctx, bucket, key, r, size, contentType, expectedETag)
 	if err != nil {
 		cs.onFailure(err)
 	} else {
@@ -217,11 +221,8 @@ func (cs *CircuitStore) PutIfMatch(ctx context.Context, bucket, key string, r io
 	return etag, err
 }
 
-// putTimeout returns a size-aware timeout for upload operations. The fixed
-// 10-second RequestTimeout is fine for the small results that originally
-// flowed through this store (~MB), but build-cache pre-scan tasks now upload
-// multi-GB shuffle files. Allow at least RequestTimeout, plus enough headroom
-// to push the payload at ~20 MB/s effective same-region S3 throughput.
+// putTimeout is no longer used — kept only because it has tests. PUT
+// operations now rely on transport-level and caller-level deadlines.
 func (cs *CircuitStore) putTimeout(size int64) time.Duration {
 	timeout := cs.config.RequestTimeout
 	if size > 0 {


### PR DESCRIPTION
## Summary
`CircuitStore.Put` no longer wraps PUT operations with a per-call `context.WithTimeout`. The transport-level `ResponseHeaderTimeout` (30 min, PR #68) and the caller's ctx are the upload bounds; circuit failure-counting still applies.

## Root cause
This was the actual cause of every Q03/Q04 SF10 failure across the last three deploys, masquerading as different timeouts at different layers.

`CircuitStore.Put` wrapped every PUT with `context.WithTimeout(ctx, putTimeout(size))` where `putTimeout` = `max(10s, size / 20MB/s)`. The 20 MB/s assumption modeled best-case same-region S3 throughput from a single uncontended connection. But:

- Multi-process clusters with bounded upload concurrency (`workers_per_node=2 × MaxConcurrentUploads=4 × multipart=2 = 16` connections per c7g.4xlarge sharing 5 Gbps) push effective per-connection throughput well below 20 MB/s.
- Small uploads (10 MB scan-filter WSHF) get the 10s floor; under contention 10s isn't enough.
- Big uploads (1 GB shuffle partition) get ~50s; also not enough under contention.

Observed in SF10 `53af98f`:
- Q04 failed at **52 seconds total query time** with "context deadline exceeded" on a small WSHF — proving none of the ctx-level timeouts I'd previously bumped (stageIdleTimeout 30m, ResponseHeaderTimeout 30m, query timeout 30m) were the cause. Had to be a small per-call deadline.
- Q03 failed at 8m58s on shuffle partition 3 — same circuit-timeout fired earlier under heavier upload load.

## Why removing the timeout is safe
- Circuit breaker's failure counting and tripping still apply. Repeated PUT errors still trip the breaker for the configured ResetTimeout.
- Inner store (`MinIOStore`) still has `ResponseHeaderTimeout = 30 min` on the http.Transport, so a genuinely stuck connection is still bounded.
- The caller's task context still bounds total upload time.

## Test plan
- [x] `go test ./internal/storage/objstore/`: PASS (existing circuit tests still cover failure counting + breaker tripping, just not the per-call timeout)
- [x] `go build ./...` clean
- [ ] SF10 redeploy after merge — confirm Q03/Q04 clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)