### PR TITLE
perf(exec): HashAggregate partial-drain unblocks Q17 SF100 mc=3

### DIFF
--- a/deploy/benchmark/terraform/sf100-distributed.tfvars
+++ b/deploy/benchmark/terraform/sf100-distributed.tfvars
@@ -9,6 +9,10 @@ mode                      = "distributed"
 coordinator_instance_type = "c7g.2xlarge"   # 8 vCPU, 16 GB
 worker_instance_type      = "c7gd.4xlarge"  # 16 vCPU, 32 GB, 237 GB NVMe
 worker_count              = 3
+data_bucket               = "wadjet-bench-sf100-use2"
+data_prefix               = ""              # SF100 data at root (lineitem/, orders/, ...), NOT under tables/
+generate_data             = false           # data is pre-staged; do not regenerate
+skip_queries              = ""
 query_timeout             = "30m"           # SF100 heavy queries need >10m default; mirrors sf10-distributed
 # 2026-05-07 Q17 investigation: 4 concurrent stage tasks each with ~5-6 GB
 # live working set overwhelmed the 21.6 GB GOMEMLIMIT, GC thrashed,
@@ -23,4 +27,12 @@ query_timeout             = "30m"           # SF100 heavy queries need >10m defa
 # =4 across the whole 22Q suite remains memory-bound on a different
 # code path. Stay at =3 until the post-Q17 bottleneck (likely
 # drainSimpleAggsToPartialGroups peak, ~749 MB at SF10) is addressed.
+# 2026-05-10 deploy of db4feab (PR #91 + #92 typed-keyvals) at mc=4:
+# Q01-Q04 PASSED (Q03 -53s vs 7m18 baseline, Q04 -1m49 vs 8m57). Q05
+# (5-way customer/orders/lineitem/supplier/nation/region join) stalled
+# after ~16 min: worker reaped (1m43s no heartbeat with 2 in-flight
+# tasks), then ~10 min no stage completions. Different signature than
+# PR #90's post-Q17 stall — this is a hash-join build/probe memory
+# pressure at SF100, NOT the drain path. Production stays at mc=3 until
+# the Q05-shape HashJoin peak is addressed. Cost of this attempt ~$1.55.
 max_concurrent            = 3

--- a/internal/engine/exec/agg_scatter.go
+++ b/internal/engine/exec/agg_scatter.go
@@ -70,6 +70,53 @@ func (fa *flatAccumArrays) appendGroup() {
 	}
 }
 
+// clearGroup zeros every non-nil SoA field at index idx. Used by the
+// partial-drain path to reset a reclaimed slot before it's recycled
+// through HashAggregate.freeGroupIDs. Caller must guarantee idx is a
+// valid index into the arrays (i.e., len(count) > idx, etc.).
+//
+// Zero is the identity element for the operators we run here: COUNT starts
+// at 0, SUM at 0, MIN/MAX at 0 with hasMin/hasMax false (which makes the
+// scatter kernels treat the first input as the seed). So a clearGroup'd
+// slot behaves identically to a fresh appendGroup'd slot for subsequent
+// scatter updates.
+func (fa *flatAccumArrays) clearGroup(idx int) {
+	fa.count[idx] = 0
+	if fa.sumI64 != nil {
+		fa.sumI64[idx] = 0
+	}
+	if fa.sumF64 != nil {
+		fa.sumF64[idx] = 0
+	}
+	if fa.sumDec != nil {
+		fa.sumDec[idx] = batch.Int128{}
+	}
+	if fa.minI64 != nil {
+		fa.minI64[idx] = 0
+	}
+	if fa.maxI64 != nil {
+		fa.maxI64[idx] = 0
+	}
+	if fa.minF64 != nil {
+		fa.minF64[idx] = 0
+	}
+	if fa.maxF64 != nil {
+		fa.maxF64[idx] = 0
+	}
+	if fa.minDec != nil {
+		fa.minDec[idx] = batch.Int128{}
+	}
+	if fa.maxDec != nil {
+		fa.maxDec[idx] = batch.Int128{}
+	}
+	if fa.hasMin != nil {
+		fa.hasMin[idx] = false
+	}
+	if fa.hasMax != nil {
+		fa.hasMax[idx] = false
+	}
+}
+
 // ensureCapacity pre-grows all non-nil arrays so that n additional
 // appendGroup calls won't trigger growslice reallocation. Called
 // before the hash lookup phase with n = batch row count as an upper

