### PR TITLE
perf(planner): fuse scan + downstream exchange-repartition into one task

### DIFF
--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -1201,6 +1201,14 @@ func (c *Coordinator) dispatchScanFilterStage(
 			ResultPrefix: resultPrefix,
 			CreatedAt:    time.Now(),
 		}
+		// Fused scan+shuffle (planner's fuseScanShuffle pass): the scan
+		// task hash-partitions its filtered output directly via the
+		// worker's writePartitionedShuffle, eliminating one S3 PUT and
+		// one S3 GET vs the legacy scan→exchange-repartition split.
+		if stage.Exchange != nil && len(stage.Exchange.Keys) > 0 {
+			t.ShuffleKeys = append([]string(nil), stage.Exchange.Keys...)
+			t.NumPartitions = stage.Exchange.Count
+		}
 		if shardCount > 1 {
 			t.ScanShardIndex = shardIdx
 			t.ScanShardCount = shardCount
@@ -1280,11 +1288,38 @@ func (c *Coordinator) dispatchScanFilterStage(
 	results := make([]taskResult, len(collected))
 	copy(results, collected)
 	mu.Unlock()
-	files := make([][]string, len(tasks))
-	for i, r := range results {
+	for _, r := range results {
 		if r.err != "" {
 			return StageOutput{}, fmt.Errorf("scan-filter stage %s: task failed: %s", stage.ID, r.err)
 		}
+	}
+	// Fused scan+shuffle: each task produced N partition files
+	// (worker writePartitionedShuffle uploads to "<prefix>partition=NNNN/<task>.wshf").
+	// Bucket all files across all tasks by partition number so the downstream
+	// consumer reads each partition's full set. Same shape as runShuffleSide.
+	if stage.Exchange != nil && len(stage.Exchange.Keys) > 0 && stage.Exchange.Count > 0 {
+		numParts := stage.Exchange.Count
+		shardFiles := make([][]string, numParts)
+		for _, r := range results {
+			for _, f := range r.files {
+				p, parseErr := parsePartitionFromPath(f)
+				if parseErr != nil {
+					return StageOutput{}, fmt.Errorf("scan-filter stage %s: parsing partition from %q: %w", stage.ID, f, parseErr)
+				}
+				if p < 0 || p >= numParts {
+					return StageOutput{}, fmt.Errorf("scan-filter stage %s: partition %d out of range [0,%d) in %q", stage.ID, p, numParts, f)
+				}
+				shardFiles[p] = append(shardFiles[p], f)
+			}
+		}
+		return StageOutput{
+			Kind:          OutputPartitioned,
+			NumPartitions: numParts,
+			Files:         shardFiles,
+		}, nil
+	}
+	files := make([][]string, len(tasks))
+	for i, r := range results {
 		files[i] = r.files
 	}
 	return StageOutput{

--- a/internal/planner/physical/audit_columns_test.go
+++ b/internal/planner/physical/audit_columns_test.go
@@ -183,6 +183,35 @@ func TestAuditFusedJoinChains(t *testing.T) {
 					s.ID, s.TableName, len(s.ScanFiles), s.EstimatedBytes, s.EstimatedRows)
 			}
 			t.Logf("=== %s SUMMARY: total fused entries across all join stages = %d ===", tc.name, fusedTotal)
+
+			// Also count stages by type so we can see whether fuseScanShuffle
+			// eliminated exchange-repartition stages we expected to absorb.
+			byType := make(map[string]int)
+			for _, s := range stages {
+				byType[s.Type]++
+			}
+			t.Logf("--- %s stage counts by type ---", tc.name)
+			for _, k := range []string{"scan", "broadcast_join", "hash_join", "aggregate", "final_aggregate", "merge_aggregate", "exchange-repartition", "exchange-replicate", "exchange-gather", "sort", "merge_sort"} {
+				if v, ok := byType[k]; ok && v > 0 {
+					t.Logf("  %-22s %d", k, v)
+				}
+			}
+
+			// Per-scan: report whether the scan now carries Exchange metadata
+			// (i.e. fused with a downstream shuffle).
+			t.Logf("--- %s scan stages with fused-shuffle (Exchange != nil) ---", tc.name)
+			fusedScans := 0
+			for _, s := range stages {
+				if s.Type != "scan" {
+					continue
+				}
+				if s.Exchange != nil {
+					fusedScans++
+					keys := strings.Join(s.Exchange.Keys, ",")
+					t.Logf("  %s table=%s shuffleKeys=[%s] count=%d", s.ID, s.TableName, keys, s.Exchange.Count)
+				}
+			}
+			t.Logf("=== %s scan-shuffle fusion: %d scan stages absorbed downstream exchange ===", tc.name, fusedScans)
 		})
 	}
 }

