### PR TITLE
perf(liveness): per-task progress heartbeat — conditional AckWait extension

### DIFF
--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -30,6 +30,13 @@ const gatherReceiveTimeout = 10 * time.Minute
 // shuffleStageTimeout still applies as a backstop for pathological cases
 // where progress signals leak (lost NATS subscription).
 //
+// In-flight forward progress: a Coordinator may attach itself via the
+// optional perTaskProgressBridge parameter. When non-nil, the bridge is
+// expected to feed `progress` on TaskProgress messages from workers
+// (rows being pushed through a long-running task), so a slow-but-healthy
+// task keeps the stage alive. Pass nil for stages that don't benefit
+// (terminal Gather, single-task stages).
+//
 // Returns nil on completion, ctx.Err() on cancellation, or a stuck/timeout
 // error otherwise.
 func awaitStageProgress(ctx context.Context, allDone <-chan struct{}, progress <-chan struct{}, label string) error {
@@ -84,6 +91,20 @@ func (c *Coordinator) executeStageDAG(
 	if err := physical.ValidateNativeDAGShape(stages); err != nil {
 		return nil, err
 	}
+
+	// Per-task progress bridge: fans worker-emitted TaskProgress
+	// messages out to per-stage progress channels so a slow-but-healthy
+	// task keeps stageIdleTimeout from firing. Each dispatch helper
+	// registers its progress channel under the stage_id; the bridge
+	// routes by that field. Bridge is closed on query exit to drop
+	// the underlying NATS subscription.
+	bridge, err := newStageProgressBridge(c.nc, queryID)
+	if err != nil {
+		c.logger.Warn("task-progress bridge subscribe failed; falling back to completion-only progress",
+			"query", queryID, "error", err)
+	}
+	defer bridge.Close()
+	ctx = withStageProgressBridge(ctx, bridge)
 
 	// Register parent queryID in the tracker so SubjectQueryActive replies
 	// "active" for this query. Without this the worker's pre-execute
@@ -683,6 +704,7 @@ func (c *Coordinator) materializeReplicate(
 	var mu sync.Mutex
 	done := make(chan struct{}, 1)
 	progress := make(chan struct{}, 1)
+	defer stageProgressBridgeFromContext(ctx).Register(stage.ID, progress)()
 	sub, err := c.nc.Subscribe(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
 		if uerr := distributed.Unmarshal(msg.Data, &r); uerr != nil {
@@ -955,6 +977,10 @@ func (c *Coordinator) dispatchScanAggregateStage(
 	var mu sync.Mutex
 	done := make(chan struct{}, 1)
 	progress := make(chan struct{}, len(tasks))
+	// Register with the per-query progress bridge so worker-emitted
+	// TaskProgress messages also count as forward progress for this
+	// stage's idle detection.
+	defer stageProgressBridgeFromContext(ctx).Register(stage.ID, progress)()
 	sub, err := c.nc.Subscribe(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
 		if uerr := distributed.Unmarshal(msg.Data, &r); uerr != nil {
@@ -1101,6 +1127,10 @@ func (c *Coordinator) dispatchScanFilterStage(
 	var mu sync.Mutex
 	done := make(chan struct{}, 1)
 	progress := make(chan struct{}, len(tasks))
+	// Register with the per-query progress bridge so worker-emitted
+	// TaskProgress messages also count as forward progress for this
+	// stage's idle detection.
+	defer stageProgressBridgeFromContext(ctx).Register(stage.ID, progress)()
 	sub, err := c.nc.Subscribe(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
 		if uerr := distributed.Unmarshal(msg.Data, &r); uerr != nil {
@@ -1336,6 +1366,10 @@ func (c *Coordinator) dispatchComputeStage(
 	var mu sync.Mutex
 	done := make(chan struct{}, 1)
 	progress := make(chan struct{}, len(tasks))
+	// Register with the per-query progress bridge so worker-emitted
+	// TaskProgress messages also count as forward progress for this
+	// stage's idle detection.
+	defer stageProgressBridgeFromContext(ctx).Register(stage.ID, progress)()
 	sub, err := c.nc.Subscribe(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
 		if err := distributed.Unmarshal(msg.Data, &r); err != nil {
@@ -1645,6 +1679,10 @@ func (c *Coordinator) runStageTasks(
 	var mu sync.Mutex
 	done := make(chan struct{}, 1)
 	progress := make(chan struct{}, len(tasks))
+	// Register with the per-query progress bridge so worker-emitted
+	// TaskProgress messages also count as forward progress for this
+	// stage's idle detection.
+	defer stageProgressBridgeFromContext(ctx).Register(stageLabel, progress)()
 	sub, err := c.nc.Subscribe(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
 		if uerr := distributed.Unmarshal(msg.Data, &r); uerr != nil {

--- a/internal/coordinator/stage_progress.go
+++ b/internal/coordinator/stage_progress.go
@@ -1,0 +1,106 @@
+package coordinator
+
+import (
+	"context"
+	"sync"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/nats-io/nats.go"
+)
+
+// stageProgressBridge fans per-task progress messages (published by
+// workers from inside their hot loops) out to the per-stage progress
+// channels that awaitStageProgress reads.
+//
+// Lifecycle: executeStageDAG creates one bridge per query, opens a
+// single NATS subscription to wadjet.task.progress.<queryID>.>, and
+// stashes the bridge in ctx via withStageProgressBridge. Each
+// dispatch helper Register()s its (stageID, progressCh) pair when it
+// starts a stage and calls the returned cleanup func when the stage
+// completes.
+//
+// Routing happens by stageID embedded in each TaskProgress message,
+// not by NATS subject — keeps the subject layout flat.
+type stageProgressBridge struct {
+	mu    sync.RWMutex
+	chans map[string]chan<- struct{}
+	sub   *nats.Subscription
+}
+
+func newStageProgressBridge(nc *nats.Conn, queryID string) (*stageProgressBridge, error) {
+	b := &stageProgressBridge{chans: make(map[string]chan<- struct{})}
+	if nc == nil {
+		return b, nil
+	}
+	subject := distributed.SubjectTaskProgress + "." + queryID + ".>"
+	sub, err := nc.Subscribe(subject, func(msg *nats.Msg) {
+		var tp distributed.TaskProgress
+		if err := distributed.Unmarshal(msg.Data, &tp); err != nil {
+			return
+		}
+		b.mu.RLock()
+		ch, ok := b.chans[tp.StageID]
+		b.mu.RUnlock()
+		if !ok {
+			return
+		}
+		select {
+		case ch <- struct{}{}:
+		default:
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+	b.sub = sub
+	return b, nil
+}
+
+// Register associates a stage's progress channel with the bridge for
+// the lifetime of the stage. Returns a cleanup func that the caller
+// MUST defer; if cleanup is missed the bridge holds the channel
+// reference past stage end (small memory leak, no correctness issue).
+func (b *stageProgressBridge) Register(stageID string, ch chan<- struct{}) func() {
+	if b == nil {
+		return func() {}
+	}
+	b.mu.Lock()
+	b.chans[stageID] = ch
+	b.mu.Unlock()
+	return func() {
+		b.mu.Lock()
+		delete(b.chans, stageID)
+		b.mu.Unlock()
+	}
+}
+
+// Close unsubscribes the NATS handler. Called by executeStageDAG on
+// query completion (success or failure). Per-stage cleanup funcs
+// remove their channels independently.
+func (b *stageProgressBridge) Close() {
+	if b == nil || b.sub == nil {
+		return
+	}
+	_ = b.sub.Unsubscribe()
+}
+
+type stageProgressBridgeKey struct{}
+
+// withStageProgressBridge attaches a bridge to ctx for the dispatch
+// helpers to find via stageProgressBridgeFromContext. Bridge is
+// per-query; nested calls just shadow if needed.
+func withStageProgressBridge(ctx context.Context, b *stageProgressBridge) context.Context {
+	return context.WithValue(ctx, stageProgressBridgeKey{}, b)
+}
+
+func stageProgressBridgeFromContext(ctx context.Context) *stageProgressBridge {
+	if ctx == nil {
+		return nil
+	}
+	v := ctx.Value(stageProgressBridgeKey{})
+	if v == nil {
+		return nil
+	}
+	b, _ := v.(*stageProgressBridge)
+	return b
+}

--- a/internal/distributed/messages.go
+++ b/internal/distributed/messages.go
@@ -299,6 +299,24 @@ type WorkerHeartbeat struct {
 	Timestamp     time.Time `json:"timestamp"`
 }
 
+// TaskProgress is published by a worker from inside a task's hot loop
+// to signal forward progress (rows/bytes processed). Coord uses these
+// to distinguish a slow-but-healthy task from a wedged task.
+//
+// Workers emit at most one TaskProgress message per ~2s per task; the
+// counters are monotonically increasing across the task's lifetime,
+// so the coord can compute throughput and detect "no row progress for
+// N seconds" stalls without needing every batch to publish.
+type TaskProgress struct {
+	QueryID        string    `json:"query_id"`
+	StageID        string    `json:"stage_id"`
+	TaskID         string    `json:"task_id"`
+	WorkerID       string    `json:"worker_id"`
+	RowsProcessed  int64     `json:"rows_processed"`
+	BytesProcessed int64     `json:"bytes_processed,omitempty"`
+	Timestamp      time.Time `json:"timestamp"`
+}
+
 // QueryManifest describes the final results of a query.
 type QueryManifest struct {
 	QueryID     string   `json:"query_id"`

--- a/internal/distributed/subjects.go
+++ b/internal/distributed/subjects.go
@@ -19,6 +19,15 @@ const (
 	// Worker heartbeats — Core NATS
 	SubjectHeartbeat = "wadjet.workers.heartbeat"
 
+	// Per-task progress — Core NATS. Published by workers from inside
+	// task hot loops (every ~2s when progress is being made). Coord
+	// subscribes via SubjectTaskProgressAll and feeds into per-stage
+	// progress detection so a long-running task that's still pushing
+	// rows is distinguishable from a wedged task that's stopped making
+	// forward progress.
+	SubjectTaskProgress    = "wadjet.task.progress"
+	SubjectTaskProgressAll = "wadjet.task.progress.>"
+
 	// Query cancellation — Core NATS
 	SubjectCancel = "wadjet.cancel"
 
@@ -105,4 +114,11 @@ func CompleteSubject(queryID string) string {
 // CompleteSubjectAll returns the wildcard subject for all completion messages.
 func CompleteSubjectAll() string {
 	return SubjectComplete + ".>"
+}
+
+// TaskProgressSubject returns the NATS subject for a specific task's
+// per-task progress messages. Published by the worker; subscribed
+// via wildcard by the coordinator.
+func TaskProgressSubject(queryID, taskID string) string {
+	return SubjectTaskProgress + "." + queryID + "." + taskID
 }

--- a/internal/engine/exec/pipeline.go
+++ b/internal/engine/exec/pipeline.go
@@ -53,6 +53,7 @@ func (p *Pipeline) allOpsCloneable() bool {
 
 // runSerial is the original single-threaded pipeline loop.
 func (p *Pipeline) runSerial(ctx context.Context) error {
+	progress := ProgressReporterFromContext(ctx)
 	batchCount := 0
 	for {
 		if batchCount&63 == 0 {
@@ -68,6 +69,13 @@ func (p *Pipeline) runSerial(ctx context.Context) error {
 		}
 		if b == nil {
 			break
+		}
+		if progress != nil {
+			// Report rows pulled from the source. Captures forward
+			// progress for the worker's task heartbeat regardless of
+			// downstream operator behaviour (filter dropping all,
+			// aggregator buffering, etc).
+			progress.AddRows(int64(b.ActiveLen()))
 		}
 
 		exhausted := false

--- a/internal/engine/exec/progress.go
+++ b/internal/engine/exec/progress.go
@@ -1,0 +1,44 @@
+package exec
+
+import "context"
+
+// ProgressReporter is a tiny interface the pipeline uses to report
+// per-batch forward progress to the surrounding task. Implemented by
+// the worker's per-task TaskProgress; the engine doesn't depend on
+// any worker types because of import-cycle constraints.
+//
+// Callers MUST tolerate a nil receiver — it's used through
+// ProgressReporterFromContext which returns nil for callers outside
+// of a worker task (standalone queries, tests).
+type ProgressReporter interface {
+	AddRows(int64)
+	AddBytes(int64)
+}
+
+type progressKey struct{}
+
+// WithProgressReporter attaches a reporter to ctx. The worker's task
+// dispatch path calls this; everyone else reads via
+// ProgressReporterFromContext.
+func WithProgressReporter(ctx context.Context, p ProgressReporter) context.Context {
+	if p == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, progressKey{}, p)
+}
+
+// ProgressReporterFromContext returns the active progress reporter or
+// nil if none. AddRows / AddBytes on the returned value are nil-safe
+// only when the type embeds the nil-tolerance behaviour itself —
+// callers should ALWAYS guard with `if p != nil` before invoking.
+func ProgressReporterFromContext(ctx context.Context) ProgressReporter {
+	if ctx == nil {
+		return nil
+	}
+	v := ctx.Value(progressKey{})
+	if v == nil {
+		return nil
+	}
+	p, _ := v.(ProgressReporter)
+	return p
+}

--- a/internal/worker/task_progress.go
+++ b/internal/worker/task_progress.go
@@ -1,0 +1,71 @@
+package worker
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/nats-io/nats.go"
+)
+
+// TaskProgress is the worker-side counter operators bump from their
+// hot loop to signal forward progress. The counter is read by the
+// per-task heartbeat goroutine to (a) decide whether to extend
+// JetStream AckWait and (b) publish TaskProgress messages to coord.
+//
+// Operators reach this via exec.ProgressReporterFromContext (the
+// engine layer doesn't depend on worker types). The exec interface
+// has AddRows / AddBytes; this struct satisfies it.
+type TaskProgress struct {
+	rows           atomic.Int64
+	bytes          atomic.Int64
+	lastUpdateNano atomic.Int64
+}
+
+// AddRows reports that n more rows have been processed by this task.
+// Updates the lastUpdate timestamp; the heartbeat goroutine reads
+// these values without needing to lock.
+func (p *TaskProgress) AddRows(n int64) {
+	if p == nil || n <= 0 {
+		return
+	}
+	p.rows.Add(n)
+	p.lastUpdateNano.Store(time.Now().UnixNano())
+}
+
+// AddBytes reports that n more bytes have been processed by this task.
+// Used for IO-bound stages (scan, shuffle write) where bytes are a
+// truer measure of forward progress than row count.
+func (p *TaskProgress) AddBytes(n int64) {
+	if p == nil || n <= 0 {
+		return
+	}
+	p.bytes.Add(n)
+	p.lastUpdateNano.Store(time.Now().UnixNano())
+}
+
+// snapshot returns the current row, byte, and last-update timestamp.
+// Cheap atomic loads only — safe to call from any goroutine.
+func (p *TaskProgress) snapshot() (rows, bytes int64, lastUpdate time.Time) {
+	rows = p.rows.Load()
+	bytes = p.bytes.Load()
+	if ns := p.lastUpdateNano.Load(); ns > 0 {
+		lastUpdate = time.Unix(0, ns)
+	}
+	return
+}
+
+// publishTaskProgress sends a TaskProgress NATS message to the coord
+// for the given task. Uses Core NATS (fire-and-forget) since
+// progress messages are advisory — a missed one doesn't break
+// correctness. Failures are silently dropped.
+func publishTaskProgress(nc *nats.Conn, msg distributed.TaskProgress) {
+	if nc == nil {
+		return
+	}
+	data, err := distributed.Marshal(msg)
+	if err != nil {
+		return
+	}
+	_ = nc.Publish(distributed.TaskProgressSubject(msg.QueryID, msg.TaskID), data)
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/engine/exec"
 	"github.com/citc-tech/wadjet/internal/metrics"
 	"github.com/citc-tech/wadjet/internal/storage/objstore"
 	"github.com/citc-tech/wadjet/internal/telemetry"
@@ -492,6 +493,13 @@ func (w *Worker) handleTask(ctx context.Context, msg jetstream.Msg) {
 		}
 		taskCtx = distributed.ContextWithTrace(taskCtx, tc)
 	}
+	// Per-task progress reporter. Operators along the hot loop (sources,
+	// sinks, exchange writers) call AddRows / AddBytes via
+	// exec.ProgressReporterFromContext; the heartbeat goroutine below
+	// reads it to make AckWait extension conditional on actual forward
+	// progress and to publish TaskProgress to coord.
+	taskProgress := &TaskProgress{}
+	taskCtx = exec.WithProgressReporter(taskCtx, taskProgress)
 	defer taskCancel()
 
 	// Start OTel child span linked to coordinator's trace
@@ -507,25 +515,42 @@ func (w *Worker) handleTask(ctx context.Context, msg jetstream.Msg) {
 		defer span.End()
 	}
 
-	// Monitor for cancellation and send NATS in-progress heartbeats.
-	// The heartbeat resets the AckWait timer so that long-running tasks
-	// (e.g., SF100 pipeline stages that take 10+ minutes) are not
-	// redelivered to other workers.
+	// Monitor for cancellation, publish per-task progress, and extend
+	// JetStream AckWait — but only when the task is actually making
+	// forward progress.
 	//
-	// Bounded extensions: a wedged task (worker process alive but stuck
-	// in a retry loop or kernel syscall) keeps this goroutine running
-	// and would indefinitely extend AckWait via msg.InProgress(). Cap
-	// at maxInProgressExtensions so a wedge is bounded — after that,
-	// AckWait expires naturally and JetStream redelivers the task to
-	// a healthy worker. With AckWait=10m the bound is ~30m total task
-	// lifetime; option-2 progress-aware InProgress will tighten further.
-	const maxInProgressExtensions = 2
+	// Three timers run inside one select:
+	//   - cancelTicker (500ms): poll for query-level cancellation.
+	//   - progressTicker (2s): publish TaskProgress to coord with the
+	//       latest row/byte counters, so coord-side awaitStageProgress
+	//       can distinguish slow-but-healthy from wedged.
+	//   - ackTicker (2min): extend JetStream AckWait via msg.InProgress
+	//       — IFF the task has reported progress in the last
+	//       progressIdleThreshold. A wedged task (worker process alive
+	//       but stuck in a retry loop or syscall) eventually stops
+	//       reporting progress; after that we stop extending and
+	//       AckWait expires, JetStream redelivers to a healthy worker.
+	//
+	// progressIdleThreshold is a worker-side floor. Coord-side
+	// per-task idle detection runs at a longer threshold (60s) so a
+	// brief stall doesn't immediately cancel the task; the worker
+	// just stops cementing AckWait so JetStream can decide.
+	const (
+		progressIdleThreshold = 60 * time.Second
+		maxInProgressExtensions = 5 // belt-and-suspenders if the progress signal stops working
+	)
 	go func() {
 		cancelTicker := time.NewTicker(500 * time.Millisecond)
 		defer cancelTicker.Stop()
-		heartbeat := time.NewTicker(2 * time.Minute)
-		defer heartbeat.Stop()
+		progressTicker := time.NewTicker(2 * time.Second)
+		defer progressTicker.Stop()
+		ackTicker := time.NewTicker(2 * time.Minute)
+		defer ackTicker.Stop()
+		var lastPublishedRows int64
 		extensions := 0
+		// Mark progress at task start so the first 60s aren't treated as idle
+		// (operators may take time to start emitting batches; the task is alive).
+		taskProgress.lastUpdateNano.Store(time.Now().UnixNano())
 		for {
 			select {
 			case <-taskCtx.Done():
@@ -535,7 +560,29 @@ func (w *Worker) handleTask(ctx context.Context, msg jetstream.Msg) {
 					taskCancel()
 					return
 				}
-			case <-heartbeat.C:
+			case <-progressTicker.C:
+				rows, bytesProc, _ := taskProgress.snapshot()
+				if rows == lastPublishedRows {
+					continue // no new progress since last publish; skip
+				}
+				lastPublishedRows = rows
+				publishTaskProgress(w.nc, distributed.TaskProgress{
+					QueryID:        task.QueryID,
+					StageID:        task.StageID,
+					TaskID:         task.ID,
+					WorkerID:       w.config.WorkerID,
+					RowsProcessed:  rows,
+					BytesProcessed: bytesProc,
+					Timestamp:      time.Now(),
+				})
+			case <-ackTicker.C:
+				_, _, lastUpdate := taskProgress.snapshot()
+				if !lastUpdate.IsZero() && time.Since(lastUpdate) > progressIdleThreshold {
+					w.logger.Warn("task progress idle; stopping AckWait extension",
+						"task_id", task.ID, "query_id", task.QueryID,
+						"idle_for", time.Since(lastUpdate).Round(time.Second))
+					return
+				}
 				if extensions >= maxInProgressExtensions {
 					w.logger.Warn("task InProgress cap reached; allowing JetStream redelivery",
 						"task_id", task.ID, "query_id", task.QueryID,


### PR DESCRIPTION
## Summary

Option 2 of the heartbeat/liveness redesign (Option 1 = #73, just merged).

Workers now bump a per-task counter from inside the pipeline hot loop.
The heartbeat goroutine extends JetStream AckWait **only when forward
progress was observed in the last 60s**. Stuck tasks stop heartbeating;
JetStream redelivers them on the natural AckWait expiry.

This is the architectural fix the Q04 stall on SF10 deploy 92833f7
demanded. Option 1's `maxInProgressExtensions=2` cap is a safety net
(bounds damage); this PR is a *signal* (distinguishes working from stuck).

## What changed

- `internal/engine/exec.ProgressReporter` — small interface (AddRows,
  AddBytes) attached to ctx by the worker, called by `runSerial`. Lives
  in `exec` to avoid an import cycle from engine → worker.
- `internal/worker.TaskProgress` — atomic counters + lastUpdate
  timestamp; implements ProgressReporter. Heartbeat goroutine
  `snapshot()`s it every 2s.
- `internal/coordinator.stageProgressBridge` — fans per-task
  TaskProgress NATS messages into the per-stage channels that
  `awaitStageProgress` already consumes. One subscription per query
  (\`wadjet.task.progress.<queryID>.>\`), routed by stageID embedded in
  the message rather than NATS subject hierarchy (keeps subjects flat).

Worker heartbeat loop now uses three tickers instead of one:
- cancel monitor: 500ms (unchanged)
- progress publish: 2s   (new — fires TaskProgress to coord)
- ack extend: 2min       (only if progress within last 60s, capped at 5 extensions)

## Why this matters for the Q04 stall

Timeline reconstruction from #73:
1. Worker went stale at 00:06:38 mid-Q03
2. Was reaped at 00:36:38 (30m TTL — now 90s after #73)
3. JetStream kept AckWait alive via \`msg.InProgress()\` ticks until reap
4. Q04 dispatched, tasks held by dead worker, never redelivered
5. Q04 hung 30 minutes waiting on phantom task completions

#73 caps absolute damage at ≈4 minutes. This PR makes the heartbeat
*observe forward progress* so genuinely-working tasks keep their
deadlines while genuinely-stuck ones release them.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/worker/... ./internal/distributed/... ./internal/engine/exec/...\` all pass
- [x] Coordinator sweep — only flake is pre-existing \`TestQueryTrackerConcurrentAccess\` (passes on retry)
- [ ] CI green
- [ ] **SF10 deploy** after merge — the Q04 silent-stall scenario is the regression target

## Follow-ups

Option 3 (coord-owned task scheduling, replacing JetStream dispatch)
deferred to its own design phase. The per-task rows/bytes plumbing
here is the foundation it'll build on — coord will be able to do
work-stealing and reassignment without re-designing dispatch again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)