### PR TITLE
fix(worker): always upload stage outputs to S3, KV becomes a cache

### DIFF
--- a/internal/worker/executor_kv_fastpath_test.go
+++ b/internal/worker/executor_kv_fastpath_test.go
@@ -15,14 +15,21 @@ import (
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
 )
 
-// TestKVFastPath_SmallOutputSkipsS3 stages the executor with both MemStore
-// (for S3 fallback) and NATS KV. A stage task whose output fits under
-// natsKVResultThreshold should put the payload into KV and NOT write to
-// the object store — proving the perf-A fast-path activates.
-func TestKVFastPath_SmallOutputSkipsS3(t *testing.T) {
+// kvFastPathFixture stages an executor with both MemStore (S3) and an
+// in-process NATS JetStream KV bucket. Returns the components a test needs
+// to drive writeStageOutput and inspect both stores.
+type kvFastPathFixture struct {
+	ctx      context.Context
+	executor *Executor
+	store    *objstore.MemStore
+	kv       jetstream.KeyValue
+	bucket   string
+}
+
+func newKVFastPathFixture(t *testing.T) *kvFastPathFixture {
+	t.Helper()
 	ctx := context.Background()
 
-	// Embedded NATS + KV bucket (same config the coordinator uses).
 	cfg := distributed.DefaultNATSConfig()
 	cfg.Port = -1
 	cfg.StoreDir = t.TempDir()
@@ -51,7 +58,6 @@ func TestKVFastPath_SmallOutputSkipsS3(t *testing.T) {
 		t.Fatalf("kv: %v", err)
 	}
 
-	// Executor with MemStore + KV wired.
 	store := objstore.NewMemStore()
 	const bucket = "test-bucket"
 	if err := store.MakeBucket(ctx, bucket); err != nil {
@@ -60,7 +66,17 @@ func TestKVFastPath_SmallOutputSkipsS3(t *testing.T) {
 	executor := NewExecutor(store, NewLRUCache(1024*1024), nil)
 	executor.SetResultKV(kv)
 
-	// Build a small batch (fits easily under the 4 MB threshold).
+	return &kvFastPathFixture{
+		ctx:      ctx,
+		executor: executor,
+		store:    store,
+		kv:       kv,
+		bucket:   bucket,
+	}
+}
+
+func (f *kvFastPathFixture) writeSmallStageOutput(t *testing.T) string {
+	t.Helper()
 	schema := []parquet.Column{{Name: "v", Type: parquet.TypeInt64, Nullable: true}}
 	b := batch.NewRecordBatch(schema, 3)
 	for i := 0; i < 3; i++ {
@@ -74,32 +90,73 @@ func TestKVFastPath_SmallOutputSkipsS3(t *testing.T) {
 		StageID:      "s",
 		Type:         distributed.TaskTypeStage,
 		StageType:    "hash_join",
-		DataBucket:   bucket,
-		ResultBucket: bucket,
+		DataBucket:   f.bucket,
+		ResultBucket: f.bucket,
 		ResultPrefix: "out/s/",
 	}
 	result := &distributed.ResultNotification{TaskID: task.ID}
-
-	if err := executor.writeStageOutput(ctx, task, []*batch.RecordBatch{b}, result); err != nil {
+	if err := f.executor.writeStageOutput(f.ctx, task, []*batch.RecordBatch{b}, result); err != nil {
 		t.Fatalf("writeStageOutput: %v", err)
 	}
-
 	if len(result.ResultFiles) != 1 {
 		t.Fatalf("expected 1 result file, got %d: %v", len(result.ResultFiles), result.ResultFiles)
 	}
-	key := result.ResultFiles[0]
+	return result.ResultFiles[0]
+}
 
-	// KV must hold the data under the dot-sanitized key.
+// TestKVCache_SmallOutputDurableInS3AndCachedInKV documents the post-2026-04-28
+// invariant: small stage outputs are written durably to S3 *and* cached in KV
+// for fast reads. The pre-fix behavior — KV-only with no S3 upload — failed
+// Q02 SF10 at 10m57s when the 5-minute KV TTL expired mid-query.
+func TestKVCache_SmallOutputDurableInS3AndCachedInKV(t *testing.T) {
+	f := newKVFastPathFixture(t)
+	key := f.writeSmallStageOutput(t)
+
+	// KV must hold the data under the dot-sanitized key (fast-read cache).
 	kvKey := natsKVKey(key)
-	if entry, err := kv.Get(ctx, kvKey); err != nil {
-		t.Fatalf("KV miss for key %q (sanitized=%q): %v", key, kvKey, err)
+	if entry, err := f.kv.Get(f.ctx, kvKey); err != nil {
+		t.Fatalf("KV cache miss for key %q (sanitized=%q): %v", key, kvKey, err)
 	} else if len(entry.Value()) == 0 {
-		t.Fatalf("KV value empty for key %q", kvKey)
+		t.Fatalf("KV cache value empty for key %q", kvKey)
 	}
 
-	// S3 (MemStore) must NOT hold the data — fast-path's whole purpose is
-	// to skip the S3 round-trip.
-	if _, _, err := store.Get(ctx, bucket, key); err == nil {
-		t.Fatalf("S3 should NOT hold the key when KV fast-path takes effect: %q", key)
+	// S3 must also hold the data (durable store of record).
+	rc, _, err := f.store.Get(f.ctx, f.bucket, key)
+	if err != nil {
+		t.Fatalf("S3 must hold the durable copy for key %q: %v", key, err)
+	}
+	rc.Close()
+}
+
+// TestKVCache_FallsBackToS3WhenKVMisses is the regression test for Q02 SF10
+// 2026-04-28: a downstream consumer encounters a missing KV entry (TTL
+// expiry, eviction, or never-written) and must still find the data in S3.
+//
+// Before the fix this would fail with `nats: key not found` + `object not
+// found` — the producer had skipped S3 in the KV-only fast path. After the
+// fix, S3 is always durable and the fallback succeeds.
+func TestKVCache_FallsBackToS3WhenKVMisses(t *testing.T) {
+	f := newKVFastPathFixture(t)
+	key := f.writeSmallStageOutput(t)
+
+	// Simulate KV expiry / eviction by purging the entry directly. The
+	// downstream stream_source.openNextFile path will then hit `nats: key
+	// not found` and must fall through to S3.
+	kvKey := natsKVKey(key)
+	if err := f.kv.Purge(f.ctx, kvKey); err != nil {
+		t.Fatalf("purging KV entry: %v", err)
+	}
+	if _, err := f.kv.Get(f.ctx, kvKey); err == nil {
+		t.Fatalf("expected KV miss after purge, got hit")
+	}
+
+	// The S3 read must succeed — this is the regression assertion.
+	rc, info, err := f.store.Get(f.ctx, f.bucket, key)
+	if err != nil {
+		t.Fatalf("S3 fallback failed for key %q: %v", key, err)
+	}
+	defer rc.Close()
+	if info.Size == 0 {
+		t.Fatalf("S3 fallback returned empty body for key %q", key)
 	}
 }

--- a/internal/worker/executor_stage.go
+++ b/internal/worker/executor_stage.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -815,30 +814,9 @@ func (e *Executor) writePartitionedShuffle(ctx context.Context, task distributed
 		}
 		key := fmt.Sprintf("%spartition=%04d/%s.wshf", task.ResultPrefix, p, task.ID)
 
-		// KV fast-path per partition file: if the partition fits, KV it
-		// and skip S3. Partition sizes vary a lot within one stage (skew),
-		// so this is a per-partition decision, not per-stage.
-		if e.resultKV != nil && fi.Size() <= natsKVResultThreshold {
-			payload := make([]byte, fi.Size())
-			if _, readErr := io.ReadFull(f, payload); readErr == nil {
-				f.Close()
-				if _, putErr := e.resultKV.Put(ctx, natsKVKey(key), payload); putErr == nil {
-					result.ResultFiles = append(result.ResultFiles, key)
-					result.SizeBytes += fi.Size()
-					_ = os.Remove(localPath)
-					continue
-				}
-				// KV put failed — re-open for S3 upload.
-				f, err = os.Open(localPath)
-				if err != nil {
-					return fmt.Errorf("stage task %s: reopen partition %d for S3: %w", task.ID, p, err)
-				}
-			} else {
-				// Read failed — fall through and let S3 Put stream from file.
-				f.Seek(0, 0)
-			}
-		}
-
+		// S3 is the durable store; KV (if small enough) is a best-effort fast
+		// cache. See writeUnpartitionedWSHF for the same rationale — KV's
+		// 5-min TTL is shorter than long-running queries.
 		_, uploadErr := e.store.Put(ctx, task.ResultBucket, key, f, fi.Size(), "application/octet-stream")
 		f.Close()
 		if uploadErr != nil {
@@ -846,12 +824,24 @@ func (e *Executor) writePartitionedShuffle(ctx context.Context, task distributed
 		}
 		result.ResultFiles = append(result.ResultFiles, key)
 		result.SizeBytes += fi.Size()
+
+		// Best-effort KV cache for small partitions. Read the local file we
+		// already wrote to disk — cheaper than re-buffering. Failure is
+		// non-fatal because S3 is now durable.
+		if e.resultKV != nil && fi.Size() <= natsKVResultThreshold {
+			if payload, readErr := os.ReadFile(localPath); readErr == nil {
+				if _, putErr := e.resultKV.Put(ctx, natsKVKey(key), payload); putErr != nil {
+					e.logger.Debug("KV cache write failed (S3 already durable)",
+						"task_id", task.ID, "key", key,
+						"payload_bytes", len(payload), "err", putErr)
+				}
+			}
+		}
+
 		// Same-worker fast path: hand the local file to the LocalStageCache
-		// so a downstream task landing on this worker can mmap it directly
-		// instead of paying an S3 download. Adopt renames the file out of
-		// the per-task spill dir (which the deferred RemoveAll wipes) into
-		// the cache's per-query dir. If adoption fails or no cache is wired,
-		// fall back to the old delete-after-upload behavior.
+		// so a downstream task on this worker can mmap it directly. Adopt
+		// renames the file out of the per-task spill dir into the cache's
+		// per-query dir.
 		if adopted := e.localCache.Adopt(task.QueryID, key, localPath); adopted == "" {
 			_ = os.Remove(localPath)
 		}
@@ -893,41 +883,34 @@ func (e *Executor) writeUnpartitionedWSHF(ctx context.Context, task distributed.
 
 	key := fmt.Sprintf("%s%s.wshf", task.ResultPrefix, task.ID)
 
-	// KV fast-path: for small outputs, write only to NATS KV and skip the
-	// S3 upload. Downstream cachedFileStreamSource checks KV first (via
-	// natsKVKey(key)) and falls back to S3 on miss. This avoids the ~500ms
-	// S3 round-trip per stage boundary for the many small intermediate
-	// outputs in a typical TPC-H query (aggregates, merge-sort finals,
-	// broadcast-join output).
-	if e.resultKV != nil && len(payload) <= natsKVResultThreshold {
-		kvKey := natsKVKey(key)
-		if _, err := e.resultKV.Put(ctx, kvKey, payload); err == nil {
-			result.ResultFiles = append(result.ResultFiles, key)
-			result.SizeBytes += int64(len(payload))
-			return nil
-		} else {
-			// KV put failed — fall through to S3. Log at Warn because silent
-			// failure here was the 2026-04-25 diagnostic gap on the pgwire→
-			// coord "object not found" cascade (project_q18_sf10_native_dag_oom).
-			// If this fires often, payloads are exceeding NATS KV's per-value
-			// max — bump the threshold or the bucket's MaxValueSize.
-			e.logger.Warn("KV put failed, falling back to store",
-				"task_id", task.ID, "key", key,
-				"payload_bytes", len(payload), "err", err)
-		}
-	}
-
+	// S3 is the durable store. NATS KV has a 5-minute TTL (coordinator.go
+	// jetstream.KeyValueConfig) and a 1 GB bucket cap — entries can expire or
+	// be evicted before downstream stages read them. Q02 SF10 2026-04-28 hit
+	// exactly this: 10m57s query, KV-only outputs vanished at minute 5,
+	// downstream `nats: key not found` + `object not found`. Always upload to
+	// S3 first; KV is a best-effort fast-read cache below.
 	_, err := e.store.Put(ctx, task.ResultBucket, key, bytes.NewReader(payload), int64(len(payload)), "application/octet-stream")
 	if err != nil {
 		return fmt.Errorf("stage task %s: uploading wshf: %w", task.ID, err)
 	}
 	result.ResultFiles = append(result.ResultFiles, key)
 	result.SizeBytes += int64(len(payload))
-	// Same-worker fast path for the S3-eligible (i.e., > KV threshold) case.
-	// Spill the in-memory buffer to a tmp file under the worker spill dir
-	// and Adopt it into the LocalStageCache. The extra disk write is much
-	// cheaper than the S3 download a same-worker consumer would otherwise
-	// pay. Best-effort — failures fall back to the existing S3 path.
+
+	// Best-effort KV cache for small payloads. Downstream consumers check KV
+	// first (~10ms) and fall back to S3 (~500ms) on miss; both are correct
+	// reads now that S3 is durable.
+	if e.resultKV != nil && len(payload) <= natsKVResultThreshold {
+		kvKey := natsKVKey(key)
+		if _, err := e.resultKV.Put(ctx, kvKey, payload); err != nil {
+			e.logger.Debug("KV cache write failed (S3 already durable)",
+				"task_id", task.ID, "key", key,
+				"payload_bytes", len(payload), "err", err)
+		}
+	}
+
+	// Same-worker fast path: adopt the local copy so a downstream task on
+	// this worker can mmap it directly. Best-effort — failures fall back to
+	// S3.
 	e.cacheUnpartitionedLocal(task.QueryID, key, payload)
 	return nil
 }


### PR DESCRIPTION
## Summary

- Q02 SF10 2026-04-28 failed at 10m57s with `nats: key not found` on a broadcast-join build cache, then `object not found` from the S3 fallback. Root cause: producer wrote payloads ≤4 MB to NATS KV **only** (no S3); KV bucket has a 5-minute TTL, query took longer than that, KV entry expired mid-flight, S3 had nothing to fall back to.
- This change reorders both stage-output paths (`writeUnpartitionedWSHF`, `writePartitionedShuffle`) so S3 is always the durable store; KV becomes a best-effort fast-read cache. Aligns with the existing `writeBatchResult` pattern (which already had this comment about the 5-min TTL).
- Failed KV-cache writes now log at Debug, not Warn — they're a perf nit, not a correctness signal, because S3 is durable.

## Why this is the right architectural fix

Trino, Spark, and Flink all separate "durable shuffle storage" from "fast read cache." Wadjet's KV bucket has both a 5-min TTL and a 1 GB cap — those are correct constraints for a **cache**, but wrong for the **store of record**. This PR keeps the cache constraints and makes S3 the store of record.

Cost: small payloads now incur an S3 PUT (~50–100 ms) in addition to the KV write. For a TPC-H query with many stage boundaries this adds ~1–2 s of stage-boundary latency. Q02 was failing at 10m57s, so the trade is overwhelmingly in favor of correctness. Periodic `ResultCleaner.CleanStale` sweeps S3 (1 hr default TTL).

## Test plan

- [x] `go test ./internal/worker/ ./internal/coordinator/` — pass (1.2 s + 212 s)
- [x] `go test -v -run TestTPCHQueries ./benchmarks/tpch/` — 22/22 pass at SF0.01
- [x] Existing `TestKVFastPath_SmallOutputSkipsS3` updated → `TestKVCache_SmallOutputDurableInS3AndCachedInKV` (asserts BOTH stores hold data)
- [x] New regression test `TestKVCache_FallsBackToS3WhenKVMisses` simulates KV expiry by purging the entry; reading via S3 must succeed
- [ ] `cmd/tpch-harness --mode=local` — currently broken on `main` itself ("NATS disconnected error=EOF" on this WSL2 box, environmental); verified via `git stash` that the harness fails identically without this change. Not a regression introduced here.
- [ ] SF10 EC2 deploy — needs explicit user approval per `feedback_no_auto_deploy`; recommend re-running Q02 to validate the failure mode is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)