### PR TITLE
perf(scan): streaming row-group iterator (per-task working set reduction)

### DIFF
--- a/internal/engine/scan/rowgroup_iter.go
+++ b/internal/engine/scan/rowgroup_iter.go
@@ -1,0 +1,126 @@
+package scan
+
+import (
+	"fmt"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	pqt "github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// RowGroupIter yields one RecordBatch per row group on demand, without
+// pre-decoding the rest of the file. Use this in long-running scan
+// pipelines (worker fragment runners) where holding every row group of
+// a file in memory would blow the per-task working set.
+//
+// At SF100 each lineitem file has ~10 row groups × ~28 MB decoded each,
+// so eager decode (ReadFileBatchesShard) costs ~280 MB live per file,
+// times 2–4 files prefetched, times 3–4 concurrent tasks = multi-GB
+// transient that the GC can't reclaim until the consumer (HashAggregate)
+// drains. Streaming one row group at a time bounds the scan-side live
+// memory to one decoded RG per scan source plus whatever is in flight
+// downstream — typically <300 MB instead of multi-GB.
+//
+// Lifecycle:
+//
+//	it, err := OpenRowGroupIter(reader, schema, selectedCols, shardIdx, shardCount)
+//	if err != nil { ... }
+//	defer it.Close()
+//	for {
+//	    b, err := it.Next(ctx)
+//	    if err != nil || b == nil { break }
+//	    // consume b, then b.Release() when done
+//	}
+//
+// The iterator does NOT support schemas containing Array/Map types — the
+// existing row-based fallback in readFileBatchesViaRows decodes the whole
+// file in one shot and predates row-group sharding. Callers must check
+// HasUnsupportedColumnarTypes(schema) and use ReadFileBatchesShard for
+// those types. The slice path stays available; this iterator is a parallel
+// fast lane for the common case.
+type RowGroupIter struct {
+	fr           *pqt.FileReader
+	readSchema   []pqt.Column
+	cur, end     int
+	closed       bool
+
+	// Empty-shard sentinel: shardIdx out of range or row-fallback shard >0
+	// returns no batches without erroring. matches ReadFileBatchesShard.
+	empty bool
+}
+
+// OpenRowGroupIter constructs a streaming iterator over the row-group
+// range assigned to (shardIdx, shardCount) of the given reader. With
+// shardCount=1 the iterator covers the whole file. Returns ErrUnsupportedColumnar
+// for schemas with Array/Map types (callers must use ReadFileBatchesShard).
+func OpenRowGroupIter(reader *pqt.Reader, schema []pqt.Column, selectedCols []string, shardIdx, shardCount int) (*RowGroupIter, error) {
+	if reader == nil {
+		return nil, fmt.Errorf("OpenRowGroupIter: nil reader")
+	}
+	if shardCount < 1 {
+		shardCount = 1
+	}
+
+	readSchema := schema
+	if len(selectedCols) > 0 {
+		readSchema = projectSchema(schema, selectedCols)
+	}
+
+	if HasUnsupportedColumnarTypes(readSchema) {
+		return nil, fmt.Errorf("RowGroupIter does not support Array/Map types; caller must fall back to ReadFileBatchesShard")
+	}
+
+	if shardIdx < 0 || shardIdx >= shardCount {
+		// Empty shard: out-of-range index. Return iterator that yields nothing.
+		return &RowGroupIter{empty: true}, nil
+	}
+
+	fr := reader.FileReader()
+	if fr == nil {
+		return nil, fmt.Errorf("OpenRowGroupIter: reader has no FileReader")
+	}
+
+	total := fr.NumRowGroups()
+	startRg, endRg := rowGroupRangeForShard(total, shardIdx, shardCount)
+	return &RowGroupIter{
+		fr:         fr,
+		readSchema: readSchema,
+		cur:        startRg,
+		end:        endRg,
+	}, nil
+}
+
+// Next returns the next decoded row group as a RecordBatch, or (nil, nil)
+// when exhausted. The returned batch's lifetime is the caller's; Release()
+// to a pool when done. Subsequent calls after exhaustion or Close return
+// (nil, nil).
+func (it *RowGroupIter) Next() (*batch.RecordBatch, error) {
+	if it == nil || it.closed || it.empty {
+		return nil, nil
+	}
+	for it.cur < it.end {
+		rgIdx := it.cur
+		it.cur++
+		b, err := ReadRowGroupNative(it.fr, rgIdx, it.readSchema, nil)
+		if err != nil {
+			return nil, fmt.Errorf("reading row group %d: %w", rgIdx, err)
+		}
+		if b == nil {
+			// Empty row group (zero rows) — skip and try the next.
+			continue
+		}
+		return b, nil
+	}
+	return nil, nil
+}
+
+// Close marks the iterator as exhausted. Idempotent. No file handles
+// are owned by the iterator (the caller's *pqt.Reader owns them), so
+// Close is mostly a cancellation signal — subsequent Next calls return
+// (nil, nil).
+func (it *RowGroupIter) Close() error {
+	if it == nil {
+		return nil
+	}
+	it.closed = true
+	return nil
+}

--- a/internal/engine/scan/rowgroup_iter_test.go
+++ b/internal/engine/scan/rowgroup_iter_test.go
@@ -1,0 +1,195 @@
+package scan
+
+import (
+	"bytes"
+	"testing"
+
+	pqt "github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// fourRowGroupFile builds an in-memory parquet file with 4 row groups of 100
+// rows each, ids tagged g*1000+i so callers can verify which group each row
+// came from. Mirrors the fixture in scan_shard_test.go.
+func fourRowGroupFile(t *testing.T) []byte {
+	t.Helper()
+	schema := []pqt.Column{{Name: "id", Type: pqt.TypeInt64}}
+	cfg := pqt.DefaultWriterConfig()
+	cfg.RowGroupSize = 100
+
+	var buf bytes.Buffer
+	w, err := pqt.NewWriter(&buf, pqt.Schema{Columns: schema}, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const rowsPerGroup = 100
+	const numGroups = 4
+	for g := 0; g < numGroups; g++ {
+		rows := make([]map[string]any, rowsPerGroup)
+		for i := range rows {
+			rows[i] = map[string]any{"id": int64(g*1000 + i)}
+		}
+		if err := w.WriteRows(rows); err != nil {
+			t.Fatalf("write group %d: %v", g, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// TestRowGroupIter_YieldsOneRowGroupPerNext verifies the iterator returns
+// exactly one row group per Next call (not the whole file at once). The
+// proof of streaming-vs-eager: after collecting one batch, the row count
+// equals the row-group size — not the file total.
+func TestRowGroupIter_YieldsOneRowGroupPerNext(t *testing.T) {
+	data := fourRowGroupFile(t)
+	reader, err := pqt.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema := []pqt.Column{{Name: "id", Type: pqt.TypeInt64}}
+
+	it, err := OpenRowGroupIter(reader, schema, nil, 0, 1)
+	if err != nil {
+		t.Fatalf("OpenRowGroupIter: %v", err)
+	}
+	defer it.Close()
+
+	const rowsPerGroup = 100
+	const numGroups = 4
+
+	for g := 0; g < numGroups; g++ {
+		b, err := it.Next()
+		if err != nil {
+			t.Fatalf("Next #%d: %v", g, err)
+		}
+		if b == nil {
+			t.Fatalf("Next #%d: expected batch, got nil", g)
+		}
+		if b.Len != rowsPerGroup {
+			t.Errorf("Next #%d: batch has %d rows, want %d (one row group)",
+				g, b.Len, rowsPerGroup)
+		}
+		// First row's id reveals which group: g*1000.
+		gotID := b.Columns[0].Int64Data[0]
+		if gotID != int64(g*1000) {
+			t.Errorf("Next #%d: first id = %d, want %d", g, gotID, g*1000)
+		}
+	}
+
+	// One more call returns (nil, nil).
+	b, err := it.Next()
+	if err != nil {
+		t.Fatalf("Next after exhaustion: %v", err)
+	}
+	if b != nil {
+		t.Errorf("Next after exhaustion: got batch len=%d, want nil", b.Len)
+	}
+}
+
+// TestRowGroupIter_RespectsShard confirms shardIdx/shardCount partition the
+// row groups across iterators with no overlap and full coverage. Mirrors the
+// existing TestReadFileBatchesShard_ReadsDisjointRowGroups guarantee.
+func TestRowGroupIter_RespectsShard(t *testing.T) {
+	data := fourRowGroupFile(t)
+	schema := []pqt.Column{{Name: "id", Type: pqt.TypeInt64}}
+
+	const shardCount = 4
+	seen := make(map[int64]bool)
+	totalRows := 0
+	for shardIdx := 0; shardIdx < shardCount; shardIdx++ {
+		reader, err := pqt.NewReader(bytes.NewReader(data), int64(len(data)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		it, err := OpenRowGroupIter(reader, schema, nil, shardIdx, shardCount)
+		if err != nil {
+			t.Fatalf("shard %d: %v", shardIdx, err)
+		}
+		for {
+			b, err := it.Next()
+			if err != nil {
+				t.Fatalf("shard %d Next: %v", shardIdx, err)
+			}
+			if b == nil {
+				break
+			}
+			for i := 0; i < b.Len; i++ {
+				id := b.Columns[0].Int64Data[i]
+				if seen[id] {
+					t.Errorf("shard %d: duplicate id %d", shardIdx, id)
+				}
+				seen[id] = true
+				totalRows++
+			}
+		}
+		it.Close()
+	}
+
+	wantTotal := 4 * 100
+	if totalRows != wantTotal {
+		t.Errorf("union of shards: %d rows, want %d", totalRows, wantTotal)
+	}
+}
+
+// TestRowGroupIter_OutOfRangeShardYieldsNothing confirms a shardIdx >=
+// shardCount produces no batches without erroring — same edge-case
+// behavior as ReadFileBatchesShard.
+func TestRowGroupIter_OutOfRangeShardYieldsNothing(t *testing.T) {
+	data := fourRowGroupFile(t)
+	reader, err := pqt.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema := []pqt.Column{{Name: "id", Type: pqt.TypeInt64}}
+
+	// shardIdx=5 with shardCount=4 — out of range.
+	it, err := OpenRowGroupIter(reader, schema, nil, 5, 4)
+	if err != nil {
+		t.Fatalf("expected nil err for out-of-range shard, got %v", err)
+	}
+	defer it.Close()
+	b, err := it.Next()
+	if err != nil {
+		t.Fatalf("Next on empty shard: %v", err)
+	}
+	if b != nil {
+		t.Errorf("Next on empty shard: got batch, want nil")
+	}
+}
+
+// TestRowGroupIter_CloseStopsFurtherReads confirms Close is honored —
+// after Close, Next returns (nil, nil) regardless of remaining row
+// groups. Important so worker shutdown can cancel in-flight scans
+// without leaking decode work.
+func TestRowGroupIter_CloseStopsFurtherReads(t *testing.T) {
+	data := fourRowGroupFile(t)
+	reader, err := pqt.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema := []pqt.Column{{Name: "id", Type: pqt.TypeInt64}}
+
+	it, err := OpenRowGroupIter(reader, schema, nil, 0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read the first row group, then close.
+	if _, err := it.Next(); err != nil {
+		t.Fatal(err)
+	}
+	if err := it.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Subsequent Next calls return (nil, nil).
+	b, err := it.Next()
+	if err != nil {
+		t.Errorf("Next after Close: err=%v, want nil", err)
+	}
+	if b != nil {
+		t.Errorf("Next after Close: got batch, want nil")
+	}
+}

--- a/internal/worker/stream_source.go
+++ b/internal/worker/stream_source.go
@@ -49,9 +49,12 @@ func (p *progressWriter) Write(b []byte) (int, error) {
 // the cache file (10+ GB at SF100) and OOM the worker before it could
 // process a single batch.
 //
-// For Parquet files (only used by older shuffle paths) we still buffer
-// row-group batches eagerly via scan.ReadFileBatches because they're already
-// lazy by row-group in the parquet reader and the file sizes are bounded.
+// For Parquet files we use a streaming row-group iterator: only one
+// decoded row group is held in memory at a time per source, instead of
+// materializing every row group of the active file up front. At SF100 a
+// lineitem file decodes to ~280 MB per row group × ~10 row groups, so
+// the eager-decode that this replaced cost ~2.8 GB live per file —
+// dominant contributor to per-task working set during scan-aggregate.
 type cachedFileStreamSource struct {
 	executor *Executor
 	bucket   string
@@ -83,9 +86,21 @@ type cachedFileStreamSource struct {
 	mmapData    []byte // mmap'd view of the current local cache file (nil if Parquet)
 	localPath   string // path the source is responsible for unlinking; "" when the file is owned by LocalStageCache or in-memory
 
-	// Buffered batches for the current Parquet file.
-	batches  []*batch.RecordBatch
-	batchIdx int
+	// Streaming row-group iterator for the current Parquet file. Yields one
+	// decoded RecordBatch per Next() call; the previous batch is GC-eligible
+	// once the consumer Releases it. Bounds Parquet-side live memory to one
+	// decoded row group at a time per source.
+	parquetIter *scan.RowGroupIter
+	// parquetReader is held alongside the iterator so its underlying buffer
+	// (the whole-file byte slice) stays live for the iterator's row-group
+	// reads. Released alongside parquetIter when the file is exhausted.
+	parquetReader *parquet.Reader
+
+	// Fallback slice for schemas with Array/Map types — RowGroupIter does not
+	// support those yet, so we keep the existing eager-decode path for them.
+	// Empty for all TPC-H scans.
+	fallbackBatches  []*batch.RecordBatch
+	fallbackBatchIdx int
 }
 
 func newCachedFileStreamSource(executor *Executor, queryID, bucket string, files []string) *cachedFileStreamSource {
@@ -140,11 +155,26 @@ func (s *cachedFileStreamSource) Next(ctx context.Context) (*batch.RecordBatch, 
 			s.releaseCurrentFile()
 		}
 
-		// Yield buffered Parquet batches.
-		if s.batchIdx < len(s.batches) {
-			b := s.batches[s.batchIdx]
-			s.batches[s.batchIdx] = nil // release for GC
-			s.batchIdx++
+		// Yield next decoded row group from the active Parquet iterator.
+		// The iterator decodes lazily — only one row group's worth of
+		// memory is live at a time per source.
+		if s.parquetIter != nil {
+			b, err := s.parquetIter.Next()
+			if err != nil {
+				return nil, err
+			}
+			if b != nil {
+				return b, nil
+			}
+			// Iterator exhausted — release reader and move on.
+			s.releaseParquetIter()
+		}
+
+		// Yield from the fallback slice (Array/Map schemas only).
+		if s.fallbackBatchIdx < len(s.fallbackBatches) {
+			b := s.fallbackBatches[s.fallbackBatchIdx]
+			s.fallbackBatches[s.fallbackBatchIdx] = nil
+			s.fallbackBatchIdx++
 			return b, nil
 		}
 
@@ -162,11 +192,23 @@ func (s *cachedFileStreamSource) Next(ctx context.Context) (*batch.RecordBatch, 
 
 func (s *cachedFileStreamSource) Close() error {
 	s.releaseCurrentFile()
-	for i := s.batchIdx; i < len(s.batches); i++ {
-		s.batches[i] = nil
+	s.releaseParquetIter()
+	for i := s.fallbackBatchIdx; i < len(s.fallbackBatches); i++ {
+		s.fallbackBatches[i] = nil
 	}
-	s.batches = nil
+	s.fallbackBatches = nil
 	return nil
+}
+
+// releaseParquetIter closes the active row-group iterator and drops the
+// reader reference so the underlying file buffer can be GC'd. Safe to
+// call multiple times.
+func (s *cachedFileStreamSource) releaseParquetIter() {
+	if s.parquetIter != nil {
+		_ = s.parquetIter.Close()
+		s.parquetIter = nil
+	}
+	s.parquetReader = nil
 }
 
 // releaseCurrentFile munmaps and deletes the local cache file backing the
@@ -308,12 +350,24 @@ func (s *cachedFileStreamSource) openNextFile(ctx context.Context) error {
 	if shardCount < 1 {
 		shardCount = 1
 	}
-	batches, err := scan.ReadFileBatchesShard(reader, projCols, nil, shardIdx, shardCount)
-	if err != nil {
-		return fmt.Errorf("reading parquet file %s: %w", filePath, err)
+	// Schemas with Array/Map types (none in TPC-H) still go through the
+	// eager-decode slice path because RowGroupIter doesn't support them.
+	// Everything else streams one row group at a time.
+	if scan.HasUnsupportedColumnarTypes(projCols) {
+		batches, err := scan.ReadFileBatchesShard(reader, projCols, nil, shardIdx, shardCount)
+		if err != nil {
+			return fmt.Errorf("reading parquet file %s (fallback): %w", filePath, err)
+		}
+		s.fallbackBatches = batches
+		s.fallbackBatchIdx = 0
+		return nil
 	}
-	s.batches = batches
-	s.batchIdx = 0
+	iter, err := scan.OpenRowGroupIter(reader, projCols, nil, shardIdx, shardCount)
+	if err != nil {
+		return fmt.Errorf("opening row-group iterator for %s: %w", filePath, err)
+	}
+	s.parquetIter = iter
+	s.parquetReader = reader
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Per-task working set during SF100 scan-aggregate is observed at 5–6 GB live, dominated by transient parquet decode buffers. The Q17 investigation memo (`project_q17_sf100_resolved_2026-05-07`) flagged this as the key architectural followup — it's why `max_concurrent=3` was needed at SF100 instead of the historical 4.

The audit found that `cachedFileStreamSource.openParquetFile` eagerly decodes every row group of a file into a slice up front via `scan.ReadFileBatchesShard`. SF100 lineitem: ~10 row groups × ~280 MB decoded each = ~2.8 GB live per file, even though the consumer (HashAggregate) processes batches one at a time.

This PR adds **`RowGroupIter`**, a streaming iterator that decodes one row group per `Next()` call. Wired into `cachedFileStreamSource` as the primary parquet path; only schemas with Array/Map types (none in TPC-H) keep the eager-decode slice path because `RowGroupIter` doesn't yet support those.

**Effect:** parquet-side live memory per scan source is bounded to one decoded row group instead of the whole file. Stepping stone toward making `max_concurrent=4` viable again at SF100 — that change stays in `sf100-distributed.tfvars` unchanged for this PR; we'll measure on EC2 before raising it.

## Test plan

- [x] `go test ./internal/engine/scan/` — 4 new `RowGroupIter` tests (basic streaming, sharded coverage, out-of-range shard, close stops further reads) — all PASS
- [x] `go test ./internal/engine/{scan,exec} ./internal/worker/` — all PASS
- [x] Single-process TPC-H SF0.01: 22/22 PASS (0.67s)
- [x] Distributed local SF1 22Q: **25/25 PASS in 145s** (vs 152s prior; Q17 2186ms vs 2461ms — small consistent speedup from lazy decode reducing GC pressure even at SF1)
- [ ] CI green

## Followup (not in this PR)

Once this lands and we measure SF100 per-task heap, the path is:
1. Reproduce SF100 22Q on this commit and compare per-task `peak_heap_mb` to baseline.
2. If the per-task peak drops as expected (~5GB → ~1–2GB), bump `max_concurrent=3` back to 4 in `sf100-distributed.tfvars` and re-run.
3. The remaining contributor to per-task heap is shuffle-side partition-output staging — separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)