### PR TITLE
fix(exec): report build-side progress in HashJoin.Build

### DIFF
--- a/internal/engine/exec/hashjoin_build_progress_test.go
+++ b/internal/engine/exec/hashjoin_build_progress_test.go
@@ -1,0 +1,81 @@
+package exec
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// countingReporter satisfies ProgressReporter and tallies AddRows / AddBytes
+// calls atomically so concurrent build paths can update without a mutex.
+type countingReporter struct {
+	rows  atomic.Int64
+	bytes atomic.Int64
+}
+
+func (c *countingReporter) AddRows(n int64)  { c.rows.Add(n) }
+func (c *countingReporter) AddBytes(n int64) { c.bytes.Add(n) }
+
+// TestHashJoin_Build_ReportsProgress is a regression test for the
+// 2026-04-29 PM SF10 hot-potato pattern. Pipeline.runSerial bumps the
+// per-task ProgressReporter for every batch, but HashJoin.Build runs its
+// own source.Next loop independently of Pipeline. For long broadcast_join
+// builds (60M-row lineitem), no rows-processed signal flowed; the per-task
+// heartbeat goroutine emitted no TaskProgress; PR #78's multi-signal
+// liveness check had nothing to fall back on; workers were reaped past
+// the 90s stale TTL even though their executor goroutines were making
+// progress.
+//
+// The fix: Build pulls the ProgressReporter from ctx and bumps it for
+// each consumed batch, mirroring Pipeline.runSerial's behaviour.
+func TestHashJoin_Build_ReportsProgress(t *testing.T) {
+	rep := &countingReporter{}
+	ctx := WithProgressReporter(context.Background(), rep)
+
+	schema := []parquet.Column{
+		{Name: "k", Type: parquet.TypeString},
+	}
+	const numRows = 4096
+	rows := make([]map[string]any, numRows)
+	for i := range rows {
+		rows[i] = map[string]any{"k": "key"}
+	}
+
+	hj := NewHashJoin(InnerJoin, []string{"k"}, []string{"k"})
+	if err := hj.Build(ctx, NewSliceSource(schema, rows)); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	if got := rep.rows.Load(); got != int64(numRows) {
+		t.Fatalf("HashJoin.Build did not report progress for build-side rows: got AddRows total=%d, want %d", got, numRows)
+	}
+}
+
+// TestHashJoin_Build_ReportsProgressKeyOnly mirrors the above for the
+// SemiAntiKeyOnly parallel build path. Different code path, same gap if
+// not patched.
+func TestHashJoin_Build_ReportsProgressKeyOnly(t *testing.T) {
+	rep := &countingReporter{}
+	ctx := WithProgressReporter(context.Background(), rep)
+
+	schema := []parquet.Column{
+		{Name: "k", Type: parquet.TypeString},
+	}
+	const numRows = 4096
+	rows := make([]map[string]any, numRows)
+	for i := range rows {
+		rows[i] = map[string]any{"k": "key"}
+	}
+
+	hj := NewHashJoin(SemiJoin, []string{"k"}, []string{"k"})
+	hj.SemiAntiKeyOnly = true
+	if err := hj.Build(ctx, NewSliceSource(schema, rows)); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	if got := rep.rows.Load(); got != int64(numRows) {
+		t.Fatalf("HashJoin.Build (key-only path) did not report progress: got AddRows total=%d, want %d", got, numRows)
+	}
+}