--- a/internal/engine/exec/aggregate.go
+++ b/internal/engine/exec/aggregate.go
@@ -150,6 +150,25 @@ type HashAggregate struct {
 	// use; Finalize k-way merges them. Distinct from spillFiles because the
 	// merge logic differs (re-aggregate raw rows vs. merge partial accs).
 	partialSpillFiles []string
+	// freeGroupIDs holds intGroupStates indices that were drained by partial
+	// spill and are available for reuse on the next int-keyed Consume. Each
+	// entry pre-points at a groupState chunk allocation in h.gsPool and at a
+	// pre-existing slot in every h.intFlatAccs[*] array (zeroed during drain).
+	// Reusing these slots avoids the O(survivors) compaction cost a "rebuild
+	// every drain" path would impose at SF100+ scale.
+	freeGroupIDs []int32
+	// drainK is the partition count fixed on the first partial SpillSome
+	// call. Stays constant for the aggregate's lifetime so partition
+	// assignments (fibHash(intKey) & (drainK-1)) are stable across drains.
+	// Zero means "not yet initialized". Adaptive: scales as
+	// nextPow2(max(numGroups/1M, 8)) capped at 512, sized so each partition
+	// is ~100 MB–1 GB at SF100–SF1000 footprints.
+	drainK uint32
+	// nextDrainPartition is the round-robin cursor over partition indices in
+	// [0, drainK). Each partial SpillSome advances by the number of
+	// partitions drained so successive calls chip away at different slices
+	// instead of churning the same one and re-rebuilding the same groups.
+	nextDrainPartition uint32
 	// unregisterSpillable, when non-nil, deregisters this aggregate from the
 	// SpillManager's cooperative-spill registry. Set on first Consume when
 	// canUseExternalMerge is true; cleared in Finalize once the merge has
@@ -498,7 +517,11 @@ func (h *HashAggregate) Consume(_ context.Context, b *batch.RecordBatch) error {
 			// drain per pressure event) instead of a write per Consume.
 			h.consumeBatch(b)
 			h.reconcileGroupMemory()
-			return h.spillPartialState()
+			// Self-triggered spill (own pressure threshold): drain the whole
+			// hash table. Cooperative spills via SpillSome use the partial-
+			// partitions path instead; this code path is unchanged from its
+			// pre-partial-drain behavior.
+			return h.spillPartialState(0)
 		}
 		// Legacy raw-row spill (extra-state aggs, grouping sets, scalar):
 		// buffer rows on disk and re-aggregate in Finalize.
@@ -1009,17 +1032,29 @@ func (h *HashAggregate) consumeBatchIntGroup(b *batch.RecordBatch) {
 			} else {
 				key = gkVec.Int64Data[row]
 			}
-			newIdx := int32(len(h.intGroupStates))
+			var newIdx int32
+			fromFree := false
+			if nf := len(h.freeGroupIDs); nf > 0 {
+				newIdx = h.freeGroupIDs[nf-1]
+				fromFree = true
+			} else {
+				newIdx = int32(len(h.intGroupStates))
+			}
 			gsIdx, ok := intIdx.GetOrInsertNoGrow(key, newIdx)
 			if ok {
 				gi[si] = gsIdx
 			} else {
 				intIdx.CheckGrow()
-				gs := h.gsPool.alloc()
-				gs.intKey = key
-				h.intGroupStates = append(h.intGroupStates, gs)
-				for ai := range h.intFlatAccs {
-					h.intFlatAccs[ai].appendGroup()
+				if fromFree {
+					h.freeGroupIDs = h.freeGroupIDs[:len(h.freeGroupIDs)-1]
+					h.intGroupStates[newIdx].intKey = key
+				} else {
+					gs := h.gsPool.alloc()
+					gs.intKey = key
+					h.intGroupStates = append(h.intGroupStates, gs)
+					for ai := range h.intFlatAccs {
+						h.intFlatAccs[ai].appendGroup()
+					}
 				}
 				gi[si] = newIdx
 			}
@@ -1039,17 +1074,29 @@ func (h *HashAggregate) consumeBatchIntGroup(b *batch.RecordBatch) {
 			} else {
 				key = gkVec.Int64Data[row]
 			}
-			newIdx := int32(len(h.intGroupStates))
+			var newIdx int32
+			fromFree := false
+			if nf := len(h.freeGroupIDs); nf > 0 {
+				newIdx = h.freeGroupIDs[nf-1]
+				fromFree = true
+			} else {
+				newIdx = int32(len(h.intGroupStates))
+			}
 			gsIdx, ok := intIdx.GetOrInsertNoGrow(key, newIdx)
 			if ok {
 				gi[row] = gsIdx
 			} else {
 				intIdx.CheckGrow()
-				gs := h.gsPool.alloc()
-				gs.intKey = key
-				h.intGroupStates = append(h.intGroupStates, gs)
-				for ai := range h.intFlatAccs {
-					h.intFlatAccs[ai].appendGroup()
+				if fromFree {
+					h.freeGroupIDs = h.freeGroupIDs[:len(h.freeGroupIDs)-1]
+					h.intGroupStates[newIdx].intKey = key
+				} else {
+					gs := h.gsPool.alloc()
+					gs.intKey = key
+					h.intGroupStates = append(h.intGroupStates, gs)
+					for ai := range h.intFlatAccs {
+						h.intFlatAccs[ai].appendGroup()
+					}
 				}
 				gi[row] = newIdx
 			}
@@ -2138,13 +2185,21 @@ func (h *HashAggregate) SpillFootprint() int64 {
 	return h.trackedGroupMem
 }
 
-// SpillSome drains the current SoA hash state to a partial-state spill file
-// and releases the freed bytes back to the tracker, returning the number of
-// bytes released. Called by SpillManager.RequestRelief on behalf of a peer
-// operator under memory pressure.
+// SpillSome drains a portion of the SoA hash state to a partial-state spill
+// file and releases the freed bytes back to the tracker, returning the
+// number of bytes released. Called by SpillManager.RequestRelief on behalf
+// of a peer operator under memory pressure.
 //
-// The target hint is advisory — partial-state spill is whole-hash-table at
-// this granularity, so we either free everything reclaimable or nothing.
+// On the int-keyed path, spillPartialState drains a hash-partition slice
+// sized roughly to `target` bytes, leaving surviving groups in place. This
+// breaks the drain-rebuild loop that whole-table draining created at SF100
+// scale (PR #88 → drain-rebuild loop → heartbeat starvation): future
+// Consume rows whose keys hash to a surviving partition continue to hit
+// existing in-memory groups, paying no rebuild cost.
+//
+// On other paths (dual-int, compact, string, generic) and when target
+// covers the full footprint, falls through to the whole-drain path —
+// semantically identical to the pre-partial-drain behavior.
 //
 // Implements memory.Spillable.
 func (h *HashAggregate) SpillSome(target int64) (int64, error) {
@@ -2157,11 +2212,9 @@ func (h *HashAggregate) SpillSome(target int64) (int64, error) {
 	if before == 0 {
 		return 0, nil
 	}
-	if err := h.spillPartialState(); err != nil {
+	if err := h.spillPartialState(target); err != nil {
 		return 0, err
 	}
-	// trackedGroupMem is reset to 0 by resetGroupStateAfterSpill (called
-	// from spillPartialState). before - 0 = before bytes freed.
 	return before - h.trackedGroupMem, nil
 }
 

--- a/internal/engine/exec/aggregate_partial_drain_cursor.go
+++ b/internal/engine/exec/aggregate_partial_drain_cursor.go
@@ -62,10 +62,18 @@ type partialGroupCursor struct {
 	// extras.accs and reading flat arrays would panic on empty slices.
 	useAoSAccs bool
 
+	// liveGroups, when non-nil, restricts the cursor to a subset of the
+	// aggregate's slots. Position p in [0, numGroups) maps to SoA slot
+	// liveGroups[p]. Used by the partial-drain spill path (subset = the
+	// drained partitions) and by finalize after partial drains (subset =
+	// surviving slots derived from intGroupIndex). nil means "all slots in
+	// 0..len-1 order" — the pre-partial-drain behavior.
+	liveGroups []int32
+
 	// Sort state (built once during construction; immutable thereafter).
 	keyArena   []byte   // contiguous serialized sort keys
-	keyOffsets []int32  // len == numGroups+1; key[i] = arena[off[i]:off[i+1]]
-	sortedIdx  []uint32 // permutation; group at sorted position j is sortedIdx[j]
+	keyOffsets []int32  // len == numGroups+1; key for position p = arena[off[p]:off[p+1]]
+	sortedIdx  []uint32 // permutation; cursor at pos emits position sortedIdx[pos]
 	pos        int
 	numGroups  int
 
@@ -88,24 +96,28 @@ type partialGroupCursor struct {
 // per Advance. This is the second-pass optimization equivalent to the one
 // shipped for Next() in PR #90 (commit 91cd65f), now applied to the spill
 // and finalize-via-merge drain paths.
-func newPartialGroupCursor(h *HashAggregate) *partialGroupCursor {
+func newPartialGroupCursor(h *HashAggregate, liveGroups []int32) *partialGroupCursor {
 	var (
 		keyMode   partialKeyMode
-		numGroups int
+		srcGroups int
 	)
 	switch {
 	case h.useIntGroupKey:
 		keyMode = partialKeyModeInt
-		numGroups = len(h.intGroupStates)
+		srcGroups = len(h.intGroupStates)
 	case h.useDualIntGroupKey:
 		keyMode = partialKeyModeDualInt
-		numGroups = len(h.intGroupStates)
+		srcGroups = len(h.intGroupStates)
 	case h.useCompactGroupKey:
 		keyMode = partialKeyModeCompact
-		numGroups = len(h.intGroupStates)
+		srcGroups = len(h.intGroupStates)
 	default: // useStrGroupKey || useGenericSoA || post-MergeSink generic
 		keyMode = partialKeyModeStrOrGeneric
-		numGroups = len(h.strGroupStates)
+		srcGroups = len(h.strGroupStates)
+	}
+	numGroups := srcGroups
+	if liveGroups != nil {
+		numGroups = len(liveGroups)
 	}
 
 	nAggs := len(h.Aggs)
@@ -122,6 +134,7 @@ func newPartialGroupCursor(h *HashAggregate) *partialGroupCursor {
 		nGroupCols:     nGroupCols,
 		keyMode:        keyMode,
 		useAoSAccs:     len(h.intFlatAccs) == 0,
+		liveGroups:     liveGroups,
 		// Initial 16 B/group arena estimate fits typical numeric-key shapes;
 		// strings will grow it via append, which is fine — arena writes are
 		// strictly append-only and slices into it remain valid after grow.
@@ -135,30 +148,35 @@ func newPartialGroupCursor(h *HashAggregate) *partialGroupCursor {
 	c.head.KeyVals = c.headKeyVals
 	c.head.Accs = c.headAccs
 
-	// Arena build pass. int / dual-int paths read SoA int values straight
-	// into the arena via typed strconv writes (skips `any` boxing). Compact
-	// and str/generic modes alias the existing gs.extras.keyValues `[]any`
-	// — those boxes were allocated at consume time and we just hand them
-	// to appendSerializedKey for serialization. No new allocations on
-	// either branch.
+	// Arena build pass. Position p in [0, numGroups) maps to SoA slot
+	// c.slotAt(p) — either p (when liveGroups is nil) or liveGroups[p]
+	// (when restricted to a subset). int / dual-int paths read SoA int
+	// values straight into the arena via typed strconv writes (skips `any`
+	// boxing). Compact and str/generic modes alias the existing
+	// gs.extras.keyValues `[]any` — those boxes were allocated at consume
+	// time and we just hand them to appendSerializedKey for serialization.
+	// No new allocations on either branch.
 	switch keyMode {
 	case partialKeyModeInt, partialKeyModeDualInt:
-		for gi := 0; gi < numGroups; gi++ {
-			c.keyOffsets[gi] = int32(len(c.keyArena))
-			c.keyArena = c.appendIntModeSortKey(c.keyArena, gi)
-			c.sortedIdx[gi] = uint32(gi)
+		for p := 0; p < numGroups; p++ {
+			slot := c.slotAt(p)
+			c.keyOffsets[p] = int32(len(c.keyArena))
+			c.keyArena = c.appendIntModeSortKey(c.keyArena, slot)
+			c.sortedIdx[p] = uint32(p)
 		}
 	case partialKeyModeCompact:
-		for gi := 0; gi < numGroups; gi++ {
-			c.keyOffsets[gi] = int32(len(c.keyArena))
-			c.keyArena = appendSerializedKey(c.keyArena, c.intGroupStates[gi].extras.keyValues)
-			c.sortedIdx[gi] = uint32(gi)
+		for p := 0; p < numGroups; p++ {
+			slot := c.slotAt(p)
+			c.keyOffsets[p] = int32(len(c.keyArena))
+			c.keyArena = appendSerializedKey(c.keyArena, c.intGroupStates[slot].extras.keyValues)
+			c.sortedIdx[p] = uint32(p)
 		}
 	default: // partialKeyModeStrOrGeneric
-		for gi := 0; gi < numGroups; gi++ {
-			c.keyOffsets[gi] = int32(len(c.keyArena))
-			c.keyArena = appendSerializedKey(c.keyArena, c.strGroupStates[gi].extras.keyValues)
-			c.sortedIdx[gi] = uint32(gi)
+		for p := 0; p < numGroups; p++ {
+			slot := c.slotAt(p)
+			c.keyOffsets[p] = int32(len(c.keyArena))
+			c.keyArena = appendSerializedKey(c.keyArena, c.strGroupStates[slot].extras.keyValues)
+			c.sortedIdx[p] = uint32(p)
 		}
 	}
 	c.keyOffsets[numGroups] = int32(len(c.keyArena))
@@ -174,6 +192,16 @@ func newPartialGroupCursor(h *HashAggregate) *partialGroupCursor {
 		c.loadHeadAt(int(c.sortedIdx[0]))
 	}
 	return c
+}
+
+// slotAt translates a cursor position to a SoA slot index. With liveGroups
+// nil, positions are slot indices directly (the pre-partial-drain default).
+// With liveGroups non-nil, positions index into the supplied subset.
+func (c *partialGroupCursor) slotAt(position int) int {
+	if c.liveGroups == nil {
+		return position
+	}
+	return int(c.liveGroups[position])
 }
 
 // populateHeadKeyVals fills c.headKeyVals (len == nGroupCols) with typed
@@ -232,7 +260,10 @@ func setPartialKeyFromInt(dst *partialKeyValue, v int64, t batch.TypeID) {
 	}
 }
 
-// loadHeadAt populates the reusable head storage from SoA at SoA index gi.
+// loadHeadAt populates the reusable head storage from the cursor's source
+// SoA arrays for the group at iteration position `position`. SortKey is read
+// from the arena (indexed by position); KeyVals/Accs are read by translating
+// position → slot via c.slotAt.
 //
 // SortKey aliases the arena slice (no copy) — the kWayMerger always copies
 // SortKey into its merged group on Pop, and the heap entry's key is captured
@@ -243,15 +274,16 @@ func setPartialKeyFromInt(dst *partialKeyValue, v int64, t batch.TypeID) {
 // during merge (typed copy of partialKeyValue slots, plus
 // `append([]kernel.Accumulator(nil), current.Accs...)`), so overwriting them
 // in place between Advance calls cannot corrupt the merger's state.
-func (c *partialGroupCursor) loadHeadAt(gi int) {
-	c.head.SortKey = c.keyArena[c.keyOffsets[gi]:c.keyOffsets[gi+1]]
-	c.populateHeadKeyVals(gi)
+func (c *partialGroupCursor) loadHeadAt(position int) {
+	c.head.SortKey = c.keyArena[c.keyOffsets[position]:c.keyOffsets[position+1]]
+	slot := c.slotAt(position)
+	c.populateHeadKeyVals(slot)
 
 	if c.useAoSAccs {
-		c.loadHeadAccsAoS(gi)
+		c.loadHeadAccsAoS(slot)
 		return
 	}
-	c.loadHeadAccsSoA(gi)
+	c.loadHeadAccsSoA(slot)
 }
 
 // loadHeadAccsSoA fills c.headAccs from the flat accumulator arrays at index
@@ -412,6 +444,7 @@ func (c *partialGroupCursor) Close() error {
 	c.dualIntKeysA = nil
 	c.dualIntKeysB = nil
 	c.groupColTypes = nil
+	c.liveGroups = nil
 	c.keyArena = nil
 	c.keyOffsets = nil
 	c.sortedIdx = nil

--- a/internal/engine/exec/aggregate_partial_spill.go
+++ b/internal/engine/exec/aggregate_partial_spill.go
@@ -1282,7 +1282,100 @@ func mapBatchTypeToParquet(t batch.TypeID) parquet.TypeID {
 	}
 }
 
-// spillPartialState drains the current SoA hash state to a partial-spill file
+// drainPlan describes the subset of partitions a single SpillSome call will
+// drain. Membership is tested via contains() in the drain-set build loop;
+// at SF100 Q17 scale that's ~20M tests, so the lookup must be O(1).
+type drainPlan struct {
+	K    uint32
+	mask []uint64 // (K+63)/64 words; bit (i*64 + j) set means partition (i*64+j) is in the drain set
+}
+
+// contains reports whether partition is in the drain plan. Caller must
+// guarantee partition < K (call sites compute partition as fibHash(key) & (K-1)).
+func (p drainPlan) contains(partition uint32) bool {
+	return p.mask[partition>>6]&(uint64(1)<<(partition&63)) != 0
+}
+
+// computeAdaptiveK picks the partition count K for a HashAggregate of the
+// given live-group count. K = nextPow2(max(numGroups/1_000_000, 8)) capped at
+// 512. Sized so each partition is ~100 MB–1 GB at typical SF100–SF1000
+// footprints (≈40 B/group avg), keeping per-drain cost roughly constant
+// across scales. Always a power of 2 so partition assignment is a cheap
+// mask (fibHash(key) & (K-1)) instead of a modulo.
+func computeAdaptiveK(numGroups int) uint32 {
+	target := numGroups / 1_000_000
+	if target < 8 {
+		target = 8
+	}
+	k := uint32(1)
+	for k < uint32(target) {
+		k <<= 1
+	}
+	if k > 512 {
+		k = 512
+	}
+	return k
+}
+
+// pickPartitionsToDrain decides how many of K partitions to drain to free
+// approximately target bytes given current footprint bytes spread across
+// numGroups groups. Returns at least 1, at most K. Returns K when target
+// >= footprint so the caller can fall through to the whole-drain path.
+func pickPartitionsToDrain(K uint32, footprint, target int64) uint32 {
+	if K == 0 {
+		return 0
+	}
+	if target <= 0 || target >= footprint {
+		return K
+	}
+	perPartition := footprint / int64(K)
+	if perPartition <= 0 {
+		return 1
+	}
+	n := (target + perPartition - 1) / perPartition
+	if n < 1 {
+		return 1
+	}
+	if uint32(n) > K {
+		return K
+	}
+	return uint32(n)
+}
+
+// buildDrainPlan returns a plan covering numPartitions partitions starting
+// at start, wrapping around K. Caller is responsible for advancing the
+// round-robin cursor after a successful drain.
+func buildDrainPlan(K, start, numPartitions uint32) drainPlan {
+	nWords := (K + 63) / 64
+	mask := make([]uint64, nWords)
+	for i := uint32(0); i < numPartitions; i++ {
+		p := (start + i) & (K - 1)
+		mask[p>>6] |= uint64(1) << (p & 63)
+	}
+	return drainPlan{K: K, mask: mask}
+}
+
+// spillPartialState dispatches a cooperative drain to either the partial-
+// partitions path (int-keyed SoA, target < footprint) or the whole-table
+// drain. Caller must hold h.mu.
+//
+// The partial path drains only a hash-partition slice sized to `target`,
+// preserving the surviving groups in-memory so subsequent Consume rows for
+// those keys do not pay a rebuild cost — this is what closes the drain-
+// rebuild loop that PR #88 created on the whole-table path at SF100 Q17.
+// The whole-table path is preserved for other key modes (dual-int, compact,
+// string, generic) and for cases where target ≥ footprint.
+func (h *HashAggregate) spillPartialState(target int64) error {
+	if h.Spill == nil {
+		return nil
+	}
+	if h.useIntGroupKey && target > 0 && target < h.trackedGroupMem {
+		return h.spillPartialPartitions(target)
+	}
+	return h.spillFullState()
+}
+
+// spillFullState drains the entire SoA hash state to a partial-spill file
 // and resets in-memory structures so subsequent Consume calls start fresh.
 // The next Consume call will rebuild flat accumulators from the next batch's
 // schema.
@@ -1294,7 +1387,7 @@ func mapBatchTypeToParquet(t batch.TypeID) parquet.TypeID {
 // drops ~7 GB per task to ~480 MB.
 //
 // Caller must hold h.mu.
-func (h *HashAggregate) spillPartialState() error {
+func (h *HashAggregate) spillFullState() error {
 	if h.Spill == nil {
 		return nil
 	}
@@ -1304,7 +1397,7 @@ func (h *HashAggregate) spillPartialState() error {
 	aggSpecs := h.buildPartialAggSpecs()
 	groupCols := h.buildPartialGroupCols()
 
-	cursor := newPartialGroupCursor(h)
+	cursor := newPartialGroupCursor(h, nil)
 	if cursor.numGroups == 0 {
 		cursor.Close()
 		h.resetGroupStateAfterSpill()
@@ -1347,6 +1440,134 @@ func (h *HashAggregate) spillPartialState() error {
 	return nil
 }
 
+// spillPartialPartitions drains a hash-partition slice of the int-keyed SoA
+// state, freeing approximately `target` bytes while leaving surviving groups
+// in place. Reclaimed slots are appended to h.freeGroupIDs for reuse by the
+// next Consume cycle.
+//
+// Caller must hold h.mu. Caller must guarantee h.useIntGroupKey == true and
+// h.trackedGroupMem > 0.
+//
+// The partition scheme: fibHash(intKey) & (drainK-1) maps each group to a
+// partition in [0, drainK). drainK is fixed on first call so the assignment
+// is stable; the nextDrainPartition cursor advances by numPartitionsToDrain
+// each call, so successive drains chip at different slices. Surviving
+// partitions stay in-memory, so probe rows whose keys hash into them hit
+// existing groups — no rebuild loop.
+func (h *HashAggregate) spillPartialPartitions(target int64) error {
+	if h.intGroupIndex == nil || h.intGroupIndex.Len() == 0 {
+		return nil
+	}
+	liveBefore := h.intGroupIndex.Len()
+	footprint := h.trackedGroupMem
+
+	if h.drainK == 0 {
+		h.drainK = computeAdaptiveK(liveBefore)
+	}
+	K := h.drainK
+	numPartitions := pickPartitionsToDrain(K, footprint, target)
+	if numPartitions == 0 {
+		return nil
+	}
+	if numPartitions >= K {
+		// Caller asked for ≥ full state; the whole-drain path is cheaper
+		// (no per-slot cleanup loop, no free-list bookkeeping) so route
+		// through it.
+		return h.spillFullState()
+	}
+	plan := buildDrainPlan(K, h.nextDrainPartition, numPartitions)
+	h.nextDrainPartition = (h.nextDrainPartition + numPartitions) & (K - 1)
+
+	// Walk live hash table entries, collect drained groupIDs. Hash table
+	// ForEach iterates only occupied slots, so dead slots from prior drains
+	// are naturally skipped — drainSet contains live groupIDs only.
+	estimate := liveBefore * int(numPartitions) / int(K)
+	if estimate < 16 {
+		estimate = 16
+	}
+	drainSet := make([]int32, 0, estimate)
+	h.intGroupIndex.ForEach(func(key int64, val int32) {
+		partition := uint32(fibHash(key)) & (K - 1)
+		if plan.contains(partition) {
+			drainSet = append(drainSet, val)
+		}
+	})
+	if len(drainSet) == 0 {
+		// Selected partitions were empty (newly inserted groups all hashed
+		// elsewhere). Cursor advanced; next call will hit a different slice.
+		return nil
+	}
+
+	aggSpecs := h.buildPartialAggSpecs()
+	groupCols := h.buildPartialGroupCols()
+	cursor := newPartialGroupCursor(h, drainSet)
+	if cursor.numGroups == 0 {
+		cursor.Close()
+		return nil
+	}
+
+	header := partialSpillHeader{
+		GroupCols: groupCols,
+		Aggs:      aggSpecs,
+	}
+	w, path, err := newPartialSpillWriter(h.Spill.SpillDir(), header)
+	if err != nil {
+		cursor.Close()
+		return err
+	}
+	for {
+		g := cursor.Peek()
+		if g == nil {
+			break
+		}
+		if werr := w.Write(*g); werr != nil {
+			w.Close()
+			cursor.Close()
+			return werr
+		}
+		if aerr := cursor.Advance(); aerr != nil {
+			w.Close()
+			cursor.Close()
+			return aerr
+		}
+	}
+	if _, err := w.Close(); err != nil {
+		cursor.Close()
+		return err
+	}
+	cursor.Close()
+	h.partialSpillFiles = append(h.partialSpillFiles, path)
+
+	// Reclaim drained slots. Delete from the hash table (back-shift keeps
+	// probe chains correct), zero the SoA accumulator slots, and push the
+	// slot indices onto the free list for the next Consume cycle to reuse.
+	for _, slot := range drainSet {
+		key := h.intGroupStates[slot].intKey
+		h.intGroupIndex.Delete(key)
+		for ai := range h.intFlatAccs {
+			h.intFlatAccs[ai].clearGroup(int(slot))
+		}
+		h.freeGroupIDs = append(h.freeGroupIDs, slot)
+	}
+
+	// Release tracker bytes proportional to the drained group count. We
+	// use liveBefore (the pre-drain live count) to derive a per-group share
+	// of footprint, then multiply by drained count. Slight rounding error
+	// is acceptable — the tracker treats this accounting as advisory.
+	drainedBytes := footprint * int64(len(drainSet)) / int64(liveBefore)
+	if drainedBytes > footprint {
+		drainedBytes = footprint
+	}
+	if drainedBytes > 0 {
+		h.Spill.ReleaseTracking(drainedBytes)
+		h.trackedGroupMem -= drainedBytes
+		if h.trackedGroupMem < 0 {
+			h.trackedGroupMem = 0
+		}
+	}
+	return nil
+}
+
 // resetGroupStateAfterSpill clears the in-memory hash table state so the
 // next Consume rebuilds it from scratch. Releases tracker bytes for the
 // drained group state. Called by spillPartialState; also a useful seam for
@@ -1373,6 +1594,13 @@ func (h *HashAggregate) resetGroupStateAfterSpill() {
 	h.dualIntKeysA = nil
 	h.dualIntKeysB = nil
 	h.dualIntNextGroup = nil
+	// Partial-drain state is meaningless after a whole-table reset: the
+	// slot indices in freeGroupIDs no longer correspond to live storage,
+	// and the partition cursor will be re-initialized from the (currently
+	// empty) hash table on next SpillSome.
+	h.freeGroupIDs = nil
+	h.drainK = 0
+	h.nextDrainPartition = 0
 	// Drop the group-state pool — its chunks are no longer referenced once
 	// the slice headers above are nil. Resetting the pool lets GC reclaim
 	// the chunks; without this, the chunk arrays stay live as roots.
@@ -1408,7 +1636,21 @@ func (h *HashAggregate) finalizeViaPartialMerge() error {
 	// dualIntKeys for its lifetime; the resetGroupStateAfterSpill call below
 	// nils h's slice headers but not the underlying arrays, which the cursor
 	// keeps live until it's drained and Close()d by closePartialMerger.
-	cursor := newPartialGroupCursor(h)
+	//
+	// When partial drains have happened (freeGroupIDs non-empty), intGroupStates
+	// has dead slots interspersed with live ones. Walk the hash table to get
+	// the live slot indices — that's the source of truth post-drain, since
+	// back-shift Delete removed the dead keys. Other paths (string/generic/
+	// dual-int/compact) never partial-drain in v1+, so liveGroups stays nil
+	// and the cursor iterates the dense slot range as before.
+	var liveGroups []int32
+	if h.useIntGroupKey && len(h.freeGroupIDs) > 0 && h.intGroupIndex != nil {
+		liveGroups = make([]int32, 0, h.intGroupIndex.Len())
+		h.intGroupIndex.ForEach(func(_ int64, val int32) {
+			liveGroups = append(liveGroups, val)
+		})
+	}
+	cursor := newPartialGroupCursor(h, liveGroups)
 
 	sources := make([]partialRunSource, 0, len(h.partialSpillFiles)+1)
 	if cursor.numGroups > 0 {

--- a/internal/engine/exec/aggregate_partial_spill_test.go
+++ b/internal/engine/exec/aggregate_partial_spill_test.go
@@ -1006,3 +1006,207 @@ func TestHashAggregateSpillable_RequestReliefRoutesHere(t *testing.T) {
 		}
 	}
 }
+
+// TestPartialDrain_IntKeyMultiSpill exercises the partition-slice partial-
+// drain path: feeds a high-cardinality int-keyed aggregate, fires multiple
+// SpillSome calls with small targets during Consume, and verifies the final
+// merged output matches a no-spill reference row-for-row.
+//
+// This is the regression test for the drain-rebuild loop that caused Q17
+// SF100 mc=3 to stall: previously SpillSome always drained the whole hash
+// table on every call, so subsequent Consume rows rebuilt the same groups
+// from scratch — pinning the heap and starving heartbeats. Partial drain
+// frees only a hash-partition slice; surviving partitions stay in-memory so
+// new rows for those keys hit existing groups instead of re-inserting.
+func TestPartialDrain_IntKeyMultiSpill(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "k", Type: parquet.TypeInt64},
+		{Name: "v", Type: parquet.TypeInt64},
+	}
+	const numGroups = 1000
+	const rowsPerBatch = 200
+	const numBatches = 25
+
+	expected := make(map[int64]int64)
+	batches := make([]*batch.RecordBatch, 0, numBatches)
+	for bi := 0; bi < numBatches; bi++ {
+		rows := make([]map[string]any, 0, rowsPerBatch)
+		for ri := 0; ri < rowsPerBatch; ri++ {
+			k := int64((bi*rowsPerBatch + ri) % numGroups)
+			v := int64(bi*1000 + ri + 1)
+			rows = append(rows, map[string]any{"k": k, "v": v})
+			expected[k] += v
+		}
+		batches = append(batches, batch.FromRows(schema, rows))
+	}
+
+	mkAgg := func(spill *memory.SpillManager) *HashAggregate {
+		h := NewHashAggregate([]string{"k"}, []AggColumn{
+			{Func: AggSum, InputCol: "v", OutputCol: "total", OutputType: parquet.TypeInt64},
+		})
+		h.Spill = spill
+		return h
+	}
+
+	// Reference run: no SpillManager, all aggregation in-memory.
+	refRows := runHashAggToMap(t, mkAgg(nil), batches)
+	if len(refRows) != numGroups {
+		t.Fatalf("reference: expected %d groups, got %d", numGroups, len(refRows))
+	}
+
+	// Partial-drain run. Large tracker so no auto-spill — drive partial
+	// drains manually via SpillSome with small targets.
+	tracker := memory.NewTracker("test", 1<<30)
+	sm, err := memory.NewSpillManager(t.TempDir(), tracker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := mkAgg(sm)
+	ctx := context.Background()
+	if err := h.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	var partialDrainsObserved int
+	var maxFreeListSeen int
+	for i, b := range batches {
+		if err := h.Consume(ctx, b); err != nil {
+			t.Fatalf("Consume #%d: %v", i, err)
+		}
+		// Every other batch: drain ~⅛ of footprint to exercise partial path.
+		if i%2 == 1 {
+			footprint := h.SpillFootprint()
+			if footprint <= 0 {
+				continue
+			}
+			target := footprint / 8
+			if target <= 0 {
+				target = 1
+			}
+			freed, err := h.SpillSome(target)
+			if err != nil {
+				t.Fatalf("SpillSome #%d: %v", i, err)
+			}
+			// Partial path returns less than footprint (would route to full
+			// drain otherwise). Non-zero confirms we actually drained.
+			if freed > 0 && freed < footprint {
+				partialDrainsObserved++
+			}
+			if n := len(h.freeGroupIDs); n > maxFreeListSeen {
+				maxFreeListSeen = n
+			}
+		}
+	}
+	if partialDrainsObserved < 3 {
+		t.Errorf("expected ≥3 partial drains, observed %d (target sizing may be off)", partialDrainsObserved)
+	}
+	if maxFreeListSeen == 0 {
+		t.Errorf("freeGroupIDs never populated — partial-drain reclamation path didn't fire")
+	}
+	if h.drainK == 0 {
+		t.Errorf("drainK never initialized — spillPartialPartitions never reached")
+	}
+
+	if err := h.Finalize(ctx); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	got := make(map[int64]int64)
+	for {
+		out, err := h.Next(ctx)
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+		if out == nil {
+			break
+		}
+		for _, r := range out.ToRows() {
+			got[r["k"].(int64)] = r["total"].(int64)
+		}
+	}
+	if err := h.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if len(got) != numGroups {
+		t.Fatalf("partial-drain group count: got %d want %d", len(got), numGroups)
+	}
+	for k, want := range expected {
+		if got[k] != want {
+			t.Errorf("k=%d: got %d want %d", k, got[k], want)
+		}
+	}
+}
+
+// TestPartialDrain_FreeListReuse asserts that slots reclaimed by a partial
+// drain are reused by the next Consume cycle: the surviving hash table
+// continues to grow only with truly-new keys, while keys that hash into a
+// drained partition recycle slots from h.freeGroupIDs.
+func TestPartialDrain_FreeListReuse(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "k", Type: parquet.TypeInt64},
+		{Name: "v", Type: parquet.TypeInt64},
+	}
+	// Pre-populate a single batch with 5000 unique keys so we have enough
+	// material to drain a partition.
+	const numKeys = 5000
+	rows := make([]map[string]any, 0, numKeys)
+	for i := 0; i < numKeys; i++ {
+		rows = append(rows, map[string]any{"k": int64(i), "v": int64(i)})
+	}
+
+	tracker := memory.NewTracker("test", 1<<30)
+	sm, err := memory.NewSpillManager(t.TempDir(), tracker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := NewHashAggregate([]string{"k"}, []AggColumn{
+		{Func: AggSum, InputCol: "v", OutputCol: "total", OutputType: parquet.TypeInt64},
+	})
+	h.Spill = sm
+	ctx := context.Background()
+	if err := h.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.Consume(ctx, batch.FromRows(schema, rows)); err != nil {
+		t.Fatal(err)
+	}
+
+	slotsBeforeDrain := len(h.intGroupStates)
+	footprint := h.SpillFootprint()
+	if footprint <= 0 {
+		t.Fatalf("post-Consume footprint: got %d want > 0", footprint)
+	}
+
+	// Drain ~⅛ of footprint. With K = max(numKeys/1M, 8) capped → K=8,
+	// numPartitionsToDrain = ceil(target/perPartition) → 1.
+	if _, err := h.SpillSome(footprint / 8); err != nil {
+		t.Fatal(err)
+	}
+	freeListSize := len(h.freeGroupIDs)
+	if freeListSize == 0 {
+		t.Fatalf("freeGroupIDs empty after partial drain — reclamation didn't run")
+	}
+	liveAfterDrain := h.intGroupIndex.Len()
+	if liveAfterDrain >= slotsBeforeDrain {
+		t.Errorf("hash table didn't shrink: liveAfter=%d slotsBefore=%d", liveAfterDrain, slotsBeforeDrain)
+	}
+	if liveAfterDrain+freeListSize != slotsBeforeDrain {
+		t.Errorf("survivor + free = %d, expected %d (slotsBefore)", liveAfterDrain+freeListSize, slotsBeforeDrain)
+	}
+
+	// Re-Consume the same keys. Drained keys should recycle slots from the
+	// free list. The intGroupStates slice length must NOT grow above
+	// slotsBeforeDrain — every drained key reuses a freed slot.
+	if err := h.Consume(ctx, batch.FromRows(schema, rows)); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(h.intGroupStates); got > slotsBeforeDrain {
+		t.Errorf("intGroupStates grew despite free-list: got %d, expected ≤ %d", got, slotsBeforeDrain)
+	}
+	// Free list should be empty again — every entry got reused.
+	if got := len(h.freeGroupIDs); got != 0 {
+		t.Errorf("freeGroupIDs not fully drained: got %d entries, expected 0", got)
+	}
+	if err := h.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/engine/exec/int_hash.go
+++ b/internal/engine/exec/int_hash.go
@@ -208,6 +208,73 @@ func (h *intHashTable) ForEach(fn func(key int64, val int32)) {
 	}
 }
 
+// Delete removes a key from the table, preserving probe-chain correctness via
+// back-shift deletion. Returns (oldVal, true) if the key was present, or
+// (0, false) otherwise. O(probe chain length) per call — O(1) amortized at
+// the 70% load factor invariant.
+//
+// Back-shift rather than tombstones because tombstones bloat the hot lookup
+// path (Get / GetOrInsertNoGrow) with an extra "is this a tombstone?" branch
+// and cause the table to never naturally shrink. Used by HashAggregate's
+// partial-drain spill path, where we Delete drained group keys before
+// recycling their slots through the free-list.
+func (h *intHashTable) Delete(key int64) (int32, bool) {
+	n := len(h.entries)
+	if n == 0 {
+		return 0, false
+	}
+	idx := fibHash(key) & h.mask
+	found := false
+	for k := 0; k < n; k++ {
+		e := &h.entries[idx]
+		if e.key == intHashEmpty {
+			return 0, false
+		}
+		if e.key == key {
+			found = true
+			break
+		}
+		idx = (idx + 1) & h.mask
+	}
+	if !found {
+		return 0, false
+	}
+	deleted := h.entries[idx].val
+
+	// Back-shift loop. Walk forward from idx; for each filled slot j, decide
+	// whether the entry at j must move back to i (the current hole) to keep
+	// its probe chain reachable. The entry at j with ideal position id is
+	// reachable via probing from id; if i lies on j's probe chain (i.e., id
+	// is closer to i than to j in cyclic forward order), vacating i would
+	// break that chain — so move the entry back. Otherwise leave it and stop.
+	i := idx
+	for k := 0; k < n; k++ {
+		j := (i + 1) & h.mask
+		e := &h.entries[j]
+		if e.key == intHashEmpty {
+			h.entries[i].key = intHashEmpty
+			h.size--
+			return deleted, true
+		}
+		id := fibHash(e.key) & h.mask
+		if ((i-id)&h.mask) < ((j-id)&h.mask) {
+			h.entries[i] = *e
+			i = j
+			continue
+		}
+		h.entries[i].key = intHashEmpty
+		h.size--
+		return deleted, true
+	}
+	// Defensive: table-wide back-shift completed without hitting an empty
+	// slot. Possible only if the table is entirely full and forms one giant
+	// probe chain — not a state the 70%-load invariant allows, but guard
+	// anyway. Empty the final hole and return.
+	h.entries[i].key = intHashEmpty
+	h.size--
+	return deleted, true
+}
+
 // grow doubles the table capacity and rehashes all entries.
 func (h *intHashTable) grow() {
 	newCap := len(h.entries) * 2

--- a/internal/engine/exec/int_hash_test.go
+++ b/internal/engine/exec/int_hash_test.go
@@ -1,0 +1,124 @@
+package exec
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestIntHashTable_DeleteBackShift(t *testing.T) {
+	h := newIntHashTable(64)
+	for i := int64(0); i < 32; i++ {
+		h.Put(i, int32(i))
+	}
+	for i := int64(0); i < 32; i++ {
+		if v, ok := h.Get(i); !ok || v != int32(i) {
+			t.Fatalf("pre-delete: Get(%d)=%d,%v want %d,true", i, v, ok, i)
+		}
+	}
+	// Delete a key whose hash chain straddles many slots; confirm the
+	// survivors remain reachable. Repeat across enough deletions to exercise
+	// the back-shift loop multiple times.
+	deleted := []int64{0, 5, 10, 17, 23, 30}
+	for _, k := range deleted {
+		v, ok := h.Delete(k)
+		if !ok || v != int32(k) {
+			t.Fatalf("Delete(%d)=%d,%v want %d,true", k, v, ok, k)
+		}
+		if _, ok := h.Get(k); ok {
+			t.Fatalf("Get(%d) after Delete: still present", k)
+		}
+	}
+	delSet := make(map[int64]bool)
+	for _, k := range deleted {
+		delSet[k] = true
+	}
+	for i := int64(0); i < 32; i++ {
+		if delSet[i] {
+			continue
+		}
+		if v, ok := h.Get(i); !ok || v != int32(i) {
+			t.Fatalf("post-delete: Get(%d)=%d,%v want %d,true", i, v, ok, i)
+		}
+	}
+	if h.Len() != 32-len(deleted) {
+		t.Fatalf("Len after deletes: got %d want %d", h.Len(), 32-len(deleted))
+	}
+}
+
+func TestIntHashTable_DeleteMissing(t *testing.T) {
+	h := newIntHashTable(16)
+	h.Put(1, 11)
+	h.Put(2, 22)
+	if v, ok := h.Delete(99); ok || v != 0 {
+		t.Fatalf("Delete(missing)=%d,%v want 0,false", v, ok)
+	}
+	if h.Len() != 2 {
+		t.Fatalf("Len unchanged on missing delete: got %d want 2", h.Len())
+	}
+}
+
+func TestIntHashTable_DeleteThenInsert(t *testing.T) {
+	h := newIntHashTable(16)
+	for i := int64(0); i < 8; i++ {
+		h.Put(i, int32(i))
+	}
+	h.Delete(3)
+	h.Delete(5)
+	h.Put(100, 200)
+	h.Put(101, 201)
+	for _, k := range []int64{0, 1, 2, 4, 6, 7, 100, 101} {
+		want := int32(k)
+		if k >= 100 {
+			want = int32(k + 100)
+		}
+		if v, ok := h.Get(k); !ok || v != want {
+			t.Fatalf("Get(%d)=%d,%v want %d,true", k, v, ok, want)
+		}
+	}
+	for _, k := range []int64{3, 5} {
+		if _, ok := h.Get(k); ok {
+			t.Fatalf("Get(%d) after delete: still present", k)
+		}
+	}
+}
+
+// Randomized stress test: insert+delete+lookup against a reference map, with
+// many collisions to exercise back-shift. Verifies the table stays consistent
+// across thousands of operations.
+func TestIntHashTable_DeleteStress(t *testing.T) {
+	h := newIntHashTable(16)
+	ref := make(map[int64]int32)
+	r := rand.New(rand.NewSource(42))
+	for op := 0; op < 5000; op++ {
+		k := int64(r.Intn(200))
+		switch r.Intn(3) {
+		case 0:
+			v := int32(r.Intn(1 << 20))
+			h.Put(k, v)
+			ref[k] = v
+		case 1:
+			if _, ok := ref[k]; ok {
+				h.Delete(k)
+				delete(ref, k)
+			} else {
+				if _, ok := h.Delete(k); ok {
+					t.Fatalf("Delete(%d) returned ok for missing key", k)
+				}
+			}
+		case 2:
+			wantV, wantOk := ref[k]
+			gotV, gotOk := h.Get(k)
+			if wantOk != gotOk || (wantOk && gotV != wantV) {
+				t.Fatalf("Get(%d)=%d,%v want %d,%v", k, gotV, gotOk, wantV, wantOk)
+			}
+		}
+	}
+	if h.Len() != len(ref) {
+		t.Fatalf("final Len: got %d want %d", h.Len(), len(ref))
+	}
+	for k, want := range ref {
+		if got, ok := h.Get(k); !ok || got != want {
+			t.Fatalf("final Get(%d)=%d,%v want %d,true", k, got, ok, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Cooperative `SpillSome` (`memory.Spillable`, PR #88) drained the entire hash table on every call. At SF100 Q17 mc=3 (~20M groups, ~800 MB inner agg), the next probe burst rebuilt everything → heap pin → heartbeat starvation → stall. See `project_sf100_mc3_reliability_findings_2026-05-12` for root cause.
- Partial path drains a hash-partition slice sized to the requested `target`, leaving surviving partitions in memory so subsequent Consume rows for those keys hit existing groups. Adaptive `K = nextPow2(max(numGroups/1M, 8))` capped at 512 keeps per-drain cost ~constant from SF100 (K=32) through SF1000 (K=256).
- Mechanism: round-robin `nextDrainPartition` cursor; `intHashTable.Delete` uses back-shift deletion (no tombstones, hot path stays inlineable); `freeGroupIDs` free-list recycles drained slot indices on the `consumeBatchIntGroup` insert hot path; `partialGroupCursor` accepts an optional `liveGroups` subset; `finalizeViaPartialMerge` walks `intGroupIndex.ForEach` when `freeGroupIDs` is non-empty so dead slots don't enter the merge.
- Whole-table drain preserved for non-int paths (dual-int, compact, string, generic), self-spill on Consume pressure, and `target >= footprint` — those code paths are unchanged.
- Includes deploy-config fix (bfc061a): `sf100-distributed.tfvars` was missing `data_bucket` and `data_prefix=""` that the other distributed tfvars pin; without them the canonical preflight command falls back to a broken cloud-init path. Sync'd with sf10 pattern.

## SF100 mc=3 validation (f5400bb)

| Query | f5400bb | db4feab baseline | Δ |
|---|---|---|---|
| Q01 | 1m24.3s | 1m27.4s | noise |
| Q02 | 1m38.2s | 1m35.8s | noise |
| Q03 | 6m32.6s | 7m41.9s | **−15%** |
| Q04 | 7m29.4s | 8m24.7s | **−11%** |
| Q05 | 18m49.6s | 8m39s | **+118% but PASSED** (ccf11dc cost-aware-refusal had STALLED here) |
| Q09 | 8m7.4s | 10m7s | **−20%** (OOM-cleared workload) |
| **Q17** | **5m15.5s** | **STALL** | **PASS — beats 46e3407 (full Spillable disable) diagnostic by 1m31s** |
| Q18 | STALL | likely also stalled at baseline (16/22 best previously) | self-spill path, separate scope |

17/22 PASS. Q18 stall is on the self-spill code path (Consume's own pressure threshold), not cooperative-spill — that path is byte-for-byte unchanged from main. Fix is one-line follow-up.

## Test plan

- [x] `go test ./internal/engine/exec/` — all pass, including new `TestIntHashTable_DeleteBackShift`, `TestIntHashTable_DeleteStress`, `TestPartialDrain_IntKeyMultiSpill`, `TestPartialDrain_FreeListReuse`
- [x] `go test ./internal/...` — full unit suite passes
- [x] `go test ./benchmarks/tpch/` SF0.01 — 22/22
- [x] `TPCH_SCALE=1 go test ./benchmarks/tpch/` SF1 — 22/22 in 40.8s
- [x] `tpch-harness --mode=local` — 25/25 (22 TPC-H + 3 micros)
- [x] Whole-drain bench unchanged (~5.3 ms / 978 KB / 30 allocs)
- [x] **SF100 mc=3 full-suite EC2 deploy** — 17/22 with Q17 PASS (the headline goal)

## Tradeoffs

- **Q05 +118%:** the 5-way join's HashAggregate sees cooperative spill more often with partial drain, adding overhead. Accepted because Q05 PASSED (the `ccf11dc` attempt at cost-aware refusal STALLED here) and the Q17 unblock is the higher priority.
- **Q18 still stalls:** out of scope for this PR. The fix is a one-line policy change (pass non-zero target on the self-spill call site at `aggregate.go:520`); will file a follow-up.

## Deferred follow-ups

- Partitioned merger (process one partition at merge time)
- Proactive admission control (operator budget, not peer relief)
- String / generic / dual-int / compact path partial drain
- Self-spill partial-drain (Q18 unblock)