--- a/internal/planner/physical/fuse_scan_shuffle.go
+++ b/internal/planner/physical/fuse_scan_shuffle.go
@@ -1,0 +1,128 @@
+package physical
+
+// fuseScanShuffle absorbs StageExchangeRepartition stages into their upstream
+// StageScan when safe, eliminating the round-trip of writing+re-reading an
+// unpartitioned WSHF between scan and shuffle.
+//
+// Today's flow:  scan → exchange-repartition → consumer
+//   scan emits unpartitioned WSHF; coord dispatches a separate shuffle task
+//   that reads it and writes partitioned WSHF; consumer reads the partitions.
+//
+// After fusion: scan(with shuffle metadata) → consumer
+//   scan task hash-partitions its filtered output directly
+//   (writePartitionedShuffle in worker) — saves one S3 PUT, one S3 GET, one
+//   NATS round-trip per fused scan-shuffle pair.
+//
+// Safety conditions:
+//  1. Exchange has exactly one dependency (the scan).
+//  2. Scan has exactly one dependent (the exchange) — no other stage reads
+//     the scan's unpartitioned output.
+//  3. Scan is a plain StageScan (not scan-aggregate, which has its own
+//     fan-out semantics via dispatchScanAggregateStage).
+//
+// Worker requirements: writeStageOutput already routes to
+// writePartitionedShuffle when ShuffleKeys+NumPartitions are set. Coord must
+// translate stage.Exchange (when set on a scan) into task.ShuffleKeys +
+// task.NumPartitions; that change lives in dispatchScanFilterStage.
+//
+// Run AFTER EnsureDistribution + the final assignStageDistributions, so the
+// exchange stages exist to absorb. Setting scan.Distribution directly here
+// is durable (no later pass overwrites it).
+func fuseScanShuffle(stages []Stage) []Stage {
+	// Count dependents per stage ID — a scan with multiple consumers can't be
+	// fused (the others would lose the unpartitioned shape).
+	depCount := make(map[string]int, len(stages))
+	for i := range stages {
+		for _, d := range stages[i].Dependencies {
+			depCount[d]++
+		}
+	}
+
+	// Map stage ID → index for efficient lookup + mutation.
+	idx := make(map[string]int, len(stages))
+	for i := range stages {
+		idx[stages[i].ID] = i
+	}
+
+	absorbed := make(map[string]string) // exchange ID → upstream scan ID
+
+	for i := range stages {
+		ex := &stages[i]
+		if ex.Type != StageExchangeRepartition {
+			continue
+		}
+		if len(ex.Dependencies) != 1 {
+			continue
+		}
+		if ex.Exchange == nil {
+			continue
+		}
+		scanIdx, ok := idx[ex.Dependencies[0]]
+		if !ok {
+			continue
+		}
+		scan := &stages[scanIdx]
+		if scan.Type != StageScan {
+			continue
+		}
+		// Don't fuse if the scan has fused partial-aggregate semantics —
+		// dispatchScanAggregateStage owns the partitioning of those.
+		if len(scan.FusedAggGroupBy) > 0 {
+			continue
+		}
+		// Don't fuse if the scan already had a non-singleton output target —
+		// can't have two different shuffle shapes off one scan.
+		if scan.Exchange != nil {
+			continue
+		}
+		// Don't fuse if any OTHER stage depends on the scan — they'd see the
+		// partitioned output and break.
+		if depCount[scan.ID] != 1 {
+			continue
+		}
+		// Don't fuse if any OTHER stage depends on the exchange — we're going
+		// to remove it, so its other dependents would lose their input.
+		if depCount[ex.ID] == 0 {
+			continue
+		}
+
+		// Absorb: scan inherits the exchange's distribution + Exchange payload.
+		// The dispatch layer reads scan.Exchange to decide whether to emit
+		// the scan task with ShuffleKeys+NumPartitions.
+		scan.Distribution = ex.Distribution
+		scan.Exchange = ex.Exchange
+		absorbed[ex.ID] = scan.ID
+	}
+
+	if len(absorbed) == 0 {
+		return stages
+	}
+
+	// Rewire downstream: any stage that depended on an absorbed exchange now
+	// depends on the upstream scan. Update Dependencies + LeftDepStage +
+	// RightDepStage in place.
+	for i := range stages {
+		s := &stages[i]
+		for k, dep := range s.Dependencies {
+			if newDep, replaced := absorbed[dep]; replaced {
+				s.Dependencies[k] = newDep
+			}
+		}
+		if newDep, replaced := absorbed[s.LeftDepStage]; replaced {
+			s.LeftDepStage = newDep
+		}
+		if newDep, replaced := absorbed[s.RightDepStage]; replaced {
+			s.RightDepStage = newDep
+		}
+	}
+
+	// Drop the absorbed exchange stages.
+	out := make([]Stage, 0, len(stages)-len(absorbed))
+	for _, s := range stages {
+		if _, dropped := absorbed[s.ID]; dropped {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/planner/physical/fuse_scan_shuffle_test.go
+++ b/internal/planner/physical/fuse_scan_shuffle_test.go
@@ -1,0 +1,100 @@
+package physical
+
+import (
+	"testing"
+)
+
+// TestFuseScanShuffle_BasicAbsorbs — exchange-repartition fed by a plain
+// scan with no other dependents gets absorbed into the scan; the downstream
+// consumer's dep is rewired to the scan.
+func TestFuseScanShuffle_BasicAbsorbs(t *testing.T) {
+	stages := []Stage{
+		{ID: "scan-0", Type: StageScan, TableName: "t"},
+		{
+			ID: "ex-1", Type: StageExchangeRepartition,
+			Dependencies: []string{"scan-0"},
+			Exchange:     &ExchangeStage{Keys: []string{"k"}, Count: 8},
+			Distribution: Distribution{Kind: DistHashPartitioned, Keys: []string{"k"}, Count: 8},
+		},
+		{
+			ID: "join-2", Type: StageHashJoin,
+			Dependencies:  []string{"ex-1", "other"},
+			LeftDepStage:  "ex-1",
+			RightDepStage: "other",
+		},
+	}
+
+	out := fuseScanShuffle(stages)
+
+	if len(out) != 2 {
+		t.Fatalf("expected 2 stages after fusion (scan + join), got %d", len(out))
+	}
+	var scan, join *Stage
+	for i := range out {
+		switch out[i].ID {
+		case "scan-0":
+			scan = &out[i]
+		case "join-2":
+			join = &out[i]
+		}
+	}
+	if scan == nil || join == nil {
+		t.Fatalf("missing expected stages after fusion: %+v", out)
+	}
+	if scan.Exchange == nil || len(scan.Exchange.Keys) != 1 || scan.Exchange.Keys[0] != "k" {
+		t.Errorf("scan should carry shuffle keys after absorb, got Exchange=%+v", scan.Exchange)
+	}
+	if scan.Distribution.Kind != DistHashPartitioned {
+		t.Errorf("scan distribution should be HashPartitioned, got %v", scan.Distribution.Kind)
+	}
+	if join.LeftDepStage != "scan-0" {
+		t.Errorf("join LeftDepStage should be rewired to scan-0, got %q", join.LeftDepStage)
+	}
+	if len(join.Dependencies) != 2 || join.Dependencies[0] != "scan-0" {
+		t.Errorf("join Dependencies should be rewired, got %v", join.Dependencies)
+	}
+}
+
+// TestFuseScanShuffle_SkipsScanWithMultipleConsumers — when the scan has
+// more than one downstream stage, fusion would partition output the other
+// consumer doesn't expect; skip.
+func TestFuseScanShuffle_SkipsScanWithMultipleConsumers(t *testing.T) {
+	stages := []Stage{
+		{ID: "scan-0", Type: StageScan, TableName: "t"},
+		{
+			ID: "ex-1", Type: StageExchangeRepartition,
+			Dependencies: []string{"scan-0"},
+			Exchange:     &ExchangeStage{Keys: []string{"k"}, Count: 8},
+		},
+		// Second consumer of scan-0: a broadcast-replicate stage.
+		{ID: "rep-2", Type: StageExchangeReplicate, Dependencies: []string{"scan-0"}},
+	}
+
+	out := fuseScanShuffle(stages)
+	if len(out) != 3 {
+		t.Fatalf("expected fusion to skip (3 stages), got %d", len(out))
+	}
+	for i := range out {
+		if out[i].ID == "scan-0" && out[i].Exchange != nil {
+			t.Errorf("scan-0 should NOT have absorbed the exchange (multiple consumers)")
+		}
+	}
+}
+
+// TestFuseScanShuffle_SkipsFusedAggScans — scans with FusedAggGroupBy are
+// owned by dispatchScanAggregateStage's RoundRobin fan-out; don't override.
+func TestFuseScanShuffle_SkipsFusedAggScans(t *testing.T) {
+	stages := []Stage{
+		{ID: "scan-0", Type: StageScan, TableName: "t", FusedAggGroupBy: []string{"g"}},
+		{
+			ID: "ex-1", Type: StageExchangeRepartition,
+			Dependencies: []string{"scan-0"},
+			Exchange:     &ExchangeStage{Keys: []string{"k"}, Count: 8},
+		},
+		{ID: "agg-2", Type: "merge_aggregate", Dependencies: []string{"ex-1"}},
+	}
+	out := fuseScanShuffle(stages)
+	if len(out) != 3 {
+		t.Fatalf("expected fusion to skip (3 stages), got %d", len(out))
+	}
+}

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -1363,6 +1363,11 @@ func (p *Planner) PlanDistributed(ctx context.Context, node *logical.Node) ([]St
 		// run it as one task instead of the N parallel tasks the exchange
 		// is feeding (Q18 SF10 OOM trigger).
 		assignStageDistributions(stages, p.WorkerCount)
+		// Fuse scan + downstream exchange-repartition into a single
+		// hash-partitioning scan task — saves one S3 round-trip per
+		// fused pair. Worker support is already there
+		// (writePartitionedShuffle); coord propagates via stage.Exchange.
+		stages = fuseScanShuffle(stages)
 		prev := BehaviorPreservingMode
 		BehaviorPreservingMode = false
 		defer func() { BehaviorPreservingMode = prev }()

--- a/internal/planner/physical/plan_tpch_test.go
+++ b/internal/planner/physical/plan_tpch_test.go
@@ -166,6 +166,7 @@ func sqlToStages(t *testing.T, cat *catalog.Catalog, ctx context.Context, sql st
 
 	planner := NewPlanner(cat)
 	planner.WorkerCount = workerCount
+	planner.UseEnsureDistribution = true // mirror production coord (always native-DAG)
 	stages, err := planner.PlanDistributed(ctx, logicalPlan)
 	if err != nil {
 		t.Fatalf("plan distributed: %v", err)

--- a/internal/planner/physical/testdata/ensure_distribution/q02.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q02.golden
@@ -2,14 +2,12 @@ scan-0	scan	Singleton
 scan-1	scan	Singleton
 scan-3	scan	Singleton
 join-4	broadcast_join	Singleton	deps=scan-0,exchange-replicate-join-4-3,scan-1
-scan-5	scan	Singleton
+scan-5	scan	Hash(ps_suppkey)/32
 exchange-repartition-6	exchange-repartition	Hash(s_suppkey)/32	deps=join-4
-exchange-repartition-7	exchange-repartition	Hash(ps_suppkey)/32	deps=scan-5
-join-8	hash_join	Hash(s_suppkey)/32	deps=exchange-repartition-6,exchange-repartition-7
-scan-9	scan	Singleton
+join-8	hash_join	Hash(s_suppkey)/32	deps=exchange-repartition-6,scan-5
+scan-9	scan	Hash(p_partkey)/32
 exchange-repartition-10	exchange-repartition	Hash(ps_partkey)/32	deps=join-8
-exchange-repartition-11	exchange-repartition	Hash(p_partkey)/32	deps=scan-9
-join-12	hash_join	Hash(ps_partkey)/32	deps=exchange-repartition-10,exchange-repartition-11
+join-12	hash_join	Hash(ps_partkey)/32	deps=exchange-repartition-10,scan-9
 scan-13	scan	Singleton
 scan-14	scan	Singleton
 scan-16	scan	Singleton

--- a/internal/planner/physical/testdata/ensure_distribution/q03.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q03.golden
@@ -1,12 +1,9 @@
-scan-0	scan	Singleton
-scan-1	scan	Singleton
-exchange-repartition-2	exchange-repartition	Hash(o_custkey)/32	deps=scan-0
-exchange-repartition-3	exchange-repartition	Hash(c_custkey)/32	deps=scan-1
-join-4	hash_join	Hash(o_custkey)/32	deps=exchange-repartition-2,exchange-repartition-3
-scan-5	scan	Singleton
+scan-0	scan	Hash(o_custkey)/32
+scan-1	scan	Hash(c_custkey)/32
+join-4	hash_join	Hash(o_custkey)/32	deps=scan-0,scan-1
+scan-5	scan	Hash(l_orderkey)/32
 exchange-repartition-6	exchange-repartition	Hash(o_orderkey)/32	deps=join-4
-exchange-repartition-7	exchange-repartition	Hash(l_orderkey)/32	deps=scan-5
-join-8	hash_join	Hash(o_orderkey)/32	deps=exchange-repartition-6,exchange-repartition-7
+join-8	hash_join	Hash(o_orderkey)/32	deps=exchange-repartition-6,scan-5
 aggregate-9	aggregate	RoundRobin	deps=join-8
 final_aggregate-10	final_aggregate	Singleton	deps=aggregate-9
 exchange-gather-final_aggregate-10	exchange-gather	Singleton	deps=final_aggregate-10

--- a/internal/planner/physical/testdata/ensure_distribution/q04.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q04.golden
@@ -1,8 +1,6 @@
-scan-0	scan	Singleton
-scan-1	scan	Singleton
-exchange-repartition-2	exchange-repartition	Hash(o_orderkey)/32	deps=scan-0
-exchange-repartition-3	exchange-repartition	Hash(l_orderkey)/32	deps=scan-1
-join-4	hash_join	Hash(o_orderkey)/32	deps=exchange-repartition-2,exchange-repartition-3
+scan-0	scan	Hash(o_orderkey)/32
+scan-1	scan	Hash(l_orderkey)/32
+join-4	hash_join	Hash(o_orderkey)/32	deps=scan-0,scan-1
 aggregate-5	aggregate	RoundRobin	deps=join-4
 final_aggregate-6	final_aggregate	Singleton	deps=aggregate-5
 exchange-gather-final_aggregate-6	exchange-gather	Singleton	deps=final_aggregate-6

--- a/internal/planner/physical/testdata/ensure_distribution/q05.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q05.golden
@@ -1,12 +1,9 @@
-scan-0	scan	Singleton
-scan-1	scan	Singleton
-exchange-repartition-2	exchange-repartition	Hash(o_custkey)/32	deps=scan-0
-exchange-repartition-3	exchange-repartition	Hash(c_custkey)/32	deps=scan-1
-join-4	hash_join	Hash(o_custkey)/32	deps=exchange-repartition-2,exchange-repartition-3
-scan-5	scan	Singleton
+scan-0	scan	Hash(o_custkey)/32
+scan-1	scan	Hash(c_custkey)/32
+join-4	hash_join	Hash(o_custkey)/32	deps=scan-0,scan-1
+scan-5	scan	Hash(l_orderkey)/32
 exchange-repartition-6	exchange-repartition	Hash(o_orderkey)/32	deps=join-4
-exchange-repartition-7	exchange-repartition	Hash(l_orderkey)/32	deps=scan-5
-join-8	hash_join	Hash(o_orderkey)/32	deps=exchange-repartition-6,exchange-repartition-7
+join-8	hash_join	Hash(o_orderkey)/32	deps=exchange-repartition-6,scan-5
 scan-9	scan	Singleton
 scan-11	scan	Singleton
 scan-13	scan	Singleton

--- a/internal/planner/physical/testdata/ensure_distribution/q07.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q07.golden
@@ -2,14 +2,12 @@ scan-0	scan	Singleton
 scan-1	scan	Singleton
 scan-3	scan	Singleton
 join-4	broadcast_join	Singleton	deps=scan-0,exchange-replicate-join-4-3,scan-1
-scan-5	scan	Singleton
+scan-5	scan	Hash(o_orderkey)/32
 exchange-repartition-6	exchange-repartition	Hash(l_orderkey)/32	deps=join-4
-exchange-repartition-7	exchange-repartition	Hash(o_orderkey)/32	deps=scan-5
-join-8	hash_join	Hash(l_orderkey)/32	deps=exchange-repartition-6,exchange-repartition-7
-scan-9	scan	Singleton
+join-8	hash_join	Hash(l_orderkey)/32	deps=exchange-repartition-6,scan-5
+scan-9	scan	Hash(c_custkey)/32
 exchange-repartition-10	exchange-repartition	Hash(o_custkey)/32	deps=join-8
-exchange-repartition-11	exchange-repartition	Hash(c_custkey)/32	deps=scan-9
-join-12	hash_join	Hash(o_custkey)/32	deps=exchange-repartition-10,exchange-repartition-11
+join-12	hash_join	Hash(o_custkey)/32	deps=exchange-repartition-10,scan-9
 scan-13	scan	Singleton
 join-14	broadcast_join	Hash(o_custkey)/32	deps=join-12,exchange-replicate-join-14-13
 aggregate-15	aggregate	RoundRobin	deps=join-14

--- a/internal/planner/physical/testdata/ensure_distribution/q08.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q08.golden
@@ -2,18 +2,15 @@ scan-0	scan	Singleton
 scan-1	scan	Singleton
 scan-3	scan	Singleton
 join-4	broadcast_join	Singleton	deps=scan-0,exchange-replicate-join-4-3,scan-1
-scan-5	scan	Singleton
+scan-5	scan	Hash(o_custkey)/32
 exchange-repartition-6	exchange-repartition	Hash(c_custkey)/32	deps=join-4
-exchange-repartition-7	exchange-repartition	Hash(o_custkey)/32	deps=scan-5
-join-8	hash_join	Hash(c_custkey)/32	deps=exchange-repartition-6,exchange-repartition-7
-scan-9	scan	Singleton
+join-8	hash_join	Hash(c_custkey)/32	deps=exchange-repartition-6,scan-5
+scan-9	scan	Hash(l_orderkey)/32
 exchange-repartition-10	exchange-repartition	Hash(o_orderkey)/32	deps=join-8
-exchange-repartition-11	exchange-repartition	Hash(l_orderkey)/32	deps=scan-9
-join-12	hash_join	Hash(o_orderkey)/32	deps=exchange-repartition-10,exchange-repartition-11
-scan-13	scan	Singleton
+join-12	hash_join	Hash(o_orderkey)/32	deps=exchange-repartition-10,scan-9
+scan-13	scan	Hash(p_partkey)/32
 exchange-repartition-14	exchange-repartition	Hash(l_partkey)/32	deps=join-12
-exchange-repartition-15	exchange-repartition	Hash(p_partkey)/32	deps=scan-13
-join-16	hash_join	Hash(l_partkey)/32	deps=exchange-repartition-14,exchange-repartition-15
+join-16	hash_join	Hash(l_partkey)/32	deps=exchange-repartition-14,scan-13
 scan-17	scan	Singleton
 scan-19	scan	Singleton
 join-20	broadcast_join	Hash(l_partkey)/32	deps=join-16,exchange-replicate-join-20-18,scan-17

--- a/internal/planner/physical/testdata/ensure_distribution/q09.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q09.golden
@@ -1,18 +1,14 @@
-scan-0	scan	Singleton
-scan-1	scan	Singleton
-exchange-repartition-2	exchange-repartition	Hash(l_partkey)/32	deps=scan-0
-exchange-repartition-3	exchange-repartition	Hash(p_partkey)/32	deps=scan-1
-join-4	hash_join	Hash(l_partkey)/32	deps=exchange-repartition-2,exchange-repartition-3
+scan-0	scan	Hash(l_partkey)/32
+scan-1	scan	Hash(p_partkey)/32
+join-4	hash_join	Hash(l_partkey)/32	deps=scan-0,scan-1
 scan-5	scan	Singleton
 join-6	broadcast_join	Hash(l_partkey)/32	deps=join-4,exchange-replicate-join-6-6
-scan-7	scan	Singleton
+scan-7	scan	Hash(ps_suppkey,ps_partkey)/32
 exchange-repartition-8	exchange-repartition	Hash(l_suppkey,l_partkey)/32	deps=join-6
-exchange-repartition-9	exchange-repartition	Hash(ps_suppkey,ps_partkey)/32	deps=scan-7
-join-10	hash_join	Hash(l_suppkey,l_partkey)/32	deps=exchange-repartition-8,exchange-repartition-9
-scan-11	scan	Singleton
+join-10	hash_join	Hash(l_suppkey,l_partkey)/32	deps=exchange-repartition-8,scan-7
+scan-11	scan	Hash(o_orderkey)/32
 exchange-repartition-12	exchange-repartition	Hash(l_orderkey)/32	deps=join-10
-exchange-repartition-13	exchange-repartition	Hash(o_orderkey)/32	deps=scan-11
-join-14	hash_join	Hash(l_orderkey)/32	deps=exchange-repartition-12,exchange-repartition-13
+join-14	hash_join	Hash(l_orderkey)/32	deps=exchange-repartition-12,scan-11
 scan-15	scan	Singleton
 join-16	broadcast_join	Hash(l_orderkey)/32	deps=join-14,exchange-replicate-join-16-16
 aggregate-17	aggregate	RoundRobin	deps=join-16

--- a/internal/planner/physical/testdata/ensure_distribution/q10.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q10.golden
@@ -1,14 +1,11 @@
-scan-0	scan	Singleton
-scan-1	scan	Singleton
-exchange-repartition-2	exchange-repartition	Hash(o_custkey)/32	deps=scan-0
-exchange-repartition-3	exchange-repartition	Hash(c_custkey)/32	deps=scan-1
-join-4	hash_join	Hash(o_custkey)/32	deps=exchange-repartition-2,exchange-repartition-3
+scan-0	scan	Hash(o_custkey)/32
+scan-1	scan	Hash(c_custkey)/32
+join-4	hash_join	Hash(o_custkey)/32	deps=scan-0,scan-1
 scan-5	scan	Singleton
 join-6	broadcast_join	Hash(o_custkey)/32	deps=join-4,exchange-replicate-join-6-6
-scan-7	scan	Singleton
+scan-7	scan	Hash(l_orderkey)/32
 exchange-repartition-8	exchange-repartition	Hash(o_orderkey)/32	deps=join-6
-exchange-repartition-9	exchange-repartition	Hash(l_orderkey)/32	deps=scan-7
-join-10	hash_join	Hash(o_orderkey)/32	deps=exchange-repartition-8,exchange-repartition-9
+join-10	hash_join	Hash(o_orderkey)/32	deps=exchange-repartition-8,scan-7
 aggregate-11	aggregate	RoundRobin	deps=join-10
 final_aggregate-12	final_aggregate	Singleton	deps=aggregate-11
 exchange-replicate-join-6-6	exchange-replicate	Broadcast	deps=scan-5

--- a/internal/planner/physical/testdata/ensure_distribution/q12.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q12.golden
@@ -1,8 +1,6 @@
-scan-0	scan	Singleton
-scan-1	scan	Singleton
-exchange-repartition-2	exchange-repartition	Hash(o_orderkey)/32	deps=scan-0
-exchange-repartition-3	exchange-repartition	Hash(l_orderkey)/32	deps=scan-1
-join-4	hash_join	Hash(o_orderkey)/32	deps=exchange-repartition-2,exchange-repartition-3
+scan-0	scan	Hash(o_orderkey)/32
+scan-1	scan	Hash(l_orderkey)/32
+join-4	hash_join	Hash(o_orderkey)/32	deps=scan-0,scan-1
 aggregate-5	aggregate	RoundRobin	deps=join-4
 final_aggregate-6	final_aggregate	Singleton	deps=aggregate-5
 exchange-gather-final_aggregate-6	exchange-gather	Singleton	deps=final_aggregate-6

--- a/internal/planner/physical/testdata/ensure_distribution/q13.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q13.golden
@@ -1,8 +1,6 @@
-scan-0	scan	Singleton
-scan-1	scan	Singleton
-exchange-repartition-2	exchange-repartition	Hash(c_custkey)/32	deps=scan-0
-exchange-repartition-3	exchange-repartition	Hash(o_custkey)/32	deps=scan-1
-join-4	hash_join	Hash(c_custkey)/32	deps=exchange-repartition-2,exchange-repartition-3
+scan-0	scan	Hash(c_custkey)/32
+scan-1	scan	Hash(o_custkey)/32
+join-4	hash_join	Hash(c_custkey)/32	deps=scan-0,scan-1
 aggregate-5	aggregate	RoundRobin	deps=join-4
 final_aggregate-6	final_aggregate	Singleton	deps=aggregate-5
 exchange-gather-final_aggregate-6	exchange-gather	Singleton	deps=final_aggregate-6

--- a/internal/planner/physical/testdata/ensure_distribution/q14.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q14.golden
@@ -1,8 +1,6 @@
-scan-0	scan	Singleton
-scan-1	scan	Singleton
-exchange-repartition-2	exchange-repartition	Hash(l_partkey)/32	deps=scan-0
-exchange-repartition-3	exchange-repartition	Hash(p_partkey)/32	deps=scan-1
-join-4	hash_join	Hash(l_partkey)/32	deps=exchange-repartition-2,exchange-repartition-3
+scan-0	scan	Hash(l_partkey)/32
+scan-1	scan	Hash(p_partkey)/32
+join-4	hash_join	Hash(l_partkey)/32	deps=scan-0,scan-1
 aggregate-5	aggregate	Singleton	deps=join-4
 final_aggregate-6	final_aggregate	Singleton	deps=aggregate-5
 exchange-gather-final_aggregate-6	exchange-gather	Singleton	deps=final_aggregate-6

--- a/internal/planner/physical/testdata/ensure_distribution/q15.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q15.golden
@@ -1,9 +1,8 @@
-scan-0	scan	Singleton
+scan-0	scan	Hash(s_suppkey)/32
 scan-1	scan	RoundRobin
 final_aggregate-40	final_aggregate	Hash(l_suppkey)/4	deps=exchange-repartition-final_aggregate-40-2
-exchange-repartition-41	exchange-repartition	Hash(s_suppkey)/32	deps=scan-0
 exchange-repartition-42	exchange-repartition	Hash(l_suppkey)/32	deps=final_aggregate-40
-join-43	hash_join	Hash(s_suppkey)/32	deps=exchange-repartition-41,exchange-repartition-42
+join-43	hash_join	Hash(s_suppkey)/32	deps=scan-0,exchange-repartition-42
 aggregate-45	aggregate	Singleton	deps=final_aggregate-40
 final_aggregate-46	final_aggregate	Singleton	deps=aggregate-45
 sort-47	sort	Singleton	deps=join-43

--- a/internal/planner/physical/testdata/ensure_distribution/q16.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q16.golden
@@ -1,8 +1,6 @@
-scan-0	scan	Singleton
-scan-1	scan	Singleton
-exchange-repartition-2	exchange-repartition	Hash(ps_partkey)/32	deps=scan-0
-exchange-repartition-3	exchange-repartition	Hash(p_partkey)/32	deps=scan-1
-join-4	hash_join	Hash(ps_partkey)/32	deps=exchange-repartition-2,exchange-repartition-3
+scan-0	scan	Hash(ps_partkey)/32
+scan-1	scan	Hash(p_partkey)/32
+join-4	hash_join	Hash(ps_partkey)/32	deps=scan-0,scan-1
 aggregate-5	aggregate	RoundRobin	deps=join-4
 final_aggregate-6	final_aggregate	Singleton	deps=aggregate-5
 exchange-gather-final_aggregate-6	exchange-gather	Singleton	deps=final_aggregate-6

--- a/internal/planner/physical/testdata/ensure_distribution/q17.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q17.golden
@@ -1,8 +1,6 @@
-scan-0	scan	Singleton
-scan-1	scan	Singleton
-exchange-repartition-2	exchange-repartition	Hash(l_partkey)/32	deps=scan-0
-exchange-repartition-3	exchange-repartition	Hash(p_partkey)/32	deps=scan-1
-join-4	hash_join	Hash(l_partkey)/32	deps=exchange-repartition-2,exchange-repartition-3
+scan-0	scan	Hash(l_partkey)/32
+scan-1	scan	Hash(p_partkey)/32
+join-4	hash_join	Hash(l_partkey)/32	deps=scan-0,scan-1
 scan-5	scan	RoundRobin
 final_aggregate-44	final_aggregate	Hash(l_partkey)/4	deps=exchange-repartition-final_aggregate-44-6
 exchange-repartition-45	exchange-repartition	Hash(p_partkey)/32	deps=join-4

--- a/internal/planner/physical/testdata/ensure_distribution/q18.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q18.golden
@@ -1,12 +1,9 @@
-scan-0	scan	Singleton
-scan-1	scan	Singleton
-exchange-repartition-2	exchange-repartition	Hash(o_custkey)/32	deps=scan-0
-exchange-repartition-3	exchange-repartition	Hash(c_custkey)/32	deps=scan-1
-join-4	hash_join	Hash(o_custkey)/32	deps=exchange-repartition-2,exchange-repartition-3
-scan-5	scan	Singleton
+scan-0	scan	Hash(o_custkey)/32
+scan-1	scan	Hash(c_custkey)/32
+join-4	hash_join	Hash(o_custkey)/32	deps=scan-0,scan-1
+scan-5	scan	Hash(l_orderkey)/32
 exchange-repartition-6	exchange-repartition	Hash(o_orderkey)/32	deps=join-4
-exchange-repartition-7	exchange-repartition	Hash(l_orderkey)/32	deps=scan-5
-join-8	hash_join	Hash(o_orderkey)/32	deps=exchange-repartition-6,exchange-repartition-7
+join-8	hash_join	Hash(o_orderkey)/32	deps=exchange-repartition-6,scan-5
 scan-9	scan	RoundRobin
 final_aggregate-48	final_aggregate	Hash(l_orderkey)/4	deps=exchange-repartition-final_aggregate-48-10
 exchange-repartition-49	exchange-repartition	Hash(o_orderkey)/32	deps=join-8

--- a/internal/planner/physical/testdata/ensure_distribution/q19.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q19.golden
@@ -1,8 +1,6 @@
-scan-0	scan	Singleton
-scan-1	scan	Singleton
-exchange-repartition-2	exchange-repartition	Hash(l_partkey)/32	deps=scan-0
-exchange-repartition-3	exchange-repartition	Hash(p_partkey)/32	deps=scan-1
-join-4	hash_join	Hash(l_partkey)/32	deps=exchange-repartition-2,exchange-repartition-3
+scan-0	scan	Hash(l_partkey)/32
+scan-1	scan	Hash(p_partkey)/32
+join-4	hash_join	Hash(l_partkey)/32	deps=scan-0,scan-1
 aggregate-5	aggregate	Singleton	deps=join-4
 final_aggregate-6	final_aggregate	Singleton	deps=aggregate-5
 exchange-gather-final_aggregate-6	exchange-gather	Singleton	deps=final_aggregate-6

--- a/internal/planner/physical/testdata/ensure_distribution/q20.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q20.golden
@@ -1,11 +1,9 @@
 scan-0	scan	Singleton
 scan-1	scan	Singleton
 join-2	broadcast_join	Singleton	deps=scan-0,exchange-replicate-join-2-2
-scan-3	scan	Singleton
-scan-4	scan	Singleton
-exchange-repartition-5	exchange-repartition	Hash(ps_partkey)/32	deps=scan-3
-exchange-repartition-6	exchange-repartition	Hash(p_partkey)/32	deps=scan-4
-join-7	hash_join	Hash(ps_partkey)/32	deps=exchange-repartition-5,exchange-repartition-6
+scan-3	scan	Hash(ps_partkey)/32
+scan-4	scan	Hash(p_partkey)/32
+join-7	hash_join	Hash(ps_partkey)/32	deps=scan-3,scan-4
 scan-8	scan	RoundRobin
 final_aggregate-47	final_aggregate	Hash(l_partkey,l_suppkey)/4	deps=exchange-repartition-final_aggregate-47-9
 exchange-repartition-48	exchange-repartition	Hash(ps_partkey,ps_suppkey)/32	deps=join-7

--- a/internal/planner/physical/testdata/ensure_distribution/q21.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q21.golden
@@ -1,20 +1,17 @@
 scan-0	scan	Singleton
 scan-1	scan	Singleton
 join-2	broadcast_join	Singleton	deps=scan-0,exchange-replicate-join-2-2
-scan-3	scan	Singleton
+scan-3	scan	Hash(o_orderkey)/32
 exchange-repartition-4	exchange-repartition	Hash(l1.l_orderkey)/32	deps=join-2
-exchange-repartition-5	exchange-repartition	Hash(o_orderkey)/32	deps=scan-3
-join-6	hash_join	Hash(l1.l_orderkey)/32	deps=exchange-repartition-4,exchange-repartition-5
+join-6	hash_join	Hash(l1.l_orderkey)/32	deps=exchange-repartition-4,scan-3
 scan-7	scan	Singleton
 join-8	broadcast_join	Hash(l1.l_orderkey)/32	deps=join-6,exchange-replicate-join-8-8
-scan-9	scan	Singleton
+scan-9	scan	Hash(l_orderkey)/32
 exchange-repartition-10	exchange-repartition	Hash(l_orderkey)/32	deps=join-8
-exchange-repartition-11	exchange-repartition	Hash(l_orderkey)/32	deps=scan-9
-join-12	hash_join	Hash(l_orderkey)/32	deps=exchange-repartition-10,exchange-repartition-11
-scan-13	scan	Singleton
+join-12	hash_join	Hash(l_orderkey)/32	deps=exchange-repartition-10,scan-9
+scan-13	scan	Hash(l_orderkey)/32
 exchange-repartition-14	exchange-repartition	Hash(l_orderkey)/32	deps=join-12
-exchange-repartition-15	exchange-repartition	Hash(l_orderkey)/32	deps=scan-13
-join-16	hash_join	Hash(l_orderkey)/32	deps=exchange-repartition-14,exchange-repartition-15
+join-16	hash_join	Hash(l_orderkey)/32	deps=exchange-repartition-14,scan-13
 aggregate-17	aggregate	RoundRobin	deps=join-16
 final_aggregate-18	final_aggregate	Singleton	deps=aggregate-17
 exchange-replicate-join-2-2	exchange-replicate	Broadcast	deps=scan-1

--- a/internal/planner/physical/testdata/ensure_distribution/q22.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q22.golden
@@ -1,8 +1,6 @@
-scan-0	scan	Singleton
-scan-1	scan	Singleton
-exchange-repartition-2	exchange-repartition	Hash(c_custkey)/32	deps=scan-0
-exchange-repartition-3	exchange-repartition	Hash(o_custkey)/32	deps=scan-1
-join-4	hash_join	Hash(c_custkey)/32	deps=exchange-repartition-2,exchange-repartition-3
+scan-0	scan	Hash(c_custkey)/32
+scan-1	scan	Hash(o_custkey)/32
+join-4	hash_join	Hash(c_custkey)/32	deps=scan-0,scan-1
 aggregate-5	aggregate	RoundRobin	deps=join-4
 final_aggregate-6	final_aggregate	Singleton	deps=aggregate-5
 exchange-gather-final_aggregate-6	exchange-gather	Singleton	deps=final_aggregate-6


### PR DESCRIPTION
## Summary

The `scan → exchange-repartition → consumer` pattern was running as two separate distributed tasks: the scan wrote an unpartitioned WSHF, then a shuffle task read it and re-emitted partitioned WSHF. This PR fuses them into a single scan task that hash-partitions its filtered output directly via the worker's existing `writePartitionedShuffle`.

**Per fused pair this saves**:
- 1 S3 PUT (intermediate unpartitioned WSHF)
- 1 S3 GET (the shuffle reading it back)
- 1 NATS round-trip (separate dispatch + completion)
- 1 batch of intermediate-task heap pressure

## Audit

`TestAuditFusedJoinChains` — fusion firing across the join-heavy queries:

| Query | scan stages absorbed | exchange-repartitions remaining |
|---|---|---|
| Q02 | 2 | 5 |
| Q07 | 2 | 2 |
| Q08 | 3 | 3 |
| Q21 | 3 | 3 |

~half of the exchange-repartition stages eliminated per query. The remaining ones are between joins (not directly downstream of a scan), which would need producer-direction fusion or multi-stage Task messages — those are deferred follow-ups.

## Implementation

- `planner/physical/fuse_scan_shuffle.go` — new pass after `EnsureDistribution` + final `assignStageDistributions`. Walks stages, finds `(scan, exchange-repartition)` pairs satisfying safety conditions, moves the exchange's keys+count onto the scan, rewires consumers, drops the exchange.
- `coordinator/execute_stage_dag.go` — `dispatchScanFilterStage` propagates `stage.Exchange.{Keys,Count}` into `task.ShuffleKeys + task.NumPartitions`, and buckets result files by partition number when fused (matching `runShuffleSide`'s contract).
- `planner/physical/plan_tpch_test.go` — `sqlToStages` now mirrors prod by setting `UseEnsureDistribution=true` (otherwise tests miss the fusion path; harness was always correct).

## Safety conditions in `fuseScanShuffle`

1. exchange has exactly one dependency (the scan)
2. scan is plain `StageScan` (not scan-aggregate — that path owns its own RoundRobin fan-out)
3. scan has no other dependents (would break their unpartitioned expectation)
4. scan has no prior `Exchange` (would conflict with this one)

## Test plan

- [x] new `TestFuseScanShuffle_BasicAbsorbs` / `SkipsScanWithMultipleConsumers` / `SkipsFusedAggScans` (planner unit tests)
- [x] `TestTPCH_EnsureDistribution_Snapshot` golden files updated to reflect absorbed exchanges across Q02-Q22 (-45 lines net)
- [x] `cmd/tpch-harness --mode=local`: 25/25 PASS — distributed correctness gate (HARD RULE per `feedback_tpch_harness_local_gate`)
- [x] `internal/coordinator`: ok (196.8s)
- [x] `internal/planner/physical`: ok
- [ ] SF10 EC2: not yet — local runs already show 5-15% per-query speedup; the EC2 win will be larger where each S3 PUT/GET round-trip is 50-200ms instead of <1ms.

## Context

This is the first incremental step on Path B from `project_per_task_setup_audit_2026-05-03.md`. The broader multi-stage Task message work (chain N stages into one worker task) remains a multi-week project; this is the contained piece that's clearly safe because the worker already supports it via `writePartitionedShuffle`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)