### PR TITLE
perf(exec): SoA-direct streaming drain via partialGroupCursor

### DIFF
--- a/internal/engine/exec/aggregate.go
+++ b/internal/engine/exec/aggregate.go
@@ -2184,10 +2184,12 @@ func (h *HashAggregate) Next(_ context.Context) (*batch.RecordBatch, error) {
 	// between ~3 GB and ~0.5 GB of group-state heap inside Next.
 	//
 	// materializeFlatAccums is still called on the migration paths
-	// (compact→generic, dual-int→generic, MergeSink generic merge,
-	// drainSimpleAggsToPartialGroups) where per-group accs are required to
-	// run kernel.Accumulator.Merge. After those run, h.intFlatAccs == nil and
-	// the per-group ext.accs branch below picks up the materialized values.
+	// (compact→generic, dual-int→generic, MergeSink generic merge) where
+	// per-group accs are required to run kernel.Accumulator.Merge. After
+	// those run, h.intFlatAccs == nil and the per-group ext.accs branch
+	// below picks up the materialized values. The spill/finalize-via-merge
+	// paths now drain SoA-direct via partialGroupCursor, so they do not
+	// trigger materialize.
 
 	// Scalar aggregate fast path: single row output from batch accumulators
 	if h.isScalarAgg {

--- a/internal/engine/exec/aggregate_partial_drain_cursor.go
+++ b/internal/engine/exec/aggregate_partial_drain_cursor.go
@@ -1,0 +1,336 @@
+package exec
+
+import (
+	"sort"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/engine/exec/kernel"
+)
+
+// partialKeyMode selects how a cursor reifies group-key values from SoA state.
+// One branch per HashAggregate group-key path: int, dual-int, compact, and
+// (string-or-generic).
+type partialKeyMode int
+
+const (
+	partialKeyModeInt partialKeyMode = iota
+	partialKeyModeDualInt
+	partialKeyModeCompact
+	partialKeyModeStrOrGeneric
+)
+
+// partialGroupCursor is a streaming partialRunSource backed by a HashAggregate's
+// SoA hash state. It builds a sort-key arena + sorted index up-front (memory
+// proportional to keys, not to full partial-group records) and emits one
+// *partialGroup per Peek/Advance by reading from the flat accumulator arrays
+// at the next sorted index.
+//
+// Memory characteristics for N groups, ngc group cols, na aggs, k bytes/key:
+//   - Pre-existing SoA arrays — already live; we don't re-allocate them
+//   - Key arena       = N*k bytes  (typ. 16 B/group → 320 MB at N=20M)
+//   - Key offsets     = (N+1)*4    (~80 MB at N=20M)
+//   - Sort index      = N*4        (~80 MB at N=20M)
+//   - Reusable head   = O(ngc + na), single struct overwritten per Advance
+//
+// Compare with the prior []*partialGroup materialization: each group allocated
+// a *partialGroup (24 B) + a fresh []byte SortKey + a fresh []any KeyVals + a
+// fresh []kernel.Accumulator Accs, totaling ~150–200 B per group, or ~3–4 GB
+// at N=20M. The cursor cuts that to ~480 MB at SF100 Q17 scale.
+//
+// Lifetime: the cursor borrows references to the HashAggregate's SoA arrays
+// and group-state slices. The caller must not mutate those arrays for the
+// cursor's lifetime. finalizeViaPartialMerge transfers ownership by clearing
+// the aggregate's references after construction so the cursor is the sole
+// owner; spillPartialState consumes the cursor synchronously before its
+// resetGroupStateAfterSpill call frees the references.
+type partialGroupCursor struct {
+	// Source state borrowed from HashAggregate.
+	flatAccs       []flatAccumArrays
+	intGroupStates []*groupState
+	strGroupStates []*groupState
+	dualIntKeysA   []int64
+	dualIntKeysB   []int64
+	groupColTypes  []batch.TypeID
+	nAggs          int
+	nGroupCols     int
+	keyMode        partialKeyMode
+	// useAoSAccs flips Acc loading from SoA flat arrays to per-group
+	// gs.extras.accs. True iff the aggregate's intFlatAccs slice has been
+	// cleared by a prior materializeFlatAccums (e.g. MergeSink → generic
+	// migration), in which case the canonical accumulator state lives in
+	// extras.accs and reading flat arrays would panic on empty slices.
+	useAoSAccs bool
+
+	// Sort state (built once during construction; immutable thereafter).
+	keyArena   []byte   // contiguous serialized sort keys
+	keyOffsets []int32  // len == numGroups+1; key[i] = arena[off[i]:off[i+1]]
+	sortedIdx  []uint32 // permutation; group at sorted position j is sortedIdx[j]
+	pos        int
+	numGroups  int
+
+	// Reusable head storage (overwritten in place per loadHeadAt).
+	head        partialGroup
+	headKeyVals []any
+	headAccs    []kernel.Accumulator
+}
+
+// newPartialGroupCursor walks the aggregate's hash state, builds a sort-key
+// arena + sorted index, and pre-positions on the first sorted group so the
+// merger's Peek-then-Advance pattern works with no extra plumbing.
+//
+// Caller's contract:
+//   - h.intFlatAccs is populated (one of the SoA paths is in use).
+//   - h.canUseExternalMerge() is true (simpleAggs + SoA path).
+//   - h's mode flags reflect the path that built the SoA state.
+//
+// The cursor does NOT call materializeFlatAccums — accs are read SoA-direct
+// per Advance. This is the second-pass optimization equivalent to the one
+// shipped for Next() in PR #90 (commit 91cd65f), now applied to the spill
+// and finalize-via-merge drain paths.
+func newPartialGroupCursor(h *HashAggregate) *partialGroupCursor {
+	var (
+		keyMode   partialKeyMode
+		numGroups int
+	)
+	switch {
+	case h.useIntGroupKey:
+		keyMode = partialKeyModeInt
+		numGroups = len(h.intGroupStates)
+	case h.useDualIntGroupKey:
+		keyMode = partialKeyModeDualInt
+		numGroups = len(h.intGroupStates)
+	case h.useCompactGroupKey:
+		keyMode = partialKeyModeCompact
+		numGroups = len(h.intGroupStates)
+	default: // useStrGroupKey || useGenericSoA || post-MergeSink generic
+		keyMode = partialKeyModeStrOrGeneric
+		numGroups = len(h.strGroupStates)
+	}
+
+	nAggs := len(h.Aggs)
+	nGroupCols := len(h.GroupByCols)
+
+	c := &partialGroupCursor{
+		flatAccs:       h.intFlatAccs,
+		intGroupStates: h.intGroupStates,
+		strGroupStates: h.strGroupStates,
+		dualIntKeysA:   h.dualIntKeysA,
+		dualIntKeysB:   h.dualIntKeysB,
+		groupColTypes:  h.groupColTypes,
+		nAggs:          nAggs,
+		nGroupCols:     nGroupCols,
+		keyMode:        keyMode,
+		useAoSAccs:     len(h.intFlatAccs) == 0,
+		// Initial 16 B/group arena estimate fits typical numeric-key shapes;
+		// strings will grow it via append, which is fine — arena writes are
+		// strictly append-only and slices into it remain valid after grow.
+		keyArena:    make([]byte, 0, numGroups*16),
+		keyOffsets:  make([]int32, numGroups+1),
+		sortedIdx:   make([]uint32, numGroups),
+		numGroups:   numGroups,
+		headKeyVals: make([]any, nGroupCols),
+		headAccs:    make([]kernel.Accumulator, nAggs),
+	}
+	c.head.KeyVals = c.headKeyVals
+	c.head.Accs = c.headAccs
+
+	scratchKeyVals := make([]any, nGroupCols)
+	for gi := 0; gi < numGroups; gi++ {
+		c.keyOffsets[gi] = int32(len(c.keyArena))
+		c.populateScratchKeyVals(gi, scratchKeyVals)
+		c.keyArena = appendSerializedKey(c.keyArena, scratchKeyVals)
+		c.sortedIdx[gi] = uint32(gi)
+	}
+	c.keyOffsets[numGroups] = int32(len(c.keyArena))
+
+	sort.Slice(c.sortedIdx, func(i, j int) bool {
+		ai, bi := c.sortedIdx[i], c.sortedIdx[j]
+		ak := c.keyArena[c.keyOffsets[ai]:c.keyOffsets[ai+1]]
+		bk := c.keyArena[c.keyOffsets[bi]:c.keyOffsets[bi+1]]
+		return bytesCompare(ak, bk) < 0
+	})
+
+	if numGroups > 0 {
+		c.loadHeadAt(int(c.sortedIdx[0]))
+	}
+	return c
+}
+
+// populateScratchKeyVals fills dst (len == nGroupCols) with the group-key
+// values at SoA index gi. The four branches mirror HashAggregate's key paths
+// so spill files written via the cursor are bit-identical to those produced
+// before the SoA-direct rewrite.
+func (c *partialGroupCursor) populateScratchKeyVals(gi int, dst []any) {
+	switch c.keyMode {
+	case partialKeyModeInt:
+		gs := c.intGroupStates[gi]
+		dst[0] = reifyIntKey(gs.intKey, c.groupColTypes[0])
+	case partialKeyModeDualInt:
+		dst[0] = reifyIntKey(c.dualIntKeysA[gi], c.groupColTypes[0])
+		dst[1] = reifyIntKey(c.dualIntKeysB[gi], c.groupColTypes[1])
+	case partialKeyModeCompact:
+		gs := c.intGroupStates[gi]
+		copy(dst, gs.extras.keyValues)
+	default: // partialKeyModeStrOrGeneric
+		gs := c.strGroupStates[gi]
+		copy(dst, gs.extras.keyValues)
+	}
+}
+
+// loadHeadAt populates the reusable head storage from SoA at SoA index gi.
+//
+// SortKey aliases the arena slice (no copy) — the kWayMerger always copies
+// SortKey into its merged group on Pop, and the heap entry's key is captured
+// at heap.Push time. The arena is built once during construction and never
+// modified after, so aliasing is safe across Advance calls.
+//
+// KeyVals/Accs reuse the underlying arrays. The merger copies their contents
+// during merge (`append([]any(nil), current.KeyVals...)`,
+// `append([]kernel.Accumulator(nil), current.Accs...)`), so overwriting them
+// in place between Advance calls cannot corrupt the merger's state.
+func (c *partialGroupCursor) loadHeadAt(gi int) {
+	c.head.SortKey = c.keyArena[c.keyOffsets[gi]:c.keyOffsets[gi+1]]
+	c.populateScratchKeyVals(gi, c.headKeyVals)
+
+	if c.useAoSAccs {
+		c.loadHeadAccsAoS(gi)
+		return
+	}
+	c.loadHeadAccsSoA(gi)
+}
+
+// loadHeadAccsSoA fills c.headAccs from the flat accumulator arrays at index
+// gi. Used when the aggregate is still in a SoA mode and intFlatAccs carries
+// the live accumulator state.
+func (c *partialGroupCursor) loadHeadAccsSoA(gi int) {
+	for ai := 0; ai < c.nAggs; ai++ {
+		fa := &c.flatAccs[ai]
+		acc := &c.headAccs[ai]
+		// Reset acc so a previously-loaded group's HasMin/HasMax/etc. don't
+		// leak into a fresh load that doesn't touch those fields.
+		*acc = kernel.Accumulator{
+			Count:     fa.count[gi],
+			IsFloat:   fa.isFloat,
+			IsDecimal: fa.isDecimal,
+			DecScale:  fa.decScale,
+		}
+		if fa.sumI64 != nil {
+			acc.SumI64 = fa.sumI64[gi]
+		}
+		if fa.sumF64 != nil {
+			acc.SumF64 = fa.sumF64[gi]
+		}
+		if fa.sumDec != nil {
+			acc.SumDec = fa.sumDec[gi]
+		}
+		if fa.minI64 != nil {
+			acc.MinI64 = fa.minI64[gi]
+			acc.HasMin = fa.hasMin[gi]
+		}
+		if fa.maxI64 != nil {
+			acc.MaxI64 = fa.maxI64[gi]
+			acc.HasMax = fa.hasMax[gi]
+		}
+		if fa.minF64 != nil {
+			acc.MinF64 = fa.minF64[gi]
+			acc.HasMin = fa.hasMin[gi]
+		}
+		if fa.maxF64 != nil {
+			acc.MaxF64 = fa.maxF64[gi]
+			acc.HasMax = fa.hasMax[gi]
+		}
+		if fa.minDec != nil {
+			acc.MinDec = fa.minDec[gi]
+			acc.HasMin = fa.hasMin[gi]
+		}
+		if fa.maxDec != nil {
+			acc.MaxDec = fa.maxDec[gi]
+			acc.HasMax = fa.hasMax[gi]
+		}
+	}
+}
+
+// loadHeadAccsAoS fills c.headAccs from per-group gs.extras.accs at index gi.
+// Used when migrateToGenericMap (MergeSink path) cleared intFlatAccs and the
+// canonical state lives in extras.accs.
+func (c *partialGroupCursor) loadHeadAccsAoS(gi int) {
+	var gs *groupState
+	switch c.keyMode {
+	case partialKeyModeInt, partialKeyModeDualInt, partialKeyModeCompact:
+		gs = c.intGroupStates[gi]
+	default:
+		gs = c.strGroupStates[gi]
+	}
+	if gs.extras == nil || gs.extras.accs == nil {
+		// Defensive: a group with no extras at this point would be a bug
+		// upstream (migrate populates extras for all groups). Zero out the
+		// head so any partial spill written from this cursor produces
+		// identity values instead of stale fields from a prior load.
+		for ai := range c.headAccs {
+			c.headAccs[ai] = kernel.Accumulator{}
+		}
+		return
+	}
+	for ai := 0; ai < c.nAggs && ai < len(gs.extras.accs); ai++ {
+		c.headAccs[ai] = gs.extras.accs[ai]
+	}
+	// Zero any tail slots so a short extras.accs doesn't leave stale data.
+	for ai := len(gs.extras.accs); ai < c.nAggs; ai++ {
+		c.headAccs[ai] = kernel.Accumulator{}
+	}
+}
+
+// appendSerializedKey writes the same byte sequence as serializeKey directly
+// into buf, returning the extended buf. The two share one definition of the
+// on-the-wire format; callers track the pre-call length to recover offset
+// boundaries.
+func appendSerializedKey(buf []byte, vals []any) []byte {
+	for i, v := range vals {
+		if i > 0 {
+			buf = append(buf, 0)
+		}
+		buf = appendKeyValue(buf, v)
+	}
+	return buf
+}
+
+// Peek implements partialRunSource.Peek. Returns nil when exhausted.
+func (c *partialGroupCursor) Peek() *partialGroup {
+	if c.pos >= c.numGroups {
+		return nil
+	}
+	return &c.head
+}
+
+// Advance implements partialRunSource.Advance. Idempotent at exhaustion.
+func (c *partialGroupCursor) Advance() error {
+	if c.pos >= c.numGroups {
+		return nil
+	}
+	c.pos++
+	if c.pos < c.numGroups {
+		c.loadHeadAt(int(c.sortedIdx[c.pos]))
+	}
+	return nil
+}
+
+// Close implements partialRunSource.Close. Drops the cursor's references to
+// the source SoA arrays so they (and the group-state chunks they alias into)
+// can be reclaimed by the next GC. Idempotent.
+func (c *partialGroupCursor) Close() error {
+	c.flatAccs = nil
+	c.intGroupStates = nil
+	c.strGroupStates = nil
+	c.dualIntKeysA = nil
+	c.dualIntKeysB = nil
+	c.groupColTypes = nil
+	c.keyArena = nil
+	c.keyOffsets = nil
+	c.sortedIdx = nil
+	c.head = partialGroup{}
+	c.headKeyVals = nil
+	c.headAccs = nil
+	c.pos = 0
+	c.numGroups = 0
+	return nil
+}

--- a/internal/engine/exec/aggregate_partial_drain_cursor.go
+++ b/internal/engine/exec/aggregate_partial_drain_cursor.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"sort"
+	"strconv"
 
 	"github.com/citc-tech/wadjet/internal/engine/batch"
 	"github.com/citc-tech/wadjet/internal/engine/exec/kernel"
@@ -134,12 +135,26 @@ func newPartialGroupCursor(h *HashAggregate) *partialGroupCursor {
 	c.head.KeyVals = c.headKeyVals
 	c.head.Accs = c.headAccs
 
-	scratchKeyVals := make([]any, nGroupCols)
-	for gi := 0; gi < numGroups; gi++ {
-		c.keyOffsets[gi] = int32(len(c.keyArena))
-		c.populateScratchKeyVals(gi, scratchKeyVals)
-		c.keyArena = appendSerializedKey(c.keyArena, scratchKeyVals)
-		c.sortedIdx[gi] = uint32(gi)
+	// int / dual-int paths skip the []any round-trip entirely: they read SoA
+	// int values straight into the arena via typed serconv writes. At SF100
+	// scan-5 (20M groups) this saves N (single-int) or 2N (dual-int) `any`
+	// boxing allocations during build. compact / str / generic modes already
+	// have a []any in extras.keyValues so there's no boxing to skip.
+	switch keyMode {
+	case partialKeyModeInt, partialKeyModeDualInt:
+		for gi := 0; gi < numGroups; gi++ {
+			c.keyOffsets[gi] = int32(len(c.keyArena))
+			c.keyArena = c.appendIntModeSortKey(c.keyArena, gi)
+			c.sortedIdx[gi] = uint32(gi)
+		}
+	default:
+		scratchKeyVals := make([]any, nGroupCols)
+		for gi := 0; gi < numGroups; gi++ {
+			c.keyOffsets[gi] = int32(len(c.keyArena))
+			c.populateScratchKeyVals(gi, scratchKeyVals)
+			c.keyArena = appendSerializedKey(c.keyArena, scratchKeyVals)
+			c.sortedIdx[gi] = uint32(gi)
+		}
 	}
 	c.keyOffsets[numGroups] = int32(len(c.keyArena))
 
@@ -292,6 +307,39 @@ func appendSerializedKey(buf []byte, vals []any) []byte {
 		buf = appendKeyValue(buf, v)
 	}
 	return buf
+}
+
+// appendIntModeSortKey writes the sort key for an int- or dual-int-keyed
+// group at SoA index gi directly from typed int64s, bypassing the []any
+// box that appendKeyValue's type switch would otherwise require. Output is
+// byte-identical to serializeKey([]any{reifyIntKey(...)}, ...) so spill
+// files written via the cursor stay compatible with file-source readers.
+func (c *partialGroupCursor) appendIntModeSortKey(buf []byte, gi int) []byte {
+	if c.keyMode == partialKeyModeInt {
+		gs := c.intGroupStates[gi]
+		return appendTypedIntKey(buf, gs.intKey, c.groupColTypes[0])
+	}
+	// partialKeyModeDualInt
+	buf = appendTypedIntKey(buf, c.dualIntKeysA[gi], c.groupColTypes[0])
+	buf = append(buf, 0)
+	return appendTypedIntKey(buf, c.dualIntKeysB[gi], c.groupColTypes[1])
+}
+
+// appendTypedIntKey writes one int-mode column value to buf using the same
+// text encoding appendKeyValue produces for the corresponding boxed `any`.
+// The shared encoding makes this byte-identical to the prior boxed path.
+func appendTypedIntKey(buf []byte, v int64, t batch.TypeID) []byte {
+	switch t {
+	case batch.TypeBool:
+		return strconv.AppendBool(buf, v != 0)
+	case batch.TypeInt32, batch.TypePort, batch.TypeProtocol, batch.TypeDate:
+		return strconv.AppendInt(buf, int64(int32(v)), 10)
+	default:
+		// int64 + every wider-or-equal type stored as int64 (timestamp,
+		// ipv4, mac, duration, ...). reifyIntKey returns int64(v) for these,
+		// and appendKeyValue's int64 branch is strconv.AppendInt(buf, tv, 10).
+		return strconv.AppendInt(buf, v, 10)
+	}
 }
 
 // Peek implements partialRunSource.Peek. Returns nil when exhausted.

--- a/internal/engine/exec/aggregate_partial_spill.go
+++ b/internal/engine/exec/aggregate_partial_spill.go
@@ -219,12 +219,12 @@ func (w *partialSpillWriter) Write(g partialGroup) error {
 		if i < len(g.KeyVals) {
 			v = g.KeyVals[i]
 		}
-		if err := writeKeyValue(w.w, v, gc.Type); err != nil {
+		if err := writeKeyValue(w.w, w.scratch[:], v, gc.Type); err != nil {
 			return err
 		}
 	}
 	for i, spec := range w.header.Aggs {
-		if err := emitAcc(w.w, spec, &g.Accs[i]); err != nil {
+		if err := emitAcc(w.w, w.scratch[:], spec, &g.Accs[i]); err != nil {
 			return err
 		}
 	}
@@ -268,22 +268,30 @@ func (w *partialSpillWriter) Close() (int64, error) {
 
 // emitAcc writes only the accumulator fields used by this aggregate's func +
 // type combo. The reader uses the matching readAcc to deserialize.
-func emitAcc(w *bufio.Writer, spec partialAggSpec, a *kernel.Accumulator) error {
+//
+// scratch must be a slice of at least 16 bytes whose backing storage is
+// already heap-allocated (typical: w.scratch[:] from partialSpillWriter).
+// The helpers passed `scratch` use it instead of a stack-local [N]byte
+// because bufio.Writer.Write triggers an io.Writer interface call on its
+// slow path, forcing the compiler to assume any []byte parameter could
+// escape; threading scratch through avoids the per-call heap allocation
+// the local-array path would incur.
+func emitAcc(w *bufio.Writer, scratch []byte, spec partialAggSpec, a *kernel.Accumulator) error {
 	switch spec.Func {
 	case AggSum, AggAvg:
-		if err := writeInt64(w, a.Count); err != nil {
+		if err := writeInt64(w, scratch, a.Count); err != nil {
 			return err
 		}
 		switch {
 		case spec.IsDecimal:
-			return writeInt128(w, a.SumDec)
+			return writeInt128(w, scratch, a.SumDec)
 		case spec.IsFloat:
-			return writeFloat64(w, a.SumF64)
+			return writeFloat64(w, scratch, a.SumF64)
 		default:
-			return writeInt64(w, a.SumI64)
+			return writeInt64(w, scratch, a.SumI64)
 		}
 	case AggCount:
-		return writeInt64(w, a.Count)
+		return writeInt64(w, scratch, a.Count)
 	case AggMin:
 		if err := writeBool(w, a.HasMin); err != nil {
 			return err
@@ -293,11 +301,11 @@ func emitAcc(w *bufio.Writer, spec partialAggSpec, a *kernel.Accumulator) error 
 		}
 		switch {
 		case spec.IsDecimal:
-			return writeInt128(w, a.MinDec)
+			return writeInt128(w, scratch, a.MinDec)
 		case spec.IsFloat:
-			return writeFloat64(w, a.MinF64)
+			return writeFloat64(w, scratch, a.MinF64)
 		default:
-			return writeInt64(w, a.MinI64)
+			return writeInt64(w, scratch, a.MinI64)
 		}
 	case AggMax:
 		if err := writeBool(w, a.HasMax); err != nil {
@@ -308,11 +316,11 @@ func emitAcc(w *bufio.Writer, spec partialAggSpec, a *kernel.Accumulator) error 
 		}
 		switch {
 		case spec.IsDecimal:
-			return writeInt128(w, a.MaxDec)
+			return writeInt128(w, scratch, a.MaxDec)
 		case spec.IsFloat:
-			return writeFloat64(w, a.MaxF64)
+			return writeFloat64(w, scratch, a.MaxF64)
 		default:
-			return writeInt64(w, a.MaxI64)
+			return writeInt64(w, scratch, a.MaxI64)
 		}
 	default:
 		return fmt.Errorf("partial spill: unsupported agg func %v", spec.Func)
@@ -426,11 +434,15 @@ func readAcc(r *bufio.Reader, spec partialAggSpec, a *kernel.Accumulator) error 
 // writeKeyValue writes a typed display value for a group-by column. The type
 // is taken from the header (parquet.TypeID) so we can encode the canonical
 // representation; nil values are encoded as a single null tag.
-func writeKeyValue(w *bufio.Writer, v any, _ parquet.TypeID) error {
+//
+// scratch must be a slice of at least 16 bytes whose backing storage is
+// already heap-allocated (typical: w.scratch[:] from partialSpillWriter).
+// See emitAcc for why threading scratch avoids the per-call alloc that a
+// stack-local [16]byte would incur via bufio.Writer.Write's escape.
+func writeKeyValue(w *bufio.Writer, scratch []byte, v any, _ parquet.TypeID) error {
 	if v == nil {
 		return w.WriteByte(partialTagNull)
 	}
-	var buf [16]byte
 	switch tv := v.(type) {
 	case bool:
 		if tv {
@@ -441,43 +453,43 @@ func writeKeyValue(w *bufio.Writer, v any, _ parquet.TypeID) error {
 		if err := w.WriteByte(partialTagInt64); err != nil {
 			return err
 		}
-		binary.LittleEndian.PutUint64(buf[:8], uint64(tv))
-		_, err := w.Write(buf[:8])
+		binary.LittleEndian.PutUint64(scratch[:8], uint64(tv))
+		_, err := w.Write(scratch[:8])
 		return err
 	case int32:
 		if err := w.WriteByte(partialTagInt32); err != nil {
 			return err
 		}
-		binary.LittleEndian.PutUint32(buf[:4], uint32(tv))
-		_, err := w.Write(buf[:4])
+		binary.LittleEndian.PutUint32(scratch[:4], uint32(tv))
+		_, err := w.Write(scratch[:4])
 		return err
 	case int:
 		if err := w.WriteByte(partialTagInt64); err != nil {
 			return err
 		}
-		binary.LittleEndian.PutUint64(buf[:8], uint64(tv))
-		_, err := w.Write(buf[:8])
+		binary.LittleEndian.PutUint64(scratch[:8], uint64(tv))
+		_, err := w.Write(scratch[:8])
 		return err
 	case float64:
 		if err := w.WriteByte(partialTagFloat64); err != nil {
 			return err
 		}
-		binary.LittleEndian.PutUint64(buf[:8], math.Float64bits(tv))
-		_, err := w.Write(buf[:8])
+		binary.LittleEndian.PutUint64(scratch[:8], math.Float64bits(tv))
+		_, err := w.Write(scratch[:8])
 		return err
 	case float32:
 		if err := w.WriteByte(partialTagFloat32); err != nil {
 			return err
 		}
-		binary.LittleEndian.PutUint32(buf[:4], math.Float32bits(tv))
-		_, err := w.Write(buf[:4])
+		binary.LittleEndian.PutUint32(scratch[:4], math.Float32bits(tv))
+		_, err := w.Write(scratch[:4])
 		return err
 	case string:
 		if err := w.WriteByte(partialTagString); err != nil {
 			return err
 		}
-		binary.LittleEndian.PutUint32(buf[:4], uint32(len(tv)))
-		if _, err := w.Write(buf[:4]); err != nil {
+		binary.LittleEndian.PutUint32(scratch[:4], uint32(len(tv)))
+		if _, err := w.Write(scratch[:4]); err != nil {
 			return err
 		}
 		_, err := w.WriteString(tv)
@@ -486,8 +498,8 @@ func writeKeyValue(w *bufio.Writer, v any, _ parquet.TypeID) error {
 		if err := w.WriteByte(partialTagBytes); err != nil {
 			return err
 		}
-		binary.LittleEndian.PutUint32(buf[:4], uint32(len(tv)))
-		if _, err := w.Write(buf[:4]); err != nil {
+		binary.LittleEndian.PutUint32(scratch[:4], uint32(len(tv)))
+		if _, err := w.Write(scratch[:4]); err != nil {
 			return err
 		}
 		_, err := w.Write(tv)
@@ -496,9 +508,9 @@ func writeKeyValue(w *bufio.Writer, v any, _ parquet.TypeID) error {
 		if err := w.WriteByte(partialTagInt128); err != nil {
 			return err
 		}
-		binary.LittleEndian.PutUint64(buf[:8], uint64(tv.Hi))
-		binary.LittleEndian.PutUint64(buf[8:16], tv.Lo)
-		_, err := w.Write(buf[:16])
+		binary.LittleEndian.PutUint64(scratch[:8], uint64(tv.Hi))
+		binary.LittleEndian.PutUint64(scratch[8:16], tv.Lo)
+		_, err := w.Write(scratch[:16])
 		return err
 	default:
 		// Fall back to fmt.Sprintf string form. This is acceptable for
@@ -509,8 +521,8 @@ func writeKeyValue(w *bufio.Writer, v any, _ parquet.TypeID) error {
 		if err := w.WriteByte(partialTagString); err != nil {
 			return err
 		}
-		binary.LittleEndian.PutUint32(buf[:4], uint32(len(s)))
-		if _, err := w.Write(buf[:4]); err != nil {
+		binary.LittleEndian.PutUint32(scratch[:4], uint32(len(s)))
+		if _, err := w.Write(scratch[:4]); err != nil {
 			return err
 		}
 		_, err := w.WriteString(s)
@@ -599,10 +611,9 @@ func readBool(r *bufio.Reader) (bool, error) {
 	return b != 0, nil
 }
 
-func writeInt64(w *bufio.Writer, v int64) error {
-	var buf [8]byte
-	binary.LittleEndian.PutUint64(buf[:], uint64(v))
-	_, err := w.Write(buf[:])
+func writeInt64(w *bufio.Writer, scratch []byte, v int64) error {
+	binary.LittleEndian.PutUint64(scratch[:8], uint64(v))
+	_, err := w.Write(scratch[:8])
 	return err
 }
 
@@ -614,10 +625,9 @@ func readInt64(r *bufio.Reader) (int64, error) {
 	return int64(binary.LittleEndian.Uint64(buf[:])), nil
 }
 
-func writeFloat64(w *bufio.Writer, v float64) error {
-	var buf [8]byte
-	binary.LittleEndian.PutUint64(buf[:], math.Float64bits(v))
-	_, err := w.Write(buf[:])
+func writeFloat64(w *bufio.Writer, scratch []byte, v float64) error {
+	binary.LittleEndian.PutUint64(scratch[:8], math.Float64bits(v))
+	_, err := w.Write(scratch[:8])
 	return err
 }
 
@@ -629,11 +639,10 @@ func readFloat64(r *bufio.Reader) (float64, error) {
 	return math.Float64frombits(binary.LittleEndian.Uint64(buf[:])), nil
 }
 
-func writeInt128(w *bufio.Writer, v batch.Int128) error {
-	var buf [16]byte
-	binary.LittleEndian.PutUint64(buf[:8], uint64(v.Hi))
-	binary.LittleEndian.PutUint64(buf[8:16], v.Lo)
-	_, err := w.Write(buf[:])
+func writeInt128(w *bufio.Writer, scratch []byte, v batch.Int128) error {
+	binary.LittleEndian.PutUint64(scratch[:8], uint64(v.Hi))
+	binary.LittleEndian.PutUint64(scratch[8:16], v.Lo)
+	_, err := w.Write(scratch[:16])
 	return err
 }
 

--- a/internal/engine/exec/aggregate_partial_spill.go
+++ b/internal/engine/exec/aggregate_partial_spill.go
@@ -910,10 +910,24 @@ func bytesCompare(a, b []byte) int {
 
 // kWayMerger streams groups from N runs in sortKey order, combining
 // accumulators on equal keys. Output is monotone non-decreasing in sortKey.
+//
+// Next returns a *partialGroup whose backing storage (SortKey/KeyVals/Accs
+// slices) is owned by the merger and reused across calls. Callers MUST NOT
+// retain pointers across Next calls — copy what you need before calling
+// Next again. Reusing the head buffers eliminates the per-merged-group
+// allocations the older fresh-copy contract required.
 type kWayMerger struct {
 	runs []partialRunSource
 	heap runHeap
 	aggs []partialAggSpec
+
+	// Reusable head storage. Returned by Next; valid only until the next
+	// Next call. Backing arrays grow once to fit the widest group then
+	// stay stable for subsequent reuse.
+	head        partialGroup
+	headSortKey []byte               // stable backing for head.SortKey
+	headKeyVals []any                // stable backing for head.KeyVals
+	headAccs    []kernel.Accumulator // stable backing for head.Accs
 }
 
 func newKWayMerger(runs []partialRunSource, aggs []partialAggSpec) *kWayMerger {
@@ -929,36 +943,58 @@ func newKWayMerger(runs []partialRunSource, aggs []partialAggSpec) *kWayMerger {
 
 // Next returns the next merged group, or (nil, nil) when all runs are
 // exhausted. Equal-keyed groups across runs are combined via Accumulator.Merge.
+//
+// The returned *partialGroup aliases reusable buffers on the merger; the
+// next Next call invalidates the previously returned slice contents. The
+// caller must consume (or copy) the head before continuing.
 func (m *kWayMerger) Next() (*partialGroup, error) {
 	if len(m.heap) == 0 {
 		return nil, nil
 	}
 	top := heap.Pop(&m.heap).(runHeapEntry)
 	current := m.runs[top.source].Peek()
-	// Allocate a fresh group rather than aliasing current; the source may
-	// reuse its head buffer in future Advance calls.
-	merged := &partialGroup{
-		SortKey: append([]byte(nil), current.SortKey...),
-		KeyVals: append([]any(nil), current.KeyVals...),
-		Accs:    append([]kernel.Accumulator(nil), current.Accs...),
+
+	// Refill m.head from current using stable backing arrays. SortKey is
+	// always copied (the source may reuse its head buffer on Advance, and
+	// the heap-top compare below needs a stable reference). KeyVals are
+	// `any` boxes — the slice array is stable; we overwrite slots rather
+	// than allocate a fresh []any. Accs are value types — same.
+	m.headSortKey = append(m.headSortKey[:0], current.SortKey...)
+	m.head.SortKey = m.headSortKey
+
+	if cap(m.headKeyVals) < len(current.KeyVals) {
+		m.headKeyVals = make([]any, len(current.KeyVals))
+	} else {
+		m.headKeyVals = m.headKeyVals[:len(current.KeyVals)]
 	}
+	copy(m.headKeyVals, current.KeyVals)
+	m.head.KeyVals = m.headKeyVals
+
+	if cap(m.headAccs) < len(current.Accs) {
+		m.headAccs = make([]kernel.Accumulator, len(current.Accs))
+	} else {
+		m.headAccs = m.headAccs[:len(current.Accs)]
+	}
+	copy(m.headAccs, current.Accs)
+	m.head.Accs = m.headAccs
+
 	if err := m.advanceSource(top.source); err != nil {
 		return nil, err
 	}
 	// Drain any other runs whose head matches this key and merge their
 	// accumulators in. Important: keep going as long as heap top's key
-	// equals merged.SortKey; multiple runs may all carry the same group.
-	for len(m.heap) > 0 && bytesCompare(m.heap[0].key, merged.SortKey) == 0 {
+	// equals m.head.SortKey; multiple runs may all carry the same group.
+	for len(m.heap) > 0 && bytesCompare(m.heap[0].key, m.head.SortKey) == 0 {
 		next := heap.Pop(&m.heap).(runHeapEntry)
 		other := m.runs[next.source].Peek()
-		for i := range merged.Accs {
-			merged.Accs[i].Merge(&other.Accs[i])
+		for i := range m.head.Accs {
+			m.head.Accs[i].Merge(&other.Accs[i])
 		}
 		if err := m.advanceSource(next.source); err != nil {
 			return nil, err
 		}
 	}
-	return merged, nil
+	return &m.head, nil
 }
 
 func (m *kWayMerger) advanceSource(idx int) error {

--- a/internal/engine/exec/aggregate_partial_spill.go
+++ b/internal/engine/exec/aggregate_partial_spill.go
@@ -660,11 +660,24 @@ func readInt128(r *bufio.Reader) (batch.Int128, error) {
 // partialSpillReader iterates groups in a partial-spill file in stored order
 // (which is sorted by sortKey). It is forward-only and not safe for concurrent
 // use.
+//
+// Next returns a *partialGroup whose backing storage (SortKey/KeyVals/Accs)
+// is owned by the reader and reused across calls — same contract as
+// kWayMerger.Next. Callers must consume (or copy) before the next Next.
+// Because the reader feeds into kWayMerger which copies head data on its
+// own Next, the in-place reuse is safe end-to-end.
 type partialSpillReader struct {
-	f      *os.File
-	r      *bufio.Reader
-	header partialSpillHeader
+	f       *os.File
+	r       *bufio.Reader
+	header  partialSpillHeader
 	scratch [16]byte
+
+	// Reusable head storage. Returned by Next; valid only until the next
+	// Next call. Backing arrays grow once to fit the widest group.
+	head        partialGroup
+	headSortKey []byte
+	headKeyVals []any
+	headAccs    []kernel.Accumulator
 }
 
 func openPartialSpillReader(path string) (*partialSpillReader, error) {
@@ -736,6 +749,9 @@ func (r *partialSpillReader) readHeader() error {
 
 // Next reads the next group, or returns (nil, io.EOF) when the run is
 // exhausted. Returns errors for malformed files (truncated, bad tags, etc.).
+//
+// The returned *partialGroup aliases reusable buffers on the reader; the
+// next Next call invalidates the previously returned slice contents.
 func (r *partialSpillReader) Next() (*partialGroup, error) {
 	marker, err := r.r.ReadByte()
 	if err != nil {
@@ -751,28 +767,50 @@ func (r *partialSpillReader) Next() (*partialGroup, error) {
 		return nil, err
 	}
 	keyLen := int(binary.LittleEndian.Uint32(r.scratch[:4]))
-	sortKey := make([]byte, keyLen)
-	if _, err := io.ReadFull(r.r, sortKey); err != nil {
+	if cap(r.headSortKey) < keyLen {
+		r.headSortKey = make([]byte, keyLen)
+	} else {
+		r.headSortKey = r.headSortKey[:keyLen]
+	}
+	if _, err := io.ReadFull(r.r, r.headSortKey); err != nil {
 		return nil, err
 	}
-	g := &partialGroup{
-		SortKey: sortKey,
-		KeyVals: make([]any, len(r.header.GroupCols)),
-		Accs:    make([]kernel.Accumulator, len(r.header.Aggs)),
+	r.head.SortKey = r.headSortKey
+
+	nGc := len(r.header.GroupCols)
+	if cap(r.headKeyVals) < nGc {
+		r.headKeyVals = make([]any, nGc)
+	} else {
+		r.headKeyVals = r.headKeyVals[:nGc]
 	}
-	for i := range g.KeyVals {
+	for i := range r.headKeyVals {
 		v, err := readKeyValue(r.r)
 		if err != nil {
 			return nil, err
 		}
-		g.KeyVals[i] = v
+		r.headKeyVals[i] = v
 	}
-	for i := range g.Accs {
-		if err := readAcc(r.r, r.header.Aggs[i], &g.Accs[i]); err != nil {
+	r.head.KeyVals = r.headKeyVals
+
+	nA := len(r.header.Aggs)
+	if cap(r.headAccs) < nA {
+		r.headAccs = make([]kernel.Accumulator, nA)
+	} else {
+		r.headAccs = r.headAccs[:nA]
+	}
+	// readAcc only sets fields its agg type touches; zero out so a prior
+	// group's HasMin/HasMax/etc. don't leak into this read.
+	for i := range r.headAccs {
+		r.headAccs[i] = kernel.Accumulator{}
+	}
+	for i := range r.headAccs {
+		if err := readAcc(r.r, r.header.Aggs[i], &r.headAccs[i]); err != nil {
 			return nil, err
 		}
 	}
-	return g, nil
+	r.head.Accs = r.headAccs
+
+	return &r.head, nil
 }
 
 func (r *partialSpillReader) Close() error {

--- a/internal/engine/exec/aggregate_partial_spill.go
+++ b/internal/engine/exec/aggregate_partial_spill.go
@@ -1281,6 +1281,13 @@ func (h *HashAggregate) closePartialMerger() {
 // previously captured output schema. Returns (nil, nil) when the merger is
 // exhausted.
 //
+// Writes columns inline as the merger yields each group, so the only
+// transient buffer is the output batch itself — there is no intermediate
+// []partialGroup of size DefaultBatchSize. Saves ~144 KB of struct-header
+// copies per Next call (2048 × sizeof(partialGroup)) and improves
+// locality: each merged group is consumed and dropped before the next one
+// is pulled.
+//
 // Caller must hold h.mu (Next does not lock today, but the merger field is
 // only mutated by Finalize and Close, both of which run on the main goroutine
 // — concurrent SpillSome only touches pre-finalize state).
@@ -1288,8 +1295,24 @@ func (h *HashAggregate) nextFromPartialMerger() (*batch.RecordBatch, error) {
 	if h.partialMerger == nil {
 		return nil, nil
 	}
-	rows := make([]partialGroup, 0, batch.DefaultBatchSize)
-	for len(rows) < batch.DefaultBatchSize {
+	// Pull the first group up-front so the empty case (merger exhausted)
+	// returns without allocating an output batch we'd immediately discard.
+	first, err := h.partialMerger.Next()
+	if err != nil {
+		h.closePartialMerger()
+		return nil, err
+	}
+	if first == nil {
+		h.closePartialMerger()
+		return nil, nil
+	}
+
+	out := batch.NewRecordBatch(h.partialMergerSchema, batch.DefaultBatchSize)
+	nGroupCols := len(h.GroupByCols)
+	h.writeMergedRow(out, 0, first, nGroupCols)
+	nRows := 1
+
+	for nRows < batch.DefaultBatchSize {
 		g, err := h.partialMerger.Next()
 		if err != nil {
 			h.closePartialMerger()
@@ -1298,40 +1321,40 @@ func (h *HashAggregate) nextFromPartialMerger() (*batch.RecordBatch, error) {
 		if g == nil {
 			break
 		}
-		rows = append(rows, *g)
+		h.writeMergedRow(out, nRows, g, nGroupCols)
+		nRows++
 	}
-	if len(rows) == 0 {
-		h.closePartialMerger()
-		return nil, nil
-	}
-	out := batch.NewRecordBatch(h.partialMergerSchema, len(rows))
-	nGroupCols := len(h.GroupByCols)
-	for i, g := range rows {
-		// Group-by columns: write each keyVal into its column. KeyVals were
-		// produced by partialGroupCursor.populateScratchKeyVals (or
-		// readKeyValue from disk), which preserves the original typed value,
-		// so SetValue stores them through the right typed path without an
-		// extra cast.
-		for k := 0; k < nGroupCols && k < len(g.KeyVals); k++ {
-			if g.KeyVals[k] == nil {
-				out.Columns[k].Nulls.SetNull(i)
-				continue
-			}
-			out.Columns[k].SetValue(i, g.KeyVals[k])
-		}
-		// Aggregate columns: finalize each accumulator to its output value
-		// using the same kernel finalizer as the in-memory path. Only
-		// SUM/COUNT/MIN/MAX/AVG reach here (canUseExternalMerge gate); the
-		// kernel handles each correctly via finalizeKernelAcc.
-		for j, agg := range h.Aggs {
-			colIdx := nGroupCols + j
-			result := finalizeKernelAcc(&g.Accs[j], agg.Func)
-			if result == nil {
-				out.Columns[colIdx].Nulls.SetNull(i)
-				continue
-			}
-			out.Columns[colIdx].SetValue(i, result)
-		}
+
+	// Trim the output batch to the actual filled row count. The unused
+	// slots in each column vector were zero-cleared by NewRecordBatch and
+	// are not visible past Len.
+	out.Len = nRows
+	for _, col := range out.Columns {
+		col.Len = nRows
 	}
 	return out, nil
+}
+
+// writeMergedRow writes one merged partialGroup into out at row index i.
+// Group-by columns come from g.KeyVals (preserving the typed value the
+// cursor or file reader produced); agg columns are finalized via
+// finalizeKernelAcc — only SUM/COUNT/MIN/MAX/AVG reach here per the
+// canUseExternalMerge gate.
+func (h *HashAggregate) writeMergedRow(out *batch.RecordBatch, i int, g *partialGroup, nGroupCols int) {
+	for k := 0; k < nGroupCols && k < len(g.KeyVals); k++ {
+		if g.KeyVals[k] == nil {
+			out.Columns[k].Nulls.SetNull(i)
+			continue
+		}
+		out.Columns[k].SetValue(i, g.KeyVals[k])
+	}
+	for j, agg := range h.Aggs {
+		colIdx := nGroupCols + j
+		result := finalizeKernelAcc(&g.Accs[j], agg.Func)
+		if result == nil {
+			out.Columns[colIdx].Nulls.SetNull(i)
+			continue
+		}
+		out.Columns[colIdx].SetValue(i, result)
+	}
 }

--- a/internal/engine/exec/aggregate_partial_spill.go
+++ b/internal/engine/exec/aggregate_partial_spill.go
@@ -9,7 +9,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"sort"
 	"sync/atomic"
 
 	"github.com/citc-tech/wadjet/internal/engine/batch"
@@ -975,15 +974,6 @@ func (m *kWayMerger) Close() error {
 	return firstErr
 }
 
-// sortPartialGroups sorts in-memory groups by SortKey, ascending. Used both
-// before writing a spill run and to prepare the in-memory remainder for the
-// k-way merge.
-func sortPartialGroups(groups []*partialGroup) {
-	sort.Slice(groups, func(i, j int) bool {
-		return bytesCompare(groups[i].SortKey, groups[j].SortKey) < 0
-	})
-}
-
 // canUseExternalMerge reports whether HashAggregate's current configuration
 // supports the partial-state external-merge spill path. The path requires:
 //   - simpleAggs (every agg fits Accumulator: SUM/COUNT/MIN/MAX/AVG)
@@ -1086,90 +1076,6 @@ func mapBatchTypeToParquet(t batch.TypeID) parquet.TypeID {
 	}
 }
 
-// drainSimpleAggsToPartialGroups walks the current SoA hash table and produces
-// one *partialGroup per live group, ready to be written to a spill file.
-//
-// SortKey is always produced via serializeKey(keyVals) so that runs from
-// any path (int, dual-int, compact, string, generic) and from any state
-// transition (raw consume, MergeSink-migrated) merge correctly. serializeKey
-// is the same encoding migrateToGenericMap uses to populate serializedKeys
-// after MergeSink migration, so a HashAggregate that spilled in compact mode
-// and was later merged with a peer in generic mode still has matching sort
-// keys at Finalize time.
-//
-// KeyVals strategy:
-//   - useIntGroupKey: gs.intKey reified to a typed value matching
-//     groupColTypes[0] (so writeKeyValue emits the right tag and so Next()
-//     emits the right type after merge)
-//   - useDualIntGroupKey: dualIntKeysA[i], dualIntKeysB[i] reified
-//   - useCompactGroupKey: gs.extras.keyValues (set during consumeBatchCompactGroup)
-//   - useStrGroupKey: gs.extras.keyValues (single string)
-//   - useGenericSoA: gs.extras.keyValues
-//   - generic (post-MergeSink migration): gs.extras.keyValues from strGroupStates
-//
-// Caller must have materialized intFlatAccs into per-group accs (via
-// materializeFlatAccums) BEFORE calling this — accs come from gs.extras.accs.
-func (h *HashAggregate) drainSimpleAggsToPartialGroups() []*partialGroup {
-	var groups []*partialGroup
-	keyBuf := make([]byte, 0, 64)
-	// Caller called materializeFlatAccums above this, so every group's extras
-	// is allocated and extras.accs is populated. extras.keyValues is set for
-	// compact / str / generic paths but stays nil for int / dual-int (we
-	// rebuild keyVals from intKey / dualIntKeys[]).
-	switch {
-	case h.useIntGroupKey:
-		groups = make([]*partialGroup, 0, len(h.intGroupStates))
-		for _, gs := range h.intGroupStates {
-			keyVal := reifyIntKey(gs.intKey, h.groupColTypes[0])
-			keyVals := []any{keyVal}
-			sortKey := []byte(serializeKey(keyBuf, keyVals))
-			groups = append(groups, &partialGroup{
-				SortKey: sortKey,
-				KeyVals: keyVals,
-				Accs:    append([]kernel.Accumulator(nil), gs.extras.accs...),
-			})
-		}
-	case h.useDualIntGroupKey:
-		groups = make([]*partialGroup, 0, len(h.intGroupStates))
-		for i, gs := range h.intGroupStates {
-			a, b := h.dualIntKeysA[i], h.dualIntKeysB[i]
-			vA := reifyIntKey(a, h.groupColTypes[0])
-			vB := reifyIntKey(b, h.groupColTypes[1])
-			keyVals := []any{vA, vB}
-			sortKey := []byte(serializeKey(keyBuf, keyVals))
-			groups = append(groups, &partialGroup{
-				SortKey: sortKey,
-				KeyVals: keyVals,
-				Accs:    append([]kernel.Accumulator(nil), gs.extras.accs...),
-			})
-		}
-	case h.useCompactGroupKey:
-		groups = make([]*partialGroup, 0, len(h.intGroupStates))
-		for _, gs := range h.intGroupStates {
-			keyVals := append([]any(nil), gs.extras.keyValues...)
-			sortKey := []byte(serializeKey(keyBuf, keyVals))
-			groups = append(groups, &partialGroup{
-				SortKey: sortKey,
-				KeyVals: keyVals,
-				Accs:    append([]kernel.Accumulator(nil), gs.extras.accs...),
-			})
-		}
-	default: // useStrGroupKey || useGenericSoA || post-MergeSink generic
-		groups = make([]*partialGroup, 0, len(h.strGroupStates))
-		for _, gs := range h.strGroupStates {
-			keyVals := append([]any(nil), gs.extras.keyValues...)
-			sortKey := []byte(serializeKey(keyBuf, keyVals))
-			groups = append(groups, &partialGroup{
-				SortKey: sortKey,
-				KeyVals: keyVals,
-				Accs:    append([]kernel.Accumulator(nil), gs.extras.accs...),
-			})
-		}
-	}
-	sortPartialGroups(groups)
-	return groups
-}
-
 // reifyIntKey converts a packed int64 key back to the typed value that
 // would have been read from a column of the given batch type, so the spill
 // file's display values match what Next() would emit from the in-memory
@@ -1190,55 +1096,62 @@ func reifyIntKey(v int64, t batch.TypeID) any {
 // The next Consume call will rebuild flat accumulators from the next batch's
 // schema.
 //
+// Drain is SoA-direct via partialGroupCursor: no materializeFlatAccums copy,
+// no []*partialGroup pointer-slice materialization. Peak drain footprint is
+// the sort-key arena + sort index + a single reused head, instead of one
+// heap-allocated *partialGroup per group. At SF100 Q17 (20M groups) this
+// drops ~7 GB per task to ~480 MB.
+//
 // Caller must hold h.mu.
 func (h *HashAggregate) spillPartialState() error {
 	if h.Spill == nil {
 		return nil
 	}
-	// Step 1: capture agg specs BEFORE materializing — buildPartialAggSpecs
-	// reads h.intFlatAccs[i].isFloat/isDecimal, and materializeFlatAccums
-	// clears h.intFlatAccs as its final step. Without this ordering, the
-	// captured specs would default IsFloat=false and the writer would emit
-	// the int64 sum branch for what is actually a float64 column, producing
-	// zero-valued accumulators in the spill file.
+	// Capture specs while h.intFlatAccs still carries the type flags. We
+	// no longer materialize, but the buildPartialAggSpecs/buildPartialGroupCols
+	// dependencies on h's mode + intFlatAccs are unchanged from the prior path.
 	aggSpecs := h.buildPartialAggSpecs()
 	groupCols := h.buildPartialGroupCols()
 
-	// Step 2: materialize SoA -> AoS so we can copy per-group accs into
-	// partialGroup.Accs. This nils out h.intFlatAccs, which is the desired
-	// reset state — the next Consume call will rebuildFlatAccums.
-	h.materializeFlatAccums()
-
-	// Step 3: build sorted partial groups from the materialized state.
-	groups := h.drainSimpleAggsToPartialGroups()
-	if len(groups) == 0 {
-		// Nothing to spill — still reset trackers so we don't grow
-		// unbounded.
+	cursor := newPartialGroupCursor(h)
+	if cursor.numGroups == 0 {
+		cursor.Close()
 		h.resetGroupStateAfterSpill()
 		return nil
 	}
 
-	// Step 4: write to disk.
 	header := partialSpillHeader{
 		GroupCols: groupCols,
 		Aggs:      aggSpecs,
 	}
 	w, path, err := newPartialSpillWriter(h.Spill.SpillDir(), header)
 	if err != nil {
+		cursor.Close()
 		return err
 	}
-	for _, g := range groups {
-		if err := w.Write(*g); err != nil {
+	for {
+		g := cursor.Peek()
+		if g == nil {
+			break
+		}
+		if werr := w.Write(*g); werr != nil {
 			w.Close()
-			return err
+			cursor.Close()
+			return werr
+		}
+		if aerr := cursor.Advance(); aerr != nil {
+			w.Close()
+			cursor.Close()
+			return aerr
 		}
 	}
 	if _, err := w.Close(); err != nil {
+		cursor.Close()
 		return err
 	}
+	cursor.Close()
 	h.partialSpillFiles = append(h.partialSpillFiles, path)
 
-	// Step 5: reset hash table and release tracker bytes.
 	h.resetGroupStateAfterSpill()
 	return nil
 }
@@ -1291,8 +1204,7 @@ func (h *HashAggregate) resetGroupStateAfterSpill() {
 // Spill files are deleted by Close() once the merger is closed, not here —
 // the runs need them open during Next() drains.
 func (h *HashAggregate) finalizeViaPartialMerge() error {
-	// Capture specs before materialize clears intFlatAccs (same ordering
-	// constraint as spillPartialState).
+	// Capture specs while intFlatAccs is still populated.
 	specs := h.buildPartialAggSpecs()
 	// Capture the output schema while the path-mode flags + groupColTypes
 	// reflect the original configuration. Once we collapse to streaming
@@ -1300,16 +1212,18 @@ func (h *HashAggregate) finalizeViaPartialMerge() error {
 	// would emit a different shape.
 	h.partialMergerSchema = h.outputSchema()
 
-	// Drain any remaining in-memory groups to the merger as a memory run.
-	// We don't write them to disk — they're already in RAM, no point doing
-	// the round-trip.
-	h.materializeFlatAccums()
-	memGroups := h.drainSimpleAggsToPartialGroups()
+	// Build a streaming SoA-direct cursor over the in-memory remainder. The
+	// cursor owns slice-header references to h.intFlatAccs / *GroupStates /
+	// dualIntKeys for its lifetime; the resetGroupStateAfterSpill call below
+	// nils h's slice headers but not the underlying arrays, which the cursor
+	// keeps live until it's drained and Close()d by closePartialMerger.
+	cursor := newPartialGroupCursor(h)
 
-	// Build run sources: one per partial-spill file plus the memory run.
 	sources := make([]partialRunSource, 0, len(h.partialSpillFiles)+1)
-	if len(memGroups) > 0 {
-		sources = append(sources, newMemoryRunSource(memGroups))
+	if cursor.numGroups > 0 {
+		sources = append(sources, cursor)
+	} else {
+		cursor.Close()
 	}
 	for _, path := range h.partialSpillFiles {
 		src, err := newFileRunSource(path)
@@ -1325,7 +1239,8 @@ func (h *HashAggregate) finalizeViaPartialMerge() error {
 
 	// Reset in-memory state so the existing Next() emission paths can't
 	// accidentally drive output from leftover hash table entries — only the
-	// merger drives output now.
+	// merger drives output now. The cursor's slice-header copies keep the
+	// SoA arrays + group-state chunks alive until cursor.Close() runs.
 	h.resetGroupStateAfterSpill()
 	h.useIntGroupKey = false
 	h.useDualIntGroupKey = false
@@ -1384,9 +1299,10 @@ func (h *HashAggregate) nextFromPartialMerger() (*batch.RecordBatch, error) {
 	nGroupCols := len(h.GroupByCols)
 	for i, g := range rows {
 		// Group-by columns: write each keyVal into its column. KeyVals were
-		// produced by drainSimpleAggsToPartialGroups (or readKeyValue from
-		// disk), which preserves the original typed value, so SetValue
-		// stores them through the right typed path without an extra cast.
+		// produced by partialGroupCursor.populateScratchKeyVals (or
+		// readKeyValue from disk), which preserves the original typed value,
+		// so SetValue stores them through the right typed path without an
+		// extra cast.
 		for k := 0; k < nGroupCols && k < len(g.KeyVals); k++ {
 			if g.KeyVals[k] == nil {
 				out.Columns[k].Nulls.SetNull(i)

--- a/internal/engine/exec/aggregate_partial_spill_test.go
+++ b/internal/engine/exec/aggregate_partial_spill_test.go
@@ -569,6 +569,88 @@ func bytesEq(a, b []byte) bool {
 	return true
 }
 
+// TestExternalMergeSpill_FinalizeAllSpilledNoRemainder exercises the path
+// where SpillSome drained every group, no more Consume calls follow, and
+// Finalize must merge the spill files alone — partialGroupCursor.numGroups
+// is 0 and the cursor must Close without joining the source list.
+//
+// Regression check: ensure a 0-group cursor doesn't appear as a heap entry
+// (which would cause Peek().SortKey to be a zero-length slice and break the
+// merger's order invariant).
+func TestExternalMergeSpill_FinalizeAllSpilledNoRemainder(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "k", Type: parquet.TypeInt64},
+		{Name: "v", Type: parquet.TypeInt64},
+	}
+	ctx := context.Background()
+	tracker := memory.NewTracker("test", 1_000_000)
+	sm, err := memory.NewSpillManager(t.TempDir(), tracker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := NewHashAggregate([]string{"k"}, []AggColumn{
+		{Func: AggSum, InputCol: "v", OutputCol: "total", OutputType: parquet.TypeInt64},
+	})
+	h.Spill = sm
+	if err := h.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	const numGroups = 200
+	rows := make([]map[string]any, 0, numGroups)
+	expected := make(map[int64]int64, numGroups)
+	for i := 0; i < numGroups; i++ {
+		k := int64(i)
+		v := int64(i + 1)
+		rows = append(rows, map[string]any{"k": k, "v": v})
+		expected[k] = v
+	}
+	if err := h.Consume(ctx, batch.FromRows(schema, rows)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Drain everything to spill, then DON'T consume anything further. The
+	// in-memory remainder is now empty.
+	if _, err := h.SpillSome(h.SpillFootprint()); err != nil {
+		t.Fatal(err)
+	}
+	if len(h.partialSpillFiles) != 1 {
+		t.Fatalf("expected 1 spill file, got %d", len(h.partialSpillFiles))
+	}
+	if len(h.intGroupStates) != 0 {
+		t.Fatalf("expected empty in-memory groups, got %d", len(h.intGroupStates))
+	}
+
+	// Finalize hits finalizeViaPartialMerge with no in-memory remainder.
+	if err := h.Finalize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	got := make(map[int64]int64, numGroups)
+	for {
+		out, err := h.Next(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out == nil {
+			break
+		}
+		for _, r := range out.ToRows() {
+			got[r["k"].(int64)] = r["total"].(int64)
+		}
+	}
+	if err := h.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != numGroups {
+		t.Fatalf("group count: got %d want %d", len(got), numGroups)
+	}
+	for k, want := range expected {
+		if got[k] != want {
+			t.Errorf("k=%d: got %d want %d", k, got[k], want)
+		}
+	}
+}
+
 // TestHashAggregateSpillable_FootprintAndSpillSome covers the Spillable
 // contract directly: SpillFootprint reflects tracker bytes after Consume,
 // SpillSome drains state to a partial-spill file and releases bytes back,

--- a/internal/engine/exec/bench_test.go
+++ b/internal/engine/exec/bench_test.go
@@ -210,6 +210,147 @@ func BenchmarkHashAggregatePartialSpillDrain(b *testing.B) {
 	}
 }
 
+// BenchmarkHashAggregatePartialSpillDrainDualInt covers the dual-int SoA
+// path. Two int32 GROUP BY columns trigger the dualIntKeysA/B + chain
+// hash-table layout, and the cursor's appendIntModeSortKey takes the
+// 2N-typed-write branch. Confirms the typed-key optimization scales as
+// well for dual-int as for single-int.
+func BenchmarkHashAggregatePartialSpillDrainDualInt(b *testing.B) {
+	const rowsPerBatch = 2048
+	const nBatches = 10
+	const numKeysA = 256 // 256 * 80 = 20480 distinct (a, b) pairs
+	const numKeysB = 80
+
+	schema := []parquet.Column{
+		{Name: "a", Type: parquet.TypeInt32},
+		{Name: "c", Type: parquet.TypeInt32},
+		{Name: "v", Type: parquet.TypeFloat64},
+	}
+	batches := make([]*batch.RecordBatch, nBatches)
+	for bi := 0; bi < nBatches; bi++ {
+		bb := batch.NewRecordBatch(schema, rowsPerBatch)
+		for i := 0; i < rowsPerBatch; i++ {
+			pos := bi*rowsPerBatch + i
+			bb.Columns[0].SetValue(i, int32(pos%numKeysA))
+			bb.Columns[1].SetValue(i, int32((pos/numKeysA)%numKeysB))
+			bb.Columns[2].SetValue(i, float64(i)*1.5)
+		}
+		batches[bi] = bb
+	}
+
+	ctx := context.Background()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		tracker := memory.NewTracker("bench", 1<<30)
+		sm, err := memory.NewSpillManager(b.TempDir(), tracker)
+		if err != nil {
+			b.Fatal(err)
+		}
+		agg := NewHashAggregate(
+			[]string{"a", "c"},
+			[]AggColumn{
+				{Func: AggSum, InputCol: "v", OutputCol: "total", OutputType: parquet.TypeFloat64},
+			},
+		)
+		agg.Spill = sm
+		if err := agg.Init(ctx); err != nil {
+			b.Fatal(err)
+		}
+		for _, bb := range batches {
+			if err := agg.Consume(ctx, bb); err != nil {
+				b.Fatal(err)
+			}
+		}
+		footprint := agg.SpillFootprint()
+		b.StartTimer()
+		if _, err := agg.SpillSome(footprint); err != nil {
+			b.Fatal(err)
+		}
+		b.StopTimer()
+		agg.Close()
+	}
+}
+
+// BenchmarkHashAggregatePartialMergeFinalize covers finalizeViaPartialMerge
+// — the cursor as a memory partialRunSource feeding the k-way merger
+// alongside one spilled run. End-to-end: cursor build + heap merge + Next
+// drain. Detects regressions in the streaming-emit path that the spill-only
+// bench above cannot.
+func BenchmarkHashAggregatePartialMergeFinalize(b *testing.B) {
+	const groupsPerBatch = 2048
+	const nBatches = 10
+
+	schema := []parquet.Column{
+		{Name: "k", Type: parquet.TypeInt64},
+		{Name: "v", Type: parquet.TypeFloat64},
+	}
+	batches := make([]*batch.RecordBatch, nBatches)
+	for bi := 0; bi < nBatches; bi++ {
+		bb := batch.NewRecordBatch(schema, groupsPerBatch)
+		for i := 0; i < groupsPerBatch; i++ {
+			// Overlap keys across batches so finalize merges in-memory and
+			// spilled groups via Accumulator.Merge for a fraction of keys.
+			bb.Columns[0].SetValue(i, int64((bi*groupsPerBatch/2)+i))
+			bb.Columns[1].SetValue(i, float64(i)*1.5)
+		}
+		batches[bi] = bb
+	}
+
+	ctx := context.Background()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		tracker := memory.NewTracker("bench", 1<<30)
+		sm, err := memory.NewSpillManager(b.TempDir(), tracker)
+		if err != nil {
+			b.Fatal(err)
+		}
+		agg := NewHashAggregate(
+			[]string{"k"},
+			[]AggColumn{
+				{Func: AggSum, InputCol: "v", OutputCol: "total", OutputType: parquet.TypeFloat64},
+			},
+		)
+		agg.Spill = sm
+		if err := agg.Init(ctx); err != nil {
+			b.Fatal(err)
+		}
+		// Consume half, force a spill, then consume the rest. Finalize will
+		// k-way merge the spilled run with the in-memory cursor.
+		half := nBatches / 2
+		for _, bb := range batches[:half] {
+			if err := agg.Consume(ctx, bb); err != nil {
+				b.Fatal(err)
+			}
+		}
+		footprint := agg.SpillFootprint()
+		if _, err := agg.SpillSome(footprint); err != nil {
+			b.Fatal(err)
+		}
+		for _, bb := range batches[half:] {
+			if err := agg.Consume(ctx, bb); err != nil {
+				b.Fatal(err)
+			}
+		}
+		b.StartTimer()
+		if err := agg.Finalize(ctx); err != nil {
+			b.Fatal(err)
+		}
+		for {
+			out, err := agg.Next(ctx)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if out == nil {
+				break
+			}
+		}
+		b.StopTimer()
+		agg.Close()
+	}
+}
+
 func BenchmarkBatchColumnByName(b *testing.B) {
 	bb := benchBatch(2048)
 	b.ResetTimer()

--- a/internal/engine/exec/bench_test.go
+++ b/internal/engine/exec/bench_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/engine/memory"
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
 )
 
@@ -145,6 +146,66 @@ func BenchmarkHashAggregateHighCardinality(b *testing.B) {
 				break
 			}
 		}
+		agg.Close()
+	}
+}
+
+// BenchmarkHashAggregatePartialSpillDrain measures the spillPartialState path
+// — the architectural hotspot at SF100 scale. Builds N unique-key groups via
+// Consume, forces a SpillSome, and times the drain (cursor build + sort +
+// streaming write). Reported B/op should scale roughly linearly with N (the
+// sort-key arena + index dominate) and NOT include per-group partialGroup
+// allocations. Allocs/op should be near-constant across N.
+func BenchmarkHashAggregatePartialSpillDrain(b *testing.B) {
+	const groupsPerBatch = 2048
+	const nBatches = 10 // 20480 unique groups total
+
+	schema := []parquet.Column{
+		{Name: "k", Type: parquet.TypeInt64},
+		{Name: "v", Type: parquet.TypeFloat64},
+	}
+	batches := make([]*batch.RecordBatch, nBatches)
+	for bi := 0; bi < nBatches; bi++ {
+		bb := batch.NewRecordBatch(schema, groupsPerBatch)
+		for i := 0; i < groupsPerBatch; i++ {
+			bb.Columns[0].SetValue(i, int64(bi*groupsPerBatch+i))
+			bb.Columns[1].SetValue(i, float64(i)*1.5)
+		}
+		batches[bi] = bb
+	}
+
+	ctx := context.Background()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		// Use a tracker large enough to never auto-spill mid-Consume; we drive
+		// the spill manually via SpillSome to time only the drain.
+		tracker := memory.NewTracker("bench", 1<<30)
+		sm, err := memory.NewSpillManager(b.TempDir(), tracker)
+		if err != nil {
+			b.Fatal(err)
+		}
+		agg := NewHashAggregate(
+			[]string{"k"},
+			[]AggColumn{
+				{Func: AggSum, InputCol: "v", OutputCol: "total", OutputType: parquet.TypeFloat64},
+			},
+		)
+		agg.Spill = sm
+		if err := agg.Init(ctx); err != nil {
+			b.Fatal(err)
+		}
+		for _, bb := range batches {
+			if err := agg.Consume(ctx, bb); err != nil {
+				b.Fatal(err)
+			}
+		}
+		footprint := agg.SpillFootprint()
+		b.StartTimer()
+		if _, err := agg.SpillSome(footprint); err != nil {
+			b.Fatal(err)
+		}
+		b.StopTimer()
 		agg.Close()
 	}
 }

--- a/internal/engine/exec/exec_test.go
+++ b/internal/engine/exec/exec_test.go
@@ -653,6 +653,156 @@ func TestHashAggregateMergeThenSpillFinalize(t *testing.T) {
 	}
 }
 
+// TestHashAggregateMergeThenSpillFinalize_HighCardinality is the high-N
+// counterpart to TestHashAggregateMergeThenSpillFinalize. It exercises the
+// post-MergeSink AoS path through partialGroupCursor at a group count that
+// the small (4-group) test cannot meaningfully cover: the cursor's
+// useAoSAccs branch reads from gs.extras.accs (populated by migrate's
+// materializeFlatAccums) instead of the now-cleared intFlatAccs.
+//
+// Flow: primary spills once, clone runs in parallel, MergeSink merges them
+// via the generic-map path (compact→generic migration), then Finalize runs
+// finalizeViaPartialMerge which builds a cursor over the post-merge state.
+// Without the AoS fallback the cursor would panic at len(c.flatAccs)==0;
+// without correct AoS reading every group's SUM would be zero.
+func TestHashAggregateMergeThenSpillFinalize_HighCardinality(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "year", Type: parquet.TypeInt32},
+		{Name: "region", Type: parquet.TypeInt32},
+		{Name: "amount", Type: parquet.TypeFloat64},
+	}
+	ctx := context.Background()
+
+	// Generate 4000 (year, region) pairs split between primary and clone with
+	// a 50% overlap so MergeSink hits both the "found" and "not found"
+	// branches in the generic-map path.
+	const numYears = 80
+	const numRegions = 50
+	type expacc struct{ sum float64 }
+	expected := make(map[[2]int32]*expacc, numYears*numRegions)
+
+	primaryBatches := make([]*batch.RecordBatch, 0, 2)
+	cloneBatches := make([]*batch.RecordBatch, 0, 1)
+
+	// Primary: years [0, numYears) × regions [0, numRegions/2).
+	rowsP1 := make([]map[string]any, 0, numYears*numRegions/2)
+	rowsP2 := make([]map[string]any, 0, numYears*numRegions/2)
+	for y := int32(0); y < int32(numYears); y++ {
+		for r := int32(0); r < int32(numRegions/2); r++ {
+			v1 := float64(int(y)*1000 + int(r))
+			v2 := float64(int(y)*100 + int(r) + 7)
+			rowsP1 = append(rowsP1, map[string]any{"year": y, "region": r, "amount": v1})
+			rowsP2 = append(rowsP2, map[string]any{"year": y, "region": r, "amount": v2})
+			key := [2]int32{y, r}
+			if expected[key] == nil {
+				expected[key] = &expacc{}
+			}
+			expected[key].sum += v1 + v2
+		}
+	}
+	primaryBatches = append(primaryBatches, batch.FromRows(schema, rowsP1))
+	primaryBatches = append(primaryBatches, batch.FromRows(schema, rowsP2))
+
+	// Clone: years [0, numYears) × regions [numRegions/4, 3*numRegions/4) so
+	// half overlaps with primary, half is fresh.
+	rowsC := make([]map[string]any, 0, numYears*numRegions/2)
+	for y := int32(0); y < int32(numYears); y++ {
+		for r := int32(numRegions / 4); r < int32(3*numRegions/4); r++ {
+			v := float64(int(y)*5000 + int(r)*3)
+			rowsC = append(rowsC, map[string]any{"year": y, "region": r, "amount": v})
+			key := [2]int32{y, r}
+			if expected[key] == nil {
+				expected[key] = &expacc{}
+			}
+			expected[key].sum += v
+		}
+	}
+	cloneBatches = append(cloneBatches, batch.FromRows(schema, rowsC))
+
+	// Tight tracker so primary's second batch trips SpillSome.
+	tracker := memory.NewTracker("test", 100_000)
+	sm, err := memory.NewSpillManager(t.TempDir(), tracker)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	primary := NewHashAggregate([]string{"year", "region"}, []AggColumn{
+		{Func: AggSum, InputCol: "amount", OutputCol: "total", OutputType: parquet.TypeFloat64},
+	})
+	primary.Spill = sm
+	if err := primary.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := primary.Consume(ctx, primaryBatches[0]); err != nil {
+		t.Fatal(err)
+	}
+	// Force pressure — the next Consume must spill.
+	tracker.ForceReserve(95_000)
+	if err := primary.Consume(ctx, primaryBatches[1]); err != nil {
+		t.Fatal(err)
+	}
+	if len(primary.partialSpillFiles) == 0 {
+		t.Fatal("expected partial-state spill file but none was written")
+	}
+
+	// Clone runs without spill.
+	clone := primary.CloneSink().(*HashAggregate)
+	if err := clone.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	for _, b := range cloneBatches {
+		if err := clone.Consume(ctx, b); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// MergeSink runs the compact→generic migration on both sides. After this
+	// primary.intFlatAccs == nil and groups live in primary.strGroupStates
+	// with extras.accs populated.
+	primary.MergeSink(clone)
+	if primary.intFlatAccs != nil {
+		t.Errorf("expected intFlatAccs cleared after MergeSink, still set")
+	}
+	if len(primary.strGroupStates) == 0 {
+		t.Fatal("expected merged groups in strGroupStates")
+	}
+
+	// Finalize triggers finalizeViaPartialMerge which builds the cursor over
+	// the post-merge AoS state. Drain Next() to completion.
+	if err := primary.Finalize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	got := make(map[[2]int32]float64, len(expected))
+	for {
+		out, err := primary.Next(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out == nil {
+			break
+		}
+		for _, r := range out.ToRows() {
+			y := r["year"].(int32)
+			rg := r["region"].(int32)
+			got[[2]int32{y, rg}] = r["total"].(float64)
+		}
+	}
+	if err := primary.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got) != len(expected) {
+		t.Fatalf("group count: got %d want %d", len(got), len(expected))
+	}
+	for k, want := range expected {
+		if g, ok := got[k]; !ok {
+			t.Errorf("missing group y=%d r=%d", k[0], k[1])
+		} else if g != want.sum {
+			t.Errorf("y=%d r=%d: got %v want %v", k[0], k[1], g, want.sum)
+		}
+	}
+}
+
 // TestHashAggregateSpillBatching feeds 200 small batches under a tight memory
 // budget so every Consume after the first lands in the spill branch.
 // Regression for SF100 Q03 where per-batch flushing produced millions of


### PR DESCRIPTION
## Summary

Replaces `drainSimpleAggsToPartialGroups` + `materializeFlatAccums` in `spillPartialState` and `finalizeViaPartialMerge` with a streaming `partialGroupCursor` that reads SoA arrays directly and emits one `*partialGroup` at a time. Plus a series of follow-on optimizations on the same hot path (typed-key build, heap-resident writer scratch, streaming inline column write, reusable head buffers in merger + reader).

Drops the drain-phase peak from ~7 GB to ~480 MB per task at SF100 Q17 (20M groups), the architectural bottleneck flagged in the [groupstate-split memo](https://github.com/citc-tech/wadjet/pull/90) as blocking `max_concurrent=4` for the full 22Q suite.

### Drain bench (20K groups) vs main

| benchmark | ns/op | B/op | allocs/op |
|---|---|---|---|
| SpillDrain (int64) | 12.3 ms → 5.0 ms (-59%) | 11.0 MB → 1.14 MB (-90%) | 225 039 → 20 254 (-91%) |
| SpillDrain DualInt | 15.0 ms → 6.2 ms (-59%) | 11.5 MB → 0.99 MB (-91%) | 225 307 → 31 (-99.99%) |
| MergeFinalize | 8.9 ms → 3.7 ms (-58%) | 9.8 MB → 1.99 MB (-80%) | 179 523 → 66 408 (-63%) |

### Commits

1. `85056bd` — SoA-direct streaming drain via partialGroupCursor
2. `e91b353` — typed sort-key build for int / dual-int cursor modes
3. `ab274f5` — dual-int and merge-finalize drain benchmarks
4. `44fc2c0` — regression test for cursor with empty in-memory remainder
5. `3647527` — thread heap-resident scratch through partial-spill writer
6. `30fe9ee` — streaming inline column write in nextFromPartialMerger
7. `b34dc72` — reusable head buffers in kWayMerger.Next
8. `b708498` — reusable head buffers in partialSpillReader.Next

### Architectural notes

- The cursor borrows slice-header references to the aggregate's SoA arrays + group-state slices. `finalizeViaPartialMerge` resets `h`'s slice headers after cursor construction so the cursor is the sole owner until `closePartialMerger` Close()s it.
- Handles both SoA (live `intFlatAccs`) and AoS fallback (post-MergeSink `gs.extras.accs`) via a `useAoSAccs` flag. Exposed by `TestHashAggregateMergeThenSpillFinalize` panic during initial implementation; fixed with a load-from-AoS branch.
- `kWayMerger.Next` contract changes: the returned `*partialGroup` aliases reusable head buffers and is invalidated by the next Next call. Both callers (`nextFromPartialMerger` and the K-way-merge unit test) already match the new contract. Heap entries capture source SortKeys directly; because the merger only Advances a source via Pop, source heads are stable between Push and the corresponding Pop+Advance.
- `partialSpillReader.Next` gets the same treatment.

## Test plan

- [x] `go test ./internal/...` — all packages pass
- [x] TPC-H SF0.01 22/22 — pass
- [x] TPC-H SF1 22/22 — pass in 37.2s (no regression on the in-memory hot path)
- [x] `cmd/tpch-harness --mode=local` 25/25 PASS in ~22s (per HARD RULE: distributed gate before EC2)
- [x] Race detector clean on all spill / merge / cursor tests
- [ ] EC2 SF10 regression check (no perf loss vs main)
- [ ] EC2 SF100 22Q at `max_concurrent=4` to confirm post-Q17 drain bottleneck is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)