### PR TITLE
fix(exec): release tracker reservations on operator Close

### DIFF
--- a/internal/engine/exec/aggregate.go
+++ b/internal/engine/exec/aggregate.go
@@ -1963,7 +1963,25 @@ func (h *HashAggregate) Finalize(_ context.Context) error {
 	return nil
 }
 
-func (h *HashAggregate) Close() error { return nil }
+// Close releases any tracker reservation HashAggregate still holds for
+// group-state memory and buffered-but-unspilled rows. Without this, a
+// non-spilling HashAggregate accumulates a phantom reservation in the
+// shared tracker for the lifetime of the process; see HashJoin.Close for
+// the full background.
+func (h *HashAggregate) Close() error {
+	if h.Spill != nil {
+		if h.trackedGroupMem > 0 {
+			h.Spill.ReleaseTracking(h.trackedGroupMem)
+			h.trackedGroupMem = 0
+		}
+		if h.spillBufferBytes > 0 {
+			h.Spill.ReleaseTracking(h.spillBufferBytes)
+			h.spillBufferBytes = 0
+		}
+	}
+	h.spillBuffer = nil
+	return nil
+}
 
 // Next returns the aggregated results in batches of DefaultBatchSize rows.
 func (h *HashAggregate) Next(_ context.Context) (*batch.RecordBatch, error) {

--- a/internal/engine/exec/join.go
+++ b/internal/engine/exec/join.go
@@ -3295,6 +3295,35 @@ func (p *HashJoinProbe) FlushUnmatched(leftSchema []parquet.Column) *batch.Recor
 
 func (p *HashJoinProbe) Close() error { return nil }
 
+// Close releases any memory still reserved with the shared MemTracker and
+// drops references to the build-side state so Go's GC can reclaim it
+// promptly. Must be called by the owner of the HashJoin (the worker
+// executor) after the probe pipeline has fully drained — including any
+// spilled-partition flushes. Calling Close more than once is safe; the
+// release amount goes to zero on the first call.
+//
+// Without this, an operator that builds-probes-completes WITHOUT spilling
+// never returns its reservation to the shared tracker. The hash table is
+// GC-eligible but the tracker thinks it's still in use, so the worker
+// reports inflated PoolPressure to the coordinator and worker-side spill
+// thresholds fire prematurely. With many concurrent broadcast joins (e.g.,
+// TPC-H Q02), phantom reservations accumulate query-over-query.
+func (h *HashJoin) Close() error {
+	if h.MemTracker != nil && h.trackedMem > 0 {
+		h.MemTracker.Release(h.trackedMem)
+		h.trackedMem = 0
+	}
+	h.trackedHashOverhead = 0
+	h.buildBatches = nil
+	h.arena = nil
+	h.arenaNext = nil
+	h.intIndex = nil
+	h.strIndex = nil
+	h.bloom = nil
+	h.bloomMask = 0
+	return nil
+}
+
 // Clone returns a new HashJoinProbe that shares the same build-side hash table
 // but has its own scratch buffers (pairsBuf, semiSelBuf, lookupBuf, indexBuf).
 func (p *HashJoinProbe) Clone() UnaryOperator {

--- a/internal/engine/exec/operator_close_releases_tracker_test.go
+++ b/internal/engine/exec/operator_close_releases_tracker_test.go
@@ -1,0 +1,172 @@
+package exec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/memory"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// TestHashJoin_Close_ReleasesTracker is a regression test for the operator
+// memory-tracker leak that surfaced in the 2026-04-29 SF10 deploy. PR #65
+// added shared-tracker accounting on HashJoin (Reserve during Build, Release
+// during spill). When a join completes WITHOUT spilling, no Release path
+// fires — the reservation accumulates in the tracker for the lifetime of
+// the worker process. Across many concurrent broadcast joins the worker
+// reports phantom-high pool pressure to the coordinator and trips
+// worker-side spill thresholds prematurely. PR #76 removed the coord-side
+// gate that turned this into a deadlock; this fix removes the leak itself.
+func TestHashJoin_Close_ReleasesTracker(t *testing.T) {
+	tracker := memory.NewTracker("test", 128*1024*1024)
+	spill, err := memory.NewSpillManager(t.TempDir(), tracker)
+	if err != nil {
+		t.Fatalf("NewSpillManager: %v", err)
+	}
+
+	leftSchema := []parquet.Column{
+		{Name: "k", Type: parquet.TypeString},
+		{Name: "amount", Type: parquet.TypeFloat64},
+	}
+	leftRows := []map[string]any{
+		{"k": "a", "amount": 1.0},
+		{"k": "b", "amount": 2.0},
+		{"k": "c", "amount": 3.0},
+	}
+	rightSchema := []parquet.Column{
+		{Name: "k", Type: parquet.TypeString},
+		{Name: "name", Type: parquet.TypeString},
+	}
+	rightRows := []map[string]any{
+		{"k": "a", "name": "Alice"},
+		{"k": "b", "name": "Bob"},
+	}
+
+	hj := NewHashJoin(InnerJoin, []string{"k"}, []string{"k"})
+	hj.MemTracker = tracker
+	hj.Spill = spill
+
+	// Use the production Build() path — it reserves through the tracker on
+	// every batch via reconcileHashMemory. BuildFromRows is a test-only
+	// helper that bypasses the tracker entirely.
+	if err := hj.Build(context.Background(), NewSliceSource(rightSchema, rightRows)); err != nil {
+		t.Fatalf("hj.Build: %v", err)
+	}
+	if got := tracker.Used(); got <= 0 {
+		t.Fatalf("expected tracker to register reservation after Build, got Used=%d", got)
+	}
+
+	pipe := &Pipeline{
+		Source: NewSliceSource(leftSchema, leftRows),
+		Ops:    []UnaryOperator{hj.Probe()},
+		Sink:   &CollectSink{},
+	}
+	if err := pipe.Run(context.Background()); err != nil {
+		t.Fatalf("pipeline.Run: %v", err)
+	}
+
+	if err := hj.Close(); err != nil {
+		t.Fatalf("hj.Close: %v", err)
+	}
+
+	if got := tracker.Used(); got != 0 {
+		t.Fatalf("HashJoin.Close did not release tracker reservation: Used=%d, want 0", got)
+	}
+}
+
+// TestSort_Close_ReleasesTracker verifies the same invariant for Sort: when
+// it completes without spilling, Close must release the tracker reservation
+// it accumulated for buffered rows.
+func TestSort_Close_ReleasesTracker(t *testing.T) {
+	tracker := memory.NewTracker("test", 128*1024*1024)
+	spill, err := memory.NewSpillManager(t.TempDir(), tracker)
+	if err != nil {
+		t.Fatalf("NewSpillManager: %v", err)
+	}
+
+	schema := []parquet.Column{
+		{Name: "v", Type: parquet.TypeInt64},
+	}
+	rows := make([]map[string]any, 256)
+	for i := range rows {
+		rows[i] = map[string]any{"v": int64(255 - i)}
+	}
+
+	s := NewSort([]SortKey{{Column: "v", Order: Ascending}})
+	s.Spill = spill
+
+	pipe := &Pipeline{
+		Source: NewSliceSource(schema, rows),
+		Sink:   s,
+	}
+	if err := pipe.Run(context.Background()); err != nil {
+		t.Fatalf("pipeline.Run: %v", err)
+	}
+
+	// Drain so finalize-side state is settled.
+	for {
+		b, err := s.Next(context.Background())
+		if err != nil || b == nil {
+			break
+		}
+	}
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("Sort.Close: %v", err)
+	}
+
+	if got := tracker.Used(); got != 0 {
+		t.Fatalf("Sort.Close did not release tracker reservation: Used=%d, want 0", got)
+	}
+}
+
+// TestHashAggregate_Close_ReleasesTracker verifies the same invariant for
+// HashAggregate: when it completes without spilling, Close must release
+// both the group-state reservation and any unspilled buffer reservation.
+func TestHashAggregate_Close_ReleasesTracker(t *testing.T) {
+	tracker := memory.NewTracker("test", 128*1024*1024)
+	spill, err := memory.NewSpillManager(t.TempDir(), tracker)
+	if err != nil {
+		t.Fatalf("NewSpillManager: %v", err)
+	}
+
+	schema := []parquet.Column{
+		{Name: "g", Type: parquet.TypeString},
+		{Name: "v", Type: parquet.TypeInt64},
+	}
+	rows := []map[string]any{
+		{"g": "a", "v": int64(1)},
+		{"g": "b", "v": int64(2)},
+		{"g": "a", "v": int64(3)},
+		{"g": "c", "v": int64(4)},
+	}
+
+	hashAgg := NewHashAggregate(
+		[]string{"g"},
+		[]AggColumn{{Func: AggSum, InputCol: "v", OutputCol: "s", OutputType: parquet.TypeInt64}},
+	)
+	hashAgg.Spill = spill
+
+	pipe := &Pipeline{
+		Source: NewSliceSource(schema, rows),
+		Sink:   hashAgg,
+	}
+	if err := pipe.Run(context.Background()); err != nil {
+		t.Fatalf("pipeline.Run: %v", err)
+	}
+
+	for {
+		b, err := hashAgg.Next(context.Background())
+		if err != nil || b == nil {
+			break
+		}
+	}
+
+	if err := hashAgg.Close(); err != nil {
+		t.Fatalf("HashAggregate.Close: %v", err)
+	}
+
+	if got := tracker.Used(); got != 0 {
+		t.Fatalf("HashAggregate.Close did not release tracker reservation: Used=%d, want 0", got)
+	}
+}

--- a/internal/engine/exec/sort.go
+++ b/internal/engine/exec/sort.go
@@ -371,7 +371,20 @@ func (s *Sort) MergeSink(other SinkSource) {
 	o.batches = nil
 }
 
-func (s *Sort) Close() error { return nil }
+// Close releases any tracker reservation Sort still holds for buffered rows
+// that never crossed the spill threshold, and drops references so the GC
+// can reclaim immediately. Without this, a non-spilling Sort accumulates a
+// phantom reservation in the shared tracker for the lifetime of the
+// process; see HashJoin.Close for the full background.
+func (s *Sort) Close() error {
+	if s.Spill != nil && s.trackedMem > 0 {
+		s.Spill.ReleaseTracking(s.trackedMem)
+		s.trackedMem = 0
+	}
+	s.batches = nil
+	s.totalRows = 0
+	return nil
+}
 
 // Next returns sorted results in batches.
 func (s *Sort) Next(_ context.Context) (*batch.RecordBatch, error) {

--- a/internal/worker/executor_stage.go
+++ b/internal/worker/executor_stage.go
@@ -257,6 +257,11 @@ func (e *Executor) executeStageHashJoin(ctx context.Context, task distributed.Ta
 		hj.Spill = e.sharedSpill
 		hj.MemTracker = e.sharedTracker
 	}
+	// Close releases trackedMem to the shared tracker once the join is done.
+	// Without this, a non-spilling broadcast_join leaks its reservation for
+	// the lifetime of the worker process — phantom pool pressure inflates
+	// across queries and triggers worker-side spill prematurely.
+	defer hj.Close()
 
 	if err := buildSource.Init(ctx); err != nil {
 		return fmt.Errorf("hash_join task %s: init build source: %w", task.ID, err)
@@ -425,6 +430,9 @@ func (e *Executor) executeStageAggregate(ctx context.Context, task distributed.T
 	if e.sharedSpill != nil {
 		hashAgg.Spill = e.sharedSpill
 	}
+	// Close releases tracker reservations once draining is complete; see
+	// HashJoin defer above for why this is required.
+	defer hashAgg.Close()
 
 	// Order: source → filters → derived-column projection → HashAggregate.
 	// Filter first so expressions only evaluate on surviving rows.
@@ -638,6 +646,9 @@ func (e *Executor) executeStageSort(ctx context.Context, task distributed.Task, 
 		keys[i] = exec.SortKey{Column: k.Column, Order: order}
 	}
 	sorter := exec.NewSort(keys)
+	// Close releases tracker reservation; see HashJoin defer for the
+	// architectural rationale.
+	defer sorter.Close()
 
 	pipeline := &exec.Pipeline{
 		Source: src,


### PR DESCRIPTION
## Summary

PR #65 added shared `MemTracker` accounting on HashJoin, Sort, and HashAggregate. Each reserves bytes during build/consume and **only** releases on the spill path. When an operator runs to completion *without* spilling — the common case for broadcast_join in healthy memory regimes — its reservation is never returned. The worker's `PoolPressure` metric stays inflated for the lifetime of the process.

In the 2026-04-29 SF10 Q02 deploy, 5 broadcast joins ran concurrently. Each leaked ~1–3 GB of phantom reservation on completion. The worker reported >85% pool pressure even when the actual Go heap was fine. The coord-side gate (now removed in PR #76) deadlocked on this; with the gate gone, the symptom shifts to: workers report inflated pressure → worker-side pool-pressure spill fires unnecessarily → queries slow without OOMing.

This PR removes the leak itself.

## Two-layer fix

1. **Operators release on `Close`.** `HashJoin` gets a new `Close()` that releases `trackedMem` and drops build-state references. `Sort.Close()` and `HashAggregate.Close()` (both previously empty) now release `trackedMem` / `trackedGroupMem` / `spillBufferBytes` via the SpillManager's tracker.
2. **Executor calls `Close`.** `Pipeline.Run` does not auto-Close (the caller may still need to drain a SinkSource via `Next`, e.g. `HashAggregate.Next`). The three call sites in `executor_stage.go` now `defer X.Close()` immediately after construction so release runs on every exit path including error paths.

`HashJoinProbe.Close` stays empty: clones share the parent `HashJoin`, so per-clone release would over-release. The single `hj.Close()` from the executor is the canonical lifecycle endpoint.

## Test plan

- [x] New `operator_close_releases_tracker_test.go` — three regression tests, one per operator, that build/probe-and-drain through the production code path with a real `Tracker`, then assert `tracker.Used()==0` after `Close`. Verified the test catches the regression: stashing the fix to `join.go` causes the test to fail to compile (`hj.Close undefined`) rather than reproducing the silent leak in production.
- [x] `go test ./internal/engine/exec/` — pass
- [x] `go test ./internal/worker/` — pass
- [x] TPC-H SF0.01 — 22/22 pass
- [ ] SF10 EC2 deploy — needs explicit user approval per `feedback_no_auto_deploy`. Combined with PR #75 (cache durability) + PR #76 (gate removal), Q02 should now exercise the actual memory regime instead of the deadlock + inflation regime.

## Why this isn't benchmark-chasing

Per HARD RULE on architectural fixes: this is a primitive correction. Memory tracker semantics were broken — Reserve had no symmetric Release for the non-spill path. No threshold was tuned, no per-query patch added. The pattern (operator Close releases its reservation) matches what HashJoin already did during spill — we're just making the contract complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)