--- a/internal/engine/exec/join.go
+++ b/internal/engine/exec/join.go
@@ -677,6 +677,17 @@ func (h *HashJoin) Build(ctx context.Context, source Source) error {
 	// and costs as much as the parallel insertion saved (~9s for 60M rows).
 	// Serial without spill is a tight loop at ~0.6s/60M rows.
 
+	// Report build-side row consumption to the per-task progress reporter.
+	// Without this, a long broadcast_join build phase (minutes for SF10
+	// lineitem) emits no rows-processed signal — the per-task heartbeat
+	// goroutine (worker.go) doesn't publish TaskProgress messages, AckWait
+	// extensions stop after the InProgress cap, and the coord's
+	// multi-signal liveness check (PR #78) has nothing to fall back on
+	// when the worker's global heartbeat goroutine is GC-starved. Result:
+	// the build task hot-potatoes across workers (observed 2026-04-29 PM
+	// SF10 deploy of 3b57e93 — task 3455f719 reaped 3× in 3 minutes).
+	progress := ProgressReporterFromContext(ctx)
+
 	for {
 		if err := ctx.Err(); err != nil {
 			return fmt.Errorf("join build cancelled: %w", err)
@@ -688,6 +699,9 @@ func (h *HashJoin) Build(ctx context.Context, source Source) error {
 		}
 		if b == nil {
 			break
+		}
+		if progress != nil {
+			progress.AddRows(int64(b.ActiveLen()))
 		}
 
 		h.mu.Lock()
@@ -1166,6 +1180,10 @@ func (h *HashJoin) buildParallelKeyOnly(ctx context.Context, source Source, work
 
 	// Insert first batch into worker 0.
 	h.insertKeyOnlyBatch(locals[0], first)
+	progress := ProgressReporterFromContext(ctx)
+	if progress != nil {
+		progress.AddRows(int64(first.ActiveLen()))
+	}
 
 	// Launch workers.
 	var sourceMu sync.Mutex
@@ -1194,6 +1212,9 @@ func (h *HashJoin) buildParallelKeyOnly(ctx context.Context, source Source, work
 				}
 				if b == nil {
 					return
+				}
+				if progress != nil {
+					progress.AddRows(int64(b.ActiveLen()))
 				}
 				h.insertKeyOnlyBatch(lb, b)
 			}


### PR DESCRIPTION
## Summary

`HashJoin.Build` runs its own `source.Next` loop independent of `Pipeline.runSerial`. The latter calls `progress.AddRows` for every batch it pulls; the former didn't. For long broadcast_join builds (60M-row lineitem at SF10 = minutes), no rows-processed signal flowed to the worker's per-task heartbeat goroutine, which therefore emitted no `TaskProgress` NATS messages, which means PR #78's multi-signal liveness check on the coord side had nothing to fall back on when the worker's global heartbeat goroutine was GC-starved.

Result, observed 2026-04-29 PM SF10 deploy (commit 3b57e93): task `3455f719` was reaped 3× across 3 different workers in 3 minutes. The hot-potato pattern that #78 was supposed to fix.

The fix mirrors `Pipeline.runSerial`: pull `ProgressReporterFromContext` at the top of Build, call `AddRows` for each consumed batch on both the serial path and the parallel `SemiAntiKeyOnly` path. The unused `buildParallel` path is left alone (the comment block at line ~675 documents it as dead code).

## Test plan

- [x] New `hashjoin_build_progress_test.go` — two regression tests, one per build path, each building a 4096-row source through a `countingReporter` and asserting `AddRows` total matches input. **Verified the tests catch the regression** by stashing the fix → both fail with `got AddRows total=0`.
- [x] `go test ./internal/engine/exec/` — pass
- [x] `go test ./internal/worker/` — pass
- [x] TPC-H SF0.01 — 22/22 pass
- [ ] SF10 EC2 deploy — needs explicit user approval per `feedback_no_auto_deploy`. With this fix, the per-task heartbeat goroutine should publish `TaskProgress` continuously throughout the lineitem build, keeping `LastSeen` fresh and preventing the reap-redispatch hot-potato.

## Why this isn't benchmark-chasing

This is a primitive correction — `Build` violated the invariant that all stage operators report rows-processed for the per-task heartbeat to function. No threshold was tuned, no per-query patch added. Same call pattern as `Pipeline.runSerial` already does, applied to the operator that had the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)