### PR TITLE
fix(coordinator): remove pool-pressure dispatch gate (deadlock under broadcast joins)

### DIFF
--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -270,23 +270,6 @@ func (c *Coordinator) executeStageDAG(
 			if err != nil {
 				return fmt.Errorf("stage %s collect inputs: %w", s.ID, err)
 			}
-			// Memory-pressure backpressure: refuse to dispatch new tasks
-			// when the cluster's shared memory pool is near exhaustion.
-			// Lets in-flight operators spill and free pool memory before
-			// piling on more concurrent work. Re-checks every 500ms so
-			// stages resume admission as soon as pressure drops.
-			//
-			// Returns 0 when no worker has reported pool stats (legacy
-			// workers, missing --shared-pool-budget); in that case the
-			// gate is effectively disabled and dispatch behaves as before.
-			const poolPressureMax = 0.85
-			for c.workers.ClusterPoolPressure() >= poolPressureMax {
-				select {
-				case <-time.After(500 * time.Millisecond):
-				case <-gctx.Done():
-					return gctx.Err()
-				}
-			}
 			// Acquire a dispatch slot now that we have inputs and are
 			// about to publish tasks. Held until the stage completes so
 			// concurrent stage count never exceeds dispatchSlots. Released

--- a/internal/coordinator/pool_pressure_dispatch_test.go
+++ b/internal/coordinator/pool_pressure_dispatch_test.go
@@ -1,0 +1,85 @@
+package coordinator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// TestExecuteStageDAG_NoPoolPressureDeadlock is a regression test for the
+// 2026-04-29 SF10 Q02 deadlock. PR #65 added a dispatcher gate that blocked
+// every per-stage goroutine while ClusterPoolPressure >= 0.85, polling every
+// 500ms. In broadcast_join chains, the build-side hash table is held in the
+// shared pool until the *probe-side* stage completes — and the probe was the
+// stage being gated. Memory could only be released by running the very stage
+// the gate was blocking. The query stalled silently for 17 minutes until the
+// 30-minute query_timeout fired. The fix removes the gate; this test
+// exercises that path with a high-pressure heartbeat injected before the
+// query runs and asserts the query completes well within the gate's old
+// 500ms poll cadence.
+//
+// If a future change re-introduces a blocking pool-pressure gate in
+// execute_stage_dag.go, this test will hit the per-test timeout and fail
+// loudly rather than reproducing the silent production stall.
+func TestExecuteStageDAG_NoPoolPressureDeadlock(t *testing.T) {
+	ctx, coord, store := setupWithNATSAndCatalog(t)
+	cat := coord.catalog
+
+	// Inject a synthetic heartbeat from a "phantom" worker that is reporting
+	// 99% pool pressure. ClusterPoolPressure aggregates across ALL active
+	// workers, so even though the real test worker reports 0% pressure, the
+	// cluster-wide value is dragged above 0.85 — the threshold the deleted
+	// gate used.
+	coord.workers.record(distributed.WorkerHeartbeat{
+		WorkerID:   "phantom-pressure-reporter",
+		ClusterID:  "local",
+		PoolUsed:   99 * 1024 * 1024 * 1024,
+		PoolBudget: 100 * 1024 * 1024 * 1024,
+		Timestamp:  time.Now(),
+	})
+	if got := coord.workers.ClusterPoolPressure(); got < 0.85 {
+		t.Fatalf("phantom heartbeat did not push pressure above gate threshold: got %.3f, want >=0.85", got)
+	}
+
+	schema := []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "v", Type: parquet.TypeFloat64},
+	}
+	rows := []map[string]any{
+		{"id": int64(1), "v": 10.0},
+		{"id": int64(2), "v": 20.0},
+		{"id": int64(3), "v": 30.0},
+	}
+	ingestTestData(t, ctx, store, cat, "pp_dispatch", schema, rows)
+
+	// Multi-stage query (aggregate forces an aggregate + final_aggregate
+	// pair, exercising the per-stage dispatch loop the deleted gate lived
+	// in). Wrap in our own deadline well below the previous gate's 500ms
+	// poll cadence — if the gate is back, this fails loudly.
+	type result struct {
+		res *SQLResult
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		r, err := coord.ExecuteSQL(ctx, "SELECT SUM(v) AS s FROM pp_dispatch")
+		done <- result{r, err}
+	}()
+
+	select {
+	case r := <-done:
+		if r.err != nil {
+			t.Fatalf("ExecuteSQL: %v", r.err)
+		}
+		if r.res == nil || r.res.Error != "" {
+			t.Fatalf("query reported error: %+v", r.res)
+		}
+		if len(r.res.Rows()) != 1 {
+			t.Fatalf("expected 1 row, got %d", len(r.res.Rows()))
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatalf("query did not complete within 15s under high pool pressure — pool-pressure dispatch gate may have been reintroduced (see execute_stage_dag.go and feedback memory project_sf10_deploy_2026-04-29.md)")
+	}
+}

