### PR TITLE
perf(worker): same-worker broadcast-join build dedup

### DIFF
--- a/internal/worker/broadcast_join_cache.go
+++ b/internal/worker/broadcast_join_cache.go
@@ -1,0 +1,170 @@
+package worker
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/engine/exec"
+)
+
+// broadcastJoinCache is a worker-local, query-scoped cache that lets multiple
+// concurrent probe tasks for the same broadcast share a single built
+// *exec.HashJoin, instead of each task independently scanning + decoding the
+// build-side files and constructing its own hashtable.
+//
+// SF100 Q21 22Q profile showed the supplier broadcast (5 files, ~154 MB cache)
+// decoded 3× per worker — once per concurrent probe task within max_concurrent=3.
+// HashJoin's probe path is already designed for concurrent use (per-instance
+// HashJoinProbe scratch via h.Probe(), atomic.Bool-guarded lazy probeKeyIdx
+// resolution), so the shared-build flow is safe.
+//
+// First arrival builds; subsequent arrivals with the same key block on the
+// builder's `ready` channel, then attach refcount++ to the existing entry.
+// Each acquire returns a release func; refcount=0 closes the HashJoin
+// (releasing tracker reservation) and evicts the entry.
+//
+// CleanupQuery drops entries belonging to a query whose probe tasks all
+// finished — mirrors LocalStageCache.CleanupQuery, called by the worker
+// when the coordinator reports query completion.
+type broadcastJoinCache struct {
+	mu      sync.Mutex
+	entries map[string]*broadcastJoinEntry
+}
+
+type broadcastJoinEntry struct {
+	hj       *exec.HashJoin
+	refcount int
+	ready    chan struct{} // closed once the builder completes
+	err      error         // set before ready closes; sticky
+	queryID  string        // for CleanupQuery scoping
+}
+
+func newBroadcastJoinCache() *broadcastJoinCache {
+	return &broadcastJoinCache{entries: make(map[string]*broadcastJoinEntry)}
+}
+
+// computeBroadcastJoinKey hashes the build-side identity of a broadcast probe
+// OpSpec. Probe tasks for the same broadcast (same query, same build files +
+// alias + join shape) produce the same key; different broadcasts (different
+// aliases or file lists) produce different keys.
+func computeBroadcastJoinKey(queryID string, spec distributed.OpSpec) string {
+	h := sha1.New()
+	fmt.Fprintf(h, "q:%s\x00a:%s\x00j:%s\x00s:%t\x00f:%s",
+		queryID, spec.BuildAlias, spec.JoinType, spec.SemiAntiKeyOnly, spec.JoinFilter)
+	for _, k := range spec.RightKeys {
+		fmt.Fprintf(h, "\x00R:%s", k)
+	}
+	files := append([]string(nil), spec.BuildFiles...)
+	sort.Strings(files)
+	for _, f := range files {
+		fmt.Fprintf(h, "\x00F:%s", f)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// Acquire returns the shared HashJoin for a broadcast build, calling build()
+// on first arrival. Concurrent callers with the same key block on the same
+// ready signal — only one Build runs.
+//
+// The returned release fn MUST be invoked when the caller is done probing.
+// When the last release drops refcount to zero, the cache calls hj.Close()
+// and evicts the entry.
+//
+// On builder error the entry is evicted before this call returns; the caller
+// receives (nil, nil, err) and must NOT call release.
+func (c *broadcastJoinCache) Acquire(key, queryID string, build func() (*exec.HashJoin, error)) (*exec.HashJoin, func(), error) {
+	c.mu.Lock()
+	if e, ok := c.entries[key]; ok {
+		e.refcount++
+		c.mu.Unlock()
+		<-e.ready
+		if e.err != nil {
+			// The builder failed; this waiter inherits the error and decrements
+			// the refcount it just claimed. When refcount hits zero the entry
+			// is evicted (hj is nil so Close is skipped).
+			c.release(key)
+			return nil, nil, e.err
+		}
+		return e.hj, c.releaseFnFor(key), nil
+	}
+	// First arrival: we are the builder.
+	e := &broadcastJoinEntry{
+		ready:    make(chan struct{}),
+		refcount: 1,
+		queryID:  queryID,
+	}
+	c.entries[key] = e
+	c.mu.Unlock()
+
+	hj, err := build()
+
+	c.mu.Lock()
+	e.hj = hj
+	e.err = err
+	close(e.ready)
+	c.mu.Unlock()
+
+	if err != nil {
+		// Builder failed: release our own refcount and report. Other waiters
+		// (if any) will see e.err and release themselves.
+		c.release(key)
+		return nil, nil, err
+	}
+	return hj, c.releaseFnFor(key), nil
+}
+
+func (c *broadcastJoinCache) releaseFnFor(key string) func() {
+	return func() { c.release(key) }
+}
+
+func (c *broadcastJoinCache) release(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[key]
+	if !ok {
+		return
+	}
+	e.refcount--
+	if e.refcount <= 0 {
+		if e.hj != nil {
+			_ = e.hj.Close()
+		}
+		delete(c.entries, key)
+	}
+}
+
+// CleanupQuery drops any entries belonging to queryID, closing their
+// HashJoins. Intended for the coordinator's "query complete" signal after
+// all probe tasks have released; safe to call on a query with no entries.
+//
+// If a probe task is still mid-probe when CleanupQuery fires, calling Close
+// on its hj would corrupt its read. Callers MUST gate this on all-tasks-done.
+func (c *broadcastJoinCache) CleanupQuery(queryID string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var dropped []*broadcastJoinEntry
+	for k, e := range c.entries {
+		if e.queryID == queryID {
+			dropped = append(dropped, e)
+			delete(c.entries, k)
+		}
+	}
+	for _, e := range dropped {
+		if e.hj != nil {
+			_ = e.hj.Close()
+		}
+	}
+	return len(dropped)
+}
+
+// Count returns the total number of cached entries across all queries.
+// Observability / test helper.
+func (c *broadcastJoinCache) Count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.entries)
+}

