### PR TITLE
perf(expr): memoize parseDateToEpochDays / parseTimestampToEpochMs

### DIFF
--- a/internal/engine/expr/expr.go
+++ b/internal/engine/expr/expr.go
@@ -2452,8 +2452,25 @@ func parseTemporalInt64(ref int64, s string) int64 {
 	return parseTimestampToEpochMs(s)
 }
 
+// Deterministic temporal-string parsers are called row-by-row from
+// Cmp.EvalBool whenever a date/timestamp column is compared against a string
+// literal (e.g., `l_shipdate <= '1998-09-02'`). At SF100 the 22Q suite spent
+// 4.24% of worker CPU (236s cum) parsing the SAME literal strings over and
+// over — every row of every filter re-walked the layout list. SQL queries
+// have a fixed, tiny set of date literals (TPC-H Q03/Q04/Q06/Q07/Q10/Q12/
+// Q14/Q15/Q20: ~1-3 literals each; suite-wide < 20 distinct strings), so a
+// memoization cache stays trivially small and never grows unbounded.
+var (
+	dateEpochDaysCache  sync.Map // map[string]int64 → epoch days
+	timestampEpochMsCache sync.Map // map[string]int64 → epoch milliseconds
+)
+
 // parseDateToEpochDays parses a date/timestamp string into epoch days.
 func parseDateToEpochDays(s string) int64 {
+	if v, ok := dateEpochDaysCache.Load(s); ok {
+		return v.(int64)
+	}
+	var result int64
 	for _, layout := range []string{
 		"2006-01-02",
 		time.RFC3339,
@@ -2462,14 +2479,20 @@ func parseDateToEpochDays(s string) int64 {
 	} {
 		if t, err := time.Parse(layout, s); err == nil {
 			epoch := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-			return int64(t.Sub(epoch).Hours() / 24)
+			result = int64(t.Sub(epoch).Hours() / 24)
+			break
 		}
 	}
-	return 0
+	dateEpochDaysCache.Store(s, result)
+	return result
 }
 
 // parseTimestampToEpochMs parses common timestamp string formats into epoch milliseconds.
 func parseTimestampToEpochMs(s string) int64 {
+	if v, ok := timestampEpochMsCache.Load(s); ok {
+		return v.(int64)
+	}
+	var result int64
 	for _, layout := range []string{
 		time.RFC3339Nano,
 		time.RFC3339,
@@ -2479,10 +2502,12 @@ func parseTimestampToEpochMs(s string) int64 {
 		"2006-01-02",
 	} {
 		if t, err := time.Parse(layout, s); err == nil {
-			return t.UnixMilli()
+			result = t.UnixMilli()
+			break
 		}
 	}
-	return 0
+	timestampEpochMsCache.Store(s, result)
+	return result
 }
 
 func toBool(e Expr, b *batch.RecordBatch, row int) bool {


### PR DESCRIPTION
## Summary

22Q SF100 worker profile post-PR #96 showed `time.Parse` at 236s cum / **4.24% of total CPU**, called per-row from `Cmp.EvalBool` → `compare` → `parseTemporalInt64`. TPC-H filters that compare a date/timestamp column against a string literal (e.g., `l_shipdate <= '1998-09-02'`) re-walk the layout list for every row.

Memoize into a `sync.Map` keyed on the input string. SQL queries have a fixed, tiny set of date literals (Q03/Q04/Q06/Q07/Q10/Q12/Q14/Q15/Q20: ~1-3 literals each; suite-wide < 20 distinct strings) so the cache stays trivially small and lock-free in the hot path.

## Mechanism

Per-row cost drops from ~5-10 µs (multiple `time.Parse` layout attempts) to a single `sync.Map.Load` (one atomic read on the cached path). The functions are deterministic — same string in always yields same int64 out — so memoization is safe regardless of caller context.

## Files changed

- `internal/engine/expr/expr.go` — wrap both temporal parsers in a sync.Map cache. The cache lookup precedes the layout walk; failures (return 0) are also cached, since the result is still deterministic.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race -short ./internal/engine/expr/...` PASS
- [x] `go test -v -run TestTPCHQueries$ ./benchmarks/tpch/` SF0.01 22/22 PASS
- [x] `cmd/tpch-harness --mode=local --slice=small` SF0.01 25/25 PASS with identical row counts
- [ ] CI green

Expected SF100 suite-wide savings: ~3-4% wall, biggest impact on lineitem-heavy date filters (Q03, Q04, Q06, Q07).

🤖 Generated with [Claude Code](https://claude.com/claude-code)