### PR TITLE
fix(coordinator): treat TaskProgress as a heartbeat-equivalent liveness signal

### DIFF
--- a/internal/coordinator/multi_signal_liveness_test.go
+++ b/internal/coordinator/multi_signal_liveness_test.go
@@ -1,0 +1,148 @@
+package coordinator
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+)
+
+// TestWorkerRegistry_TaskProgressKeepsWorkerAlive is a regression test for
+// the 2026-04-29 SF10 Q03 hot-potato pattern. Workers GC-thrashed under
+// lineitem broadcast-join build pressure and their global heartbeat
+// goroutine starved past the 90s stale TTL — even while per-task goroutines
+// still emitted TaskProgress. Coord reaped them, JetStream redelivered to
+// other equally-stressed workers, and the cluster cycled until query
+// timeout.
+//
+// The fix has the WorkerRegistry treat TaskProgress messages as a
+// heartbeat-equivalent liveness signal: any TaskProgress for a registered
+// worker bumps its LastSeen. This test simulates the exact failure shape
+// (heartbeat silent, TaskProgress flowing) and asserts the worker is NOT
+// reaped.
+func TestWorkerRegistry_TaskProgressKeepsWorkerAlive(t *testing.T) {
+	cfg := distributed.DefaultNATSConfig()
+	cfg.Port = -1
+	cfg.StoreDir = t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	en, err := distributed.NewEmbeddedNATS(cfg, logger)
+	if err != nil {
+		t.Fatalf("NATS: %v", err)
+	}
+	defer en.Shutdown()
+
+	nc, err := distributed.ConnectInProcess(en.Server())
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer nc.Close()
+
+	// Aggressive 200ms stale TTL so the test runs in <2s.
+	wr := NewWorkerRegistry(nc, logger, 200*time.Millisecond)
+	defer wr.Close()
+
+	// Step 1: register a worker via heartbeat, the only path that creates
+	// a WorkerInfo entry. After this the worker should be active.
+	hb := distributed.WorkerHeartbeat{
+		WorkerID:      "w-progress",
+		ClusterID:     "test",
+		ActiveTaskIDs: []string{"task-A"},
+		Timestamp:     time.Now(),
+	}
+	data, err := distributed.Marshal(hb)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := nc.Publish(distributed.SubjectHeartbeat, data); err != nil {
+		t.Fatal(err)
+	}
+	nc.Flush()
+	time.Sleep(50 * time.Millisecond)
+
+	// Step 2: stop heartbeats. Emit only TaskProgress for the same worker,
+	// at 100ms intervals (faster than the 200ms stale TTL). With the fix,
+	// each TaskProgress arrival bumps LastSeen and prevents reap. Without
+	// the fix, the worker would be reaped after 200ms of heartbeat silence.
+	publishProgress := func() {
+		tp := distributed.TaskProgress{
+			QueryID:       "q",
+			StageID:       "s",
+			TaskID:        "task-A",
+			WorkerID:      "w-progress",
+			RowsProcessed: 1,
+			Timestamp:     time.Now(),
+		}
+		data, err := distributed.Marshal(tp)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := nc.Publish(distributed.TaskProgressSubject(tp.QueryID, tp.TaskID), data); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Run the no-heartbeat phase for 600ms = 3× the stale TTL.
+	deadline := time.Now().Add(600 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		publishProgress()
+		nc.Flush()
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Step 3: ReapStale should leave the worker alive because TaskProgress
+	// arrivals kept LastSeen fresh. Without the fix, the worker would have
+	// been reaped 400ms ago.
+	if reaped := wr.ReapStale(); reaped != 0 {
+		t.Fatalf("worker was reaped despite active TaskProgress: ReapStale returned %d", reaped)
+	}
+	active := wr.ActiveWorkers()
+	if len(active) != 1 || active[0].WorkerID != "w-progress" {
+		t.Fatalf("worker not active after TaskProgress flow: active=%+v", active)
+	}
+}
+
+// TestWorkerRegistry_ReapStillFiresWhenTaskProgressStops verifies the gate
+// works in the other direction: when TaskProgress stops too, the worker is
+// reaped at the configured stale TTL. We don't want the multi-signal
+// behavior to swallow genuine deaths.
+func TestWorkerRegistry_ReapStillFiresWhenTaskProgressStops(t *testing.T) {
+	cfg := distributed.DefaultNATSConfig()
+	cfg.Port = -1
+	cfg.StoreDir = t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	en, err := distributed.NewEmbeddedNATS(cfg, logger)
+	if err != nil {
+		t.Fatalf("NATS: %v", err)
+	}
+	defer en.Shutdown()
+
+	nc, err := distributed.ConnectInProcess(en.Server())
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer nc.Close()
+
+	wr := NewWorkerRegistry(nc, logger, 200*time.Millisecond)
+	defer wr.Close()
+
+	hb := distributed.WorkerHeartbeat{
+		WorkerID:  "w-dead",
+		ClusterID: "test",
+		Timestamp: time.Now(),
+	}
+	data, _ := distributed.Marshal(hb)
+	nc.Publish(distributed.SubjectHeartbeat, data)
+	nc.Flush()
+	time.Sleep(50 * time.Millisecond)
+
+	// No further heartbeat, no TaskProgress. After the stale TTL the worker
+	// is genuinely silent.
+	time.Sleep(400 * time.Millisecond)
+	if reaped := wr.ReapStale(); reaped != 1 {
+		t.Fatalf("genuinely silent worker not reaped: ReapStale returned %d", reaped)
+	}
+}

--- a/internal/coordinator/workers.go
+++ b/internal/coordinator/workers.go
@@ -25,7 +25,9 @@ type WorkerInfo struct {
 }
 
 // TaskLiveness tracks when each in-flight task was last reported active.
-// Updated from worker heartbeats. Used to detect stuck tasks.
+// Updated from worker heartbeats AND from per-task TaskProgress messages —
+// either signal is proof the worker process is alive (see WorkerRegistry's
+// progress subscription for why we need both). Used to detect stuck tasks.
 type TaskLiveness struct {
 	mu    sync.RWMutex
 	tasks map[string]time.Time // task ID → last heartbeat time
@@ -68,13 +70,14 @@ func (tl *TaskLiveness) StuckTasks(threshold time.Duration) []string {
 
 // WorkerRegistry tracks active workers from heartbeats.
 type WorkerRegistry struct {
-	mu       sync.RWMutex
-	workers  map[string]*WorkerInfo
-	stale    time.Duration // workers not heard from in this long are considered dead
-	logger   *slog.Logger
-	nc       *nats.Conn
-	sub      *nats.Subscription
-	Liveness *TaskLiveness // per-task progress tracking from heartbeats
+	mu          sync.RWMutex
+	workers     map[string]*WorkerInfo
+	stale       time.Duration // workers not heard from in this long are considered dead
+	logger      *slog.Logger
+	nc          *nats.Conn
+	sub         *nats.Subscription
+	progressSub *nats.Subscription // per-task progress, used as a heartbeat-equivalent liveness signal
+	Liveness    *TaskLiveness      // per-task progress tracking from heartbeats AND TaskProgress messages
 }
 
 // NewWorkerRegistry creates a worker registry that subscribes to heartbeats.
@@ -121,7 +124,48 @@ func NewWorkerRegistry(nc *nats.Conn, logger *slog.Logger, staleTTL time.Duratio
 	}
 	wr.sub = sub
 
+	// Per-task progress is published from a separate worker goroutine on a
+	// 2s cadence (see worker.go's per-task heartbeat goroutine). Treating
+	// it as a heartbeat-equivalent liveness signal decouples worker
+	// liveness from the global heartbeat goroutine being scheduled. In the
+	// 2026-04-29 SF10 Q03 reproduction, workers were GC-thrashing under
+	// lineitem broadcast-join build pressure; the global heartbeat
+	// goroutine starved past 90s, the workers were reaped, JetStream
+	// redelivered tasks to other workers that thrashed identically, and
+	// the cluster hot-potato'd until query timeout. With this signal,
+	// even one stalled goroutine in a multi-goroutine process keeps the
+	// worker alive in coord's view.
+	progressSub, err := nc.Subscribe(distributed.SubjectTaskProgressAll, func(msg *nats.Msg) {
+		var tp distributed.TaskProgress
+		if err := distributed.Unmarshal(msg.Data, &tp); err != nil {
+			return
+		}
+		wr.recordTaskProgress(tp)
+	})
+	if err != nil {
+		logger.Error("failed to subscribe to task progress", "error", err)
+	} else {
+		wr.progressSub = progressSub
+	}
+
 	return wr
+}
+
+// recordTaskProgress treats a per-task progress message as proof of life
+// for the emitting worker. Only updates an EXISTING WorkerInfo's LastSeen
+// — registration still requires a real heartbeat with cluster ID and pool
+// stats. If the worker hasn't registered yet, the progress message is
+// recorded for the task only.
+func (wr *WorkerRegistry) recordTaskProgress(tp distributed.TaskProgress) {
+	now := time.Now()
+	wr.mu.Lock()
+	if info, ok := wr.workers[tp.WorkerID]; ok {
+		info.LastSeen = now
+	}
+	wr.mu.Unlock()
+	if wr.Liveness != nil {
+		wr.Liveness.Update([]string{tp.TaskID}, now)
+	}
 }
 
 func (wr *WorkerRegistry) record(hb distributed.WorkerHeartbeat) {
@@ -302,9 +346,12 @@ func (wr *WorkerRegistry) StartReaper(ctx context.Context) {
 	}()
 }
 
-// Close unsubscribes from heartbeats.
+// Close unsubscribes from heartbeats and task progress.
 func (wr *WorkerRegistry) Close() {
 	if wr.sub != nil {
 		wr.sub.Unsubscribe()
+	}
+	if wr.progressSub != nil {
+		wr.progressSub.Unsubscribe()
 	}
 }


### PR DESCRIPTION
## Summary

In the 2026-04-29 SF10 Q03 deploy, workers GC-thrashed under lineitem broadcast-join build pressure. The global heartbeat goroutine starved past the 90s stale TTL even though per-task heartbeat goroutines kept emitting `TaskProgress`. Coord reaped them; JetStream redelivered tasks to other equally-stressed workers; cluster hot-potato'd until query timeout. Diagnostic: same `worker_id` UUIDs reappearing across reap/register cycles — UUIDs are per-process, so the workers were not crashing, just unresponsive.

This PR has the coord's `WorkerRegistry` subscribe to `wadjet.task.progress.>` alongside the existing heartbeat subscription. A `TaskProgress` arrival bumps `WorkerInfo.LastSeen` for the emitting worker. Reap is unchanged in shape but its single `LastSeen` signal is now fed by two sources: heartbeat **or** per-task progress. A worker is reaped only when both go silent past the stale TTL.

## Why this works even though both signals share a NATS connection

Per-task progress is published from per-task goroutines (one per running task, 2-second cadence) while the global heartbeat is published from a single goroutine (10-second cadence). When a process is GC-thrashing, individual goroutines are scheduled unevenly. The aggregate "any goroutine got CPU recently" signal is more robust than the single-goroutine "global heartbeat goroutine got CPU recently" signal.

Architecturally this matches Trino/Spark: cluster managers use multiple liveness signals (heartbeat, per-task progress, TCP keepalive) rather than betting on one. Worker code unchanged.

## Test plan

- [x] New `TestWorkerRegistry_TaskProgressKeepsWorkerAlive` — simulates the exact failure shape (heartbeat silent past TTL while `TaskProgress` flows), asserts the worker is NOT reaped. **Verified the test catches the regression** by stashing the fix: test fails with "worker was reaped despite active TaskProgress."
- [x] New `TestWorkerRegistry_ReapStillFiresWhenTaskProgressStops` — verifies reap still fires when **both** signals go silent (don't want multi-signal to swallow genuine deaths).
- [x] `go test ./internal/coordinator/` — 200+ tests pass; 2 pre-existing env failures (`TestDistributedTPCH{BuildCacheSF100Sample,Q12SF100Sample}`) unrelated.
- [x] `go test ./internal/worker/` — pass.
- [x] TPC-H SF0.01 — 22/22 pass.
- [ ] SF10 EC2 deploy — needs explicit user approval per `feedback_no_auto_deploy`. Combined with #75/#76/#77, Q03 should now make forward progress through its lineitem broadcast joins instead of cycling in the reap-redispatch hot-potato.

## Why this isn't benchmark-chasing

Per HARD RULE on architectural fixes: a single-signal liveness check is architecturally fragile when the signal source can be locally starved. Adding a second independent signal source is a primitive correction, not a threshold tweak. No knob added; the existing 90s stale TTL still applies — it's now just measured against a richer signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)