--- a/internal/worker/broadcast_join_cache_test.go
+++ b/internal/worker/broadcast_join_cache_test.go
@@ -1,0 +1,181 @@
+package worker
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/engine/exec"
+)
+
+func TestBroadcastJoinCache_SingleAcquireRelease(t *testing.T) {
+	c := newBroadcastJoinCache()
+	var built int32
+	hj, release, err := c.Acquire("k1", "q1", func() (*exec.HashJoin, error) {
+		atomic.AddInt32(&built, 1)
+		return exec.NewHashJoin(exec.InnerJoin, []string{"a"}, []string{"b"}), nil
+	})
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	if hj == nil {
+		t.Fatal("hj is nil")
+	}
+	if got := atomic.LoadInt32(&built); got != 1 {
+		t.Errorf("built=%d, want 1", got)
+	}
+	if c.Count() != 1 {
+		t.Errorf("Count=%d, want 1", c.Count())
+	}
+	release()
+	if c.Count() != 0 {
+		t.Errorf("Count after release=%d, want 0 (evicted)", c.Count())
+	}
+}
+
+func TestBroadcastJoinCache_ConcurrentAcquireSharesBuild(t *testing.T) {
+	c := newBroadcastJoinCache()
+	var built int32
+	const concurrency = 8
+	var wg sync.WaitGroup
+	releases := make(chan func(), concurrency)
+	hjs := make(chan *exec.HashJoin, concurrency)
+	start := make(chan struct{})
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			hj, release, err := c.Acquire("shared-key", "q1", func() (*exec.HashJoin, error) {
+				atomic.AddInt32(&built, 1)
+				return exec.NewHashJoin(exec.InnerJoin, []string{"a"}, []string{"b"}), nil
+			})
+			if err != nil {
+				t.Errorf("acquire: %v", err)
+				return
+			}
+			hjs <- hj
+			releases <- release
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(hjs)
+	close(releases)
+
+	if got := atomic.LoadInt32(&built); got != 1 {
+		t.Errorf("built=%d, want 1 (build called once across %d acquires)", got, concurrency)
+	}
+
+	var first *exec.HashJoin
+	for hj := range hjs {
+		if first == nil {
+			first = hj
+		} else if hj != first {
+			t.Error("acquires returned different *HashJoin instances; want all same")
+		}
+	}
+	if c.Count() != 1 {
+		t.Errorf("Count=%d, want 1 (one entry shared across acquires)", c.Count())
+	}
+
+	released := 0
+	for r := range releases {
+		r()
+		released++
+		if released < concurrency && c.Count() != 1 {
+			t.Errorf("Count=%d after %d releases, want 1 (not yet evicted)", c.Count(), released)
+		}
+	}
+	if c.Count() != 0 {
+		t.Errorf("Count after %d releases=%d, want 0 (evicted)", concurrency, c.Count())
+	}
+}
+
+func TestBroadcastJoinCache_BuilderErrorDoesNotLeak(t *testing.T) {
+	c := newBroadcastJoinCache()
+	wantErr := errors.New("build failed")
+	hj, release, err := c.Acquire("k1", "q1", func() (*exec.HashJoin, error) {
+		return nil, wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Errorf("err=%v, want %v", err, wantErr)
+	}
+	if hj != nil {
+		t.Error("hj should be nil on builder error")
+	}
+	if release != nil {
+		t.Error("release should be nil on builder error")
+	}
+	if c.Count() != 0 {
+		t.Errorf("Count=%d, want 0 (evicted on error)", c.Count())
+	}
+}
+
+func TestBroadcastJoinCache_CleanupQuery(t *testing.T) {
+	c := newBroadcastJoinCache()
+	// Two distinct broadcasts in q1 (different keys), one in q2.
+	cases := []struct{ q, k string }{
+		{"q1", "q1:a"},
+		{"q1", "q1:b"},
+		{"q2", "q2:a"},
+	}
+	for _, tc := range cases {
+		_, _, err := c.Acquire(tc.k, tc.q, func() (*exec.HashJoin, error) {
+			return exec.NewHashJoin(exec.InnerJoin, []string{"a"}, []string{"b"}), nil
+		})
+		if err != nil {
+			t.Fatalf("acquire %s/%s: %v", tc.q, tc.k, err)
+		}
+	}
+	if c.Count() != 3 {
+		t.Errorf("Count=%d, want 3", c.Count())
+	}
+	if dropped := c.CleanupQuery("q1"); dropped != 2 {
+		t.Errorf("CleanupQuery q1 dropped=%d, want 2", dropped)
+	}
+	if c.Count() != 1 {
+		t.Errorf("Count after q1 cleanup=%d, want 1", c.Count())
+	}
+	if dropped := c.CleanupQuery("q2"); dropped != 1 {
+		t.Errorf("CleanupQuery q2 dropped=%d, want 1", dropped)
+	}
+	if c.Count() != 0 {
+		t.Errorf("Count after q2 cleanup=%d, want 0", c.Count())
+	}
+}
+
+func TestComputeBroadcastJoinKey_IdentityAcrossTasks(t *testing.T) {
+	// Two probe tasks for the same broadcast: identical spec → identical key.
+	specA := distributed.OpSpec{
+		BuildAlias:      "supplier",
+		BuildFiles:      []string{"s3://b/q/sh/build/p=0.wshf", "s3://b/q/sh/build/p=1.wshf"},
+		JoinType:        "inner",
+		LeftKeys:        []string{"l_suppkey"},
+		RightKeys:       []string{"s_suppkey"},
+		SemiAntiKeyOnly: false,
+	}
+	specB := specA
+	if computeBroadcastJoinKey("q1", specA) != computeBroadcastJoinKey("q1", specB) {
+		t.Error("identical specs produced different keys")
+	}
+	// File order invariance: shuffled file order should not change the key.
+	specC := specA
+	specC.BuildFiles = []string{specA.BuildFiles[1], specA.BuildFiles[0]}
+	if computeBroadcastJoinKey("q1", specA) != computeBroadcastJoinKey("q1", specC) {
+		t.Error("file-order-permuted spec produced different key; sort-then-hash expected")
+	}
+	// Different queries → different keys.
+	if computeBroadcastJoinKey("q1", specA) == computeBroadcastJoinKey("q2", specA) {
+		t.Error("different queryIDs collided to same key")
+	}
+	// Different aliases → different keys.
+	specD := specA
+	specD.BuildAlias = "part"
+	if computeBroadcastJoinKey("q1", specA) == computeBroadcastJoinKey("q1", specD) {
+		t.Error("different aliases collided to same key")
+	}
+}

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -68,11 +68,23 @@ type Executor struct {
 	// table now share one budget and cooperatively spill.
 	sharedTracker *memory.Tracker
 	sharedSpill   *memory.SpillManager
+
+	// Same-worker dedup of broadcast-join build state. Probe tasks for the
+	// same broadcast (max_concurrent=3 concurrent tasks reading the same
+	// build cache) share a single *exec.HashJoin instead of each rebuilding
+	// from scratch. See broadcast_join_cache.go.
+	broadcastCache *broadcastJoinCache
 }
 
 // NewExecutor creates a new task executor.
 func NewExecutor(store objstore.Store, cache *LRUCache, js jetstream.JetStream) *Executor {
-	return &Executor{store: store, js: js, cache: cache, logger: slog.Default()}
+	return &Executor{
+		store:          store,
+		js:             js,
+		cache:          cache,
+		logger:         slog.Default(),
+		broadcastCache: newBroadcastJoinCache(),
+	}
 }
 
 // SetMemoryBudget configures the per-task memory budget and the spill

--- a/internal/worker/executor_fragment.go
+++ b/internal/worker/executor_fragment.go
@@ -871,43 +871,74 @@ func (e *Executor) buildFragmentJoinProbe(ctx context.Context, task distributed.
 	if bucket == "" {
 		bucket = task.ResultBucket
 	}
-	buildSrc, err := e.sourceForAlias(task.QueryID, bucket, spec.BuildAlias, spec.BuildFiles)
-	if err != nil {
-		return nil, nil, fmt.Errorf("build source: %w", err)
-	}
-	if err := buildSrc.Init(ctx); err != nil {
-		buildSrc.Close()
-		return nil, nil, fmt.Errorf("build source init: %w", err)
+	// Build the HashJoin once, then share it across same-worker probe tasks
+	// for the same broadcast. HashJoinProbe is designed for concurrent use:
+	// each Probe() call returns its own scratch buffers, and lazy probeKeyIdx
+	// resolution is atomic.Bool + mutex guarded. Build()-completed HashJoin
+	// state (intIndex, arena, buildBatches) is read-only.
+	//
+	// Hash-shuffle probes don't share a build (each task probes its own
+	// partition) so they take the direct path.
+	buildHJ := func() (*exec.HashJoin, error) {
+		src, err := e.sourceForAlias(task.QueryID, bucket, spec.BuildAlias, spec.BuildFiles)
+		if err != nil {
+			return nil, fmt.Errorf("build source: %w", err)
+		}
+		if err := src.Init(ctx); err != nil {
+			src.Close()
+			return nil, fmt.Errorf("build source init: %w", err)
+		}
+		defer src.Close()
+
+		hj := exec.NewHashJoin(mapJoinTypeString(spec.JoinType), spec.LeftKeys, spec.RightKeys)
+		hj.BuildTableAlias = spec.BuildAlias
+		hj.QualifyAllBuildCols = spec.QualifyAllBuildCols
+		if spec.BuildRowHint > 0 {
+			hj.BuildRowHint = spec.BuildRowHint
+		}
+		hj.SemiAntiKeyOnly = spec.SemiAntiKeyOnly
+		if spec.JoinFilter != "" {
+			hj.SemiAntiFilter = physical.BuildSemiAntiFilter(spec.JoinFilter)
+		}
+		if e.sharedSpill != nil {
+			hj.Spill = e.sharedSpill
+			hj.MemTracker = e.sharedTracker
+			// Broadcast probes always force partition-on-arrival to bound peak
+			// heap; shuffle-side probes opt in based on observed pool pressure.
+			// See executeStageHashJoin for the policy rationale.
+			if spec.Type == distributed.OpBroadcastProbe {
+				hj.PartitionOnArrival = true
+			} else {
+				hj.PartitionOnArrival = exec.SharedPoolUnderPressure(e.sharedTracker)
+			}
+		}
+		if err := hj.Build(ctx, src); err != nil {
+			return nil, fmt.Errorf("building hash table: %w", err)
+		}
+		hj.FixKeyAssignment()
+		return hj, nil
 	}
 
-	hj := exec.NewHashJoin(mapJoinTypeString(spec.JoinType), spec.LeftKeys, spec.RightKeys)
-	hj.BuildTableAlias = spec.BuildAlias
-	hj.QualifyAllBuildCols = spec.QualifyAllBuildCols
-	if spec.BuildRowHint > 0 {
-		hj.BuildRowHint = spec.BuildRowHint
-	}
-	hj.SemiAntiKeyOnly = spec.SemiAntiKeyOnly
-	if spec.JoinFilter != "" {
-		hj.SemiAntiFilter = physical.BuildSemiAntiFilter(spec.JoinFilter)
-	}
-	if e.sharedSpill != nil {
-		hj.Spill = e.sharedSpill
-		hj.MemTracker = e.sharedTracker
-		// Broadcast probes always force partition-on-arrival to bound peak
-		// heap; shuffle-side probes opt in based on observed pool pressure.
-		// See executeStageHashJoin for the policy rationale.
-		if spec.Type == distributed.OpBroadcastProbe {
-			hj.PartitionOnArrival = true
-		} else {
-			hj.PartitionOnArrival = exec.SharedPoolUnderPressure(e.sharedTracker)
+	var (
+		hj      *exec.HashJoin
+		cleanup func()
+	)
+	if spec.Type == distributed.OpBroadcastProbe && e.broadcastCache != nil {
+		key := computeBroadcastJoinKey(task.QueryID, spec)
+		built, release, err := e.broadcastCache.Acquire(key, task.QueryID, buildHJ)
+		if err != nil {
+			return nil, nil, err
 		}
+		hj = built
+		cleanup = release
+	} else {
+		built, err := buildHJ()
+		if err != nil {
+			return nil, nil, err
+		}
+		hj = built
+		cleanup = func() { hj.Close() }
 	}
-	if err := hj.Build(ctx, buildSrc); err != nil {
-		buildSrc.Close()
-		return nil, nil, fmt.Errorf("building hash table: %w", err)
-	}
-	buildSrc.Close()
-	hj.FixKeyAssignment()
 
 	probe := hj.Probe()
 	if len(spec.OutputColumns) > 0 {
@@ -917,7 +948,6 @@ func (e *Executor) buildFragmentJoinProbe(ctx context.Context, task distributed.
 		}
 		probe.OutputFilter = filter
 	}
-	cleanup := func() { hj.Close() }
 	return []exec.UnaryOperator{probe}, cleanup, nil
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -257,6 +257,9 @@ func (w *Worker) Start(ctx context.Context) error {
 		if w.executor.localCache != nil {
 			w.executor.localCache.CleanupQuery(queryID)
 		}
+		if w.executor.broadcastCache != nil {
+			w.executor.broadcastCache.CleanupQuery(queryID)
+		}
 		w.logger.Debug("query cancelled", "query_id", queryID)
 	})
 	if err != nil {
@@ -272,6 +275,12 @@ func (w *Worker) Start(ctx context.Context) error {
 			n := w.executor.localCache.CleanupQuery(queryID)
 			if n > 0 {
 				w.logger.Debug("released local stage cache",
+					"query_id", queryID, "entries", n)
+			}
+		}
+		if w.executor.broadcastCache != nil {
+			if n := w.executor.broadcastCache.CleanupQuery(queryID); n > 0 {
+				w.logger.Debug("released broadcast-join cache",
 					"query_id", queryID, "entries", n)
 			}
 		}


### PR DESCRIPTION
## Summary

Refcounted, query-scoped, worker-local cache that lets concurrent probe tasks for the same broadcast share a single built `*exec.HashJoin` instead of each rebuilding from scratch. Targets Q21's known **3× decode redundancy** on the supplier broadcast (per `project_q21_replicate_threshold_2026-05-22`).

## Mechanism

`HashJoinProbe` was already designed for concurrent use — each `Probe()` returns per-instance scratch (`pairsBuf`, `indexBuf`, `keyBuf`), and lazy `probeKeyIdx` resolution is `atomic.Bool` + mutex guarded. After `Build()` returns, `intIndex`, `arena`, `buildBatches` are read-only. The only thing missing was a sharing layer.

`broadcastJoinCache` is the layer:
- **First arrival**: cache miss → run the build → store entry (refcount=1)
- **Subsequent arrivals**: block on the entry's `ready` channel until the first builder finishes → attach refcount++
- **Release**: refcount-- per task; when refcount hits zero, `hj.Close()` (returns shared-tracker bytes) + evict
- **CleanupQuery**: on cancel/complete signals, drops any entries belonging to a query — mirrors `LocalStageCache.CleanupQuery`

Cache key includes `queryID`, `BuildAlias`, sorted `BuildFiles`, `JoinType`, `RightKeys`, `SemiAntiKeyOnly`, `JoinFilter`.

Wired only into `OpBroadcastProbe`; shuffle-side hash joins each probe their own partition (no shared build to dedup).

## Expected savings

Q21 has 3+ broadcast-join stages chained on lineitem self-joins. Each stage saves ~2/3 of the build CPU per worker (3 concurrent tasks → 1 build). Estimated **30-60s wall on Q21 (~5-7% Q21 reduction)**. Other broadcast-join-heavy queries (Q02, Q22) get smaller proportional wins. **Not validated on SF100 in this PR** — locally-gated only.

## Files

- `internal/worker/broadcast_join_cache.go` — new (151 LOC); cache + key hashing
- `internal/worker/broadcast_join_cache_test.go` — new (170 LOC); 5 unit tests covering single acquire, concurrent shared build, builder-error eviction, CleanupQuery, key identity
- `internal/worker/executor.go` — add `broadcastCache` field + init in `NewExecutor`
- `internal/worker/executor_fragment.go` — refactor `buildFragmentJoinProbe` to wrap build in `buildHJ` closure; broadcast path goes through `cache.Acquire`, shuffle path unchanged
- `internal/worker/worker.go` — extend cancel + complete handlers to call `broadcastCache.CleanupQuery`

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race -short ./internal/... -timeout 10m` PASS (including 5 new cache tests)
- [x] `go test -v -run TestTPCHQueries$ ./benchmarks/tpch/` SF0.01 22/22 PASS, exact rows
- [x] `cmd/tpch-harness --mode=local --slice=small` SF0.01 25/25 PASS with identical row counts
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)