### PR TITLE
perf(worker): apply OutputFilter to distributed hash_join probes

### DIFF
--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -1480,6 +1480,14 @@ func (c *Coordinator) dispatchComputeStage(
 			ResultBucket:    c.config.ResultBucket,
 			ResultPrefix:    resultPrefix,
 			CreatedAt:       time.Now(),
+			// Output column projection for hash_join / broadcast_join stages.
+			// The worker applies these as the probe operator's OutputFilter so
+			// the join emits only the columns the downstream stage consumes,
+			// instead of the full union of build+probe schemas. Without this
+			// the wide post-join schema rides every chained shuffle (which
+			// can't prune via prunedScanColumns because TableName="" upstream
+			// of a join). Aggregate/sort stages ignore this field.
+			Columns: append([]string(nil), stage.Columns...),
 			// Filters attached to a compute stage (HAVING on
 			// aggregate/final_aggregate, residual predicates on
 			// hash_join) reference OUTPUT columns and must run after

--- a/internal/distributed/messages.go
+++ b/internal/distributed/messages.go
@@ -60,6 +60,15 @@ type Task struct {
 	// Scan-specific
 	Files           []string          `json:"files,omitempty"`
 	PartitionFilter map[string]string `json:"partition_filter,omitempty"`
+	// Columns has dual semantics by stage type:
+	//   - scan / shuffle tasks: input projection (columns to read from
+	//     parquet/wshf source).
+	//   - hash_join / broadcast_join tasks: output projection — the worker
+	//     applies these as the probe operator's OutputFilter so the join
+	//     emits only what the downstream stage consumes, instead of the
+	//     full union of build+probe schemas.
+	//   - aggregate / sort tasks: ignored (output schema is determined by
+	//     AggSpecs / SortKeys).
 	Columns         []string          `json:"columns,omitempty"`
 	FilterExprs     []string          `json:"filter_exprs,omitempty"` // SQL filter expressions for pushdown
 	// PostFilterExprs are SQL filter expressions applied to the stage's

--- a/internal/planner/physical/audit_columns_test.go
+++ b/internal/planner/physical/audit_columns_test.go
@@ -1,0 +1,126 @@
+package physical
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestAuditStageColumns dumps every stage's Columns slice for Q21/Q18 and
+// flags any planner-level leak of lineitem columns the query doesn't use.
+// Used during the 2026-05-03 column-pruning audit.
+//
+// Finding: planner-level Columns are well-pruned (no l_comment leaks at
+// stage boundaries). The real bytes-through-pipeline leak is at the worker
+// runtime, NOT at the planner — distributed hash_join workers don't propagate
+// stage.Columns into the probe's OutputFilter, so the join emits the FULL
+// union of build+probe schemas regardless of what's needed downstream. See
+// project_perf_pass_planner_column_pruning_2026-05-03.md for the full audit.
+//
+// Run:
+//   go test -v -run TestAuditStageColumns ./internal/planner/physical/
+func TestAuditStageColumns(t *testing.T) {
+	const q18 = `SELECT
+		c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice,
+		SUM(l_quantity) as total_qty
+	FROM customer
+	JOIN orders ON c_custkey = o_custkey
+	JOIN lineitem ON o_orderkey = l_orderkey
+	WHERE o_orderkey IN (
+		SELECT l_orderkey
+		FROM lineitem
+		GROUP BY l_orderkey
+		HAVING SUM(l_quantity) > 300
+	)
+	GROUP BY c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice
+	ORDER BY o_totalprice DESC, o_orderdate
+	LIMIT 100`
+
+	cases := []struct {
+		name     string
+		sql      string
+		liNeeded []string // lineitem cols actually referenced
+	}{
+		{"Q21", tpchPlanQueries["Q21"], []string{"l_orderkey", "l_suppkey", "l_receiptdate", "l_commitdate"}},
+		{"Q18", q18, []string{"l_orderkey", "l_quantity"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			auditQueryWithSQL(t, tc.name, tc.sql, tc.liNeeded)
+		})
+	}
+}
+
+func auditQueryWithSQL(t *testing.T, queryKey, sql string, liNeeded []string) {
+	cat, ctx := setupTPCHCatalog(t)
+	stages := sqlToStages(t, cat, ctx, sql, 3)
+
+	neededSet := make(map[string]bool, len(liNeeded))
+	for _, c := range liNeeded {
+		neededSet[c] = true
+	}
+
+	// Lineitem columns the query does NOT reference.
+	allLineitem := []string{
+		"l_orderkey", "l_partkey", "l_suppkey", "l_linenumber", "l_quantity",
+		"l_extendedprice", "l_discount", "l_tax", "l_returnflag", "l_linestatus",
+		"l_shipdate", "l_commitdate", "l_receiptdate", "l_shipinstruct",
+		"l_shipmode", "l_comment",
+	}
+	leakSet := make(map[string]bool, len(allLineitem))
+	for _, c := range allLineitem {
+		if !neededSet[c] {
+			leakSet[c] = true
+		}
+	}
+
+	t.Logf("=== %s STAGE COLUMNS AUDIT (%d stages) ===", queryKey, len(stages))
+	t.Logf("%s needs lineitem cols: %v", queryKey, liNeeded)
+	t.Logf("")
+
+	leakCount := 0
+	for _, s := range stages {
+		colsCopy := append([]string(nil), s.Columns...)
+		sort.Strings(colsCopy)
+		desc := s.Type
+		if s.TableName != "" {
+			desc += " table=" + s.TableName
+		}
+		if s.ScanAlias != "" && s.ScanAlias != s.TableName {
+			desc += " alias=" + s.ScanAlias
+		}
+		if s.Exchange != nil && len(s.Exchange.Keys) > 0 {
+			desc += " shuffleKeys=" + strings.Join(s.Exchange.Keys, ",")
+		}
+		t.Logf("STAGE %-22s [%s]", s.ID, desc)
+		if len(colsCopy) == 0 {
+			t.Logf("  Columns: <nil> (SELECT *)")
+		} else {
+			t.Logf("  Columns (%d): %v", len(colsCopy), colsCopy)
+		}
+
+		// Flag leaks.
+		var leaks []string
+		for _, c := range colsCopy {
+			if leakSet[c] {
+				leaks = append(leaks, c)
+			}
+		}
+		if len(leaks) > 0 {
+			leakCount++
+			t.Logf("  *** LEAK: stage carries %d lineitem cols %s doesn't use: %v", len(leaks), queryKey, leaks)
+		}
+		t.Logf("")
+	}
+	t.Logf("=== %s SUMMARY: %d stages with leaked lineitem cols ===", queryKey, leakCount)
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/worker/executor_stage.go
+++ b/internal/worker/executor_stage.go
@@ -448,6 +448,20 @@ func (e *Executor) executeStageHashJoin(ctx context.Context, task distributed.Ta
 	// the wider probe schema after all fused joins have run.
 	probeOps := make([]exec.UnaryOperator, 0, len(task.FusedJoins)+1)
 	fusedJoins := make([]*exec.HashJoin, 0, len(task.FusedJoins))
+	// Output column projection: the planner sets stage.Columns to the columns
+	// the downstream stage consumes from this join's output. The probe operator
+	// uses OutputFilter to drop everything else, so the join writes a tight
+	// schema to its WSHF instead of the full union of build+probe columns.
+	// Empty Columns → nil filter → preserves "emit everything" semantics.
+	// Qualified names (e.g. "n2.n_name" from self-joins) are handled by the
+	// probe's lookup (see internal/engine/exec/join.go OutputSchema dot-strip).
+	var outputFilter map[string]bool
+	if len(task.Columns) > 0 {
+		outputFilter = make(map[string]bool, len(task.Columns))
+		for _, c := range task.Columns {
+			outputFilter[c] = true
+		}
+	}
 	// Defer cleanup BEFORE building any fused joins so that an error
 	// partway through the loop still releases tracker reservations and
 	// closes spill files for every fjHJ that was constructed. The earlier
@@ -513,10 +527,19 @@ func (e *Executor) executeStageHashJoin(ctx context.Context, task distributed.Ta
 		}
 		fjBuildSrc.Close()
 		fjHJ.FixKeyAssignment()
+		// No OutputFilter on fused probes: each fused probe must emit columns
+		// that LATER probes in the chain (including the primary) consume —
+		// e.g. probe-side keys for the next join. task.Columns reflects the
+		// primary's NeededColumns only, so applying it to a fused probe would
+		// silently drop those downstream-key columns mid-chain.
 		probeOps = append(probeOps, fjHJ.Probe())
 	}
-	// Primary probe last — the original consumer-of-fused position.
-	probeOps = append(probeOps, hj.Probe())
+	// Primary probe last — its output is what the stage emits. OutputFilter
+	// here is safe: nothing downstream of the primary consumes intermediate
+	// columns that aren't already in task.Columns.
+	primaryProbe := hj.Probe()
+	primaryProbe.OutputFilter = outputFilter
+	probeOps = append(probeOps, primaryProbe)
 
 	// Probe pipeline with CollectSink; we post-process batches into the
 	// configured output sink. CollectSink is memory-bounded by the build

--- a/internal/worker/executor_stage_hashjoin_test.go
+++ b/internal/worker/executor_stage_hashjoin_test.go
@@ -199,3 +199,161 @@ func TestExecuteStageHashJoin_PartitionedOutput(t *testing.T) {
 		}
 	}
 }
+
+// TestExecuteStageHashJoin_OutputFilterPrunesColumns verifies that
+// task.Columns is wired into probe.OutputFilter so the join's WSHF output
+// only contains the requested columns, not the full union of build+probe
+// schemas. Regression for the column-pruning audit (2026-05-03).
+func TestExecuteStageHashJoin_OutputFilterPrunesColumns(t *testing.T) {
+	ctx := context.Background()
+	const bucket = "test-stage-outfilter"
+
+	buildData := makeBuildWshf(t, [][2]int64{{1, 100}, {2, 200}, {3, 300}})
+	probeData := makeProbeWshf(t, []struct {
+		ID   int64
+		Name string
+	}{{1, "alice"}, {2, "bob"}, {4, "dave"}})
+
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(ctx, bucket); err != nil {
+		t.Fatalf("MakeBucket: %v", err)
+	}
+	buildKey := "in/build/t.wshf"
+	probeKey := "in/probe/t.wshf"
+	if _, err := store.Put(ctx, bucket, buildKey, bytes.NewReader(buildData), int64(len(buildData)), "application/octet-stream"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Put(ctx, bucket, probeKey, bytes.NewReader(probeData), int64(len(probeData)), "application/octet-stream"); err != nil {
+		t.Fatal(err)
+	}
+
+	cache := NewLRUCache(4 * 1024 * 1024)
+	executor := NewExecutor(store, cache, nil)
+
+	// Without OutputFilter the join would emit the full union {id, val, name}.
+	// With Columns=["name"] only the probe-side string column should remain.
+	task := distributed.Task{
+		ID:              "hj-outfilter",
+		QueryID:         "q",
+		StageID:         "join-out",
+		Type:            distributed.TaskTypeStage,
+		StageType:       "hash_join",
+		JoinType:        "inner",
+		JoinLeftKeys:    []string{"id"},
+		JoinRightKeys:   []string{"id"},
+		BuildTableAlias: "build",
+		Columns:         []string{"name"},
+		Inputs: map[string][]string{
+			"build": {buildKey},
+			"probe": {probeKey},
+		},
+		DataBucket:   bucket,
+		ResultBucket: bucket,
+		ResultPrefix: "out/join-out/",
+	}
+
+	result := &distributed.ResultNotification{TaskID: task.ID}
+	if err := executor.executeStage(ctx, task, result); err != nil {
+		t.Fatalf("executeStage: %v", err)
+	}
+	if result.NumRows != 2 {
+		t.Fatalf("expected 2 joined rows (ids 1+2), got %d", result.NumRows)
+	}
+	if len(result.ResultFiles) != 1 {
+		t.Fatalf("expected 1 output file, got %d", len(result.ResultFiles))
+	}
+
+	got, _, err := store.Get(ctx, bucket, result.ResultFiles[0])
+	if err != nil {
+		t.Fatalf("get result file: %v", err)
+	}
+	defer got.Close()
+	var raw bytes.Buffer
+	if _, err := raw.ReadFrom(got); err != nil {
+		t.Fatalf("read result file: %v", err)
+	}
+	payload, err := DecompressShuffleData(raw.Bytes())
+	if err != nil {
+		t.Fatalf("decompress: %v", err)
+	}
+	rdr, err := newShuffleChunkReader(payload)
+	if err != nil {
+		t.Fatalf("newShuffleChunkReader: %v", err)
+	}
+	if len(rdr.schema) != 1 {
+		names := make([]string, len(rdr.schema))
+		for i, c := range rdr.schema {
+			names[i] = c.Name
+		}
+		t.Fatalf("expected 1 output column with OutputFilter=[name], got %d: %v", len(rdr.schema), names)
+	}
+	if rdr.schema[0].Name != "name" {
+		t.Errorf("expected output column 'name', got %q", rdr.schema[0].Name)
+	}
+}
+
+// TestExecuteStageHashJoin_OutputFilterEmptyAllowsAllColumns verifies that
+// when task.Columns is empty (e.g. tasks dispatched before the audit fix
+// landed, or stages without a tighter projection), the probe behaves as
+// before: emit all build+probe columns.
+func TestExecuteStageHashJoin_OutputFilterEmptyAllowsAllColumns(t *testing.T) {
+	ctx := context.Background()
+	const bucket = "test-stage-noflt"
+
+	buildData := makeBuildWshf(t, [][2]int64{{1, 10}})
+	probeData := makeProbeWshf(t, []struct {
+		ID   int64
+		Name string
+	}{{1, "x"}})
+
+	store := objstore.NewMemStore()
+	_ = store.MakeBucket(ctx, bucket)
+	store.Put(ctx, bucket, "b.wshf", bytes.NewReader(buildData), int64(len(buildData)), "application/octet-stream")
+	store.Put(ctx, bucket, "p.wshf", bytes.NewReader(probeData), int64(len(probeData)), "application/octet-stream")
+
+	cache := NewLRUCache(4 * 1024 * 1024)
+	executor := NewExecutor(store, cache, nil)
+
+	task := distributed.Task{
+		ID:              "hj-nofilter",
+		QueryID:         "q",
+		StageID:         "join-nf",
+		Type:            distributed.TaskTypeStage,
+		StageType:       "hash_join",
+		JoinType:        "inner",
+		JoinLeftKeys:    []string{"id"},
+		JoinRightKeys:   []string{"id"},
+		BuildTableAlias: "build",
+		// Columns: nil — preserve legacy "emit all" semantics.
+		Inputs: map[string][]string{
+			"build": {"b.wshf"},
+			"probe": {"p.wshf"},
+		},
+		DataBucket:   bucket,
+		ResultBucket: bucket,
+		ResultPrefix: "out/join-nf/",
+	}
+
+	result := &distributed.ResultNotification{TaskID: task.ID}
+	if err := executor.executeStage(ctx, task, result); err != nil {
+		t.Fatalf("executeStage: %v", err)
+	}
+	got, _, err := store.Get(ctx, bucket, result.ResultFiles[0])
+	if err != nil {
+		t.Fatalf("get result file: %v", err)
+	}
+	defer got.Close()
+	var raw bytes.Buffer
+	raw.ReadFrom(got)
+	payload, err := DecompressShuffleData(raw.Bytes())
+	if err != nil {
+		t.Fatalf("decompress: %v", err)
+	}
+	rdr, err := newShuffleChunkReader(payload)
+	if err != nil {
+		t.Fatalf("reader: %v", err)
+	}
+	if len(rdr.schema) < 2 {
+		t.Errorf("expected ≥2 output columns when Columns is nil (full union), got %d", len(rdr.schema))
+	}
+}


### PR DESCRIPTION
## Summary
- Distributed hash_join workers were not setting `probe.OutputFilter`, so each join emitted the full union of build+probe schemas. Downstream chained shuffles couldn't prune (`TableName=""` → `prunedScanColumns` returns nil), so the wide schema rode every stage until the aggregate. The local single-process plan path already does this via `plan.go:3458/3487/3560`; this brings the distributed path to parity.
- **Coord** (`execute_stage_dag.go:1461-1491`): propagates `stage.Columns` to compute tasks.
- **Worker** (`executor_stage.go`): builds an `OutputFilter` from `task.Columns` and applies it to the **primary probe only**. Fused-chain probes pass through — `task.Columns` reflects the primary's `NeededColumns` and applying it mid-chain would drop columns later probes need (e.g. probe-side keys for the next join).

Motivated by the 2026-05-03 SF10 22/22 CPU profile: 20.6% memmove, 11% s2 codec on byte-column copies. Audit (`audit_columns_test.go`) confirmed planner-level Columns is correctly pruned for Q21/Q18 — the leak was at runtime.

## SF10 EC2 validation (da8e639 vs 851d4d5 baseline)

**22/22 PASS, total wall ~14 min vs 29 min baseline (-52%).** Cluster: c7g.2xlarge coord + 3× c7gd.4xlarge workers, on-demand, workers_per_node=1, max_concurrent=2.

Top wins (all join-heavy):

| Q | This run | Baseline | Δ |
|---|---|---|---|
| Q21 (anti-join chain) | 2m7s | 10m20s | **-79%** |
| Q22 | 15.4s | 1m20s | **-81%** |
| Q18 (IN-subquery, the audit's case) | 1m12s | 4m9s | **-71%** |
| Q13 | 30s | 1m14s | -59% |
| Q09 | 42s | 1m17s | -45% |
| Q05 | 48s | 1m19s | -39% |
| Q07 | 53s | 1m9s | -23% |
| Q03 | 1m1s | 1m17s | -21% |

Aggregate-only queries (Q01, Q06, Q15) within ±2% as expected — fix doesn't apply where there's no cross-join byte traffic.

Results: `s3://wadjet-bench-sf10-use2/results/da8e639-outputfilter/`

## Test plan
- [x] `internal/worker`: 2 new regression tests in `executor_stage_hashjoin_test.go` (Columns=[name] → 1-col output; nil Columns → full union preserved)
- [x] `internal/coordinator`: 362/362 PASS, 0 FAIL
- [x] `internal/planner/physical/audit_columns_test.go`: confirms Q21/Q18 stage Columns are tight
- [x] `cmd/tpch-harness --mode=local`: 25/25 PASS — distributed correctness gate
- [x] SF10 EC2 deploy: 22/22 PASS with -52% total wall

🤖 Generated with [Claude Code](https://claude.com/claude-code)