### PR TITLE
perf(coordinator): cap fused scan-shuffle task count to workerCount

### DIFF
--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -1170,6 +1170,19 @@ func (c *Coordinator) dispatchScanFilterStage(
 		// which keeps each task's heap below the 32GB worker limit and avoids
 		// the OOM-restart-then-idle-timeout pattern observed on Q04 SF10.
 		taskCount := scanFanOutTaskCount(workerCount, capacity, len(stage.ScanFiles))
+		// Fused scan+shuffle: each task hash-partitions into Exchange.Count
+		// output files, so total partition files = taskCount × Exchange.Count.
+		// The legacy unfused path used workerCount shuffle tasks; allowing the
+		// fused scan to fan out beyond workerCount produces MORE partition
+		// files than the legacy path (e.g. SF10 max_concurrent=2 cluster:
+		// scanFanOut=6 vs workerCount=3 ⇒ 2× partition files). Downstream
+		// hash_join tasks then read 2× more S3 objects per partition,
+		// dominating the savings from skipping the intermediate WSHF.
+		// Cap to workerCount when fused; per-task heap is bounded by the
+		// per-task memory budget × max_concurrent already.
+		if stage.Exchange != nil && len(stage.Exchange.Keys) > 0 && taskCount > workerCount {
+			taskCount = workerCount
+		}
 		fileSets = splitFilesEvenly(stage.ScanFiles, taskCount)
 	}
 	actualTasks := len(fileSets)


### PR DESCRIPTION
## Summary

Fix the Q05 (48s→8m29s) and Q07 (53s→1m45s) regression caught on the SF10 deploy of #85. Root cause: scan task fan-out is `max(workerCount, capacity) = 6` (with `max_concurrent=2`), but the legacy shuffle stage used only `workerCount = 3` tasks. Fused scan produced 6×24 = 144 partition files vs legacy 3×24 = 72; downstream hash_join read 2× more S3 objects per partition, dominating the savings from skipping the intermediate WSHF.

**Fix**: when `stage.Exchange` is set (fused), cap scan `taskCount` to `workerCount`. Per-task heap stays bounded by `per-task budget × max_concurrent`.

## SF10 deploy of `3c1a9bc` (with #85 alone)

| Q | Result | Baseline | Δ |
|---|---|---|---|
| Q01 | 14.9s | 14.5s | ~0% |
| Q02 | 28.9s | 29.9s | -3% |
| **Q03** | **50.7s** | 60.9s | **-17%** ✓ |
| **Q04** | **57.7s** | 80.2s | **-28%** ✓ |
| **Q05** | **8m29s** | 48s | **+1000%** ❌ |
| Q06 | 11.9s | 12.9s | ~0% |
| **Q07** | **1m45s** | 52.8s | **+98%** ❌ |

Run torn down at Q07 per `feedback_ec2_teardown_discipline`. Cost ~$0.30.

## What's preserved

- Q03/Q04 wins from #85 (those scans don't fan out beyond `workerCount`).
- The S3 PUT savings on the scan side (skipping the intermediate unpartitioned WSHF).
- Total partition file count after fix matches the legacy shuffle stage exactly.

## Test plan
- [x] `cmd/tpch-harness --mode=local`: 25/25 PASS
- [ ] `internal/coordinator`: pending (running)
- [ ] SF10 EC2 re-deploy to verify Q05/Q07 recovered, Q03/Q04 wins held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)