--- a/internal/coordinator/workers.go
+++ b/internal/coordinator/workers.go
@@ -180,11 +180,11 @@ func (wr *WorkerRegistry) Count() int {
 // ClusterPoolPressure returns the cluster-wide shared memory pool pressure
 // as a value in [0.0, 1.0], computed from the most recent heartbeat each
 // active worker reported. Returns 0 when no worker has reported pool stats
-// (legacy workers, or worker without --shared-pool-budget).
-//
-// The dispatcher uses this to throttle new task admission when the cluster
-// is near memory exhaustion — refusing to dispatch lets in-flight operators
-// spill and free pool memory before piling on more concurrent work.
+// (legacy workers, or worker without --shared-pool-budget). Observability
+// only — earlier per-stage dispatch gating on this value caused a deadlock
+// in broadcast_join chains (the probe-side stage that would free build-side
+// memory was itself gated on memory dropping). Worker-side pool-pressure
+// spill is the load-shedding primitive now.
 func (wr *WorkerRegistry) ClusterPoolPressure() float64 {
 	wr.mu.RLock()
 	defer wr.mu.RUnlock()


### PR DESCRIPTION
## Summary

- PR #65 added a per-stage dispatcher gate that blocks while `ClusterPoolPressure >= 0.85`. In broadcast_join chains, the build-side hash table is held in the worker's pool until the **probe-side** stage completes — and the probe was exactly the stage being gated. Permanent deadlock.
- Production evidence (SF10 Q02, 2026-04-29 deploy of 52a54a8): coord silent for 17 minutes between `repartition-19 complete num_partitions=48` and the 30-min `query_timeout`. No dispatch line for the post-shuffle consumer. The gate ate the query.
- Fix removes the gate. Worker-side spill (PR #65) + reap+restart (PR #73, #74) + cache durability (PR #75) handle pressure correctly without coord-side gating. This matches the Trino/Spark architecture: task-level memory tracking, not dispatcher-level pressure gates.

## Why this is the right architectural fix

The gate's premise was "block dispatch until stress drops." That premise assumes some stage in flight will free memory on its own. For broadcast_join, that's wrong: the build holds memory **until the probe completes**, and the probe is the next stage in line. The gate enforces the worst possible ordering — block exactly the stage that would shed load.

`ClusterPoolPressure` itself is kept (observability metric; could be used for future *query-admission* gating at intake rather than per-stage).

## Why workers also took 8.5 min to recover during the same Q02

Same root cause. Heartbeat goroutine on the worker likely blocked because the process was thrashing under pool pressure (pool-pressure spill holding internal locks, GC churn, or `nc.Publish` blocking on a saturated NATS publish queue). Worker UUID was identical when it returned at 07:18:12, confirming the process was the same. Memory pressure → worker stops responding → coord reaps → memory clears when join finishes → worker resumes heartbeating. Removing the dispatcher gate cuts the duration of the high-pressure window directly.

## Test plan

- [x] `go test ./internal/coordinator/` — 202/202 unit tests pass; 2 pre-existing env failures on main are unrelated (`TestDistributedTPCH{BuildCacheSF100Sample,Q12SF100Sample}` — missing `/tmp/sf100-sample/region-0_0.parquet` fixture).
- [x] `go test ./internal/worker/` — pass.
- [x] `go test -v -run TestTPCHQueries ./benchmarks/tpch/` — SF0.01 22/22 pass.
- [x] New `TestExecuteStageDAG_NoPoolPressureDeadlock` — injects a phantom heartbeat reporting 99% pool pressure, asserts a multi-stage aggregate query completes within 15s. **Verified the test catches the regression** by temporarily re-introducing the gate and confirming the test fails with a clear timeout message.
- [ ] SF10 EC2 deploy — needs explicit user approval per `feedback_no_auto_deploy`. Recommend re-running Q01+Q02 to confirm the post-shuffle stage now dispatches in <1s instead of the 17-min stall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)