### PR TITLE
perf(worker,scan,coordinator): parallelism cascade — Q18 SF100 -28%, suite -20%

### DIFF
--- a/internal/coordinator/orchestrate_repartition.go
+++ b/internal/coordinator/orchestrate_repartition.go
@@ -163,10 +163,18 @@ func (c *Coordinator) runShuffleSide(
 	// Note: intentionally accepting nil here (SELECT * fallback) rather than
 	// returning an error for a catalog miss during shuffle setup.
 
-	// Split source files across workers. splitFilesEvenly handles the case where
-	// there are fewer files than workers by capping n at len(files), so
-	// actualTasks ≤ workerCount.
-	fileSets := splitFilesEvenly(sourceStage.ScanFiles, workerCount)
+	// Fan out shuffle tasks across the cluster's effective concurrency capacity
+	// (sum of each worker's auto-tuned MaxConcurrent reported in heartbeats),
+	// not just worker count. With 3 workers × MaxConcurrent=3 the cluster can
+	// run 9 shuffle tasks at once; sizing to 3 leaves 6 task slots idle and
+	// pegs each worker to a single fragment-pipeline. 2026-05-22 SF100 Q18
+	// stage timeline showed exchange-repartition-15 wall = 3m09s with only
+	// 3 tasks (workerCount), while workers had MaxConcurrent=3 → 6 task slots
+	// sat idle for the whole stage. This mirrors scanFanOutTaskCount's policy
+	// (used by dispatchScanAggregateStage et al) — see execute_stage_dag.go.
+	capacity := c.workers.ClusterCapacity()
+	taskCount := scanFanOutTaskCount(workerCount, capacity, len(sourceStage.ScanFiles))
+	fileSets := splitFilesEvenly(sourceStage.ScanFiles, taskCount)
 	actualTasks := len(fileSets)
 	if actualTasks == 0 {
 		// No files — nothing to shuffle. Return empty partition layout.

--- a/internal/engine/scan/columnar_native.go
+++ b/internal/engine/scan/columnar_native.go
@@ -4,6 +4,9 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"runtime"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/citc-tech/wadjet/internal/engine/batch"
 	pqt "github.com/citc-tech/wadjet/internal/storage/parquet"
@@ -110,22 +113,38 @@ func ReadRowGroupNative(fr *pqt.FileReader, rgIdx int, schema []pqt.Column, pool
 		}
 	}
 
+	// Per-column reads write only to their own b.Columns[i] slot, and
+	// FileReader is read-only after construction (immutable meta + leaves;
+	// each ColumnPages call allocates a fresh ColumnPageReader). Parallelize
+	// the per-column work to use idle worker cores: 2026-05-22 SF100 Q18
+	// profile showed cachedFileStreamSource.Next at 22.7% cum CPU with the
+	// per-column loop serial within a single fragment goroutine.
+	limit := len(schema)
+	if gp := runtime.GOMAXPROCS(0); limit > gp {
+		limit = gp
+	}
+	g := new(errgroup.Group)
+	g.SetLimit(limit)
 	for i, col := range schema {
+		i, col := i, col
 		// ROW: read each child field as a separate leaf column.
 		if col.Type == pqt.TypeRow && len(col.Fields) > 0 {
-			for j, field := range col.Fields {
-				key := col.Name + "." + field.Name
-				childIdx, ok := leafByPath[key]
-				if !ok {
-					for k := 0; k < numRows; k++ {
-						b.Columns[i].Children[j].Nulls.SetNull(k)
+			g.Go(func() error {
+				for j, field := range col.Fields {
+					key := col.Name + "." + field.Name
+					childIdx, ok := leafByPath[key]
+					if !ok {
+						for k := 0; k < numRows; k++ {
+							b.Columns[i].Children[j].Nulls.SetNull(k)
+						}
+						continue
 					}
-					continue
+					if err := readColumnNative(b.Columns[i].Children[j], fr, rgIdx, childIdx, numRows, field.Type); err != nil {
+						return fmt.Errorf("reading ROW field %s.%s: %w", col.Name, field.Name, err)
+					}
 				}
-				if err := readColumnNative(b.Columns[i].Children[j], fr, rgIdx, childIdx, numRows, field.Type); err != nil {
-					return nil, fmt.Errorf("reading ROW field %s.%s: %w", col.Name, field.Name, err)
-				}
-			}
+				return nil
+			})
 			continue
 		}
 
@@ -142,6 +161,7 @@ func ReadRowGroupNative(fr *pqt.FileReader, rgIdx int, schema []pqt.Column, pool
 			}
 			if !found {
 				// Column not in parquet file — leave as all nulls.
+				// Run synchronously: trivial work, no decode.
 				for j := 0; j < numRows; j++ {
 					b.Columns[i].Nulls.SetNull(j)
 				}
@@ -149,9 +169,16 @@ func ReadRowGroupNative(fr *pqt.FileReader, rgIdx int, schema []pqt.Column, pool
 			}
 		}
 
-		if err := readColumnNative(b.Columns[i], fr, rgIdx, colIdx, numRows, col.Type); err != nil {
-			return nil, fmt.Errorf("reading column %s: %w", col.Name, err)
-		}
+		ci := colIdx
+		g.Go(func() error {
+			if err := readColumnNative(b.Columns[i], fr, rgIdx, ci, numRows, col.Type); err != nil {
+				return fmt.Errorf("reading column %s: %w", col.Name, err)
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
 
 	return b, nil

--- a/internal/worker/executor_fragment.go
+++ b/internal/worker/executor_fragment.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/citc-tech/wadjet/internal/distributed"
 	"github.com/citc-tech/wadjet/internal/engine/batch"
 	"github.com/citc-tech/wadjet/internal/engine/exec"
@@ -257,6 +259,21 @@ func (e *Executor) executeFragment(ctx context.Context, task distributed.Task, r
 
 // runFragmentLinear streams batches from src through unary ops into the sink.
 // No pipeline-breaker — every batch flows end-to-end before the next is read.
+//
+// Producer/consumer split: the source pull (parquet decode + S3 GET — CPU-
+// and I/O-heavy) runs in one goroutine; the operator chain + sink consume
+// (CPU-heavy too: HashJoin probe, shuffle write, agg merge) runs in another,
+// connected by a small bounded channel. 2026-05-22 SF100 Q18 profile (v3)
+// showed source.Next 22.7% cum + sink consume 15.2% cum running serially per
+// batch in a single goroutine; workers used ~1.4 / 16 cores. Splitting lets
+// source decode batch N+1 while the consumer processes batch N — wall time
+// drops to max(producer, consumer) per batch instead of the sum.
+//
+// Channel cap is intentionally small (2 batches × ≤2048 rows). Memory is
+// bounded; backpressure remains natural (producer blocks on send when consumer
+// is slow). All fragmentProgress accesses are kept inside the consumer
+// goroutine to avoid races on its counters; applyBackpressure (heap-pressure
+// pause) lives in the consumer so the pause reflects the full pipeline state.
 func (e *Executor) runFragmentLinear(ctx context.Context, task distributed.Task, src exec.Source, ops []exec.UnaryOperator, sink fragmentSink, result *distributed.ResultNotification) error {
 	progress := exec.ProgressReporterFromContext(ctx)
 	fp := newFragmentProgress(e.logger, task, e)
@@ -273,34 +290,59 @@ func (e *Executor) runFragmentLinear(ctx context.Context, task distributed.Task,
 		fp.addRows(n)
 		return nil
 	}
-	for {
-		if err := fp.applyBackpressure(ctx); err != nil {
-			return err
-		}
-		b, err := src.Next(ctx)
-		if err != nil {
-			return fmt.Errorf("fragment task %s: source next: %w", task.ID, err)
-		}
-		if b == nil {
-			break
-		}
-		cur := b
-		for _, op := range ops {
-			cur, err = op.Execute(ctx, cur)
+
+	const batchChanCap = 2
+	ch := make(chan *batch.RecordBatch, batchChanCap)
+
+	g, gctx := errgroup.WithContext(ctx)
+	// Producer: source.Next → channel. Closes ch on EOF or error.
+	g.Go(func() error {
+		defer close(ch)
+		for {
+			b, err := src.Next(gctx)
 			if err != nil {
-				return fmt.Errorf("fragment task %s: unary exec: %w", task.ID, err)
+				return fmt.Errorf("source next: %w", err)
 			}
-			if cur == nil {
-				break
+			if b == nil {
+				return nil
+			}
+			select {
+			case <-gctx.Done():
+				return gctx.Err()
+			case ch <- b:
 			}
 		}
-		if cur == nil || cur.ActiveLen() == 0 {
-			continue
+	})
+	// Consumer: ops + sink. Drives backpressure (heap pause) and progress.
+	g.Go(func() error {
+		for b := range ch {
+			if err := fp.applyBackpressure(gctx); err != nil {
+				return err
+			}
+			cur := b
+			var err error
+			for _, op := range ops {
+				cur, err = op.Execute(gctx, cur)
+				if err != nil {
+					return fmt.Errorf("unary exec: %w", err)
+				}
+				if cur == nil {
+					break
+				}
+			}
+			if cur == nil || cur.ActiveLen() == 0 {
+				continue
+			}
+			if err := consume(gctx, cur); err != nil {
+				return fmt.Errorf("sink consume: %w", err)
+			}
 		}
-		if err := consume(ctx, cur); err != nil {
-			return fmt.Errorf("fragment task %s: sink consume: %w", task.ID, err)
-		}
+		return nil
+	})
+	if err := g.Wait(); err != nil {
+		return fmt.Errorf("fragment task %s: %w", task.ID, err)
 	}
+
 	// Spilled-partition flush. Grace Hash Join probes route rows whose hash
 	// partition was evicted to disk; without this drain, those probe rows
 	// never re-enter the chain and the join silently drops matches. Mirror

--- a/internal/worker/partitioned_shuffle_sink.go
+++ b/internal/worker/partitioned_shuffle_sink.go
@@ -8,7 +8,10 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/citc-tech/wadjet/internal/engine/batch"
 	"github.com/citc-tech/wadjet/internal/engine/exec"
@@ -151,15 +154,45 @@ func (s *partitionedShuffleSink) Consume(_ context.Context, b *batch.RecordBatch
 		}
 	}
 
+	// Pre-warm the source batch's lazy Bitmap.HasNulls() cache on every
+	// column before launching parallel goroutines: HasNulls memoizes its
+	// result on first call (bitmap.go:127-158), and parallel readers calling
+	// HasNulls on the same column race on that write. Touching each column's
+	// Nulls.HasNulls() once here, single-threaded, populates the cache so all
+	// subsequent reads in appendRowsBulk hit the fast path (b.hasNulls >= 0).
+	for _, col := range b.Columns {
+		_ = col.Nulls.HasNulls()
+	}
+
+	// Each partitionWriter is fully independent (own file handle, bufio.Writer,
+	// shuffleWriter, rowBuf). Run per-partition append + threshold-flush in
+	// parallel: 2026-05-22 SF100 Q18 profile showed appendRowsBulk 84.5s cum +
+	// flushIfNeeded 54.8s cum, all serial in this loop, while workers used only
+	// ~9% of 16 available cores. Bounded at min(numParts, GOMAXPROCS) to avoid
+	// goroutine explosion on hot shuffles.
+	limit := s.numParts
+	if gp := runtime.GOMAXPROCS(0); limit > gp {
+		limit = gp
+	}
+	g := new(errgroup.Group)
+	g.SetLimit(limit)
 	for p := 0; p < s.numParts; p++ {
 		if len(s.perPartRows[p]) == 0 {
 			continue
 		}
-		if err := s.appendRowsBulk(p, b, s.perPartRows[p]); err != nil {
-			return err
-		}
+		p := p
+		g.Go(func() error {
+			if err := s.appendRowsBulk(p, b, s.perPartRows[p]); err != nil {
+				return err
+			}
+			pw := s.parts[p]
+			if pw.rowBuf == nil || pw.bufRows == 0 || pw.bufBytes < s.flushBytes {
+				return nil
+			}
+			return s.flushPartition(p)
+		})
 	}
-	return s.flushIfNeeded()
+	return g.Wait()
 }
 
 // appendRowsBulk appends `len(rows)` rows from b into the accumulator buffer
@@ -428,22 +461,6 @@ func growBatchTo(dst *batch.RecordBatch, n int) {
 	}
 }
 
-// flushIfNeeded writes any partition whose buffer exceeds the flush threshold.
-func (s *partitionedShuffleSink) flushIfNeeded() error {
-	for p, pw := range s.parts {
-		if pw.rowBuf == nil || pw.bufRows == 0 {
-			continue
-		}
-		if pw.bufBytes < s.flushBytes {
-			continue
-		}
-		if err := s.flushPartition(p); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func (s *partitionedShuffleSink) flushPartition(p int) error {
 	pw := s.parts[p]
 	if pw.rowBuf == nil || pw.bufRows == 0 {
@@ -491,46 +508,51 @@ func (s *partitionedShuffleSink) flushPartition(p int) error {
 func (s *partitionedShuffleSink) Finalize(_ context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	for p := range s.parts {
-		if err := s.flushPartition(p); err != nil {
-			return err
-		}
+	// Per-partition flush + header-patch + fsync. All steps touch only the
+	// target partition's writer; safe to run in parallel across partitions.
+	limit := s.numParts
+	if gp := runtime.GOMAXPROCS(0); limit > gp {
+		limit = gp
 	}
-	for p, pw := range s.parts {
-		if pw.writer == nil {
-			// Empty partition — leave file at zero bytes; downstream treats as no rows.
-			if err := pw.file.Sync(); err != nil {
+	g := new(errgroup.Group)
+	g.SetLimit(limit)
+	for p := range s.parts {
+		p := p
+		g.Go(func() error {
+			if err := s.flushPartition(p); err != nil {
 				return err
 			}
-			continue
-		}
-		// The bufio.Writer must be flushed before we Seek the underlying
-		// file: a Seek bypasses the buffer, so any unflushed bytes would
-		// land at the wrong offset.
-		if pw.bufFile != nil {
-			if err := pw.bufFile.Flush(); err != nil {
-				return fmt.Errorf("partition %d flush: %w", p, err)
+			pw := s.parts[p]
+			if pw.writer == nil {
+				// Empty partition — leave file at zero bytes; downstream treats as no rows.
+				return pw.file.Sync()
 			}
-		}
-		// Patch chunk count in header. Layout (see shuffle_format.go):
-		//   offset 0..4 = magic "WSHF"
-		//   offset 4..8 = numChunks (uint32 LE) — placeholder written by writeHeader
-		if _, err := pw.file.Seek(4, 0); err != nil {
-			return fmt.Errorf("partition %d seek: %w", p, err)
-		}
-		var buf [4]byte
-		binary.LittleEndian.PutUint32(buf[:], pw.writer.numChunks)
-		if _, err := pw.file.Write(buf[:]); err != nil {
-			return fmt.Errorf("partition %d patch: %w", p, err)
-		}
-		if _, err := pw.file.Seek(0, 2); err != nil {
-			return fmt.Errorf("partition %d seek end: %w", p, err)
-		}
-		if err := pw.file.Sync(); err != nil {
-			return err
-		}
+			// The bufio.Writer must be flushed before we Seek the underlying
+			// file: a Seek bypasses the buffer, so any unflushed bytes would
+			// land at the wrong offset.
+			if pw.bufFile != nil {
+				if err := pw.bufFile.Flush(); err != nil {
+					return fmt.Errorf("partition %d flush: %w", p, err)
+				}
+			}
+			// Patch chunk count in header. Layout (see shuffle_format.go):
+			//   offset 0..4 = magic "WSHF"
+			//   offset 4..8 = numChunks (uint32 LE) — placeholder written by writeHeader
+			if _, err := pw.file.Seek(4, 0); err != nil {
+				return fmt.Errorf("partition %d seek: %w", p, err)
+			}
+			var buf [4]byte
+			binary.LittleEndian.PutUint32(buf[:], pw.writer.numChunks)
+			if _, err := pw.file.Write(buf[:]); err != nil {
+				return fmt.Errorf("partition %d patch: %w", p, err)
+			}
+			if _, err := pw.file.Seek(0, 2); err != nil {
+				return fmt.Errorf("partition %d seek end: %w", p, err)
+			}
+			return pw.file.Sync()
+		})
 	}
-	return nil
+	return g.Wait()
 }
 
 // Close releases all file handles. Idempotent.


### PR DESCRIPTION
## Summary

Four architectural primitives stacked to unblock worker-cluster parallelism. Q18 SF100 wall **11m45.5s → 8m32.2s (−23%)** in the full 22Q suite; full-suite wall **1h39m21s → 1h19m08s (−20.4%)**. 22/22 queries PASS, exact row counts, **no regressions**. Mechanism walkthrough in commit message.

### Mechanism

SF100 Q18 worker profile showed workers using only ~1.4 of 16 cores during the 11-min query, with serial work distributed across four hot-path levels:

1. `partitionedShuffleSink.Consume` — per-partition append+flush loop, serial
2. `ReadRowGroupNative` — per-column decode loop (parquet zstd), serial
3. `runFragmentLinear` — source→ops→sink in one goroutine
4. `runShuffleSide` — dispatched only `workerCount` (3) tasks vs cluster capacity (`workers × MaxConcurrent` = 9)

Each level was independent work serialized for no architectural reason. Fix (4) is the keystone: it's what unlocks the CPU savings from (1)–(3), because with only 3 shuffle tasks running cluster-wide, per-fragment optimizations were invisible.

### Per-query wins (where baseline known)

| Q | Baseline | This PR | Δ |
|---|---|---|---|
| Q17 | 5m51s | 3m36s | **−38%** |
| Q04 | 7m35s | 4m54s | **−35%** |
| Q09 | 7m24s | 5m12s | **−30%** |
| Q03 | 6m31s | 4m41s | **−28%** |
| Q18 | 11m06s | 8m32s | **−23%** (original target) |
| Q08 | 8m46s | 7m38s | **−13%** |
| Q21 | 14m57s | 13m18s | **−11%** |

Stage-timeline on Q18: `exchange-repartition-15` (the re-shuffle of `join-8` output for `join-17`) went **3m09s → 1m13s (−62%)** — the single biggest stage win, exactly where fix (4) targeted.

## Files changed

- `internal/worker/partitioned_shuffle_sink.go` — errgroup over per-partition `appendRowsBulk` + threshold-flush in `Consume`; same in `Finalize`. Pre-warms `Bitmap.HasNulls()` lazy cache on source columns to avoid race detector firing on the shared input batch.
- `internal/engine/scan/columnar_native.go` — errgroup over per-column `readColumnNative` in `ReadRowGroupNative`. FileReader is read-only after construction; each `ColumnPages` call returns a fresh `ColumnPageReader`; per-column destinations are disjoint `b.Columns[i]` slots.
- `internal/worker/executor_fragment.go` — producer/consumer split of `runFragmentLinear` via bounded channel (cap=2). `fragmentProgress` accesses stay in the consumer goroutine to keep its counters race-free; errgroup propagates cancel + first error.
- `internal/coordinator/orchestrate_repartition.go` — `runShuffleSide` now uses `scanFanOutTaskCount(workerCount, capacity, fileCount)`, mirroring `dispatchScanAggregateStage`'s existing policy.

## Test plan

- [x] `go test -race -short ./internal/...` PASS (caught + fixed a Bitmap.HasNulls lazy-cache race in the parallel sink; fix is the pre-warm in `Consume`)
- [x] `go test -v -run TestTPCHQueries$ ./benchmarks/tpch/` SF0.01 22/22 PASS
- [x] `cmd/tpch-harness --mode=local --slice=small` SF0.01 25/25 PASS with identical row counts vs baseline
- [x] SF100 22Q distributed PASS — 1h19m08s, all 22 queries with exact baseline row counts
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)