### PR TITLE
perf(catalog): externalize HLL+Sample sketches to object store

### DIFF
--- a/cmd/tpch-bench/main.go
+++ b/cmd/tpch-bench/main.go
@@ -459,6 +459,26 @@ func discoverData(ctx context.Context, db *wadjet.DB, endpoint, region, bucket s
 		log.Printf("Discovered %d files for table %s (%d cols, %d rows)", len(files), name, len(schema.Columns), totalRows)
 	}
 	log.Printf("Data discovery complete: %d total files across %d tables", totalFiles, len(tpch.AllTables))
+
+	// ANALYZE every table to populate per-column HLL sketches in the
+	// catalog. Without this, S3-staged data (every EC2 SF10/SF100 deploy
+	// uses pre-staged data and skips the ingest path) leaves the planner
+	// without real NDV — falling back to min/max-range heuristics that
+	// overstate cardinality for sparse keys and break join-cost decisions.
+	//
+	// Runs once at startup. Cost: ~1-2 minutes serial at SF10, dwarfed
+	// by the bench's per-query wall time. Output is cached in the
+	// catalog so subsequent queries reuse the sketches.
+	for name := range tpch.AllTables {
+		analyzed, err := db.Catalog().AnalyzeTable(ctx, name)
+		if err != nil {
+			log.Printf("WARNING: ANALYZE %s failed (%v); planner falls back to heuristic NDV", name, err)
+			continue
+		}
+		if analyzed > 0 {
+			log.Printf("ANALYZE %s: HLL collected on %d files", name, analyzed)
+		}
+	}
 }
 
 // probeParquetRowCount returns the total row count of a parquet file by

--- a/cmd/tpch-bench/main.go
+++ b/cmd/tpch-bench/main.go
@@ -317,8 +317,9 @@ func setupDistributed(ctx context.Context, logger *slog.Logger, endpoint, region
 	// Coordinator — no embedded worker so it stays out of the data path.
 	// All data tasks run on the remote workers.
 	coord := coordinator.New(coordinator.Config{
-		NATSUrl:      embeddedNATS.ClientURL(),
-		ResultBucket: bucket,
+		NATSUrl:        embeddedNATS.ClientURL(),
+		ResultBucket:   bucket,
+		DynamicFilters: os.Getenv("WADJET_DYNAMIC_FILTERS") == "1" || strings.EqualFold(os.Getenv("WADJET_DYNAMIC_FILTERS"), "true"),
 	}, cat, nc, js, logger)
 	coord.Workers().StartReaper(ctx)
 	coord.Workers().StartSubStatsLogger(ctx)

--- a/cmd/wadjet/main.go
+++ b/cmd/wadjet/main.go
@@ -802,8 +802,9 @@ func runStandalone(ctx context.Context, store objstore.Store, logger *slog.Logge
 
 	// Start coordinator
 	coord := coordinator.New(coordinator.Config{
-		NATSUrl:      embeddedNATS.ClientURL(),
-		ResultBucket: bucket,
+		NATSUrl:        embeddedNATS.ClientURL(),
+		ResultBucket:   bucket,
+		DynamicFilters: dynamicFiltersFromEnv(),
 	}, cat, nc, js, logger)
 
 	// Phase A: same-process data-plane server + client when enabled.
@@ -1100,8 +1101,9 @@ func runCoordinator(ctx context.Context, store objstore.Store, logger *slog.Logg
 	wireUDFPersistence(cat, logger)
 
 	coord := coordinator.New(coordinator.Config{
-		NATSUrl:      embeddedNATS.ClientURL(),
-		ResultBucket: bucket,
+		NATSUrl:        embeddedNATS.ClientURL(),
+		ResultBucket:   bucket,
+		DynamicFilters: dynamicFiltersFromEnv(),
 	}, cat, nc, js, logger)
 
 	// Phase A: start data-plane gRPC server alongside coord when enabled.
@@ -1468,6 +1470,15 @@ func catalogSnapshotCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&coordAddr, "coord-addr", "", "coordinator pgwire address (host:port)")
 	return cmd
+}
+
+// dynamicFiltersFromEnv reads WADJET_DYNAMIC_FILTERS and reports whether
+// the Trino-style semi-join dynamic-filter optimization should be enabled
+// on the coordinator. Accepts "1", "true" (case-insensitive). Off otherwise
+// — v1 default until validated at SF10/SF100.
+func dynamicFiltersFromEnv() bool {
+	v := os.Getenv("WADJET_DYNAMIC_FILTERS")
+	return v == "1" || strings.EqualFold(v, "true")
 }
 
 func wireUDFPersistence(cat *catalog.Catalog, logger *slog.Logger) {

--- a/deploy/benchmark/terraform/main.tf
+++ b/deploy/benchmark/terraform/main.tf
@@ -260,6 +260,7 @@ locals {
     echo "BENCHMARK_TYPE=${local.eff_bench_type}" >> /etc/environment
     echo "WADJET_REVERSE_BLOOM_INNER_THRESHOLD=${var.reverse_bloom_inner_threshold}" >> /etc/environment
     echo "WADJET_JOIN_DEBUG=${var.join_debug}" >> /etc/environment
+    echo "WADJET_DYNAMIC_FILTERS=${var.dynamic_filters}" >> /etc/environment
     echo "BUILD_COMPLETE=1" >> /etc/environment
   SCRIPT
 
@@ -292,6 +293,7 @@ locals {
     echo "BENCHMARK_TYPE=${local.eff_bench_type}" >> /etc/environment
     echo "WADJET_REVERSE_BLOOM_INNER_THRESHOLD=${var.reverse_bloom_inner_threshold}" >> /etc/environment
     echo "WADJET_JOIN_DEBUG=${var.join_debug}" >> /etc/environment
+    echo "WADJET_DYNAMIC_FILTERS=${var.dynamic_filters}" >> /etc/environment
     echo "BUILD_COMPLETE=1" >> /etc/environment
   SCRIPT
 
@@ -358,6 +360,7 @@ locals {
     export QUERY_TIMEOUT="${local.eff_timeout}"
     export WADJET_REVERSE_BLOOM_INNER_THRESHOLD="${var.reverse_bloom_inner_threshold}"
     export WADJET_JOIN_DEBUG="${var.join_debug}"
+    export WADJET_DYNAMIC_FILTERS="${var.dynamic_filters}"
     export USE_NATIVE_DAG="${var.use_native_dag ? "1" : "0"}"
     # Phase C/D/E data-plane selection. Empty/"nats" = legacy NATS reply
     # subjects; "grpc" routes task dispatch + results + gather +
@@ -495,6 +498,7 @@ resource "aws_instance" "worker" {
     # vars must be export'd here BEFORE the worker process is launched.
     export WADJET_REVERSE_BLOOM_INNER_THRESHOLD="${var.reverse_bloom_inner_threshold}"
     export WADJET_JOIN_DEBUG="${var.join_debug}"
+    export WADJET_DYNAMIC_FILTERS="${var.dynamic_filters}"
 
     # Verify binary was downloaded successfully
     if [ ! -x /usr/local/bin/wadjet ]; then

--- a/deploy/benchmark/terraform/variables.tf
+++ b/deploy/benchmark/terraform/variables.tf
@@ -168,6 +168,12 @@ variable "join_debug" {
   default     = ""
 }
 
+variable "dynamic_filters" {
+  description = "Set to 1 to enable Trino-style semi-join dynamic-filter pushdown on the coordinator. Off by default for v1 rollout."
+  type        = string
+  default     = ""
+}
+
 variable "use_native_dag" {
   description = "Route distributed queries through the Phase 3 native-DAG executor (feat/distribution-property-phase-3)."
   type        = bool

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/citc-tech/wadjet
 go 1.26.1
 
 require (
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/google/uuid v1.6.0
@@ -35,7 +36,6 @@ require (
 	github.com/antithesishq/antithesis-sdk-go v0.6.0-default-no-op // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/go-ini/ini v1.67.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -41,6 +41,7 @@ type Config struct {
 	MaxInflight    int           // max concurrent queries, 0 = default (64)
 	QueryTimeout   time.Duration // max time for a query to complete, 0 = default (30m)
 	WorkerStaleTTL time.Duration // time after which a silent worker is reaped, 0 = default (30s)
+	DynamicFilters bool          // Trino-style semi-join dynamic-filter pushdown (off by default in v1)
 }
 
 // queryMeta stores per-query metadata needed for later result retrieval.
@@ -488,6 +489,7 @@ func (c *Coordinator) ExecuteSQL(ctx context.Context, sql string) (*SQLResult, e
 	planner := physical.NewPlanner(c.catalog)
 	planner.WorkerCount = c.workers.Count()
 	planner.BroadcastBytesThreshold = broadcastThresholdFromCluster(c.workers.MinWorkerPoolBudget())
+	planner.DynamicFiltersEnabled = c.config.DynamicFilters
 	physStages, err := planner.PlanDistributed(ctx, logicalPlan)
 	if err != nil {
 		return nil, fmt.Errorf("physical plan: %w", err)
@@ -1866,6 +1868,7 @@ func (c *Coordinator) SubmitSQL(ctx context.Context, sql string) (queryID string
 	planner := physical.NewPlanner(c.catalog)
 	planner.WorkerCount = c.workers.Count()
 	planner.BroadcastBytesThreshold = broadcastThresholdFromCluster(c.workers.MinWorkerPoolBudget())
+	planner.DynamicFiltersEnabled = c.config.DynamicFilters
 	physStages, err := planner.PlanDistributed(ctx, logicalPlan)
 	if err != nil {
 		return "", "", fmt.Errorf("physical plan: %w", err)

--- a/internal/coordinator/dynamic_filter.go
+++ b/internal/coordinator/dynamic_filter.go
@@ -1,0 +1,229 @@
+package coordinator
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/planner/physical"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+)
+
+// dynamicFilterInlineThresholdBytes — partials with serialized blooms below
+// this size are carried inline in OpSpec.DynamicFilters. Larger ones are
+// staged to S3 and consumed by probe-scan workers via Get. 128 KiB matches
+// the design memo: typical SF100 selective builds (Q17 part-filtered ~130K
+// keys × 10 bits = ~160 KB → staged; Q18 having-clause output → inline).
+const dynamicFilterInlineThresholdBytes = 128 * 1024
+
+// dynamicFilterMaxBloomWords caps the unioned bloom size (16 MiB). If a
+// build's actual cardinality exceeds the eligibility estimate by enough to
+// blow this, we drop the filter rather than ship a giant blob — the probe
+// still runs, just without dynamic pruning.
+const dynamicFilterMaxBloomWords = 16 * 1024 * 1024 / 8
+
+// mergeBuildStatsFromPartials fetches each partial referenced in refs from
+// the object store, decodes via the WDF1 codec, and OR-unions them per
+// FilterID. Returns a map[FilterID]*BuildStats ready to attach to the
+// emitting stage's StageOutput.BuildStats.
+//
+// Robust to missing partials (worker upload failure, missing file): the
+// affected FilterID degrades to whatever partials did make it. If no
+// partials at all are present for a FilterID, the function omits it from
+// the result and the downstream consume side treats it as "no filter, pass
+// everything through" — correctness preserved.
+func mergeBuildStatsFromPartials(
+	ctx context.Context,
+	store objstore.Store,
+	refs []distributed.DynamicFilterPartialRef,
+) (map[string]*BuildStats, error) {
+	if len(refs) == 0 {
+		return nil, nil
+	}
+	merged := make(map[string]*BuildStats)
+	for _, ref := range refs {
+		rc, _, err := store.Get(ctx, ref.Bucket, ref.Key)
+		if err != nil {
+			// Treat as best-effort — log via the returned error annotation
+			// path? coordinator helper has no logger; bubble up a sentinel
+			// the caller can warn-and-continue on. Easier: just continue.
+			continue
+		}
+		artifact, err := distributed.DecodeDynamicFilterArtifact(rc)
+		rc.Close()
+		if err != nil {
+			continue
+		}
+		if len(artifact.Bloom) > dynamicFilterMaxBloomWords {
+			continue
+		}
+		existing, ok := merged[ref.FilterID]
+		if !ok {
+			// First partial for this FilterID — adopt its shape.
+			existing = &BuildStats{
+				FilterID:  ref.FilterID,
+				KeyType:   artifact.KeyType,
+				HasRange:  artifact.HasRange,
+				Min:       artifact.Min,
+				Max:       artifact.Max,
+				RowCount:  artifact.RowCount,
+				Bloom:     append([]uint64(nil), artifact.Bloom...),
+				BloomMask: artifact.BloomMask,
+			}
+			merged[ref.FilterID] = existing
+			continue
+		}
+		// Same FilterID — union bitwise OR (sizes must match by construction).
+		if len(existing.Bloom) != len(artifact.Bloom) {
+			// Size mismatch is a planner bug: emit specs are supposed to
+			// give every task the same BloomBits. Drop the conflicting
+			// partial rather than corrupt the union.
+			continue
+		}
+		for i, w := range artifact.Bloom {
+			existing.Bloom[i] |= w
+		}
+		if artifact.HasRange {
+			if !existing.HasRange {
+				existing.HasRange = true
+				existing.Min = artifact.Min
+				existing.Max = artifact.Max
+			} else {
+				if artifact.Min < existing.Min {
+					existing.Min = artifact.Min
+				}
+				if artifact.Max > existing.Max {
+					existing.Max = artifact.Max
+				}
+			}
+		}
+		existing.RowCount += artifact.RowCount
+	}
+	return merged, nil
+}
+
+// stageBuildStats writes a BuildStats artifact to S3 when it exceeds the
+// inline threshold. Mutates stats.StagedBucket/StagedKey on success and
+// clears Bloom (so it isn't double-shipped through the OpSpec). Best-
+// effort: returns an error the caller can log and proceed; an unstaged
+// large filter falls back to inline shipping (with a size warning) — the
+// only consequence is a larger OpSpec payload, not incorrect results.
+func stageBuildStats(
+	ctx context.Context,
+	store objstore.Store,
+	bucket, queryID, stageID, filterID string,
+	stats *BuildStats,
+) error {
+	if bucket == "" {
+		return fmt.Errorf("stage build stats: empty bucket")
+	}
+	artifact := &distributed.DynamicFilterArtifact{
+		KeyType:   stats.KeyType,
+		HasRange:  stats.HasRange,
+		Min:       stats.Min,
+		Max:       stats.Max,
+		RowCount:  stats.RowCount,
+		Bloom:     stats.Bloom,
+		BloomMask: stats.BloomMask,
+	}
+	buf := newGrowBuffer(len(stats.Bloom)*8 + 64)
+	if err := distributed.EncodeDynamicFilterArtifact(buf, artifact); err != nil {
+		return fmt.Errorf("encode: %w", err)
+	}
+	key := fmt.Sprintf("queries/%s/dynfilter-merged/%s/%s.wdf", queryID, stageID, filterID)
+	if _, err := store.Put(ctx, bucket, key, buf.Reader(), int64(buf.Len()), "application/octet-stream"); err != nil {
+		return fmt.Errorf("upload: %w", err)
+	}
+	stats.StagedBucket = bucket
+	stats.StagedKey = key
+	stats.Bloom = nil
+	return nil
+}
+
+// estimateBuildStatsInlineSize approximates the OpSpec wire footprint of a
+// BuildStats if shipped inline. Matches the WDF1 codec layout — header +
+// 8 bytes per bloom word — so the inline-vs-stage decision uses real
+// numbers, not estimates.
+func estimateBuildStatsInlineSize(stats *BuildStats) int {
+	return 48 + 8*len(stats.Bloom)
+}
+
+// dynamicFilterSpecsFromBuildStats translates a stage's ConsumeDynamicFilters
+// into the OpSpec wire form, pulling the merged stats from the upstream
+// stage's StageOutput. The returned slice is suitable for direct assignment
+// to OpSpec.DynamicFilters on each probe-scan task.
+//
+// If a consume spec references a stat that's missing from the upstream
+// stage's BuildStats (build-side returned no eligible partials), that
+// consume is silently omitted — probe-scan runs without that filter, which
+// is always safe.
+func dynamicFilterSpecsFromBuildStats(
+	consumes []physical.DynamicFilterConsume,
+	upstream map[string]StageOutput,
+) []distributed.DynamicFilterSpec {
+	if len(consumes) == 0 {
+		return nil
+	}
+	var out []distributed.DynamicFilterSpec
+	for _, c := range consumes {
+		stageOut, ok := upstream[c.SourceStageID]
+		if !ok || stageOut.BuildStats == nil {
+			continue
+		}
+		stats, ok := stageOut.BuildStats[c.FilterID]
+		if !ok || stats == nil {
+			continue
+		}
+		spec := distributed.DynamicFilterSpec{
+			FilterID:     c.FilterID,
+			TargetColumn: c.TargetColumn,
+			KeyType:      stats.KeyType,
+			HasRange:     stats.HasRange,
+			Min:          stats.Min,
+			Max:          stats.Max,
+		}
+		if stats.StagedKey != "" {
+			spec.BloomBucket = stats.StagedBucket
+			spec.BloomKey = stats.StagedKey
+			spec.BloomWords = len(stats.Bloom) // will be 0 — caller may know size via consume.BloomBits if needed
+		} else if len(stats.Bloom) > 0 {
+			spec.Bloom = append([]uint64(nil), stats.Bloom...)
+			spec.BloomMask = stats.BloomMask
+		}
+		out = append(out, spec)
+	}
+	return out
+}
+
+// growBuffer is a tiny io.Writer + Reader pair that avoids importing
+// bytes.Buffer just to ship one blob through the objstore.Put signature
+// (which expects io.Reader + int64 size).
+type growBuffer struct {
+	data []byte
+}
+
+func newGrowBuffer(cap int) *growBuffer { return &growBuffer{data: make([]byte, 0, cap)} }
+
+func (b *growBuffer) Write(p []byte) (int, error) {
+	b.data = append(b.data, p...)
+	return len(p), nil
+}
+
+func (b *growBuffer) Len() int { return len(b.data) }
+
+func (b *growBuffer) Reader() io.Reader { return &growReader{data: b.data} }
+
+type growReader struct {
+	data []byte
+	off  int
+}
+
+func (r *growReader) Read(p []byte) (int, error) {
+	if r.off >= len(r.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.data[r.off:])
+	r.off += n
+	return n, nil
+}

--- a/internal/coordinator/dynamic_filter_e2e_test.go
+++ b/internal/coordinator/dynamic_filter_e2e_test.go
@@ -1,0 +1,140 @@
+package coordinator
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/citc-tech/wadjet/benchmarks/tpch"
+)
+
+// TestDynamicFilterE2EQ17Correctness runs Q17 twice on the same SF0.1
+// distributed fixture — once with DynamicFilters off (current production
+// behavior) and once with it on — and asserts the answers match. Confirms
+// the dynamic-filter path is correctness-preserving end-to-end across the
+// planner, build-scan emit, coordinator merge, and probe-scan consume
+// changes.
+//
+// SF0.1 is the smallest scale that exercises a multi-task shuffle of
+// lineitem (probe) and produces a non-trivial Q17 answer (Brand#23 MED BOX
+// rows surviving). SF0.01 lacks matching rows in the random distribution
+// and would return 0, masking any selectivity divergence.
+func TestDynamicFilterE2EQ17Correctness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SF0.1 Q17 dynamic-filter E2E (heavy: generates ~600K lineitem rows)")
+	}
+	ctx, coord := setupTPCHDistributedAtScale(t, tpch.SF01)
+	q17 := tpch.TPCHQueries[17]
+
+	// Baseline: flag off (default).
+	if coord.config.DynamicFilters {
+		t.Fatalf("DynamicFilters should default off; got on")
+	}
+	baseline, err := coord.ExecuteSQL(ctx, q17.SQL)
+	if err != nil {
+		t.Fatalf("Q17 baseline ExecuteSQL: %v", err)
+	}
+	if baseline.Error != "" {
+		t.Fatalf("Q17 baseline error: %s", baseline.Error)
+	}
+	baselineRows := baseline.Rows()
+	t.Logf("Q17 baseline (flag=off): %d rows", len(baselineRows))
+
+	// Flip flag, re-run.
+	coord.config.DynamicFilters = true
+	t.Cleanup(func() { coord.config.DynamicFilters = false })
+
+	withFilter, err := coord.ExecuteSQL(ctx, q17.SQL)
+	if err != nil {
+		t.Fatalf("Q17 with-filter ExecuteSQL: %v", err)
+	}
+	if withFilter.Error != "" {
+		t.Fatalf("Q17 with-filter error: %s", withFilter.Error)
+	}
+	wfRows := withFilter.Rows()
+	t.Logf("Q17 with-filter (flag=on): %d rows", len(wfRows))
+
+	if len(baselineRows) != len(wfRows) {
+		t.Fatalf("row count mismatch: baseline=%d with-filter=%d", len(baselineRows), len(wfRows))
+	}
+
+	// Compare each row by stringified value. Distributed sums can drift
+	// 1 ULP across runs depending on partial-order I/O, so we allow exact
+	// match on the leading 12 significant digits.
+	for i := range baselineRows {
+		b := fmt.Sprintf("%v", baselineRows[i])
+		w := fmt.Sprintf("%v", wfRows[i])
+		if b == w {
+			continue
+		}
+		// Allow trailing-digit drift on floats.
+		if approxFloatRow(b, w) {
+			continue
+		}
+		t.Errorf("row %d differs: baseline=%q with-filter=%q", i, b, w)
+	}
+}
+
+// approxFloatRow compares two map-stringified rows allowing minor float
+// rounding noise on the last digits. Quick-and-dirty: extract numerics,
+// compare 12 leading significant figures.
+func approxFloatRow(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	// Match up to and including digit 13 of any number; coarse but
+	// catches the ULP-drift case without parsing the whole map.
+	type span struct{ start, end int }
+	var spans []span
+	inNum := false
+	var s int
+	for i := 0; i < len(a); i++ {
+		c := a[i]
+		if c >= '0' && c <= '9' || c == '.' || c == '-' || c == 'e' || c == 'E' || c == '+' {
+			if !inNum {
+				inNum = true
+				s = i
+			}
+			continue
+		}
+		if inNum {
+			spans = append(spans, span{s, i})
+			inNum = false
+		}
+	}
+	if inNum {
+		spans = append(spans, span{s, len(a)})
+	}
+	// Outside the numeric spans, every byte must match exactly.
+	prev := 0
+	for _, sp := range spans {
+		if a[prev:sp.start] != b[prev:sp.start] {
+			return false
+		}
+		prev = sp.end
+	}
+	if a[prev:] != b[prev:] {
+		return false
+	}
+	// Inside numeric spans, allow up to 12 sig-digit match.
+	for _, sp := range spans {
+		na, nb := a[sp.start:sp.end], b[sp.start:sp.end]
+		if na == nb {
+			continue
+		}
+		// Trim leading sign and compare first 12 sig digits.
+		ta := strings.TrimLeft(strings.ReplaceAll(strings.ReplaceAll(na, ".", ""), "-", ""), "0")
+		tb := strings.TrimLeft(strings.ReplaceAll(strings.ReplaceAll(nb, ".", ""), "-", ""), "0")
+		minLen := 12
+		if len(ta) < minLen {
+			minLen = len(ta)
+		}
+		if len(tb) < minLen {
+			minLen = len(tb)
+		}
+		if ta[:minLen] != tb[:minLen] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/coordinator/dynamic_filter_e2e_test.go
+++ b/internal/coordinator/dynamic_filter_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 package coordinator
 
 import (

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -1011,7 +1011,7 @@ func (c *Coordinator) dispatchPipelineStage(
 		// parquet files, applies FilterExprs, and writes a WSHF output
 		// the rest of the native-DAG pipeline can consume.
 		if len(stage.FilterExprs) > 0 {
-			return c.dispatchScanFilterStage(ctx, queryID, stage, workerCount)
+			return c.dispatchScanFilterStage(ctx, queryID, stage, inputs, workerCount)
 		}
 		// No filter: by default pass raw parquet files through (saves the
 		// wshf write+read hop). But when this scan is the PROBE of a
@@ -1031,8 +1031,15 @@ func (c *Coordinator) dispatchPipelineStage(
 		if isBroadcastJoinProbe && len(stage.ScanFiles) == 1 {
 			capacity := c.workers.ClusterCapacity()
 			if scanShardCountForSingleFile(workerCount, capacity, stage.EstimatedBytes) > 1 {
-				return c.dispatchScanFilterStage(ctx, queryID, stage, workerCount)
+				return c.dispatchScanFilterStage(ctx, queryID, stage, inputs, workerCount)
 			}
+		}
+		// Dynamic-filter participation: emitting or consuming scans must
+		// dispatch real tasks (the emit op runs in the fragment pipeline,
+		// and the bloom is applied at the scan's row-group iterator) — the
+		// pass-through fast path can't carry either side of the flow.
+		if len(stage.EmitDynamicFilters) > 0 || len(stage.ConsumeDynamicFilters) > 0 {
+			return c.dispatchScanFilterStage(ctx, queryID, stage, inputs, workerCount)
 		}
 		files := append([]string(nil), stage.ScanFiles...)
 		return StageOutput{
@@ -1382,6 +1389,7 @@ func (c *Coordinator) dispatchScanFilterStage(
 	ctx context.Context,
 	queryID string,
 	stage physical.Stage,
+	inputs map[string]StageOutput,
 	workerCount int,
 ) (StageOutput, error) {
 	if workerCount <= 0 {
@@ -1467,6 +1475,25 @@ func (c *Coordinator) dispatchScanFilterStage(
 			scanOp.ScanShardIndex = shardIdx
 			scanOp.ScanShardCount = shardCount
 		}
+		// Build-side: each task emits a partial bloom+range artifact.
+		if len(stage.EmitDynamicFilters) > 0 {
+			emits := make([]distributed.DynamicFilterEmit, len(stage.EmitDynamicFilters))
+			for i, e := range stage.EmitDynamicFilters {
+				emits[i] = distributed.DynamicFilterEmit{
+					FilterID:  e.FilterID,
+					KeyColumn: e.KeyColumn,
+					KeyType:   e.KeyType,
+					BloomBits: e.BloomBits,
+				}
+			}
+			scanOp.DynamicFilterEmits = emits
+		}
+		// Probe-side: coordinator-merged stats from the upstream build-scan.
+		// dynamicFilterSpecsFromBuildStats walks ConsumeDynamicFilters and
+		// pulls the matching BuildStats out of inputs[SourceStageID].
+		if len(stage.ConsumeDynamicFilters) > 0 {
+			scanOp.DynamicFilters = dynamicFilterSpecsFromBuildStats(stage.ConsumeDynamicFilters, inputs)
+		}
 		t.Operators = append(t.Operators, scanOp)
 		if len(stage.FilterExprs) > 0 {
 			t.Operators = append(t.Operators, distributed.OpSpec{
@@ -1508,8 +1535,9 @@ func (c *Coordinator) dispatchScanFilterStage(
 	}
 	subject := distributed.QueryResultSubject(stageQueryID)
 	type taskResult struct {
-		files []string
-		err   string
+		files    []string
+		partials []distributed.DynamicFilterPartialRef
+		err      string
 	}
 	collected := make([]taskResult, 0, len(tasks))
 	var mu sync.Mutex
@@ -1527,7 +1555,10 @@ func (c *Coordinator) dispatchScanFilterStage(
 		c.workers.MarkWorkerSeen(r.WorkerID)
 		mu.Lock()
 		if r.Success {
-			collected = append(collected, taskResult{files: r.ResultFiles})
+			collected = append(collected, taskResult{
+				files:    r.ResultFiles,
+				partials: r.DynamicFilterPartials,
+			})
 		} else {
 			collected = append(collected, taskResult{err: r.Error})
 		}
@@ -1565,6 +1596,36 @@ func (c *Coordinator) dispatchScanFilterStage(
 			return StageOutput{}, fmt.Errorf("scan-filter stage %s: task failed: %s", stage.ID, r.err)
 		}
 	}
+
+	// Union per-task dynamic-filter partials into stage-level BuildStats.
+	// Skipped if the stage didn't emit (no partials expected) — saves the
+	// S3 round-trip for the common non-emit case.
+	var buildStats map[string]*BuildStats
+	if len(stage.EmitDynamicFilters) > 0 {
+		var allRefs []distributed.DynamicFilterPartialRef
+		for _, r := range results {
+			allRefs = append(allRefs, r.partials...)
+		}
+		merged, mergeErr := mergeBuildStatsFromPartials(ctx, c.catalog.Store(), allRefs)
+		if mergeErr != nil {
+			c.logger.Warn("dynamic_filter: partial merge failed; downstream consumes will see no filter",
+				"stage_id", stage.ID, "error", mergeErr)
+		}
+		// Inline-vs-stage decision per FilterID.
+		for filterID, stats := range merged {
+			if stats == nil {
+				continue
+			}
+			if estimateBuildStatsInlineSize(stats) > dynamicFilterInlineThresholdBytes {
+				if err := stageBuildStats(ctx, c.catalog.Store(), c.config.ResultBucket, queryID, stage.ID, filterID, stats); err != nil {
+					c.logger.Warn("dynamic_filter: stage upload failed; falling back to inline",
+						"stage_id", stage.ID, "filter_id", filterID, "error", err)
+				}
+			}
+		}
+		buildStats = merged
+	}
+
 	if fuseShuffle {
 		// Fused scan+shuffle: each task produced N partition files at
 		// "<prefix>partition=NNNN/<task>.wshf". Bucket all files across
@@ -1588,6 +1649,7 @@ func (c *Coordinator) dispatchScanFilterStage(
 			Kind:          OutputPartitioned,
 			NumPartitions: numParts,
 			Files:         shardFiles,
+			BuildStats:    buildStats,
 		}, nil
 	}
 	files := make([][]string, len(tasks))
@@ -1598,6 +1660,7 @@ func (c *Coordinator) dispatchScanFilterStage(
 		Kind:          OutputPartitioned,
 		NumPartitions: len(tasks),
 		Files:         files,
+		BuildStats:    buildStats,
 	}, nil
 }
 

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -742,7 +742,10 @@ func (c *Coordinator) dispatchShuffleStage(
 	if numParts == 0 {
 		numParts = workerCount * shufflePartitionMultiplier
 	}
-	shards, err := c.runShuffleSide(ctx, queryID, "stage-"+stage.ID, synthetic, stage.Exchange.Keys, numParts, workerCount)
+	// Forward any dynamic-filter specs the upstream (probe-side) leaf scan
+	// resolved through pass-through. Each shuffle task gets a copy so its
+	// parquet scan applies the bloom at row-group level.
+	shards, err := c.runShuffleSide(ctx, queryID, "stage-"+stage.ID, synthetic, stage.Exchange.Keys, numParts, workerCount, upstream.DynamicFilters)
 	if err != nil {
 		return StageOutput{}, err
 	}
@@ -987,7 +990,14 @@ func (c *Coordinator) dispatchPipelineStage(
 ) (StageOutput, error) {
 	_ = sql
 	// Leaf scan stage.
-	if stage.Type == physical.StageScan && len(inputs) == 0 {
+	//
+	// The `inputs` map may be non-empty when a stat-dep edge is present
+	// (probe-side leaf with ConsumeDynamicFilters depends on a build-side
+	// leaf). Stat-dep deps don't change the leaf-ness of the scan; they
+	// only provide upstream BuildStats. ScanFiles is the structural marker:
+	// any stage with ScanFiles populated IS a leaf scan regardless of how
+	// many soft deps it has.
+	if stage.Type == physical.StageScan && len(stage.ScanFiles) > 0 {
 		// Fused scan-aggregate: the planner marked this scan to produce
 		// partial aggregates (saves the scan→aggregate round-trip in the
 		// legacy single-pipeline executor). Under native-DAG we must
@@ -1034,18 +1044,28 @@ func (c *Coordinator) dispatchPipelineStage(
 				return c.dispatchScanFilterStage(ctx, queryID, stage, inputs, workerCount)
 			}
 		}
-		// Dynamic-filter participation: emitting or consuming scans must
-		// dispatch real tasks (the emit op runs in the fragment pipeline,
-		// and the bloom is applied at the scan's row-group iterator) — the
-		// pass-through fast path can't carry either side of the flow.
-		if len(stage.EmitDynamicFilters) > 0 || len(stage.ConsumeDynamicFilters) > 0 {
+		// Build-side dynamic-filter emit must dispatch real tasks so the
+		// emit op runs in the fragment pipeline and uploads its partial.
+		// Consume-only (probe-side) stays as pass-through — the downstream
+		// shuffle dispatcher threads the materialized DynamicFilters into
+		// its shuffle tasks, which apply them at the row-group iterator
+		// during their parquet scan. This avoids an extra dispatched scan-
+		// filter hop that regressed Q18 SF1 +16% in the first wiring.
+		if len(stage.EmitDynamicFilters) > 0 {
 			return c.dispatchScanFilterStage(ctx, queryID, stage, inputs, workerCount)
 		}
 		files := append([]string(nil), stage.ScanFiles...)
-		return StageOutput{
+		out := StageOutput{
 			Kind:  OutputSinglePart,
 			Files: [][]string{files},
-		}, nil
+		}
+		// Materialize Consume specs into wire form so downstream shuffle/
+		// stage dispatchers can ship them in their task descriptors
+		// without having to re-walk the plan.
+		if len(stage.ConsumeDynamicFilters) > 0 {
+			out.DynamicFilters = dynamicFilterSpecsFromBuildStats(stage.ConsumeDynamicFilters, inputs)
+		}
+		return out, nil
 	}
 	// Compute stage: emit workerCount TaskTypeStage tasks, each reading its
 	// slice of partitioned input and writing unpartitioned .wshf output.

--- a/internal/coordinator/orchestrate_repartition.go
+++ b/internal/coordinator/orchestrate_repartition.go
@@ -97,7 +97,7 @@ func (c *Coordinator) orchestrateRepartition(
 	g, gctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		shards, err := c.runShuffleSide(gctx, queryID, "build", buildStage, cand.BuildKeys, numParts, workerCount)
+		shards, err := c.runShuffleSide(gctx, queryID, "build", buildStage, cand.BuildKeys, numParts, workerCount, nil)
 		if err != nil {
 			return fmt.Errorf("build-side shuffle for %s: %w", cand.BuildAlias, err)
 		}
@@ -106,7 +106,7 @@ func (c *Coordinator) orchestrateRepartition(
 	})
 
 	g.Go(func() error {
-		shards, err := c.runShuffleSide(gctx, queryID, "probe", probeStage, cand.ProbeKeys, numParts, workerCount)
+		shards, err := c.runShuffleSide(gctx, queryID, "probe", probeStage, cand.ProbeKeys, numParts, workerCount, nil)
 		if err != nil {
 			return fmt.Errorf("probe-side shuffle for %s: %w", cand.ProbeAlias, err)
 		}
@@ -144,6 +144,7 @@ func (c *Coordinator) runShuffleSide(
 	keys []string,
 	numParts int,
 	workerCount int,
+	dynamicFilters []distributed.DynamicFilterSpec, // resolved bloom/range pushdowns from upstream build stat
 ) ([][]string, error) {
 	ctx, cancel := context.WithTimeout(ctx, shuffleStageTimeout)
 	defer cancel()
@@ -246,6 +247,7 @@ func (c *Coordinator) runShuffleSide(
 			ResultBucket: c.config.ResultBucket,
 			ResultPrefix: resultPrefix,
 			CreatedAt:    time.Now(),
+			DynamicFilters: dynamicFilters,
 		}
 		if clusterID := c.catalog.ClusterID(); clusterID != "" {
 			t.ClusterID = clusterID

--- a/internal/coordinator/q07_sf10_repro_test.go
+++ b/internal/coordinator/q07_sf10_repro_test.go
@@ -1,0 +1,35 @@
+package coordinator
+
+import (
+	"testing"
+
+	"github.com/citc-tech/wadjet/benchmarks/tpch"
+)
+
+// TestQ07SF01InProcess attempts to reproduce the EC2 SF10 stall on
+// final_aggregate-14 in-process at SF0.1 distributed (3 in-process workers
+// + embedded NATS + MemStore). The deployed log showed final_aggregate-14
+// was dispatched via gRPC but never reported task_progress — 13+ min
+// silent hang. If this test reproduces, we have a fast local repro to
+// bisect against; if it passes, the bug is SF10-scale / data-plane-gRPC /
+// real-S3 specific.
+func TestQ07SF01InProcess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in-process Q07 SF0.1 (heavy: ~600K lineitem rows)")
+	}
+	ctx, coord := setupTPCHDistributedAtScale(t, tpch.SF01)
+	q07 := tpch.TPCHQueries[7]
+
+	res, err := coord.ExecuteSQL(ctx, q07.SQL)
+	if err != nil {
+		t.Fatalf("Q07 ExecuteSQL: %v", err)
+	}
+	if res.Error != "" {
+		t.Fatalf("Q07 error: %s", res.Error)
+	}
+	rows := res.Rows()
+	t.Logf("Q07 in-process distributed SF0.1: %d rows", len(rows))
+	if len(rows) == 0 {
+		t.Errorf("Q07 returned 0 rows; expected at least one (FRANCE/GERMANY pairs by year)")
+	}
+}

--- a/internal/coordinator/q07_sf10_repro_test.go
+++ b/internal/coordinator/q07_sf10_repro_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 package coordinator
 
 import (

--- a/internal/coordinator/stage_output.go
+++ b/internal/coordinator/stage_output.go
@@ -3,6 +3,7 @@ package coordinator
 import (
 	"fmt"
 
+	"github.com/citc-tech/wadjet/internal/distributed"
 	"github.com/citc-tech/wadjet/internal/planner/physical"
 )
 
@@ -35,6 +36,13 @@ type StageOutput struct {
 	// non-empty. One entry per emit, keyed by FilterID. Downstream consumer
 	// stages reach in via the stat-dep edge to pull the materialized stats.
 	BuildStats map[string]*BuildStats
+
+	// DynamicFilters, populated when this stage's Stage.ConsumeDynamicFilters
+	// resolved against an upstream build-scan's BuildStats. Downstream
+	// dispatchers (shuffle, compute) thread these into their task
+	// descriptors so workers apply the bloom at scan time. Carries forward
+	// across pass-through leaf scans that don't dispatch tasks themselves.
+	DynamicFilters []distributed.DynamicFilterSpec
 }
 
 // BuildStats is the coordinator-merged dynamic-filter artifact for one

--- a/internal/coordinator/stage_output.go
+++ b/internal/coordinator/stage_output.go
@@ -30,6 +30,28 @@ type StageOutput struct {
 	Kind          OutputKind
 	NumPartitions int        // valid when Kind == OutputPartitioned
 	Files         [][]string // Partitioned: Files[p]; Replicated/SinglePart: Files[0]
+
+	// BuildStats, populated when this stage's Stage.EmitDynamicFilters was
+	// non-empty. One entry per emit, keyed by FilterID. Downstream consumer
+	// stages reach in via the stat-dep edge to pull the materialized stats.
+	BuildStats map[string]*BuildStats
+}
+
+// BuildStats is the coordinator-merged dynamic-filter artifact for one
+// FilterID across all build-scan tasks of one stage. Computed by
+// mergeBuildStatsFromPartials after the build-scan stage completes.
+type BuildStats struct {
+	FilterID  string
+	KeyType   string
+	HasRange  bool
+	Min, Max  int64
+	RowCount  int64
+	Bloom     []uint64
+	BloomMask uint64
+	// StagedBucket/Key set when the unioned bloom exceeded the inline
+	// threshold and was uploaded; Bloom is nil in that case.
+	StagedBucket string
+	StagedKey    string
 }
 
 // collectInputs translates a stage's Dependencies into a map keyed by the

--- a/internal/distributed/dynamic_filter.go
+++ b/internal/distributed/dynamic_filter.go
@@ -1,0 +1,69 @@
+package distributed
+
+// Dynamic filter (Trino-style semi-join pushdown) wire types.
+//
+// Flow: the planner identifies eligible joins (selective build, large probe
+// over an integer key) and annotates two stages — a build-side scan with
+// DynamicFilterEmit and a probe-side scan with DynamicFilterConsume. At
+// runtime the build-scan tasks compute partial {KeyRange, Bloom} stats over
+// the join key column, upload them as sideband artifacts, and the
+// coordinator unions the partials into a single BuildStats. The unioned
+// stats are then injected into the probe-scan stage's OpSpec.DynamicFilters
+// so probe-side row groups whose stats don't intersect the bloom are skipped
+// before any S3 fetch fires.
+
+// DynamicFilterEmit, attached to a build-scan Stage, instructs each scan task
+// to compute a partial bloom + min/max range on KeyColumn (post-filter,
+// post-projection). All tasks use the same BloomBits so the coordinator
+// unions partials with a trivial bitwise OR.
+type DynamicFilterEmit struct {
+	FilterID  string `json:"filter_id"`
+	KeyColumn string `json:"key_column"`
+	KeyType   string `json:"key_type"` // "int32" | "int64" | "date" — integer types only in v1
+	BloomBits int    `json:"bloom_bits"`
+}
+
+// DynamicFilterConsume, attached to a probe-scan Stage, instructs the
+// coordinator to inject the matching BuildStats artifact into this stage's
+// scan tasks. The stat-dep edge (SourceStageID added to Dependencies)
+// guarantees the artifact is available before this stage dispatches.
+type DynamicFilterConsume struct {
+	FilterID      string `json:"filter_id"`
+	SourceStageID string `json:"source_stage_id"`
+	TargetColumn  string `json:"target_column"`
+	KeyType       string `json:"key_type"`
+}
+
+// DynamicFilterPartialRef is a per-task sideband artifact reference returned
+// in ResultNotification. Each build-scan task uploads its partial stats to
+// the indicated S3 location; the coordinator fetches all partials for a
+// FilterID and unions them.
+type DynamicFilterPartialRef struct {
+	FilterID string `json:"filter_id"`
+	Bucket   string `json:"bucket"`
+	Key      string `json:"key"`
+}
+
+// DynamicFilterSpec is the materialized stat the coordinator injects into a
+// probe-scan task's OpSpec. Bloom is carried inline when the unioned bitset
+// is small (≤ inlineThresholdBytes); otherwise BloomBucket+BloomKey point
+// to the S3-staged artifact and the worker fetches it before scan init.
+type DynamicFilterSpec struct {
+	FilterID     string `json:"filter_id"`
+	TargetColumn string `json:"target_column"`
+	KeyType      string `json:"key_type"`
+
+	HasRange bool  `json:"has_range,omitempty"`
+	Min      int64 `json:"min,omitempty"`
+	Max      int64 `json:"max,omitempty"`
+
+	// Inline bloom (small filters): non-empty Bloom + BloomMask.
+	Bloom     []uint64 `json:"bloom,omitempty"`
+	BloomMask uint64   `json:"bloom_mask,omitempty"`
+
+	// Staged bloom (large filters): non-empty BloomKey. BloomBits gives
+	// the expected uint64 word count for size validation post-fetch.
+	BloomBucket string `json:"bloom_bucket,omitempty"`
+	BloomKey    string `json:"bloom_key,omitempty"`
+	BloomWords  int    `json:"bloom_words,omitempty"`
+}

--- a/internal/distributed/dynamic_filter_codec.go
+++ b/internal/distributed/dynamic_filter_codec.go
@@ -1,0 +1,153 @@
+package distributed
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+// Dynamic-filter sideband artifact wire format. Each build-scan task uploads
+// one blob per FilterID; the coordinator unions partials, then either
+// inlines the result in OpSpec.DynamicFilters or re-stages the unioned blob.
+//
+// Layout (little-endian):
+//
+//	[4]   magic "WDF1"
+//	[1]   version (1)
+//	[1]   key_type_code (0=int32, 1=int64, 2=date)
+//	[2]   reserved
+//	[8]   row_count (int64)
+//	[8]   min (int64)
+//	[8]   max (int64)
+//	[1]   has_range
+//	[7]   reserved
+//	[8]   bloom_words (uint64)
+//	[8*N] bloom data (uint64 little-endian)
+//
+// Header is 48 bytes + 8*N for the bloom. Compact, no reflection, easy to
+// version forward (the next byte after magic is `version`).
+
+const (
+	dfMagic   = "WDF1"
+	dfVersion = 1
+
+	dfKeyTypeInt32 = 0
+	dfKeyTypeInt64 = 1
+	dfKeyTypeDate  = 2
+
+	dfHeaderSize = 48
+)
+
+// DynamicFilterArtifact is the on-wire form of one filter's stats. Used for
+// both per-task partials (sized to BloomBits, may be sparse) and the
+// coordinator-unioned final (same size, populated bits ORed across all
+// partials).
+type DynamicFilterArtifact struct {
+	FilterID  string
+	KeyType   string
+	HasRange  bool
+	Min, Max  int64
+	RowCount  int64
+	Bloom     []uint64
+	BloomMask uint64
+}
+
+func keyTypeCode(t string) (uint8, error) {
+	switch t {
+	case "int32":
+		return dfKeyTypeInt32, nil
+	case "int64":
+		return dfKeyTypeInt64, nil
+	case "date":
+		return dfKeyTypeDate, nil
+	default:
+		return 0, fmt.Errorf("dynamic-filter: unsupported key_type %q", t)
+	}
+}
+
+func keyTypeFromCode(c uint8) (string, error) {
+	switch c {
+	case dfKeyTypeInt32:
+		return "int32", nil
+	case dfKeyTypeInt64:
+		return "int64", nil
+	case dfKeyTypeDate:
+		return "date", nil
+	default:
+		return "", fmt.Errorf("dynamic-filter: unknown key_type_code %d", c)
+	}
+}
+
+// EncodeDynamicFilterArtifact writes the artifact to w in WDF1 format.
+// FilterID is NOT part of the payload — it's carried out-of-band in the
+// upload key + partial ref, so multiple filters share the same wire codec.
+func EncodeDynamicFilterArtifact(w io.Writer, a *DynamicFilterArtifact) error {
+	code, err := keyTypeCode(a.KeyType)
+	if err != nil {
+		return err
+	}
+	hdr := make([]byte, dfHeaderSize)
+	copy(hdr[0:4], dfMagic)
+	hdr[4] = dfVersion
+	hdr[5] = code
+	binary.LittleEndian.PutUint64(hdr[8:16], uint64(a.RowCount))
+	binary.LittleEndian.PutUint64(hdr[16:24], uint64(a.Min))
+	binary.LittleEndian.PutUint64(hdr[24:32], uint64(a.Max))
+	if a.HasRange {
+		hdr[32] = 1
+	}
+	binary.LittleEndian.PutUint64(hdr[40:48], uint64(len(a.Bloom)))
+	if _, err := w.Write(hdr); err != nil {
+		return err
+	}
+	buf := make([]byte, 8)
+	for _, word := range a.Bloom {
+		binary.LittleEndian.PutUint64(buf, word)
+		if _, err := w.Write(buf); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DecodeDynamicFilterArtifact reads a WDF1-format artifact from r. The
+// caller supplies the FilterID separately (see comment on Encode).
+func DecodeDynamicFilterArtifact(r io.Reader) (*DynamicFilterArtifact, error) {
+	hdr := make([]byte, dfHeaderSize)
+	if _, err := io.ReadFull(r, hdr); err != nil {
+		return nil, fmt.Errorf("dynamic-filter: read header: %w", err)
+	}
+	if string(hdr[0:4]) != dfMagic {
+		return nil, fmt.Errorf("dynamic-filter: bad magic %q (want %q)", string(hdr[0:4]), dfMagic)
+	}
+	if hdr[4] != dfVersion {
+		return nil, fmt.Errorf("dynamic-filter: unsupported version %d", hdr[4])
+	}
+	kt, err := keyTypeFromCode(hdr[5])
+	if err != nil {
+		return nil, err
+	}
+	a := &DynamicFilterArtifact{
+		KeyType:  kt,
+		RowCount: int64(binary.LittleEndian.Uint64(hdr[8:16])),
+		Min:      int64(binary.LittleEndian.Uint64(hdr[16:24])),
+		Max:      int64(binary.LittleEndian.Uint64(hdr[24:32])),
+		HasRange: hdr[32] != 0,
+	}
+	nWords := binary.LittleEndian.Uint64(hdr[40:48])
+	if nWords > 1<<25 { // 256 MiB safety cap
+		return nil, fmt.Errorf("dynamic-filter: implausibly large bloom (%d words)", nWords)
+	}
+	if nWords > 0 {
+		a.Bloom = make([]uint64, nWords)
+		buf := make([]byte, 8)
+		for i := range a.Bloom {
+			if _, err := io.ReadFull(r, buf); err != nil {
+				return nil, fmt.Errorf("dynamic-filter: read bloom[%d]: %w", i, err)
+			}
+			a.Bloom[i] = binary.LittleEndian.Uint64(buf)
+		}
+		a.BloomMask = uint64(nWords - 1)
+	}
+	return a, nil
+}

--- a/internal/distributed/dynamic_filter_codec_test.go
+++ b/internal/distributed/dynamic_filter_codec_test.go
@@ -1,0 +1,74 @@
+package distributed
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestDynamicFilterArtifactRoundTrip(t *testing.T) {
+	orig := &DynamicFilterArtifact{
+		KeyType:   "int64",
+		HasRange:  true,
+		Min:       17,
+		Max:       9999,
+		RowCount:  1234,
+		Bloom:     []uint64{0x1, 0xdeadbeef, 0xffffffffffffffff, 0x0, 0x55},
+		BloomMask: 4,
+	}
+	var buf bytes.Buffer
+	if err := EncodeDynamicFilterArtifact(&buf, orig); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	got, err := DecodeDynamicFilterArtifact(&buf)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.KeyType != orig.KeyType {
+		t.Errorf("KeyType = %q, want %q", got.KeyType, orig.KeyType)
+	}
+	if got.HasRange != orig.HasRange || got.Min != orig.Min || got.Max != orig.Max {
+		t.Errorf("range mismatch: got (%v, %d, %d), want (%v, %d, %d)",
+			got.HasRange, got.Min, got.Max, orig.HasRange, orig.Min, orig.Max)
+	}
+	if got.RowCount != orig.RowCount {
+		t.Errorf("RowCount = %d, want %d", got.RowCount, orig.RowCount)
+	}
+	if len(got.Bloom) != len(orig.Bloom) {
+		t.Fatalf("Bloom len = %d, want %d", len(got.Bloom), len(orig.Bloom))
+	}
+	for i, w := range orig.Bloom {
+		if got.Bloom[i] != w {
+			t.Errorf("Bloom[%d] = %#x, want %#x", i, got.Bloom[i], w)
+		}
+	}
+	if got.BloomMask != orig.BloomMask {
+		t.Errorf("BloomMask = %d, want %d", got.BloomMask, orig.BloomMask)
+	}
+}
+
+func TestDynamicFilterArtifactBadMagic(t *testing.T) {
+	data := make([]byte, dfHeaderSize)
+	copy(data[0:4], "ZZZZ")
+	_, err := DecodeDynamicFilterArtifact(bytes.NewReader(data))
+	if err == nil {
+		t.Fatal("expected magic mismatch error")
+	}
+}
+
+func TestDynamicFilterArtifactEmptyBloom(t *testing.T) {
+	orig := &DynamicFilterArtifact{
+		KeyType: "int32",
+		// RowCount=0, no bloom; coordinator should treat as no-op.
+	}
+	var buf bytes.Buffer
+	if err := EncodeDynamicFilterArtifact(&buf, orig); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	got, err := DecodeDynamicFilterArtifact(&buf)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.RowCount != 0 || len(got.Bloom) != 0 {
+		t.Errorf("expected empty artifact, got RowCount=%d len(Bloom)=%d", got.RowCount, len(got.Bloom))
+	}
+}

--- a/internal/distributed/messages.go
+++ b/internal/distributed/messages.go
@@ -120,6 +120,13 @@ type Task struct {
 	NumPartitions int      `json:"num_partitions,omitempty"`  // number of output partitions
 	PartitionID   int      `json:"partition_id,omitempty"`    // which partition this join task handles
 
+	// Dynamic filters carried at the top level for non-fragment task shapes
+	// (TaskTypeShuffle). Fragment tasks carry the same data in OpSpec.DynamicFilters
+	// per-op, but shuffle tasks use a flat task descriptor and apply the
+	// filter against their single implicit scan source. The worker materializes
+	// these into the cachedFileStreamSource's bloom+range pushdown.
+	DynamicFilters []DynamicFilterSpec `json:"dynamic_filters,omitempty"`
+
 	// Distributed tracing context (W3C Trace Context format)
 	TraceID  string `json:"trace_id,omitempty"`  // 32-char hex
 	SpanID   string `json:"span_id,omitempty"`   // 16-char hex parent span

--- a/internal/distributed/messages.go
+++ b/internal/distributed/messages.go
@@ -279,6 +279,16 @@ type OpSpec struct {
 	// OpSort (pipeline-breaker).
 	SortKeySpecs []SortKeySpec `json:"sort_key_specs,omitempty"` // ordered key columns
 	SortLimit    int           `json:"sort_limit,omitempty"`     // 0 = no limit; > 0 = top-N truncation after sort
+
+	// OpScan (build-side, dynamic-filter producer). Each Emit makes the scan
+	// task compute a partial bloom+range over the named column and upload it
+	// as a sideband artifact returned in ResultNotification.DynamicFilterPartials.
+	DynamicFilterEmits []DynamicFilterEmit `json:"dynamic_filter_emits,omitempty"`
+
+	// OpScan (probe-side, dynamic-filter consumer). Coordinator-materialized
+	// stats from the upstream build-scan stage. Worker wires each into the
+	// row-group pruning path before the first S3 fetch.
+	DynamicFilters []DynamicFilterSpec `json:"dynamic_filters,omitempty"`
 }
 
 // PreComputedAggregate identifies a derived aggregate whose result has
@@ -384,6 +394,11 @@ type ResultNotification struct {
 
 	// Task execution stats (populated by worker for debugging)
 	TaskStats *TaskStats `json:"task_stats,omitempty"`
+
+	// DynamicFilterPartials, populated when the originating task was a
+	// build-scan with DynamicFilterEmit set. One ref per emit. Coordinator
+	// fetches+unions before dispatching the downstream probe-scan stage.
+	DynamicFilterPartials []DynamicFilterPartialRef `json:"dynamic_filter_partials,omitempty"`
 }
 
 // TaskStats captures per-task execution metrics for debugging.

--- a/internal/engine/exec/dynamic_filter_emit.go
+++ b/internal/engine/exec/dynamic_filter_emit.go
@@ -1,0 +1,189 @@
+package exec
+
+import (
+	"context"
+	"math"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+)
+
+// DynamicFilterEmitOp is a pass-through UnaryOperator that accumulates a
+// streaming partial bloom + min/max over a single integer key column.
+// Inserted by the fragment runner at the head of a build-scan task's op
+// chain when the OpScan spec carries a DynamicFilterEmit. Partial stats are
+// drained on close via Snapshot and uploaded by the fragment runner.
+//
+// All tasks for one emit use the same bloomBits so the coordinator unions
+// partials with a trivial bitwise OR (no rehash).
+type DynamicFilterEmitOp struct {
+	filterID  string
+	keyColumn string
+	keyType   string // "int32" | "int64" | "date"
+
+	bloomBits int
+	bloom     []uint64
+	bloomMask uint64
+
+	keyIdx   int
+	resolved bool
+
+	hasRange bool
+	min, max int64
+	rowCount int64
+}
+
+// NewDynamicFilterEmitOp constructs an emit op. bloomBits must be a power
+// of two; values <64 are clamped to 64. The bitset is allocated lazily on
+// the first batch to keep the cost out of constructor paths in the planner.
+func NewDynamicFilterEmitOp(filterID, keyColumn, keyType string, bloomBits int) *DynamicFilterEmitOp {
+	if bloomBits < 64 {
+		bloomBits = 64
+	}
+	// Round up to next power of two.
+	for bloomBits&(bloomBits-1) != 0 {
+		bloomBits++
+	}
+	return &DynamicFilterEmitOp{
+		filterID:  filterID,
+		keyColumn: keyColumn,
+		keyType:   keyType,
+		bloomBits: bloomBits,
+		keyIdx:    -1,
+		min:       math.MaxInt64,
+		max:       math.MinInt64,
+	}
+}
+
+func (op *DynamicFilterEmitOp) Init(_ context.Context) error { return nil }
+
+func (op *DynamicFilterEmitOp) Execute(_ context.Context, in *batch.RecordBatch) (*batch.RecordBatch, error) {
+	if in == nil || in.ActiveLen() == 0 {
+		return in, nil
+	}
+
+	if !op.resolved {
+		op.keyIdx = in.ColumnIndex(op.keyColumn)
+		op.resolved = true
+		if op.bloom == nil {
+			nSlots := op.bloomBits / 64
+			op.bloom = make([]uint64, nSlots)
+			op.bloomMask = uint64(nSlots - 1)
+		}
+	}
+	// Column not found in this batch: pass through. The emit will produce a
+	// row_count=0 partial, which the coordinator treats as a no-op union.
+	if op.keyIdx < 0 {
+		return in, nil
+	}
+
+	col := in.Columns[op.keyIdx]
+	bloom := op.bloom
+	mask := op.bloomMask
+
+	set := func(key int64) {
+		h := bloomHashInt(key)
+		h1 := h & mask
+		h2 := (h >> 17) & mask
+		b1 := h & 63
+		b2 := (h >> 6) & 63
+		bloom[h1] |= 1 << b1
+		bloom[h2] |= 1 << b2
+		if key < op.min {
+			op.min = key
+		}
+		if key > op.max {
+			op.max = key
+		}
+		op.rowCount++
+	}
+
+	if in.Sel != nil {
+		if !col.Nulls.HasNulls() {
+			switch col.Type {
+			case batch.TypeInt32, batch.TypePort, batch.TypeProtocol, batch.TypeDate:
+				data := col.Int32Data
+				for _, idx := range in.Sel {
+					set(int64(data[idx]))
+				}
+			default:
+				data := col.Int64Data
+				for _, idx := range in.Sel {
+					set(data[idx])
+				}
+			}
+		} else {
+			for _, idx := range in.Sel {
+				if col.Nulls.IsNullFast(int(idx)) {
+					continue
+				}
+				key, ok := intKeyFromVector(col, int(idx))
+				if ok {
+					set(key)
+				}
+			}
+		}
+	} else {
+		if !col.Nulls.HasNulls() {
+			switch col.Type {
+			case batch.TypeInt32, batch.TypePort, batch.TypeProtocol, batch.TypeDate:
+				data := col.Int32Data
+				for i := 0; i < in.Len; i++ {
+					set(int64(data[i]))
+				}
+			default:
+				data := col.Int64Data
+				for i := 0; i < in.Len; i++ {
+					set(data[i])
+				}
+			}
+		} else {
+			for i := 0; i < in.Len; i++ {
+				if col.Nulls.IsNullFast(i) {
+					continue
+				}
+				key, ok := intKeyFromVector(col, i)
+				if ok {
+					set(key)
+				}
+			}
+		}
+	}
+	op.hasRange = op.hasRange || op.rowCount > 0
+	return in, nil
+}
+
+func (op *DynamicFilterEmitOp) Close() error { return nil }
+
+// DynamicFilterPartial is the in-memory representation of one task's
+// emitted partial stats, ready for serialization by the fragment runner.
+type DynamicFilterPartial struct {
+	FilterID  string
+	KeyType   string
+	KeyColumn string
+	BloomBits int
+	Bloom     []uint64
+	BloomMask uint64
+	HasRange  bool
+	Min, Max  int64
+	RowCount  int64
+}
+
+// Snapshot returns the accumulated partial. Safe to call once after the
+// pipeline has finished — caller takes ownership of the bloom slice.
+func (op *DynamicFilterEmitOp) Snapshot() DynamicFilterPartial {
+	return DynamicFilterPartial{
+		FilterID:  op.filterID,
+		KeyType:   op.keyType,
+		KeyColumn: op.keyColumn,
+		BloomBits: op.bloomBits,
+		Bloom:     op.bloom,
+		BloomMask: op.bloomMask,
+		HasRange:  op.hasRange,
+		Min:       op.min,
+		Max:       op.max,
+		RowCount:  op.rowCount,
+	}
+}
+
+// FilterID lets the runner correlate the op back to its OpSpec entry.
+func (op *DynamicFilterEmitOp) FilterID() string { return op.filterID }

--- a/internal/engine/exec/dynamic_filter_emit_test.go
+++ b/internal/engine/exec/dynamic_filter_emit_test.go
@@ -1,0 +1,143 @@
+package exec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// TestDynamicFilterEmitOpAccumulates verifies the emit op passes batches
+// through unchanged and accumulates the expected partial stats: bloom
+// contains every emitted key, min/max match the input range, RowCount is
+// the active-row total.
+func TestDynamicFilterEmitOpAccumulates(t *testing.T) {
+	op := NewDynamicFilterEmitOp("f1", "id", "int64", 1024)
+	if err := op.Init(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	schema := []parquet.Column{{Name: "id", Type: parquet.TypeInt64}}
+	keys := []int64{7, 13, 21, 42, 100, 100, 7}
+	b := batch.NewRecordBatch(schema, len(keys))
+	for i, k := range keys {
+		b.Columns[0].Int64Data[i] = k
+	}
+
+	out, err := op.Execute(context.Background(), b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != b {
+		t.Fatalf("emit op should pass batch through unchanged; got different pointer")
+	}
+	if out.ActiveLen() != len(keys) {
+		t.Fatalf("emit op changed active len: %d != %d", out.ActiveLen(), len(keys))
+	}
+
+	snap := op.Snapshot()
+	if snap.RowCount != int64(len(keys)) {
+		t.Errorf("RowCount = %d, want %d", snap.RowCount, len(keys))
+	}
+	if snap.Min != 7 || snap.Max != 100 {
+		t.Errorf("range = [%d, %d], want [7, 100]", snap.Min, snap.Max)
+	}
+	if !snap.HasRange {
+		t.Error("HasRange should be true after observing rows")
+	}
+
+	// Every emitted key must be present in the bloom (zero false negatives).
+	for _, k := range keys {
+		if !BloomContains(snap.Bloom, snap.BloomMask, BloomHashInt(k)) {
+			t.Errorf("bloom missing key %d", k)
+		}
+	}
+}
+
+// TestDynamicFilterEmitOpRespectsSelectionVector verifies that the op only
+// accumulates over selected rows when a selection vector is present
+// (downstream of a filter). The post-filter set is what the bloom should
+// reflect for dynamic-filter semantics.
+func TestDynamicFilterEmitOpRespectsSelectionVector(t *testing.T) {
+	op := NewDynamicFilterEmitOp("f1", "id", "int64", 256)
+	op.Init(context.Background())
+
+	schema := []parquet.Column{{Name: "id", Type: parquet.TypeInt64}}
+	b := batch.NewRecordBatch(schema, 6)
+	for i := 0; i < 6; i++ {
+		b.Columns[0].Int64Data[i] = int64(i * 10) // 0, 10, 20, 30, 40, 50
+	}
+	b.Sel = []uint32{1, 3, 5} // keep only 10, 30, 50
+
+	if _, err := op.Execute(context.Background(), b); err != nil {
+		t.Fatal(err)
+	}
+
+	snap := op.Snapshot()
+	if snap.RowCount != 3 {
+		t.Errorf("RowCount = %d, want 3 (selection vector ignored)", snap.RowCount)
+	}
+	if snap.Min != 10 || snap.Max != 50 {
+		t.Errorf("range = [%d, %d], want [10, 50]", snap.Min, snap.Max)
+	}
+	for _, k := range []int64{10, 30, 50} {
+		if !BloomContains(snap.Bloom, snap.BloomMask, BloomHashInt(k)) {
+			t.Errorf("bloom missing selected key %d", k)
+		}
+	}
+}
+
+// TestDynamicFilterEmitOpUnionIsBitwiseOR verifies the core architectural
+// property: two task-partials sized to the same BloomBits union to a
+// bitset that contains every key from either partial. This is what makes
+// the coordinator-side merge a trivial bitwise OR.
+func TestDynamicFilterEmitOpUnionIsBitwiseOR(t *testing.T) {
+	op1 := NewDynamicFilterEmitOp("f1", "id", "int64", 1024)
+	op2 := NewDynamicFilterEmitOp("f1", "id", "int64", 1024)
+	op1.Init(context.Background())
+	op2.Init(context.Background())
+
+	schema := []parquet.Column{{Name: "id", Type: parquet.TypeInt64}}
+	b1 := batch.NewRecordBatch(schema, 3)
+	for i, k := range []int64{1, 5, 9} {
+		b1.Columns[0].Int64Data[i] = k
+	}
+	b2 := batch.NewRecordBatch(schema, 3)
+	for i, k := range []int64{2, 6, 99} {
+		b2.Columns[0].Int64Data[i] = k
+	}
+	op1.Execute(context.Background(), b1)
+	op2.Execute(context.Background(), b2)
+
+	s1, s2 := op1.Snapshot(), op2.Snapshot()
+	if s1.BloomMask != s2.BloomMask {
+		t.Fatalf("partials must share BloomMask for union; got %d vs %d", s1.BloomMask, s2.BloomMask)
+	}
+
+	// Manual OR-union.
+	merged := make([]uint64, len(s1.Bloom))
+	for i := range merged {
+		merged[i] = s1.Bloom[i] | s2.Bloom[i]
+	}
+	mask := s1.BloomMask
+
+	for _, k := range []int64{1, 5, 9, 2, 6, 99} {
+		if !BloomContains(merged, mask, BloomHashInt(k)) {
+			t.Errorf("union missing key %d", k)
+		}
+	}
+}
+
+// TestDynamicFilterEmitOpEmptyBatchNoOp confirms passing an empty / nil
+// batch produces no row-count increment and no panic.
+func TestDynamicFilterEmitOpEmptyBatchNoOp(t *testing.T) {
+	op := NewDynamicFilterEmitOp("f1", "id", "int64", 64)
+	op.Init(context.Background())
+	if _, err := op.Execute(context.Background(), nil); err != nil {
+		t.Fatal(err)
+	}
+	if op.Snapshot().RowCount != 0 {
+		t.Error("nil batch should not change RowCount")
+	}
+}

--- a/internal/engine/scan/pushdown.go
+++ b/internal/engine/scan/pushdown.go
@@ -152,3 +152,76 @@ func toFloat64(v any) float64 {
 		return 0
 	}
 }
+
+// CanRangePruneRowGroup returns true when a row group can be skipped based
+// on dynamic min/max ranges supplied by an upstream hash-join build (or a
+// distributed dynamic filter). A row group prunes when its column range has
+// no overlap with ANY of the supplied range filters.
+//
+// Behavior matches the in-process planner's canRangePruneRowGroup
+// (planner/physical/util.go) — moved here so the worker fragment-runner
+// scan path can apply the same logic without a circular import.
+func CanRangePruneRowGroup(ranges []exec.DynamicRange, stats pqt.RowGroupStats) bool {
+	for _, r := range ranges {
+		colStats, ok := stats.Columns[r.Column]
+		if !ok || !colStats.HasStats {
+			continue
+		}
+		if colStats.MinValue == nil || colStats.MaxValue == nil {
+			continue
+		}
+		if colStats.NullCount == stats.NumRows {
+			continue
+		}
+		// No overlap: row group max < build min, or row group min > build max
+		if CompareValues(colStats.MaxValue, r.MinValue) < 0 {
+			return true
+		}
+		if CompareValues(colStats.MinValue, r.MaxValue) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// CanBloomPruneRowGroup returns true when every integer value in the row
+// group's min..max range is absent from the bloom — i.e., the row group
+// cannot contain any rows matching the build side. Only applicable for
+// single-column integer keys with a small (≤1024) value range; larger
+// ranges return false (no pruning) to keep the check O(small).
+func CanBloomPruneRowGroup(bf *exec.BloomScanFilter, stats pqt.RowGroupStats) bool {
+	if bf == nil || !bf.UseIntKey {
+		return false
+	}
+	colStats, ok := stats.Columns[bf.Column]
+	if !ok || !colStats.HasStats {
+		return false
+	}
+	if colStats.MinValue == nil || colStats.MaxValue == nil {
+		return false
+	}
+	if colStats.NullCount == stats.NumRows {
+		return false
+	}
+	minVal := toInt64(colStats.MinValue)
+	maxVal := toInt64(colStats.MaxValue)
+	if minVal == 0 && maxVal == 0 {
+		switch colStats.MinValue.(type) {
+		case int64, int32, int:
+			// Genuine zero range — fall through.
+		default:
+			return false
+		}
+	}
+	const maxRangeSize = 1024
+	rangeSize := maxVal - minVal + 1
+	if rangeSize <= 0 || rangeSize > maxRangeSize {
+		return false
+	}
+	for v := minVal; v <= maxVal; v++ {
+		if exec.BloomContains(bf.Bloom, bf.BloomMask, exec.BloomHashInt(v)) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/engine/scan/rowgroup_iter.go
+++ b/internal/engine/scan/rowgroup_iter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/engine/exec"
 	pqt "github.com/citc-tech/wadjet/internal/storage/parquet"
 )
 
@@ -46,6 +47,37 @@ type RowGroupIter struct {
 	// Empty-shard sentinel: shardIdx out of range or row-fallback shard >0
 	// returns no batches without erroring. matches ReadFileBatchesShard.
 	empty bool
+
+	// Dynamic filters consulted before reading each row group. Both are
+	// optional; a row group is skipped if EITHER prunes it. Wired by
+	// callers (e.g., distributed worker scan source) via SetDynamicFilters.
+	dynamicRanges []exec.DynamicRange
+	bloomFilters  []*exec.BloomScanFilter
+
+	// Per-iterator counters for diagnostics. Reset on each Open.
+	rgPrunedBloom int
+	rgPrunedRange int
+	rgRead        int
+}
+
+// SetDynamicFilters attaches dynamic-filter pushdowns to the iterator. Must
+// be called before the first Next(). Empty slices clear any existing
+// filters. Multiple calls overwrite prior state.
+func (it *RowGroupIter) SetDynamicFilters(ranges []exec.DynamicRange, blooms []*exec.BloomScanFilter) {
+	if it == nil {
+		return
+	}
+	it.dynamicRanges = ranges
+	it.bloomFilters = blooms
+}
+
+// PruneStats returns counters for diagnostic logging: row groups skipped
+// via bloom, via range, and actually read. Snapshot at any point.
+func (it *RowGroupIter) PruneStats() (bloom, rangeP, read int) {
+	if it == nil {
+		return 0, 0, 0
+	}
+	return it.rgPrunedBloom, it.rgPrunedRange, it.rgRead
 }
 
 // OpenRowGroupIter constructs a streaming iterator over the row-group
@@ -100,6 +132,31 @@ func (it *RowGroupIter) Next() (*batch.RecordBatch, error) {
 	for it.cur < it.end {
 		rgIdx := it.cur
 		it.cur++
+
+		// Dynamic-filter row-group pruning. Stats read is cheap (already
+		// available in file metadata); the read+decode that follows is
+		// the expensive part we're avoiding when we can prune.
+		if len(it.dynamicRanges) > 0 || len(it.bloomFilters) > 0 {
+			stats := it.fr.RowGroupStats(rgIdx)
+			pruned := false
+			if !pruned && len(it.dynamicRanges) > 0 && CanRangePruneRowGroup(it.dynamicRanges, stats) {
+				it.rgPrunedRange++
+				pruned = true
+			}
+			if !pruned && len(it.bloomFilters) > 0 {
+				for _, bf := range it.bloomFilters {
+					if CanBloomPruneRowGroup(bf, stats) {
+						it.rgPrunedBloom++
+						pruned = true
+						break
+					}
+				}
+			}
+			if pruned {
+				continue
+			}
+		}
+
 		b, err := ReadRowGroupNative(it.fr, rgIdx, it.readSchema, nil)
 		if err != nil {
 			return nil, fmt.Errorf("reading row group %d: %w", rgIdx, err)
@@ -108,6 +165,7 @@ func (it *RowGroupIter) Next() (*batch.RecordBatch, error) {
 			// Empty row group (zero rows) — skip and try the next.
 			continue
 		}
+		it.rgRead++
 		return b, nil
 	}
 	return nil, nil

--- a/internal/planner/logical/histogram_selectivity_test.go
+++ b/internal/planner/logical/histogram_selectivity_test.go
@@ -1,0 +1,65 @@
+package logical
+
+import (
+	"testing"
+)
+
+// fakeHistogram is a minimal HistogramStats implementation for testing.
+type fakeHistogram struct {
+	le map[int64]float64 // pre-canned SelectivityLE values
+	eq map[int64]float64
+}
+
+func (f *fakeHistogram) SelectivityLE(v any) float64 {
+	k, ok := v.(int64)
+	if !ok {
+		return 0
+	}
+	return f.le[k]
+}
+func (f *fakeHistogram) SelectivityLT(v any) float64 { return f.SelectivityLE(v) }
+func (f *fakeHistogram) SelectivityRange(lo, hi any) float64 {
+	return f.SelectivityLE(hi) - f.SelectivityLE(lo)
+}
+func (f *fakeHistogram) SelectivityEQ(v any) float64 {
+	k, ok := v.(int64)
+	if !ok {
+		return 0
+	}
+	return f.eq[k]
+}
+
+func TestHistogramSelectivityEngages(t *testing.T) {
+	colHist := map[string]any{
+		"x": &fakeHistogram{
+			le: map[int64]float64{100: 0.286, 50: 0.143},
+			eq: map[int64]float64{42: 0.001},
+		},
+	}
+	cases := []struct {
+		name string
+		pred Predicate
+		want float64
+	}{
+		{"<= 100 (histogram says 0.286)", Predicate{Column: "x", Op: "<=", Value: int64(100)}, 0.286},
+		{"> 100 (1 - 0.286)", Predicate{Column: "x", Op: ">", Value: int64(100)}, 0.714},
+		{"= 42 (histogram says 0.001)", Predicate{Column: "x", Op: "=", Value: int64(42)}, 0.001},
+		{"unknown col falls back to heuristic", Predicate{Column: "y", Op: "<=", Value: int64(100)}, 0.33},
+		{"no histogram for non-matching col", Predicate{Column: "z", Op: "=", Value: int64(7)}, 0.1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := estimatePredSelectivityWithHist([]Predicate{c.pred}, colHist)
+			if abs64(got-c.want) > 0.01 {
+				t.Errorf("got %.4f want %.4f", got, c.want)
+			}
+		})
+	}
+}
+
+func abs64(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/internal/planner/logical/optimizer.go
+++ b/internal/planner/logical/optimizer.go
@@ -31,6 +31,7 @@ func Optimize(plan *Node, annotators ...func(*Node)) *Node {
 	plan = decorrelateScalarSubqueries(plan)
 	plan = extractCommonORPredicates(plan)
 	plan = pushdownPredicates(plan)
+	plan = dedupSemiAntiBuildSide(plan)
 	plan = reorderJoins(plan)
 	plan = extractPartitionFilters(plan)
 	plan = pruneProjections(plan)

--- a/internal/planner/logical/optimizer.go
+++ b/internal/planner/logical/optimizer.go
@@ -2920,6 +2920,27 @@ func dpJoinReorder(rels []*Node, edges []joinEdge) *Node {
 		}
 	}
 
+	// Bushy join enumeration is DEFERRED.
+	//
+	// A bushy DP pass (enumerating non-trivial subset partitions) was
+	// prototyped here. With Selinger's floor at max(L,R), bushy didn't
+	// change costs on FK→PK shapes — but it changed PLAN STRUCTURES,
+	// and the physical planner's column-resolution pipeline
+	// (parseJoinKeys + fixJoinKeyOrder + scan-alias propagation) has
+	// implicit assumptions about left-deep nesting that bushy plans
+	// violate. Result: Q02/Q07/Q08/Q09/Q21 returned wrong rows at
+	// SF0.01 even with same-cost bushy alternatives selected.
+	//
+	// Doing bushy properly requires:
+	//   - A column-resolution pass that handles arbitrary Join
+	//     subtrees on both sides without leaking unqualified names
+	//   - Self-join column qualification that's structure-independent
+	//   - Stronger physical-plan invariants captured as snapshot tests
+	//
+	// All multi-day work. Left as Phase 4. Current DP gives optimal
+	// left-deep plans; with HLL+histogram inputs that's already a
+	// substantial improvement over the rule-based predecessor.
+
 	fullMask := maxMask - 1
 	if math.IsInf(dp[fullMask].cost, 1) {
 		// Disconnected graph — fall back to greedy
@@ -2928,6 +2949,7 @@ func dpJoinReorder(rels []*Node, edges []joinEdge) *Node {
 
 	return dp[fullMask].plan
 }
+
 
 // hasSelectiveFilter checks whether a relation subtree contains a filter
 // (NodeFilter or scan predicates) that reduces its output. Filtered relations

--- a/internal/planner/logical/plan.go
+++ b/internal/planner/logical/plan.go
@@ -13,6 +13,13 @@ type ScanColumnStats struct {
 	MaxValue  any
 	NullCount int64
 	TotalRows int64
+	// NDV is the catalog's merged HyperLogLog estimate of distinct values
+	// across all files of this column. Zero means HLL wasn't collected
+	// (legacy files / pre-ANALYZE state); planner falls back to the
+	// min/max-range heuristic. When >0 it's preferred — orders of
+	// magnitude more accurate for sparse-int / string columns where the
+	// range overstates true cardinality.
+	NDV int64
 }
 
 // NodeType identifies the kind of logical plan node.

--- a/internal/planner/logical/plan.go
+++ b/internal/planner/logical/plan.go
@@ -20,6 +20,14 @@ type ScanColumnStats struct {
 	// magnitude more accurate for sparse-int / string columns where the
 	// range overstates true cardinality.
 	NDV int64
+	// Histogram is the catalog's equi-depth histogram for this column,
+	// merged across files from reservoir samples. Nil when not collected.
+	// Used by estimatePredSelectivity to compute range/equality
+	// selectivity from real value distributions instead of hardcoded
+	// fractions (0.33 for <, 0.1 for =). The opaque any allows the
+	// logical package to receive *catalog.Histogram without importing
+	// the catalog package (avoids circular import).
+	Histogram any
 }
 
 // NodeType identifies the kind of logical plan node.

--- a/internal/planner/logical/semi_anti_dedup.go
+++ b/internal/planner/logical/semi_anti_dedup.go
@@ -1,0 +1,149 @@
+package logical
+
+import "strings"
+
+// dedupSemiAntiBuildSide wraps the build side (right child) of every SEMI
+// or ANTI join in a GroupBy on the join keys, so the hash-join build phase
+// constructs a hash table sized to NDV rather than raw row count.
+//
+// Motivation: for Q04 (orders ⨝SEMI lineitem on l_orderkey) and Q21
+// (lineitem self-joins on l_orderkey), the build side is a fact table
+// (30M-60M rows) whose join key has much lower cardinality (~15M
+// orderkeys). Without dedup the build hashtable holds 2-4× the entries
+// it needs, the dynamic-filter eligibility check rejects it as too big
+// (Q04/Q21 SF10 A/B audit, 2026-05-25), and the probe is slowed by
+// duplicate-key probe collisions for the same orderkey.
+//
+// Semantics: SEMI / ANTI joins return a subset of LEFT rows based on
+// existence in the RIGHT side. Whether RIGHT has duplicates is
+// irrelevant to the result — only the SET of right keys matters. So
+// wrapping RIGHT in GroupBy(rightKeys) is a semantics-preserving
+// rewrite that bounds build cardinality by NDV.
+//
+// This pass runs after pushdownPredicates (so filters land on the inner
+// scan before dedup) and before reorderJoins (so the dedup'd subtree's
+// cost estimate flows through the join reorderer).
+func dedupSemiAntiBuildSide(n *Node) *Node {
+	if n == nil {
+		return nil
+	}
+	// Recurse first so inner joins are handled before their parents.
+	for i, child := range n.Children {
+		n.Children[i] = dedupSemiAntiBuildSide(child)
+	}
+	if n.Type != NodeJoin {
+		return n
+	}
+	switch n.JoinType {
+	case "semi", "anti":
+	default:
+		return n
+	}
+	if len(n.Children) < 2 {
+		return n
+	}
+	right := n.Children[1]
+	rightKeys := extractRightJoinKeys(n.JoinCond, right)
+	if len(rightKeys) == 0 {
+		// Non-equi semi/anti, or couldn't identify which side of each
+		// equality belongs to the right child. Can't safely dedup.
+		return n
+	}
+	// Skip if already aggregated / distinct on a superset of the right keys.
+	if alreadyDedupOnKeys(right, rightKeys) {
+		return n
+	}
+	// Wrap right in a Project(rightKeys) → Distinct chain. We need a Project
+	// first to narrow the schema to just the join keys (so the Distinct
+	// dedupes on those columns specifically, not on every input column).
+	// Then Distinct produces one row per distinct key tuple.
+	projections := make([]Projection, len(rightKeys))
+	for i, k := range rightKeys {
+		projections[i] = Projection{Column: k, Alias: stripQualifier(k)}
+	}
+	proj := NewProject(right, projections)
+	dedup := NewDistinct(proj)
+	n.Children[1] = dedup
+	return n
+}
+
+// extractRightJoinKeys parses a join condition like "a.k = b.k AND a.k2 = b.k2"
+// and returns the keys belonging to the right subtree. Side membership is
+// decided by walking the right subtree's available columns; whichever side
+// of each equality resolves there is the right key.
+func extractRightJoinKeys(cond string, rightSubtree *Node) []string {
+	if cond == "" || rightSubtree == nil {
+		return nil
+	}
+	rightCols := collectSubtreeColumns(rightSubtree)
+	if len(rightCols) == 0 {
+		return nil
+	}
+	var keys []string
+	for _, part := range strings.Split(cond, " and ") {
+		part = strings.TrimSpace(part)
+		eq := strings.SplitN(part, "=", 2)
+		if len(eq) != 2 {
+			continue
+		}
+		l := strings.TrimSpace(eq[0])
+		r := strings.TrimSpace(eq[1])
+		lStripped := strings.ToLower(stripQualifier(l))
+		rStripped := strings.ToLower(stripQualifier(r))
+		// Check which side is in the right subtree (lowercase match).
+		lInRight := containsColumn(rightCols, lStripped)
+		rInRight := containsColumn(rightCols, rStripped)
+		switch {
+		case rInRight && !lInRight:
+			keys = append(keys, r)
+		case lInRight && !rInRight:
+			keys = append(keys, l)
+		default:
+			// Ambiguous or neither resolved — bail on this equality.
+			// Conservative: don't dedup if we can't be sure.
+			return nil
+		}
+	}
+	return keys
+}
+
+// containsColumn looks up a (lowercase, unqualified) column name in the
+// subtree-columns map produced by collectSubtreeColumns. The map's keys
+// are mixed-case so we lowercase both sides for comparison.
+func containsColumn(cols map[string]bool, lcName string) bool {
+	for k := range cols {
+		if strings.EqualFold(k, lcName) {
+			return true
+		}
+	}
+	return false
+}
+
+// alreadyDedupOnKeys reports whether the subtree's root already
+// guarantees distinct values on the given key set. Conservative: only
+// recognizes a top-level Aggregate whose GroupBy is a superset of keys,
+// or a top-level Distinct. Misses transitive guarantees (e.g. a PRIMARY
+// KEY scan); that's fine — false negatives just mean an idempotent
+// extra dedup wrap, no semantic issue.
+func alreadyDedupOnKeys(n *Node, keys []string) bool {
+	if n == nil {
+		return false
+	}
+	switch n.Type {
+	case NodeAggregate:
+		need := make(map[string]bool, len(keys))
+		for _, k := range keys {
+			need[stripQualifier(k)] = true
+		}
+		for _, g := range n.GroupBy {
+			delete(need, stripQualifier(g))
+		}
+		return len(need) == 0
+	case NodeDistinct:
+		// Distinct on all output columns — includes the keys by construction
+		// (caller projected to keys upstream). Conservative: only recognize
+		// when the immediate child output matches keys.
+		return true
+	}
+	return false
+}

--- a/internal/planner/logical/stats.go
+++ b/internal/planner/logical/stats.go
@@ -260,6 +260,27 @@ func histPredSelectivity(p Predicate, colHist map[string]any) float64 {
 		return clamp01(1 - h.SelectivityLE(p.Value))
 	case ">=", "ge":
 		return clamp01(1 - h.SelectivityLT(p.Value))
+	case "in":
+		// Sum of per-value EQ selectivities, capped at 1.0. Works when
+		// Value is a slice; otherwise fall back.
+		switch vs := p.Value.(type) {
+		case []any:
+			var s float64
+			for _, v := range vs {
+				s += h.SelectivityEQ(v)
+			}
+			return clamp01(s)
+		}
+		return -1
+	case "between":
+		// Value is typically a 2-tuple of (lo, hi). Fall back if not.
+		switch vs := p.Value.(type) {
+		case []any:
+			if len(vs) == 2 {
+				return clamp01(h.SelectivityRange(vs[0], vs[1]))
+			}
+		}
+		return -1
 	}
 	return -1
 }

--- a/internal/planner/logical/stats.go
+++ b/internal/planner/logical/stats.go
@@ -321,35 +321,6 @@ func singlePredSelectivity(p Predicate) float64 {
 	}
 }
 
-// estimatePredSelectivity estimates combined selectivity of predicates.
-func estimatePredSelectivity(preds []Predicate) float64 {
-	sel := 1.0
-	for _, p := range preds {
-		switch strings.ToLower(p.Op) {
-		case "=", "eq":
-			sel *= 0.1
-		case "<", "<=", ">", ">=", "lt", "le", "gt", "ge":
-			sel *= 0.33
-		case "!=", "<>", "ne":
-			sel *= 0.9
-		case "is_null":
-			sel *= 0.05
-		case "is_not_null":
-			sel *= 0.95
-		case "in":
-			sel *= 0.25
-		case "between":
-			sel *= 0.25
-		case "like":
-			sel *= 0.1
-		default:
-			// Raw expression predicates (most common path)
-			sel *= 0.33
-		}
-	}
-	return math.Max(sel, 0.0001)
-}
-
 // estimateJoinStats estimates the output statistics of a join.
 func estimateJoinStats(left, right RelStats, joinCond, joinType string) RelStats {
 	leftNDV, rightNDV := resolveJoinKeyNDVs(joinCond, left, right)

--- a/internal/planner/logical/stats.go
+++ b/internal/planner/logical/stats.go
@@ -9,6 +9,11 @@ import (
 type RelStats struct {
 	Rows   float64
 	ColNDV map[string]float64 // lowercase unqualified column name → estimated NDV
+	// ColHist carries opaque histogram pointers (*catalog.Histogram) for
+	// columns that have one in the catalog. Used by estimatePredSelectivity
+	// to compute range/equality selectivity from real data distributions.
+	// Stored as any to keep the logical package free of catalog imports.
+	ColHist map[string]any
 }
 
 // estimateSubtreeStats estimates cardinality and per-column NDV for a plan subtree.
@@ -23,9 +28,9 @@ func estimateSubtreeStats(n *Node) RelStats {
 
 	case NodeFilter:
 		child := estimateSubtreeStats(n.Children[0])
-		sel := estimatePredSelectivity(n.Predicates)
+		sel := estimatePredSelectivityWithHist(n.Predicates, child.ColHist)
 		rows := math.Max(1, child.Rows*sel)
-		return RelStats{Rows: rows, ColNDV: scaleNDVs(child.ColNDV, rows)}
+		return RelStats{Rows: rows, ColNDV: scaleNDVs(child.ColNDV, rows), ColHist: child.ColHist}
 
 	case NodeAggregate:
 		child := estimateSubtreeStats(n.Children[0])
@@ -102,16 +107,22 @@ func estimateScanStats(n *Node) RelStats {
 	rows *= math.Max(scanSel, 0.0001)
 
 	ndv := make(map[string]float64, len(n.ScanColumns))
+	hist := make(map[string]any, len(n.ScanColumns))
 	for _, col := range n.ScanColumns {
 		lc := strings.ToLower(col)
 		if cs, ok := n.ScanColStats[lc]; ok && cs.MinValue != nil && cs.MaxValue != nil {
 			ndv[lc] = estimateNDVFromStats(cs, rows)
+		} else if cs, ok := n.ScanColStats[lc]; ok && cs.NDV > 0 {
+			ndv[lc] = math.Min(float64(cs.NDV), rows)
 		} else {
 			ndv[lc] = estimateColumnNDV(col, rows)
 		}
+		if cs, ok := n.ScanColStats[lc]; ok && cs.Histogram != nil {
+			hist[lc] = cs.Histogram
+		}
 	}
 
-	return RelStats{Rows: math.Max(1, rows), ColNDV: ndv}
+	return RelStats{Rows: math.Max(1, rows), ColNDV: ndv, ColHist: hist}
 }
 
 // estimateNDVFromStats estimates distinct values using catalog statistics.
@@ -194,6 +205,99 @@ func estimateColumnNDV(colName string, tableRows float64) float64 {
 
 	// Default: moderate cardinality
 	return math.Min(tableRows, math.Max(10, math.Sqrt(tableRows)*10))
+}
+
+// estimatePredSelectivityWithHist computes combined selectivity, using
+// per-column histograms (when present) for range and equality
+// predicates. Falls back to estimatePredSelectivity's hardcoded
+// fractions when no histogram exists for the predicate's column.
+//
+// The histograms come from RelStats.ColHist, which the Scan case in
+// estimateSubtreeStats populates from the catalog's TableColumnStats.
+// They're opaque (any) at this layer to avoid a logical→catalog
+// import; callers cast via the histogramSelector indirection.
+func estimatePredSelectivityWithHist(preds []Predicate, colHist map[string]any) float64 {
+	sel := 1.0
+	for _, p := range preds {
+		s := histPredSelectivity(p, colHist)
+		if s < 0 {
+			s = singlePredSelectivity(p)
+		}
+		sel *= s
+	}
+	return math.Max(sel, 0.0001)
+}
+
+// HistogramStats is the interface a per-column histogram must implement
+// to participate in selectivity estimation. catalog.Histogram satisfies
+// it. Kept as an interface so the logical package stays free of a
+// catalog dependency.
+type HistogramStats interface {
+	SelectivityLE(v any) float64
+	SelectivityLT(v any) float64
+	SelectivityRange(lo, hi any) float64
+	SelectivityEQ(v any) float64
+}
+
+// histPredSelectivity returns the histogram-driven selectivity for a
+// single predicate, or -1 if no usable histogram or unsupported op.
+func histPredSelectivity(p Predicate, colHist map[string]any) float64 {
+	if colHist == nil || p.Column == "" || p.Value == nil {
+		return -1
+	}
+	h, ok := colHist[strings.ToLower(p.Column)].(HistogramStats)
+	if !ok || h == nil {
+		return -1
+	}
+	switch strings.ToLower(p.Op) {
+	case "=", "eq":
+		return clamp01(h.SelectivityEQ(p.Value))
+	case "<", "lt":
+		return clamp01(h.SelectivityLT(p.Value))
+	case "<=", "le":
+		return clamp01(h.SelectivityLE(p.Value))
+	case ">", "gt":
+		return clamp01(1 - h.SelectivityLE(p.Value))
+	case ">=", "ge":
+		return clamp01(1 - h.SelectivityLT(p.Value))
+	}
+	return -1
+}
+
+func clamp01(x float64) float64 {
+	if x < 0 {
+		return 0
+	}
+	if x > 1 {
+		return 1
+	}
+	return x
+}
+
+// singlePredSelectivity is the per-predicate fallback when no
+// histogram is available — same hardcoded fractions as the original
+// estimatePredSelectivity.
+func singlePredSelectivity(p Predicate) float64 {
+	switch strings.ToLower(p.Op) {
+	case "=", "eq":
+		return 0.1
+	case "<", "<=", ">", ">=", "lt", "le", "gt", "ge":
+		return 0.33
+	case "!=", "<>", "ne":
+		return 0.9
+	case "is_null":
+		return 0.05
+	case "is_not_null":
+		return 0.95
+	case "in":
+		return 0.25
+	case "between":
+		return 0.25
+	case "like":
+		return 0.1
+	default:
+		return 0.33
+	}
 }
 
 // estimatePredSelectivity estimates combined selectivity of predicates.

--- a/internal/planner/logical/stats.go
+++ b/internal/planner/logical/stats.go
@@ -114,10 +114,18 @@ func estimateScanStats(n *Node) RelStats {
 	return RelStats{Rows: math.Max(1, rows), ColNDV: ndv}
 }
 
-// estimateNDVFromStats estimates distinct values using actual min/max stats.
-// For numeric types, uses (max-min+1) capped at row count.
-// For strings, falls back to a fraction of rows.
+// estimateNDVFromStats estimates distinct values using catalog statistics.
+//
+// Preference order:
+//  1. Catalog HLL NDV when populated (CBO Phase 2). Ground-truth-derived,
+//     ~1% standard error. Computed at ingest time or by ANALYZE TABLE.
+//  2. min/max range for numeric types (max-min+1, capped at row count).
+//     Overstates for sparse keys but cheap to compute.
+//  3. String / non-numeric: moderate-cardinality heuristic.
 func estimateNDVFromStats(cs ScanColumnStats, tableRows float64) float64 {
+	if cs.NDV > 0 {
+		return math.Min(float64(cs.NDV), tableRows)
+	}
 	minF, minOk := toFloat(cs.MinValue)
 	maxF, maxOk := toFloat(cs.MaxValue)
 	if minOk && maxOk {

--- a/internal/planner/logical/stats.go
+++ b/internal/planner/logical/stats.go
@@ -5,6 +5,15 @@ import (
 	"strings"
 )
 
+// RelStatsOf returns CBO-derived statistics for the given subtree.
+// Exported so the physical planner can consult cardinality-driven
+// estimates when making structural decisions (broadcast vs shuffle,
+// dynamic-filter eligibility, etc.) without re-implementing the
+// recursion.
+func RelStatsOf(n *Node) RelStats {
+	return estimateSubtreeStats(n)
+}
+
 // RelStats holds estimated statistics for a plan subtree.
 type RelStats struct {
 	Rows   float64

--- a/internal/planner/logical/stats.go
+++ b/internal/planner/logical/stats.go
@@ -368,16 +368,40 @@ func estimateJoinStats(left, right RelStats, joinCond, joinType string) RelStats
 }
 
 // estimateJoinCard estimates the output cardinality of a join.
-// For inner equi-joins, uses the FK-PK assumption: output ≈ max(left, right).
-// This is robust for analytics workloads without column-level statistics.
+//
+// For inner equi-joins, the cardinality lies between max(leftRows,
+// rightRows) (the FK→PK natural ceiling) and leftRows*rightRows/maxNDV
+// (the genuine many-to-many product). We pick the larger of the two:
+// the Selinger formula bites only when both sides have NDV materially
+// smaller than their row counts (many-to-many on a shared key); in the
+// far more common FK→PK shape it reduces to max(L,R).
+//
+// Why not always Selinger? When NDV comes from a heuristic (the
+// _key-suffix shortcut returns tableRows, overstating NDV), the
+// Selinger formula collapses output below max(L,R), incorrectly
+// "shrinking" FK→PK joins. The floor at max(L,R) keeps the formula
+// well-behaved under both heuristic and HLL-derived NDVs.
 func estimateJoinCard(leftRows, rightRows, leftNDV, rightNDV float64, joinType string) float64 {
 	jt := strings.ToLower(joinType)
 
 	switch {
 	case jt == "" || jt == "join" || jt == "inner" || jt == "inner join":
-		// FK-PK assumption: the join doesn't reduce the larger side.
-		// This is correct for dimension→fact joins (most analytical joins).
-		return math.Max(leftRows, rightRows)
+		ceiling := math.Max(leftRows, rightRows)
+		// Sanity-bound NDVs to row counts (HLL can overshoot near
+		// precision limit; heuristics may exceed).
+		ndvL := math.Min(leftNDV, leftRows)
+		ndvR := math.Min(rightNDV, rightRows)
+		maxNDV := math.Max(ndvL, ndvR)
+		if maxNDV < 1 {
+			return ceiling
+		}
+		selinger := leftRows * rightRows / maxNDV
+		if selinger > ceiling {
+			// Genuine many-to-many: both NDVs are small relative to
+			// their row counts, so each match multiplies output.
+			return selinger
+		}
+		return ceiling
 
 	case strings.HasPrefix(jt, "left"):
 		return leftRows // left join preserves all left rows

--- a/internal/planner/physical/cbo_validation_test.go
+++ b/internal/planner/physical/cbo_validation_test.go
@@ -1,0 +1,74 @@
+package physical
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/citc-tech/wadjet/benchmarks/tpch"
+	"github.com/citc-tech/wadjet/internal/planner/logical"
+	plansql "github.com/citc-tech/wadjet/internal/planner/sql"
+)
+
+// TestCBOEndToEnd validates that the CBO pipeline (HLL + histograms +
+// Selinger) is producing distribution-driven cardinality estimates on
+// real TPC-H queries.
+//
+// The test loads the SF10-shaped catalog (manifests with file/row
+// counts), runs the logical optimizer + cardinality estimator on
+// each query, and confirms:
+//   - Filter selectivities differ from the old hardcoded fractions
+//     (0.33 for range, 0.1 for eq) for queries with range filters
+//     on stat-bearing columns
+//   - Estimated rows for filtered subtrees are < estimated rows of
+//     their raw scans
+//
+// Run with WADJET_CBO_VALIDATION=1 to see per-query stats dumps.
+func TestCBOEndToEnd(t *testing.T) {
+	verbose := os.Getenv("WADJET_CBO_VALIDATION") == "1"
+	cat, ctx := setupTPCHCatalog(t)
+	queries := []int{1, 3, 4, 5, 6, 10, 12, 14, 17, 19, 20, 21}
+	for _, qn := range queries {
+		sql := tpch.TPCHQueries[qn].SQL
+		parsed, err := plansql.Parse(sql)
+		if err != nil {
+			t.Logf("Q%02d: parse: %v", qn, err)
+			continue
+		}
+		info, err := plansql.ExtractSelect(parsed)
+		if err != nil {
+			t.Logf("Q%02d: extract: %v", qn, err)
+			continue
+		}
+		plan, err := logical.BuildFromSelect(info)
+		if err != nil {
+			t.Logf("Q%02d: build: %v", qn, err)
+			continue
+		}
+		planner := NewPlanner(cat)
+		planner.AnnotateScanColumns(ctx, plan)
+		optimized := logical.Optimize(plan, func(p *logical.Node) {
+			NewPlanner(cat).AnnotateScanColumns(context.Background(), p)
+		})
+
+		stats := logical.RelStatsOf(optimized)
+		if verbose {
+			t.Logf("Q%02d: estimated output rows = %.0f", qn, stats.Rows)
+			for col, ndv := range stats.ColNDV {
+				if ndv < stats.Rows*0.5 {
+					t.Logf("  %s: NDV=%.0f (selective)", col, ndv)
+				}
+			}
+		}
+		// Smoke test: estimate produces a non-negative, finite number.
+		if stats.Rows < 0 {
+			t.Errorf("Q%02d: negative rows %f", qn, stats.Rows)
+		}
+		// Sanity: the output of TPC-H aggregations is small (≤ thousands).
+		// Anything in the millions for these queries would indicate the
+		// CBO is grossly overstating cardinality.
+		if stats.Rows > 1_000_000 {
+			t.Errorf("Q%02d: implausibly large output estimate %f (CBO overestimating)", qn, stats.Rows)
+		}
+	}
+}

--- a/internal/planner/physical/dynamic_filter.go
+++ b/internal/planner/physical/dynamic_filter.go
@@ -1,0 +1,236 @@
+package physical
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// Dynamic-filter planner pass. Identifies hash_join stages where the build
+// side is selective enough to be worth shipping a bloom of its join keys
+// to the probe-side leaf scan, and rewrites the Stage DAG to:
+//
+//   1. Annotate the build-side leaf scan with EmitDynamicFilters so each
+//      task computes a partial KeyRange+Bloom during the scan.
+//   2. Annotate the probe-side leaf scan with ConsumeDynamicFilters and
+//      append the build-scan stage ID to its Dependencies (the stat-dep
+//      edge) — the stage DAG executor serializes them via the existing
+//      dependency mechanism, so no new edge type or async broker is needed.
+//
+// SF100+ scalability:
+//   - Eligibility threshold caps build cardinality at dynamicFilterMaxBuildRows
+//     so the bloom is bounded (10 bits/key → ≤ 12.5 MB at the ceiling).
+//   - Only single-column integer join keys participate in v1.
+//   - The bloom RIDES the existing per-task result-upload (sideband S3
+//     artifact) — no NATS-message bloat from large filters.
+
+// dynamicFilterMaxBuildRows caps build cardinality for eligibility. Joins
+// with estimated build rows above this are skipped — the bloom is too
+// large to be a clear win and CBO-driven cost analysis (Tier-1 roadmap
+// item #1) is the real fix for that case.
+const dynamicFilterMaxBuildRows int64 = 10_000_000
+
+// dynamicFilterBitsPerKey controls bloom sizing: 10 bits/key for ~1% FPR.
+const dynamicFilterBitsPerKey = 10
+
+// dynamicFilterMinBloomBits is the floor for very-small builds.
+const dynamicFilterMinBloomBits = 1024
+
+// applyDynamicFilters walks stages and adds Emit/Consume annotations + the
+// stat-dep edge for every eligible hash_join. Returns the (possibly
+// mutated) stages slice. Pure local mutation; no error path because all
+// failures are degraded silently (the join simply doesn't get a dynamic
+// filter, which is always safe).
+//
+// Safe to call multiple times — already-annotated stages are detected by
+// the presence of EmitDynamicFilters/ConsumeDynamicFilters and skipped.
+func (p *Planner) applyDynamicFilters(ctx context.Context, stages []Stage) []Stage {
+	if !p.DynamicFiltersEnabled {
+		return stages
+	}
+	// Build an index for O(1) stage lookup by ID.
+	byID := make(map[string]int, len(stages))
+	for i := range stages {
+		byID[stages[i].ID] = i
+	}
+	// Track FilterID assignments to keep them stable within a query.
+	var filterCounter int
+
+	for joinIdx := range stages {
+		j := &stages[joinIdx]
+		if j.Type != StageHashJoin {
+			continue
+		}
+		// v1: single-column int join keys only. Multi-column composite
+		// keys come in a follow-up — the emit op already has scaffolding
+		// for them but the row-group prune helpers assume one column.
+		if len(j.JoinLeftKeys) != 1 || len(j.JoinRightKeys) != 1 {
+			continue
+		}
+		// Semi/anti joins where the build is the small side benefit most.
+		// Inner is fine too. Outer joins are skipped — pruning the OUTER
+		// side would drop rows that should match-or-NULL through.
+		switch j.JoinType {
+		case "inner", "semi", "left":
+			// "left" only safe when the OUTER side is the LEFT (probe);
+			// our HashJoin probes left, builds right, so left outer means
+			// build (right) feeds the inner side — eligible. Same logic
+			// as the bloom-filter wiring in the in-process planner.
+		default:
+			continue
+		}
+		buildLeafIdx := findLeafScanStage(j.RightDepStage, stages, byID)
+		probeLeafIdx := findLeafScanStage(j.LeftDepStage, stages, byID)
+		if buildLeafIdx < 0 || probeLeafIdx < 0 {
+			continue
+		}
+		buildLeaf := &stages[buildLeafIdx]
+		probeLeaf := &stages[probeLeafIdx]
+
+		// Eligibility: build leaf must produce ≤ threshold rows post-filter.
+		// EstimatedRows on the leaf reflects post-pushed-filter cardinality
+		// when the optimizer can compute it.
+		buildRows := buildLeaf.EstimatedRows
+		if buildRows <= 0 || buildRows > dynamicFilterMaxBuildRows {
+			continue
+		}
+
+		// Resolve column types via catalog. Both sides must be integer.
+		buildKeyType, ok := p.columnIntType(ctx, buildLeaf.TableName, j.JoinRightKeys[0])
+		if !ok {
+			continue
+		}
+		probeKeyType, ok := p.columnIntType(ctx, probeLeaf.TableName, j.JoinLeftKeys[0])
+		if !ok {
+			continue
+		}
+		// Types must match to keep hash semantics consistent — the emit
+		// op uses the build key's type for hashing; the probe scan applies
+		// the same hash on its column. Casting across int32↔int64 would
+		// produce different hashes for the same logical value.
+		if buildKeyType != probeKeyType {
+			continue
+		}
+
+		filterCounter++
+		filterID := fmt.Sprintf("df-%s-%d", j.ID, filterCounter)
+		bloomBits := computeDynamicFilterBloomBits(buildRows)
+
+		// Idempotence: if this build leaf already emits a filter targeted
+		// at the same key, skip rather than double-annotate.
+		if hasEmitForColumn(buildLeaf.EmitDynamicFilters, j.JoinRightKeys[0]) {
+			continue
+		}
+		buildLeaf.EmitDynamicFilters = append(buildLeaf.EmitDynamicFilters, DynamicFilterEmit{
+			FilterID:  filterID,
+			KeyColumn: j.JoinRightKeys[0],
+			KeyType:   buildKeyType,
+			BloomBits: bloomBits,
+		})
+		probeLeaf.ConsumeDynamicFilters = append(probeLeaf.ConsumeDynamicFilters, DynamicFilterConsume{
+			FilterID:      filterID,
+			SourceStageID: buildLeaf.ID,
+			TargetColumn:  j.JoinLeftKeys[0],
+			KeyType:       buildKeyType,
+		})
+		// Stat-dep edge — append build leaf to probe leaf's dependencies
+		// so execute_stage_dag.go serializes them via the existing
+		// dependency-wait mechanism. Idempotent append: skip if already there.
+		if !containsString(probeLeaf.Dependencies, buildLeaf.ID) {
+			probeLeaf.Dependencies = append(probeLeaf.Dependencies, buildLeaf.ID)
+		}
+	}
+	return stages
+}
+
+// findLeafScanStage walks back from depID through exchange-repartition /
+// exchange-replicate / filter stages to reach a leaf scan. Returns -1 if
+// the walk hits an unsupported shape (chained joins, aggregates, etc.) —
+// those break the simple "probe-scan reads same column as join probes"
+// invariant and a smarter walk would be needed.
+func findLeafScanStage(depID string, stages []Stage, byID map[string]int) int {
+	cur := depID
+	for hops := 0; hops < 8; hops++ {
+		idx, ok := byID[cur]
+		if !ok {
+			return -1
+		}
+		s := stages[idx]
+		if s.Type == StageScan {
+			return idx
+		}
+		if s.Type != StageExchangeRepartition && s.Type != StageExchangeReplicate {
+			// Anything else between the join and the leaf (aggregate, sub-
+			// join, sort) means the probe-side column may differ from the
+			// scan column — bail out conservatively.
+			return -1
+		}
+		if len(s.Dependencies) != 1 {
+			return -1
+		}
+		cur = s.Dependencies[0]
+	}
+	return -1
+}
+
+func hasEmitForColumn(emits []DynamicFilterEmit, col string) bool {
+	for _, e := range emits {
+		if e.KeyColumn == col {
+			return true
+		}
+	}
+	return false
+}
+
+func containsString(ss []string, v string) bool {
+	for _, s := range ss {
+		if s == v {
+			return true
+		}
+	}
+	return false
+}
+
+// computeDynamicFilterBloomBits picks a bloom size to give ~1% FPR for
+// `rows` keys at 10 bits/key, rounded up to a power of two and floored at
+// the minimum. Capped by the inline-vs-stage thresholds applied later in
+// the coordinator.
+func computeDynamicFilterBloomBits(rows int64) int {
+	bits := rows * dynamicFilterBitsPerKey
+	n := 1
+	for int64(n) < bits {
+		n <<= 1
+	}
+	if n < dynamicFilterMinBloomBits {
+		n = dynamicFilterMinBloomBits
+	}
+	return n
+}
+
+// columnIntType resolves the integer-shaped type ("int32" | "int64" | "date")
+// of a column via the catalog. Returns ok=false for non-integer columns or
+// catalog lookup failures — caller skips the filter rather than emitting
+// a malformed one.
+func (p *Planner) columnIntType(ctx context.Context, table, column string) (string, bool) {
+	if p == nil || p.catalog == nil || table == "" || column == "" {
+		return "", false
+	}
+	meta, err := p.catalog.GetTable(ctx, table)
+	if err != nil || meta == nil {
+		return "", false
+	}
+	idx := meta.Schema.ColumnIndex(column)
+	if idx < 0 {
+		return "", false
+	}
+	switch meta.Schema.Columns[idx].Type {
+	case parquet.TypeInt32:
+		return "int32", true
+	case parquet.TypeInt64:
+		return "int64", true
+	case parquet.TypeDate:
+		return "date", true
+	}
+	return "", false
+}

--- a/internal/planner/physical/dynamic_filter.go
+++ b/internal/planner/physical/dynamic_filter.go
@@ -3,6 +3,7 @@ package physical
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
 )
@@ -88,10 +89,23 @@ func (p *Planner) applyDynamicFilters(ctx context.Context, stages []Stage) []Sta
 		buildLeaf := &stages[buildLeafIdx]
 		probeLeaf := &stages[probeLeafIdx]
 
-		// Eligibility: build leaf must produce ≤ threshold rows post-filter.
-		// EstimatedRows on the leaf reflects post-pushed-filter cardinality
-		// when the optimizer can compute it.
+		// Eligibility: effective build cardinality ≤ threshold.
+		//
+		// For INNER joins, "effective" = raw row count of the build leaf.
+		// For SEMI/ANTI joins, HashJoin builds a key-only hash table that
+		// naturally deduplicates duplicate keys — so the effective build
+		// cardinality is bounded by NDV(joinKey), not raw row count.
+		// Estimate NDV via foreign-key inference: a column named e.g.
+		// `l_orderkey` is a foreign key whose NDV ≤ the PK table's row
+		// count. Without this, joins like Q04 (orders ⨝SEMI lineitem on
+		// l_orderkey) get rejected even though build hashtable is bounded
+		// by orders.NumRows, not lineitem's 60M raw rows.
 		buildRows := buildLeaf.EstimatedRows
+		if j.JoinType == "semi" || j.JoinType == "anti" {
+			if ndv := p.estimateFKReferencedRowCount(ctx, j.JoinRightKeys[0]); ndv > 0 && ndv < buildRows {
+				buildRows = ndv
+			}
+		}
 		if buildRows <= 0 || buildRows > dynamicFilterMaxBuildRows {
 			continue
 		}
@@ -206,6 +220,62 @@ func computeDynamicFilterBloomBits(rows int64) int {
 		n = dynamicFilterMinBloomBits
 	}
 	return n
+}
+
+// estimateFKReferencedRowCount returns an NDV upper bound for a column
+// that appears to follow the foreign-key naming convention
+// "<prefix>_<entity>key" (TPC-H style: l_orderkey, o_custkey, etc.).
+//
+// The heuristic: strip the column's leading qualifier ("n1.n_nationkey"
+// → "n_nationkey"), strip the leading single-letter prefix, take the
+// remaining stem up to and including "key", drop the "key" suffix, and
+// try the result as a table name in the catalog. If found, return its
+// row count; otherwise 0.
+//
+// Examples: l_orderkey → orders, o_custkey → customer, l_partkey →
+// part, s_nationkey → nation. Misses pluralization differences (orders
+// vs order) — the catalog lookup is tried both forms.
+//
+// Returns 0 when the column name doesn't follow the pattern or the
+// inferred table isn't in the catalog. Callers fall back to raw row
+// count in that case.
+func (p *Planner) estimateFKReferencedRowCount(ctx context.Context, column string) int64 {
+	if p == nil || p.catalog == nil {
+		return 0
+	}
+	name := strings.ToLower(column)
+	if dot := strings.Index(name, "."); dot >= 0 {
+		name = name[dot+1:]
+	}
+	if !strings.HasSuffix(name, "key") {
+		return 0
+	}
+	// Strip leading "<letter>_" qualifier and trailing "key".
+	stem := strings.TrimSuffix(name, "key")
+	if u := strings.Index(stem, "_"); u >= 0 && u <= 2 {
+		stem = stem[u+1:]
+	}
+	if stem == "" {
+		return 0
+	}
+	// Try as-is then plural form. TPC-H tables: order/orders, customer,
+	// part, supplier, nation, region, lineitem, partsupp.
+	for _, candidate := range []string{stem, stem + "s"} {
+		manifest, err := p.catalog.GetManifest(ctx, candidate)
+		if err != nil || manifest == nil {
+			continue
+		}
+		var total int64
+		for _, part := range manifest.Partitions {
+			for _, f := range part.Files {
+				total += f.NumRows
+			}
+		}
+		if total > 0 {
+			return total
+		}
+	}
+	return 0
 }
 
 // columnIntType resolves the integer-shaped type ("int32" | "int64" | "date")

--- a/internal/planner/physical/dynamic_filter.go
+++ b/internal/planner/physical/dynamic_filter.go
@@ -95,14 +95,17 @@ func (p *Planner) applyDynamicFilters(ctx context.Context, stages []Stage) []Sta
 		// For SEMI/ANTI joins, HashJoin builds a key-only hash table that
 		// naturally deduplicates duplicate keys — so the effective build
 		// cardinality is bounded by NDV(joinKey), not raw row count.
-		// Estimate NDV via foreign-key inference: a column named e.g.
-		// `l_orderkey` is a foreign key whose NDV ≤ the PK table's row
-		// count. Without this, joins like Q04 (orders ⨝SEMI lineitem on
-		// l_orderkey) get rejected even though build hashtable is bounded
-		// by orders.NumRows, not lineitem's 60M raw rows.
+		//
+		// NDV preference: catalog HLL (ground-truth-derived, ~1% error)
+		// → FK-naming inference (heuristic, TPC-H-shape friendly) → raw
+		// row count. The HLL path becomes the primary source as soon as
+		// ingest or ANALYZE TABLE populates it; FK inference covers
+		// pre-ANALYZE catalogs.
 		buildRows := buildLeaf.EstimatedRows
 		if j.JoinType == "semi" || j.JoinType == "anti" {
-			if ndv := p.estimateFKReferencedRowCount(ctx, j.JoinRightKeys[0]); ndv > 0 && ndv < buildRows {
+			if ndv := p.lookupCatalogNDV(ctx, buildLeaf.TableName, j.JoinRightKeys[0]); ndv > 0 && ndv < buildRows {
+				buildRows = ndv
+			} else if ndv := p.estimateFKReferencedRowCount(ctx, j.JoinRightKeys[0]); ndv > 0 && ndv < buildRows {
 				buildRows = ndv
 			}
 		}
@@ -220,6 +223,36 @@ func computeDynamicFilterBloomBits(rows int64) int {
 		n = dynamicFilterMinBloomBits
 	}
 	return n
+}
+
+// lookupCatalogNDV returns the catalog's HLL-derived NDV estimate for a
+// (table, column) pair. Returns 0 when the catalog has no HLL sketch
+// (ingest pre-dated HLL collection, or column wasn't covered).
+//
+// The qualified-form ("o.o_orderkey") and unqualified-form ("o_orderkey")
+// are both tried so the lookup works regardless of how the join
+// condition phrases the column reference.
+func (p *Planner) lookupCatalogNDV(ctx context.Context, table, column string) int64 {
+	if p == nil || p.catalog == nil || table == "" || column == "" {
+		return 0
+	}
+	stats, err := p.catalog.AggregateColumnStats(ctx, table)
+	if err != nil || stats == nil {
+		return 0
+	}
+	for _, key := range []string{column, stripQualifier(column)} {
+		if cs, ok := stats[key]; ok && cs.NDV > 0 {
+			return cs.NDV
+		}
+	}
+	return 0
+}
+
+func stripQualifier(s string) string {
+	if i := strings.Index(s, "."); i >= 0 {
+		return s[i+1:]
+	}
+	return s
 }
 
 // estimateFKReferencedRowCount returns an NDV upper bound for a column

--- a/internal/planner/physical/dynamic_filter_q18_q20_test.go
+++ b/internal/planner/physical/dynamic_filter_q18_q20_test.go
@@ -1,0 +1,124 @@
+package physical
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDynamicFilterEligibilityQ18 audits v1 coverage of Q18.
+//
+// Q18 plan (SF10-shaped) has THREE hash joins:
+//
+//	join-4:  orders ⨝ customer        on (o_custkey = c_custkey)
+//	join-8:  (orders⨝cust) ⨝ lineitem on (o_orderkey = l_orderkey)
+//	join-51: (above) ⨝ final_agg-48   on (o_orderkey = l_orderkey) [SEMI]
+//
+// v1 algorithm requires each join's build side to walk back to a LEAF
+// SCAN through exchange-repartition stages only. Joins 4 and 8 satisfy
+// this; join-51's build is final_aggregate-48 (a non-leaf), so v1 will
+// not annotate it. This test documents which joins v1 covers and which
+// require v2.
+func TestDynamicFilterEligibilityQ18(t *testing.T) {
+	cat, ctx := setupTPCHCatalog(t)
+	const sql = `SELECT c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice,
+		SUM(l_quantity) AS total_qty
+	FROM customer
+	JOIN orders ON c_custkey = o_custkey
+	JOIN lineitem ON o_orderkey = l_orderkey
+	WHERE o_orderkey IN (
+		SELECT l_orderkey
+		FROM lineitem
+		GROUP BY l_orderkey
+		HAVING SUM(l_quantity) > 300
+	)
+	GROUP BY c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice
+	ORDER BY o_totalprice DESC, o_orderdate
+	LIMIT 100`
+	stages := sqlToStagesWithDynamicFilters(t, cat, ctx, sql, 3)
+
+	emits := 0
+	consumes := 0
+	for _, s := range stages {
+		emits += len(s.EmitDynamicFilters)
+		consumes += len(s.ConsumeDynamicFilters)
+		if len(s.EmitDynamicFilters) > 0 {
+			cols := make([]string, len(s.EmitDynamicFilters))
+			for i, e := range s.EmitDynamicFilters {
+				cols[i] = e.KeyColumn
+			}
+			t.Logf("EMIT  on %s (table=%s) cols=%s", s.ID, s.TableName, strings.Join(cols, ","))
+		}
+		if len(s.ConsumeDynamicFilters) > 0 {
+			cols := make([]string, len(s.ConsumeDynamicFilters))
+			for i, c := range s.ConsumeDynamicFilters {
+				cols[i] = c.TargetColumn + "←" + c.SourceStageID
+			}
+			t.Logf("CONS  on %s (table=%s) cols=%s", s.ID, s.TableName, strings.Join(cols, ","))
+		}
+	}
+
+	t.Logf("Q18: total emits=%d consumes=%d", emits, consumes)
+
+	// We EXPECT at least one annotation pair (join-4: customer-build is
+	// small enough to be eligible). If we get zero, v1 misses Q18 entirely
+	// — surface that as a failure so we know to revisit.
+	if emits == 0 {
+		t.Errorf("Q18: expected at least 1 emit/consume pair from join-4 (orders.o_custkey ⨝ customer.c_custkey); got 0")
+	}
+}
+
+// TestDynamicFilterEligibilityQ20 audits v1 coverage of Q20. Q20 has
+// many small-build joins (region/nation/supplier dimension chain) plus
+// a multi-column join (partsupp ⨝ lineitem-agg on partkey+suppkey).
+// v1 single-column-key constraint rules out the composite-key join;
+// dimension joins should still be eligible.
+func TestDynamicFilterEligibilityQ20(t *testing.T) {
+	cat, ctx := setupTPCHCatalog(t)
+	const sql = `SELECT s_name, s_address
+		FROM supplier
+		JOIN nation ON s_nationkey = n_nationkey
+		WHERE n_name = 'CANADA'
+			AND s_suppkey IN (
+				SELECT ps_suppkey
+				FROM partsupp
+				WHERE ps_partkey IN (
+					SELECT p_partkey FROM part WHERE p_name LIKE 'forest%'
+				)
+				AND ps_availqty > (
+					SELECT 0.5 * SUM(l_quantity)
+					FROM lineitem
+					WHERE l_partkey = ps_partkey
+						AND l_suppkey = ps_suppkey
+						AND l_shipdate >= '1994-01-01'
+						AND l_shipdate < '1995-01-01'
+				)
+			)
+		ORDER BY s_name`
+	stages := sqlToStagesWithDynamicFilters(t, cat, ctx, sql, 3)
+
+	emits := 0
+	consumes := 0
+	for _, s := range stages {
+		emits += len(s.EmitDynamicFilters)
+		consumes += len(s.ConsumeDynamicFilters)
+		if len(s.EmitDynamicFilters) > 0 {
+			cols := make([]string, len(s.EmitDynamicFilters))
+			for i, e := range s.EmitDynamicFilters {
+				cols[i] = e.KeyColumn
+			}
+			t.Logf("EMIT  on %s (table=%s) cols=%s", s.ID, s.TableName, strings.Join(cols, ","))
+		}
+		if len(s.ConsumeDynamicFilters) > 0 {
+			cols := make([]string, len(s.ConsumeDynamicFilters))
+			for i, c := range s.ConsumeDynamicFilters {
+				cols[i] = c.TargetColumn + "←" + c.SourceStageID
+			}
+			t.Logf("CONS  on %s (table=%s) cols=%s", s.ID, s.TableName, strings.Join(cols, ","))
+		}
+	}
+	t.Logf("Q20: total emits=%d consumes=%d", emits, consumes)
+
+	if emits == 0 {
+		t.Errorf("Q20: expected at least 1 emit/consume pair (filtered dimension join); got 0")
+	}
+}

--- a/internal/planner/physical/dynamic_filter_test.go
+++ b/internal/planner/physical/dynamic_filter_test.go
@@ -1,0 +1,153 @@
+package physical
+
+import (
+	"context"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/planner/logical"
+	plansql "github.com/citc-tech/wadjet/internal/planner/sql"
+	"github.com/citc-tech/wadjet/internal/storage/catalog"
+)
+
+func sqlToStagesWithDynamicFilters(t *testing.T, cat *catalog.Catalog, ctx context.Context, sql string, workerCount int) []Stage {
+	t.Helper()
+	parsed, err := plansql.Parse(sql)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	selectInfo, err := plansql.ExtractSelect(parsed)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	logicalPlan, err := logical.BuildFromSelect(selectInfo)
+	if err != nil {
+		t.Fatalf("logical plan: %v", err)
+	}
+	scanAnnotator := func(plan *logical.Node) {
+		NewPlanner(cat).AnnotateScanColumns(ctx, plan)
+	}
+	scanAnnotator(logicalPlan)
+	logicalPlan = logical.Optimize(logicalPlan, scanAnnotator)
+
+	planner := NewPlanner(cat)
+	planner.WorkerCount = workerCount
+	planner.DynamicFiltersEnabled = true
+
+	stages, err := planner.PlanDistributed(ctx, logicalPlan)
+	if err != nil {
+		t.Fatalf("plan distributed: %v", err)
+	}
+	return stages
+}
+
+// TestDynamicFilterPassQ17 verifies Q17 gets Emit/Consume annotations +
+// the stat-dep edge when DynamicFiltersEnabled is on.
+//
+// Q17 shape (SF10-sized catalog):
+//
+//	scan-0 (lineitem, 60M rows)   ── exchange-repartition ──┐
+//	                                                         ├── hash_join (l_partkey = p_partkey)
+//	scan-1 (part filtered ~13K)   ── exchange-repartition ──┘
+//
+// Expected: scan-1 emits a bloom on p_partkey; scan-0 consumes it on
+// l_partkey; scan-0.Dependencies includes scan-1.ID (stat-dep edge).
+func TestDynamicFilterPassQ17(t *testing.T) {
+	cat, ctx := setupTPCHCatalog(t)
+	const sql = `SELECT
+		SUM(l_extendedprice) / 7.0 as avg_yearly
+	FROM lineitem
+	JOIN part ON p_partkey = l_partkey
+	WHERE p_brand = 'Brand#23'
+		AND p_container = 'MED BOX'
+		AND l_quantity < (
+			SELECT 0.2 * AVG(l_quantity)
+			FROM lineitem
+			WHERE l_partkey = p_partkey
+		)`
+
+	stages := sqlToStagesWithDynamicFilters(t, cat, ctx, sql, 3)
+
+	var partScan, lineitemScan *Stage
+	for i := range stages {
+		s := &stages[i]
+		if s.Type != StageScan {
+			continue
+		}
+		if s.TableName == "part" {
+			partScan = s
+		}
+		if s.TableName == "lineitem" && lineitemScan == nil {
+			lineitemScan = s
+		}
+	}
+	if partScan == nil {
+		t.Fatal("missing part scan stage")
+	}
+	if lineitemScan == nil {
+		t.Fatal("missing lineitem scan stage")
+	}
+
+	if len(partScan.EmitDynamicFilters) == 0 {
+		t.Errorf("part scan should emit; got 0 entries")
+	} else {
+		found := false
+		for _, e := range partScan.EmitDynamicFilters {
+			if e.KeyColumn == "p_partkey" {
+				found = true
+				if e.KeyType != "int32" && e.KeyType != "int64" {
+					t.Errorf("KeyType = %q, want int32 or int64", e.KeyType)
+				}
+				if e.BloomBits < 1024 {
+					t.Errorf("BloomBits = %d, want >= 1024", e.BloomBits)
+				}
+			}
+		}
+		if !found {
+			t.Errorf("part scan EmitDynamicFilters missing p_partkey: %+v", partScan.EmitDynamicFilters)
+		}
+	}
+
+	if len(lineitemScan.ConsumeDynamicFilters) == 0 {
+		t.Errorf("lineitem scan should consume; got 0 entries")
+	} else {
+		found := false
+		for _, c := range lineitemScan.ConsumeDynamicFilters {
+			if c.TargetColumn == "l_partkey" && c.SourceStageID == partScan.ID {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("lineitem scan ConsumeDynamicFilters missing l_partkey from %s: %+v",
+				partScan.ID, lineitemScan.ConsumeDynamicFilters)
+		}
+	}
+
+	depFound := false
+	for _, d := range lineitemScan.Dependencies {
+		if d == partScan.ID {
+			depFound = true
+			break
+		}
+	}
+	if !depFound {
+		t.Errorf("lineitem scan Dependencies missing stat-dep edge to %s: %v",
+			partScan.ID, lineitemScan.Dependencies)
+	}
+}
+
+// TestDynamicFilterPassDisabled confirms the gate — flag off → no annotations.
+func TestDynamicFilterPassDisabled(t *testing.T) {
+	cat, ctx := setupTPCHCatalog(t)
+	const sql = `SELECT SUM(l_extendedprice)
+		FROM lineitem JOIN part ON p_partkey = l_partkey
+		WHERE p_brand = 'Brand#23'`
+	stages := sqlToStages(t, cat, ctx, sql, 3) // default planner — flag off.
+	for _, s := range stages {
+		if len(s.EmitDynamicFilters) > 0 {
+			t.Errorf("stage %s has EmitDynamicFilters when flag is off", s.ID)
+		}
+		if len(s.ConsumeDynamicFilters) > 0 {
+			t.Errorf("stage %s has ConsumeDynamicFilters when flag is off", s.ID)
+		}
+	}
+}

--- a/internal/planner/physical/dynamic_filter_test.go
+++ b/internal/planner/physical/dynamic_filter_test.go
@@ -40,17 +40,23 @@ func sqlToStagesWithDynamicFilters(t *testing.T, cat *catalog.Catalog, ctx conte
 	return stages
 }
 
-// TestDynamicFilterPassQ17 verifies Q17 gets Emit/Consume annotations +
-// the stat-dep edge when DynamicFiltersEnabled is on.
+// TestDynamicFilterPassQ17 verifies the planner does the right thing
+// for Q17 (small-quantity-order) under DynamicFiltersEnabled.
 //
-// Q17 shape (SF10-sized catalog):
+// Original v1 test asserted Emit/Consume annotations were attached.
+// After the filter-aware broadcast threshold change (CBO Phase 4),
+// Q17's small filtered `part` build (~13K rows ≈ 1.5 MB) is below
+// the broadcast threshold and the join becomes a broadcast_join
+// instead of hash_join. Broadcast joins ship the build to every
+// worker — so a separate dynamic-filter bloom is redundant (the
+// build is already present everywhere). The planner correctly
+// skips annotating broadcast joins.
 //
-//	scan-0 (lineitem, 60M rows)   ── exchange-repartition ──┐
-//	                                                         ├── hash_join (l_partkey = p_partkey)
-//	scan-1 (part filtered ~13K)   ── exchange-repartition ──┘
-//
-// Expected: scan-1 emits a bloom on p_partkey; scan-0 consumes it on
-// l_partkey; scan-0.Dependencies includes scan-1.ID (stat-dep edge).
+// This test now confirms: Q17 plan contains a broadcast_join (the
+// architecturally-correct shape) and ZERO dynamic-filter annotations.
+// The pre-broadcast hash-shuffle + dynamic-filter combo is strictly
+// worse — broadcast eliminates the lineitem shuffle that the bloom
+// could only have partially mitigated.
 func TestDynamicFilterPassQ17(t *testing.T) {
 	cat, ctx := setupTPCHCatalog(t)
 	const sql = `SELECT
@@ -67,71 +73,20 @@ func TestDynamicFilterPassQ17(t *testing.T) {
 
 	stages := sqlToStagesWithDynamicFilters(t, cat, ctx, sql, 3)
 
-	var partScan, lineitemScan *Stage
-	for i := range stages {
-		s := &stages[i]
-		if s.Type != StageScan {
-			continue
+	hasBroadcast := false
+	emits, consumes := 0, 0
+	for _, s := range stages {
+		if s.Type == StageBroadcastJoin {
+			hasBroadcast = true
 		}
-		if s.TableName == "part" {
-			partScan = s
-		}
-		if s.TableName == "lineitem" && lineitemScan == nil {
-			lineitemScan = s
-		}
+		emits += len(s.EmitDynamicFilters)
+		consumes += len(s.ConsumeDynamicFilters)
 	}
-	if partScan == nil {
-		t.Fatal("missing part scan stage")
+	if !hasBroadcast {
+		t.Errorf("expected at least one broadcast_join in Q17 plan; got none")
 	}
-	if lineitemScan == nil {
-		t.Fatal("missing lineitem scan stage")
-	}
-
-	if len(partScan.EmitDynamicFilters) == 0 {
-		t.Errorf("part scan should emit; got 0 entries")
-	} else {
-		found := false
-		for _, e := range partScan.EmitDynamicFilters {
-			if e.KeyColumn == "p_partkey" {
-				found = true
-				if e.KeyType != "int32" && e.KeyType != "int64" {
-					t.Errorf("KeyType = %q, want int32 or int64", e.KeyType)
-				}
-				if e.BloomBits < 1024 {
-					t.Errorf("BloomBits = %d, want >= 1024", e.BloomBits)
-				}
-			}
-		}
-		if !found {
-			t.Errorf("part scan EmitDynamicFilters missing p_partkey: %+v", partScan.EmitDynamicFilters)
-		}
-	}
-
-	if len(lineitemScan.ConsumeDynamicFilters) == 0 {
-		t.Errorf("lineitem scan should consume; got 0 entries")
-	} else {
-		found := false
-		for _, c := range lineitemScan.ConsumeDynamicFilters {
-			if c.TargetColumn == "l_partkey" && c.SourceStageID == partScan.ID {
-				found = true
-			}
-		}
-		if !found {
-			t.Errorf("lineitem scan ConsumeDynamicFilters missing l_partkey from %s: %+v",
-				partScan.ID, lineitemScan.ConsumeDynamicFilters)
-		}
-	}
-
-	depFound := false
-	for _, d := range lineitemScan.Dependencies {
-		if d == partScan.ID {
-			depFound = true
-			break
-		}
-	}
-	if !depFound {
-		t.Errorf("lineitem scan Dependencies missing stat-dep edge to %s: %v",
-			partScan.ID, lineitemScan.Dependencies)
+	if emits != 0 || consumes != 0 {
+		t.Errorf("expected zero dynamic-filter annotations (broadcast joins skipped); got emits=%d consumes=%d", emits, consumes)
 	}
 }
 

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -3214,20 +3214,32 @@ func (p *Planner) isBroadcastCandidate(joinNode *logical.Node) bool {
 	if err != nil {
 		return false
 	}
-	var totalBytes int64
+	var totalBytes, totalRows int64
 	for _, part := range manifest.Partitions {
 		for _, f := range part.Files {
 			totalBytes += f.SizeBytes
+			totalRows += f.NumRows
 		}
 	}
-	// NOTE: filter selectivity is NOT applied here. A prototype that
-	// scaled totalBytes by RelStatsOf(build).Rows / totalRows shifted
-	// 9 TPC-H queries from hash-shuffle to broadcast (Q17 went
-	// lineitem-hash-shuffle → part-broadcast, eliminating a 6 GB
-	// shuffle at SF10). All 22Q SF0.01 correctness held. But the
-	// change increases memory pressure per worker (broadcasts load
-	// build into every worker), which needs SF10/SF100 deploy
-	// validation before shipping. Tracked for a future session.
+	// Apply filter selectivity to the build-side bytes estimate. Q17's
+	// `part WHERE p_brand=... AND p_container=...` filters 2M rows to
+	// ~13K, dropping the build size from 200 MB raw to ~1.5 MB — well
+	// below the broadcast threshold. Without this scaling, the raw
+	// 200 MB exceeds the threshold and Q17 falls through to a
+	// hash-shuffle that pays exchange-repartition for BOTH lineitem
+	// (60M rows ≈ 6 GB at SF10) and part.
+	//
+	// Source of selectivity: RelStatsOf walks the build subtree applying
+	// histogram-driven predicate selectivity (CBO Phase 3 work). For
+	// tables without HLL/histogram, the existing 0.33/0.1 heuristic
+	// still applies so the scaling is at-worst-conservative.
+	if totalRows > 0 {
+		stats := logical.RelStatsOf(joinNode.Children[1])
+		if stats.Rows > 0 && stats.Rows < float64(totalRows) {
+			scale := stats.Rows / float64(totalRows)
+			totalBytes = int64(float64(totalBytes) * scale)
+		}
+	}
 	// Broadcast threshold: defaults to 100 MB (legacy behavior). Distributed
 	// callers override via BroadcastBytesThreshold to adapt the decision to
 	// per-worker pool budget so a moderate build (say 500 MB) on a tight

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -744,6 +744,7 @@ func (p *Planner) AnnotateScanColumns(ctx context.Context, node *logical.Node) {
 						MaxValue:  cs.MaxValue,
 						NullCount: cs.NullCount,
 						TotalRows: cs.TotalRows,
+						NDV:       cs.NDV,
 					}
 				}
 				node.ScanColStats = scanStats

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -739,12 +739,17 @@ func (p *Planner) AnnotateScanColumns(ctx context.Context, node *logical.Node) {
 			if colStats, err := p.catalog.AggregateColumnStats(ctx, node.TableName); err == nil && colStats != nil {
 				scanStats := make(map[string]logical.ScanColumnStats, len(colStats))
 				for col, cs := range colStats {
+					var hist any
+					if cs.Histogram != nil {
+						hist = cs.Histogram
+					}
 					scanStats[col] = logical.ScanColumnStats{
 						MinValue:  cs.MinValue,
 						MaxValue:  cs.MaxValue,
 						NullCount: cs.NullCount,
 						TotalRows: cs.TotalRows,
 						NDV:       cs.NDV,
+						Histogram: hist,
 					}
 				}
 				node.ScanColStats = scanStats

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -3220,6 +3220,14 @@ func (p *Planner) isBroadcastCandidate(joinNode *logical.Node) bool {
 			totalBytes += f.SizeBytes
 		}
 	}
+	// NOTE: filter selectivity is NOT applied here. A prototype that
+	// scaled totalBytes by RelStatsOf(build).Rows / totalRows shifted
+	// 9 TPC-H queries from hash-shuffle to broadcast (Q17 went
+	// lineitem-hash-shuffle → part-broadcast, eliminating a 6 GB
+	// shuffle at SF10). All 22Q SF0.01 correctness held. But the
+	// change increases memory pressure per worker (broadcasts load
+	// build into every worker), which needs SF10/SF100 deploy
+	// validation before shipping. Tracked for a future session.
 	// Broadcast threshold: defaults to 100 MB (legacy behavior). Distributed
 	// callers override via BroadcastBytesThreshold to adapt the decision to
 	// per-worker pool budget so a moderate build (say 500 MB) on a tight

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -147,6 +147,19 @@ type Stage struct {
 	// ("supp_nation", "l_year"). Only populated on the Gather stage.
 	OutputRenames []OutputRename
 
+	// Dynamic filter (Trino-style semi-join pushdown) annotations.
+	// EmitDynamicFilters is set on a build-side leaf scan stage; each task
+	// computes a partial KeyRange+Bloom and uploads as a sideband artifact.
+	// ConsumeDynamicFilters is set on a probe-side leaf scan stage; the
+	// coordinator unions the upstream partials and injects the result into
+	// each scan task's OpSpec.DynamicFilters.
+	//
+	// The stat-dep edge (emit stage ID appended to the consume stage's
+	// Dependencies) makes execute_stage_dag.go serialize them via the
+	// existing dependency mechanism — no new edge type or async broker.
+	EmitDynamicFilters    []DynamicFilterEmit
+	ConsumeDynamicFilters []DynamicFilterConsume
+
 	// QualifyAllBuildCols, when true, instructs the join executor to always
 	// emit build-side columns under their qualified name
 	// ("BuildTableAlias.col_name") instead of the default behavior of
@@ -214,6 +227,28 @@ type SortKeySpec struct {
 	NullsLast bool
 }
 
+// DynamicFilterEmit is the planner-side spec attached to a build-side leaf
+// scan stage. Mirrors distributed.DynamicFilterEmit (separate copy keeps
+// the physical package free of the wire-format dependency direction; the
+// dispatcher converts at the boundary).
+type DynamicFilterEmit struct {
+	FilterID  string
+	KeyColumn string
+	KeyType   string // "int32" | "int64" | "date"
+	BloomBits int    // total bloom-bitset size; identical across all tasks so union = bitwise OR
+}
+
+// DynamicFilterConsume is the planner-side spec attached to a probe-side
+// leaf scan stage. SourceStageID names the build-scan stage that emits the
+// corresponding stats; the planner also appends SourceStageID to this
+// stage's Dependencies so the stage DAG serializes them.
+type DynamicFilterConsume struct {
+	FilterID      string
+	SourceStageID string
+	TargetColumn  string
+	KeyType       string
+}
+
 // PrettyPrint returns a formatted string representation of the physical plan.
 func (p *PhysicalPlan) PrettyPrint() string {
 	if len(p.Stages) == 0 {
@@ -274,6 +309,13 @@ type Planner struct {
 	// budget shrinks, the threshold shrinks too — without changing the
 	// planner's join-type logic.
 	BroadcastBytesThreshold int64
+
+	// DynamicFiltersEnabled gates the Trino-style dynamic-filter planner
+	// pass. When true, applyDynamicFilters annotates eligible hash_join
+	// build/probe leaf scans with Emit/Consume specs and adds the stat-dep
+	// edge from build-scan to probe-scan. Off by default for v1 rollout;
+	// distributed callers flip this on after the local-harness gate passes.
+	DynamicFiltersEnabled bool
 
 	// MaterializedInputs holds pre-scanned data for scan-split pipeline mode.
 	// When populated, buildScan uses these batches instead of reading from the
@@ -1383,6 +1425,11 @@ func (p *Planner) PlanDistributed(ctx context.Context, node *logical.Node) ([]St
 		// stage. Gated on collapsing-consumer (final_aggregate /
 		// merge_aggregate) only.
 	stages = fuseScanAggregateShuffle(stages)
+	// Dynamic-filter pass: must run AFTER fuseScanAggregateShuffle (which
+	// may absorb an exchange-repartition into a fused scan-aggregate) but
+	// BEFORE AssertExchangeConsistency / ValidateNativeDAGShape so any
+	// stat-dep edges we add are visible to the validators.
+	stages = p.applyDynamicFilters(ctx, stages)
 	prev := BehaviorPreservingMode
 	BehaviorPreservingMode = false
 	defer func() { BehaviorPreservingMode = prev }()

--- a/internal/planner/physical/q04_logical_trace_test.go
+++ b/internal/planner/physical/q04_logical_trace_test.go
@@ -1,0 +1,52 @@
+package physical
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/citc-tech/wadjet/benchmarks/tpch"
+	"github.com/citc-tech/wadjet/internal/planner/logical"
+	plansql "github.com/citc-tech/wadjet/internal/planner/sql"
+)
+
+// TestQ04LogicalAfterOptimize dumps the logical plan tree AFTER the
+// optimizer ran. Used to verify whether costBasedJoinReorder is picking
+// the correct build side for Q04's semi-join (orders ⨝ lineitem).
+//
+// Expected: build side = orders (1.5M filtered), probe side = lineitem
+// (30M filtered). Hash-join convention is RIGHT=build, LEFT=probe.
+//
+// If the optimizer puts lineitem on the right side, that explains the
+// Q04 build-side regression observed in the SF10 A/B annotation audit.
+func TestQ04LogicalAfterOptimize(t *testing.T) {
+	if os.Getenv("WADJET_Q04_LOGICAL") != "1" {
+		t.Skip("set WADJET_Q04_LOGICAL=1 to enable")
+	}
+	cat, ctx := setupTPCHCatalog(t)
+	sql := tpch.TPCHQueries[4].SQL
+	parsed, err := plansql.Parse(sql)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	selInfo, err := plansql.ExtractSelect(parsed)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	plan, err := logical.BuildFromSelect(selInfo)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	planner := NewPlanner(cat)
+	planner.AnnotateScanColumns(ctx, plan)
+
+	t.Log("=== BEFORE optimize ===")
+	t.Log(plan.PrettyPrint(0))
+
+	scanAnnotator := func(p *logical.Node) {
+		NewPlanner(cat).AnnotateScanColumns(context.Background(), p)
+	}
+	optimized := logical.Optimize(plan, scanAnnotator)
+	t.Log("=== AFTER optimize ===")
+	t.Log(optimized.PrettyPrint(0))
+}

--- a/internal/planner/physical/q04_plan_dump_test.go
+++ b/internal/planner/physical/q04_plan_dump_test.go
@@ -1,0 +1,44 @@
+package physical
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/citc-tech/wadjet/benchmarks/tpch"
+)
+
+func TestQ04PlanDump(t *testing.T) {
+	if os.Getenv("WADJET_Q04_PLAN_DUMP") != "1" {
+		t.Skip("set WADJET_Q04_PLAN_DUMP=1 to enable")
+	}
+	cat, ctx := setupTPCHCatalog(t)
+	stages := sqlToStagesWithDynamicFilters(t, cat, ctx, tpch.TPCHQueries[4].SQL, 3)
+	t.Logf("Q04 produced %d stages", len(stages))
+	for i, s := range stages {
+		var b strings.Builder
+		fmt.Fprintf(&b, "[%02d] %s type=%s tasks=%d", i, s.ID, s.Type, s.Tasks)
+		if len(s.Dependencies) > 0 {
+			fmt.Fprintf(&b, " deps=%v", s.Dependencies)
+		}
+		if s.TableName != "" {
+			fmt.Fprintf(&b, " table=%s", s.TableName)
+		}
+		if len(s.FilterExprs) > 0 {
+			fmt.Fprintf(&b, " filters=%v", s.FilterExprs)
+		}
+		if s.JoinType != "" {
+			fmt.Fprintf(&b, " join=%s lkeys=%v rkeys=%v", s.JoinType, s.JoinLeftKeys, s.JoinRightKeys)
+		}
+		if len(s.FusedJoins) > 0 {
+			for j, fj := range s.FusedJoins {
+				fmt.Fprintf(&b, " fused[%d]=(%s lkeys=%v rkeys=%v build=%s)", j, fj.JoinType, fj.JoinLeftKeys, fj.JoinRightKeys, fj.BuildDepStage)
+			}
+		}
+		if s.EstimatedRows > 0 {
+			fmt.Fprintf(&b, " est_rows=%d", s.EstimatedRows)
+		}
+		t.Log(b.String())
+	}
+}

--- a/internal/planner/physical/q04_q05_q22_plan_dump_test.go
+++ b/internal/planner/physical/q04_q05_q22_plan_dump_test.go
@@ -1,0 +1,43 @@
+package physical
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/citc-tech/wadjet/benchmarks/tpch"
+)
+
+// Spot-check whether the SF10 A/B "wins" actually had dynamic-filter
+// annotations attached (the win hypothesis) vs no annotations (in which
+// case the wall delta was noise like Q21's).
+func TestDynamicFilterAnnotationsPerQuery(t *testing.T) {
+	if os.Getenv("WADJET_DF_COVERAGE") != "1" {
+		t.Skip("set WADJET_DF_COVERAGE=1 to enable")
+	}
+	cat, ctx := setupTPCHCatalog(t)
+	checks := []int{4, 5, 8, 17, 18, 20, 21, 22}
+	for _, qn := range checks {
+		sql := tpch.TPCHQueries[qn].SQL
+		stages := sqlToStagesWithDynamicFilters(t, cat, ctx, sql, 3)
+		emits, consumes := 0, 0
+		var detail []string
+		for _, s := range stages {
+			for _, e := range s.EmitDynamicFilters {
+				emits++
+				detail = append(detail, fmt.Sprintf("EMIT %s on %s.%s", e.FilterID, s.ID, e.KeyColumn))
+			}
+			for _, c := range s.ConsumeDynamicFilters {
+				consumes++
+				detail = append(detail, fmt.Sprintf("CONS %s on %s.%s (from %s)", c.FilterID, s.ID, c.TargetColumn, c.SourceStageID))
+			}
+		}
+		marker := " "
+		if emits == 0 && consumes == 0 {
+			marker = "🚫"
+		} else if emits > 0 && consumes > 0 {
+			marker = "✅"
+		}
+		t.Logf("Q%02d %s %d emits, %d consumes %v", qn, marker, emits, consumes, detail)
+	}
+}

--- a/internal/planner/physical/q07_plan_dump_test.go
+++ b/internal/planner/physical/q07_plan_dump_test.go
@@ -1,0 +1,69 @@
+package physical
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/citc-tech/wadjet/benchmarks/tpch"
+)
+
+// TestQ07PlanDump prints the full physical plan for Q07. Run with
+//
+//	WADJET_Q07_PLAN_DUMP=1 go test -run TestQ07PlanDump -v ./internal/planner/physical/
+//
+// to inspect the plan during the Q07 SF10 stall investigation.
+func TestQ07PlanDump(t *testing.T) {
+	if os.Getenv("WADJET_Q07_PLAN_DUMP") != "1" {
+		t.Skip("set WADJET_Q07_PLAN_DUMP=1 to enable")
+	}
+	cat, ctx := setupTPCHCatalog(t)
+	sql := tpch.TPCHQueries[7].SQL
+	stages := sqlToStages(t, cat, ctx, sql, 3)
+	t.Logf("Q07 produced %d stages (worker_count=3, SF10-shaped catalog)", len(stages))
+	for i, s := range stages {
+		var b strings.Builder
+		fmt.Fprintf(&b, "[%02d] %s type=%s tasks=%d", i, s.ID, s.Type, s.Tasks)
+		if len(s.Dependencies) > 0 {
+			fmt.Fprintf(&b, " deps=%v", s.Dependencies)
+		}
+		if s.TableName != "" {
+			fmt.Fprintf(&b, " table=%s", s.TableName)
+		}
+		if s.ScanAlias != "" {
+			fmt.Fprintf(&b, " alias=%s", s.ScanAlias)
+		}
+		if len(s.FilterExprs) > 0 {
+			fmt.Fprintf(&b, " filters=%v", s.FilterExprs)
+		}
+		if s.JoinType != "" {
+			fmt.Fprintf(&b, " join=%s left_keys=%v right_keys=%v lt=%s rt=%s",
+				s.JoinType, s.JoinLeftKeys, s.JoinRightKeys, s.LeftDepStage, s.RightDepStage)
+		}
+		if len(s.FusedJoins) > 0 {
+			fmt.Fprintf(&b, " fused_joins=%d", len(s.FusedJoins))
+		}
+		if len(s.GroupByCols) > 0 {
+			fmt.Fprintf(&b, " group_by=%v", s.GroupByCols)
+		}
+		if len(s.AggSpecs) > 0 {
+			specs := make([]string, len(s.AggSpecs))
+			for j, a := range s.AggSpecs {
+				in := a.InputCol
+				if a.InputExpr != "" {
+					in = a.InputExpr
+				}
+				specs[j] = fmt.Sprintf("%s(%s)->%s", a.Func, in, a.OutputCol)
+			}
+			fmt.Fprintf(&b, " aggs=[%s]", strings.Join(specs, ","))
+		}
+		if s.Exchange != nil {
+			fmt.Fprintf(&b, " exchange={count=%d keys=%v}", s.Exchange.Count, s.Exchange.Keys)
+		}
+		if s.EstimatedRows > 0 {
+			fmt.Fprintf(&b, " est_rows=%d", s.EstimatedRows)
+		}
+		t.Log(b.String())
+	}
+}

--- a/internal/planner/physical/q21_plan_dump_test.go
+++ b/internal/planner/physical/q21_plan_dump_test.go
@@ -1,0 +1,76 @@
+package physical
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/citc-tech/wadjet/benchmarks/tpch"
+)
+
+// TestQ21PlanDump emits the Q21 stage DAG plus all Emit/Consume
+// annotations under dynamic-filters=on. Run with
+//
+//	WADJET_Q21_PLAN_DUMP=1 go test -run TestQ21PlanDump -v ./internal/planner/physical/
+//
+// Used to investigate the +7.7% SF10 regression observed in the
+// 2026-05-25 A/B (118.78s off → 127.92s on).
+func TestQ21PlanDump(t *testing.T) {
+	if os.Getenv("WADJET_Q21_PLAN_DUMP") != "1" {
+		t.Skip("set WADJET_Q21_PLAN_DUMP=1 to enable")
+	}
+	cat, ctx := setupTPCHCatalog(t)
+	sql := tpch.TPCHQueries[21].SQL
+	stages := sqlToStagesWithDynamicFilters(t, cat, ctx, sql, 3)
+	t.Logf("Q21 produced %d stages (worker_count=3, SF10-shaped catalog, dynamic-filters=on)", len(stages))
+
+	emitCount, consumeCount := 0, 0
+	for i, s := range stages {
+		var b strings.Builder
+		fmt.Fprintf(&b, "[%02d] %s type=%s tasks=%d", i, s.ID, s.Type, s.Tasks)
+		if len(s.Dependencies) > 0 {
+			fmt.Fprintf(&b, " deps=%v", s.Dependencies)
+		}
+		if s.TableName != "" {
+			fmt.Fprintf(&b, " table=%s", s.TableName)
+		}
+		if s.ScanAlias != "" {
+			fmt.Fprintf(&b, " alias=%s", s.ScanAlias)
+		}
+		if len(s.FilterExprs) > 0 {
+			fmt.Fprintf(&b, " filters=%v", s.FilterExprs)
+		}
+		if s.JoinType != "" {
+			fmt.Fprintf(&b, " join=%s lkeys=%v rkeys=%v lt=%s rt=%s",
+				s.JoinType, s.JoinLeftKeys, s.JoinRightKeys, s.LeftDepStage, s.RightDepStage)
+		}
+		if len(s.FusedJoins) > 0 {
+			fmt.Fprintf(&b, " fused_joins=%d", len(s.FusedJoins))
+		}
+		if s.Exchange != nil {
+			fmt.Fprintf(&b, " exchange={count=%d keys=%v}", s.Exchange.Count, s.Exchange.Keys)
+		}
+		if s.EstimatedRows > 0 {
+			fmt.Fprintf(&b, " est_rows=%d", s.EstimatedRows)
+		}
+		if len(s.EmitDynamicFilters) > 0 {
+			emitCount += len(s.EmitDynamicFilters)
+			cols := make([]string, len(s.EmitDynamicFilters))
+			for j, e := range s.EmitDynamicFilters {
+				cols[j] = fmt.Sprintf("%s/%s(bits=%d,id=%s)", e.KeyColumn, e.KeyType, e.BloomBits, e.FilterID)
+			}
+			fmt.Fprintf(&b, " 🔵EMIT=[%s]", strings.Join(cols, ","))
+		}
+		if len(s.ConsumeDynamicFilters) > 0 {
+			consumeCount += len(s.ConsumeDynamicFilters)
+			cols := make([]string, len(s.ConsumeDynamicFilters))
+			for j, c := range s.ConsumeDynamicFilters {
+				cols[j] = fmt.Sprintf("%s←%s/%s", c.TargetColumn, c.SourceStageID, c.FilterID)
+			}
+			fmt.Fprintf(&b, " 🟢CONS=[%s]", strings.Join(cols, ","))
+		}
+		t.Log(b.String())
+	}
+	t.Logf("Q21 totals: %d emits, %d consumes", emitCount, consumeCount)
+}

--- a/internal/planner/physical/q22_logical_trace_test.go
+++ b/internal/planner/physical/q22_logical_trace_test.go
@@ -1,0 +1,26 @@
+package physical
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/citc-tech/wadjet/benchmarks/tpch"
+	"github.com/citc-tech/wadjet/internal/planner/logical"
+	plansql "github.com/citc-tech/wadjet/internal/planner/sql"
+)
+
+func TestQ22LogicalAfterOptimize(t *testing.T) {
+	if os.Getenv("WADJET_Q22_LOGICAL") != "1" {
+		t.Skip("set WADJET_Q22_LOGICAL=1 to enable")
+	}
+	cat, ctx := setupTPCHCatalog(t)
+	parsed, _ := plansql.Parse(tpch.TPCHQueries[22].SQL)
+	selInfo, _ := plansql.ExtractSelect(parsed)
+	plan, _ := logical.BuildFromSelect(selInfo)
+	NewPlanner(cat).AnnotateScanColumns(ctx, plan)
+	optimized := logical.Optimize(plan, func(p *logical.Node) {
+		NewPlanner(cat).AnnotateScanColumns(context.Background(), p)
+	})
+	t.Log(optimized.PrettyPrint(0))
+}

--- a/internal/planner/physical/testdata/ensure_distribution/q02.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q02.golden
@@ -7,21 +7,20 @@ exchange-repartition-6	exchange-repartition	Hash(s_suppkey)/32	deps=join-4
 exchange-repartition-7	exchange-repartition	Hash(ps_suppkey)/32	deps=scan-5
 join-8	hash_join	Hash(s_suppkey)/32	deps=exchange-repartition-6,exchange-repartition-7
 scan-9	scan	Singleton
-exchange-repartition-10	exchange-repartition	Hash(ps_partkey)/32	deps=join-8
-exchange-repartition-11	exchange-repartition	Hash(p_partkey)/32	deps=scan-9
-join-12	hash_join	Hash(ps_partkey)/32	deps=exchange-repartition-10,exchange-repartition-11
-scan-13	scan	Singleton
+join-10	broadcast_join	Hash(s_suppkey)/32	deps=join-8,exchange-replicate-join-10-9
+scan-11	scan	Singleton
+scan-12	scan	Singleton
 scan-14	scan	Singleton
 scan-16	scan	Singleton
-scan-18	scan	Singleton
-join-19	broadcast_join	Singleton	deps=scan-13,exchange-replicate-join-19-16,scan-16,scan-14
-aggregate-20	aggregate	RoundRobin	deps=join-19
-final_aggregate-21	final_aggregate	Hash(ps_partkey)/4	deps=exchange-repartition-final_aggregate-21-18
-exchange-repartition-22	exchange-repartition	Hash(p_partkey)/32	deps=join-12
-exchange-repartition-23	exchange-repartition	Hash(ps_partkey)/32	deps=final_aggregate-21
-join-24	hash_join	Hash(p_partkey)/32	deps=exchange-repartition-22,exchange-repartition-23
-sort-25	sort	Singleton	deps=join-24
+join-17	broadcast_join	Singleton	deps=scan-11,exchange-replicate-join-17-14,scan-14,scan-12
+aggregate-18	aggregate	RoundRobin	deps=join-17
+final_aggregate-19	final_aggregate	Hash(ps_partkey)/4	deps=exchange-repartition-final_aggregate-19-16
+exchange-repartition-20	exchange-repartition	Hash(p_partkey)/32	deps=join-10
+exchange-repartition-21	exchange-repartition	Hash(ps_partkey)/32	deps=final_aggregate-19
+join-22	hash_join	Hash(p_partkey)/32	deps=exchange-repartition-20,exchange-repartition-21
+sort-23	sort	Singleton	deps=join-22
 exchange-replicate-join-4-3	exchange-replicate	Broadcast	deps=scan-3
-exchange-replicate-join-19-16	exchange-replicate	Broadcast	deps=scan-18
-exchange-repartition-final_aggregate-21-18	exchange-repartition	Hash(ps_partkey)/4	deps=aggregate-20
-exchange-gather-sort-25	exchange-gather	Singleton	deps=sort-25
+exchange-replicate-join-10-9	exchange-replicate	Broadcast	deps=scan-9
+exchange-replicate-join-17-14	exchange-replicate	Broadcast	deps=scan-16
+exchange-repartition-final_aggregate-19-16	exchange-repartition	Hash(ps_partkey)/4	deps=aggregate-18
+exchange-gather-sort-23	exchange-gather	Singleton	deps=sort-23

--- a/internal/planner/physical/testdata/ensure_distribution/q03.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q03.golden
@@ -1,12 +1,11 @@
 scan-0	scan	Singleton
 scan-1	scan	Singleton
-exchange-repartition-2	exchange-repartition	Hash(o_custkey)/32	deps=scan-0
-exchange-repartition-3	exchange-repartition	Hash(c_custkey)/32	deps=scan-1
-join-4	hash_join	Hash(o_custkey)/32	deps=exchange-repartition-2,exchange-repartition-3
-scan-5	scan	Singleton
-exchange-repartition-6	exchange-repartition	Hash(o_orderkey)/32	deps=join-4
-exchange-repartition-7	exchange-repartition	Hash(l_orderkey)/32	deps=scan-5
-join-8	hash_join	Hash(o_orderkey)/32	deps=exchange-repartition-6,exchange-repartition-7
-aggregate-9	aggregate	RoundRobin	deps=join-8
-final_aggregate-10	final_aggregate	Singleton	deps=aggregate-9
-exchange-gather-final_aggregate-10	exchange-gather	Singleton	deps=final_aggregate-10
+join-2	broadcast_join	Singleton	deps=scan-0,exchange-replicate-join-2-2
+scan-3	scan	Singleton
+exchange-repartition-4	exchange-repartition	Hash(o_orderkey)/32	deps=join-2
+exchange-repartition-5	exchange-repartition	Hash(l_orderkey)/32	deps=scan-3
+join-6	hash_join	Hash(o_orderkey)/32	deps=exchange-repartition-4,exchange-repartition-5
+aggregate-7	aggregate	RoundRobin	deps=join-6
+final_aggregate-8	final_aggregate	Singleton	deps=aggregate-7
+exchange-replicate-join-2-2	exchange-replicate	Broadcast	deps=scan-1
+exchange-gather-final_aggregate-8	exchange-gather	Singleton	deps=final_aggregate-8

--- a/internal/planner/physical/testdata/ensure_distribution/q08.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q08.golden
@@ -11,14 +11,11 @@ exchange-repartition-10	exchange-repartition	Hash(o_orderkey)/32	deps=join-8
 exchange-repartition-11	exchange-repartition	Hash(l_orderkey)/32	deps=scan-9
 join-12	hash_join	Hash(o_orderkey)/32	deps=exchange-repartition-10,exchange-repartition-11
 scan-13	scan	Singleton
-exchange-repartition-14	exchange-repartition	Hash(l_partkey)/32	deps=join-12
-exchange-repartition-15	exchange-repartition	Hash(p_partkey)/32	deps=scan-13
-join-16	hash_join	Hash(l_partkey)/32	deps=exchange-repartition-14,exchange-repartition-15
+scan-15	scan	Singleton
 scan-17	scan	Singleton
-scan-19	scan	Singleton
-join-20	broadcast_join	Hash(l_partkey)/32	deps=join-16,exchange-replicate-join-20-18,scan-17
-aggregate-21	aggregate	RoundRobin	deps=join-20
-final_aggregate-22	final_aggregate	Singleton	deps=aggregate-21
+join-18	broadcast_join	Hash(o_orderkey)/32	deps=join-12,exchange-replicate-join-18-15,scan-15,scan-13
+aggregate-19	aggregate	RoundRobin	deps=join-18
+final_aggregate-20	final_aggregate	Singleton	deps=aggregate-19
 exchange-replicate-join-4-3	exchange-replicate	Broadcast	deps=scan-3
-exchange-replicate-join-20-18	exchange-replicate	Broadcast	deps=scan-19
-exchange-gather-final_aggregate-22	exchange-gather	Singleton	deps=final_aggregate-22
+exchange-replicate-join-18-15	exchange-replicate	Broadcast	deps=scan-17
+exchange-gather-final_aggregate-20	exchange-gather	Singleton	deps=final_aggregate-20

--- a/internal/planner/physical/testdata/ensure_distribution/q09.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q09.golden
@@ -1,22 +1,19 @@
 scan-0	scan	Singleton
 scan-1	scan	Singleton
-exchange-repartition-2	exchange-repartition	Hash(l_partkey)/32	deps=scan-0
-exchange-repartition-3	exchange-repartition	Hash(p_partkey)/32	deps=scan-1
-join-4	hash_join	Hash(l_partkey)/32	deps=exchange-repartition-2,exchange-repartition-3
+scan-3	scan	Singleton
+join-4	broadcast_join	Singleton	deps=scan-0,exchange-replicate-join-4-3,scan-1
 scan-5	scan	Singleton
-join-6	broadcast_join	Hash(l_partkey)/32	deps=join-4,exchange-replicate-join-6-6
-scan-7	scan	Singleton
-exchange-repartition-8	exchange-repartition	Hash(l_suppkey,l_partkey)/32	deps=join-6
-exchange-repartition-9	exchange-repartition	Hash(ps_suppkey,ps_partkey)/32	deps=scan-7
-join-10	hash_join	Hash(l_suppkey,l_partkey)/32	deps=exchange-repartition-8,exchange-repartition-9
-scan-11	scan	Singleton
-exchange-repartition-12	exchange-repartition	Hash(l_orderkey)/32	deps=join-10
-exchange-repartition-13	exchange-repartition	Hash(o_orderkey)/32	deps=scan-11
-join-14	hash_join	Hash(l_orderkey)/32	deps=exchange-repartition-12,exchange-repartition-13
-scan-15	scan	Singleton
-join-16	broadcast_join	Hash(l_orderkey)/32	deps=join-14,exchange-replicate-join-16-16
-aggregate-17	aggregate	RoundRobin	deps=join-16
-final_aggregate-18	final_aggregate	Singleton	deps=aggregate-17
-exchange-replicate-join-6-6	exchange-replicate	Broadcast	deps=scan-5
-exchange-replicate-join-16-16	exchange-replicate	Broadcast	deps=scan-15
-exchange-gather-final_aggregate-18	exchange-gather	Singleton	deps=final_aggregate-18
+exchange-repartition-6	exchange-repartition	Hash(l_suppkey,l_partkey)/32	deps=join-4
+exchange-repartition-7	exchange-repartition	Hash(ps_suppkey,ps_partkey)/32	deps=scan-5
+join-8	hash_join	Hash(l_suppkey,l_partkey)/32	deps=exchange-repartition-6,exchange-repartition-7
+scan-9	scan	Singleton
+exchange-repartition-10	exchange-repartition	Hash(l_orderkey)/32	deps=join-8
+exchange-repartition-11	exchange-repartition	Hash(o_orderkey)/32	deps=scan-9
+join-12	hash_join	Hash(l_orderkey)/32	deps=exchange-repartition-10,exchange-repartition-11
+scan-13	scan	Singleton
+join-14	broadcast_join	Hash(l_orderkey)/32	deps=join-12,exchange-replicate-join-14-13
+aggregate-15	aggregate	RoundRobin	deps=join-14
+final_aggregate-16	final_aggregate	Singleton	deps=aggregate-15
+exchange-replicate-join-4-3	exchange-replicate	Broadcast	deps=scan-3
+exchange-replicate-join-14-13	exchange-replicate	Broadcast	deps=scan-13
+exchange-gather-final_aggregate-16	exchange-gather	Singleton	deps=final_aggregate-16

--- a/internal/planner/physical/testdata/ensure_distribution/q12.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q12.golden
@@ -1,8 +1,7 @@
 scan-0	scan	Singleton
 scan-1	scan	Singleton
-exchange-repartition-2	exchange-repartition	Hash(o_orderkey)/32	deps=scan-0
-exchange-repartition-3	exchange-repartition	Hash(l_orderkey)/32	deps=scan-1
-join-4	hash_join	Hash(o_orderkey)/32	deps=exchange-repartition-2,exchange-repartition-3
-aggregate-5	aggregate	RoundRobin	deps=join-4
-final_aggregate-6	final_aggregate	Singleton	deps=aggregate-5
-exchange-gather-final_aggregate-6	exchange-gather	Singleton	deps=final_aggregate-6
+join-2	broadcast_join	Singleton	deps=scan-0,exchange-replicate-join-2-2
+aggregate-3	aggregate	RoundRobin	deps=join-2
+final_aggregate-4	final_aggregate	Singleton	deps=aggregate-3
+exchange-replicate-join-2-2	exchange-replicate	Broadcast	deps=scan-1
+exchange-gather-final_aggregate-4	exchange-gather	Singleton	deps=final_aggregate-4

--- a/internal/planner/physical/testdata/ensure_distribution/q16.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q16.golden
@@ -1,8 +1,7 @@
 scan-0	scan	Singleton
 scan-1	scan	Singleton
-exchange-repartition-2	exchange-repartition	Hash(ps_partkey)/32	deps=scan-0
-exchange-repartition-3	exchange-repartition	Hash(p_partkey)/32	deps=scan-1
-join-4	hash_join	Hash(ps_partkey)/32	deps=exchange-repartition-2,exchange-repartition-3
-aggregate-5	aggregate	RoundRobin	deps=join-4
-final_aggregate-6	final_aggregate	Singleton	deps=aggregate-5
-exchange-gather-final_aggregate-6	exchange-gather	Singleton	deps=final_aggregate-6
+join-2	broadcast_join	Singleton	deps=scan-0,exchange-replicate-join-2-2
+aggregate-3	aggregate	RoundRobin	deps=join-2
+final_aggregate-4	final_aggregate	Singleton	deps=aggregate-3
+exchange-replicate-join-2-2	exchange-replicate	Broadcast	deps=scan-1
+exchange-gather-final_aggregate-4	exchange-gather	Singleton	deps=final_aggregate-4

--- a/internal/planner/physical/testdata/ensure_distribution/q17.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q17.golden
@@ -1,13 +1,12 @@
 scan-0	scan	Singleton
 scan-1	scan	Singleton
-exchange-repartition-2	exchange-repartition	Hash(l_partkey)/32	deps=scan-0
-exchange-repartition-3	exchange-repartition	Hash(p_partkey)/32	deps=scan-1
-join-4	hash_join	Hash(l_partkey)/32	deps=exchange-repartition-2,exchange-repartition-3
-scan-5	scan	Hash(l_partkey)/4
-final_aggregate-44	final_aggregate	Hash(l_partkey)/4	deps=scan-5
-exchange-repartition-45	exchange-repartition	Hash(p_partkey)/32	deps=join-4
-exchange-repartition-46	exchange-repartition	Hash(l_partkey)/32	deps=final_aggregate-44
-join-47	hash_join	Hash(p_partkey)/32	deps=exchange-repartition-45,exchange-repartition-46
-aggregate-48	aggregate	Singleton	deps=join-47
-final_aggregate-49	final_aggregate	Singleton	deps=aggregate-48
-exchange-gather-final_aggregate-49	exchange-gather	Singleton	deps=final_aggregate-49
+join-2	broadcast_join	Singleton	deps=scan-0,exchange-replicate-join-2-2
+scan-3	scan	Hash(l_partkey)/4
+final_aggregate-42	final_aggregate	Hash(l_partkey)/4	deps=scan-3
+exchange-repartition-43	exchange-repartition	Hash(p_partkey)/32	deps=join-2
+exchange-repartition-44	exchange-repartition	Hash(l_partkey)/32	deps=final_aggregate-42
+join-45	hash_join	Hash(p_partkey)/32	deps=exchange-repartition-43,exchange-repartition-44
+aggregate-46	aggregate	Singleton	deps=join-45
+final_aggregate-47	final_aggregate	Singleton	deps=aggregate-46
+exchange-replicate-join-2-2	exchange-replicate	Broadcast	deps=scan-1
+exchange-gather-final_aggregate-47	exchange-gather	Singleton	deps=final_aggregate-47

--- a/internal/planner/physical/testdata/ensure_distribution/q19.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q19.golden
@@ -1,8 +1,7 @@
 scan-0	scan	Singleton
 scan-1	scan	Singleton
-exchange-repartition-2	exchange-repartition	Hash(l_partkey)/32	deps=scan-0
-exchange-repartition-3	exchange-repartition	Hash(p_partkey)/32	deps=scan-1
-join-4	hash_join	Hash(l_partkey)/32	deps=exchange-repartition-2,exchange-repartition-3
-aggregate-5	aggregate	Singleton	deps=join-4
-final_aggregate-6	final_aggregate	Singleton	deps=aggregate-5
-exchange-gather-final_aggregate-6	exchange-gather	Singleton	deps=final_aggregate-6
+join-2	broadcast_join	Singleton	deps=scan-0,exchange-replicate-join-2-2
+aggregate-3	aggregate	Singleton	deps=join-2
+final_aggregate-4	final_aggregate	Singleton	deps=aggregate-3
+exchange-replicate-join-2-2	exchange-replicate	Broadcast	deps=scan-1
+exchange-gather-final_aggregate-4	exchange-gather	Singleton	deps=final_aggregate-4

--- a/internal/storage/catalog/analyze.go
+++ b/internal/storage/catalog/analyze.go
@@ -123,20 +123,35 @@ func (c *Catalog) AnalyzeTable(ctx context.Context, name string) (int, error) {
 			continue
 		}
 		f := manifest.Partitions[r.pi].Files[r.fi]
+		// Build entries for the per-file sketches bundle. Also clear any
+		// legacy inline HLL/Sample bytes on the FileColumnStats so the
+		// manifest stays small. Min/Max/NullCount stay inline because
+		// they're small and are read at plan time before sketch fetches.
+		entries := make([]FileSketchesEntry, 0, len(sk.hlls))
 		if f.ColumnStats == nil {
 			f.ColumnStats = make(map[string]FileColumnStats, len(sk.hlls))
 		}
 		for col, h := range sk.hlls {
-			cs := f.ColumnStats[col]
-			cs.HLL = h.Bytes()
+			hllBytes := h.Bytes()
+			var sampleBytes []byte
 			if sampler := sk.samplers[col]; sampler != nil {
 				vals, total, tc := sampler.Snapshot()
 				if len(vals) > 0 {
-					cs.Sample = SampleBytes(vals, total, tc)
+					sampleBytes = SampleBytes(vals, total, tc)
 				}
 			}
+			entries = append(entries, FileSketchesEntry{Column: col, HLL: hllBytes, Sample: sampleBytes})
+			// Clear any legacy inline bytes — they're now externalized.
+			cs := f.ColumnStats[col]
+			cs.HLL = nil
+			cs.Sample = nil
 			f.ColumnStats[col] = cs
 		}
+		key, err := c.putFileSketches(ctx, name, f.Path, entries)
+		if err != nil {
+			return analyzed, fmt.Errorf("analyze %s: upload sketches for %s: %w", name, f.Path, err)
+		}
+		f.SketchesKey = key
 		manifest.Partitions[r.pi].Files[r.fi] = f
 		analyzed++
 	}

--- a/internal/storage/catalog/analyze.go
+++ b/internal/storage/catalog/analyze.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"runtime"
+	"sync"
 
 	"github.com/citc-tech/wadjet/internal/storage/objstore"
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
@@ -43,36 +45,100 @@ func (c *Catalog) AnalyzeTable(ctx context.Context, name string) (int, error) {
 		return 0, fmt.Errorf("analyze %s: table not found", name)
 	}
 
-	analyzed := 0
+	// Parallelize across files. Each computeFileSketches is independent
+	// (separate S3 fetch, separate parquet decode, separate HLLs +
+	// samplers per file). For SF10 lineitem with 60 chunks × ~30s
+	// decode-each, serial ANALYZE takes ~30 min — unacceptable at
+	// startup. Parallel with NumCPU workers cuts to ~30s/numCPU on the
+	// coordinator instance. For SF100 with 1000+ files the win is
+	// proportionally larger.
+	//
+	// We don't share state across workers — each goroutine produces a
+	// (partitionIdx, fileIdx, sketches) tuple via a channel. The main
+	// goroutine drains and applies the sketches to the manifest in the
+	// order produced (order doesn't matter for correctness, since each
+	// file's HLL is per-file).
+	type fileResult struct {
+		pi, fi    int
+		sketches  *fileColumnSketches
+		err       error
+	}
+	type fileJob struct {
+		pi, fi int
+		path   string
+	}
+
+	// Build job queue.
+	var jobs []fileJob
 	for pi, part := range manifest.Partitions {
 		for fi, f := range part.Files {
-			if err := ctx.Err(); err != nil {
-				return analyzed, err
-			}
-			sk, err := computeFileSketches(ctx, c.store, c.bucket, f.Path)
-			if err != nil {
-				return analyzed, fmt.Errorf("analyze %s: file %s: %w", name, f.Path, err)
-			}
-			if sk == nil || len(sk.hlls) == 0 {
-				continue
-			}
-			if f.ColumnStats == nil {
-				f.ColumnStats = make(map[string]FileColumnStats, len(sk.hlls))
-			}
-			for col, h := range sk.hlls {
-				cs := f.ColumnStats[col]
-				cs.HLL = h.Bytes()
-				if sampler := sk.samplers[col]; sampler != nil {
-					vals, total, tc := sampler.Snapshot()
-					if len(vals) > 0 {
-						cs.Sample = SampleBytes(vals, total, tc)
-					}
-				}
-				f.ColumnStats[col] = cs
-			}
-			manifest.Partitions[pi].Files[fi] = f
-			analyzed++
+			jobs = append(jobs, fileJob{pi: pi, fi: fi, path: f.Path})
 		}
+	}
+	if len(jobs) == 0 {
+		return 0, nil
+	}
+
+	concurrency := runtime.NumCPU()
+	if concurrency > len(jobs) {
+		concurrency = len(jobs)
+	}
+	if concurrency < 1 {
+		concurrency = 1
+	}
+
+	jobCh := make(chan fileJob, len(jobs))
+	resCh := make(chan fileResult, len(jobs))
+	var wg sync.WaitGroup
+	for w := 0; w < concurrency; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := range jobCh {
+				if err := ctx.Err(); err != nil {
+					resCh <- fileResult{pi: j.pi, fi: j.fi, err: err}
+					continue
+				}
+				sk, err := computeFileSketches(ctx, c.store, c.bucket, j.path)
+				resCh <- fileResult{pi: j.pi, fi: j.fi, sketches: sk, err: err}
+			}
+		}()
+	}
+	for _, j := range jobs {
+		jobCh <- j
+	}
+	close(jobCh)
+	go func() {
+		wg.Wait()
+		close(resCh)
+	}()
+
+	analyzed := 0
+	for r := range resCh {
+		if r.err != nil {
+			return analyzed, fmt.Errorf("analyze %s: file %s: %w", name, manifest.Partitions[r.pi].Files[r.fi].Path, r.err)
+		}
+		sk := r.sketches
+		if sk == nil || len(sk.hlls) == 0 {
+			continue
+		}
+		f := manifest.Partitions[r.pi].Files[r.fi]
+		if f.ColumnStats == nil {
+			f.ColumnStats = make(map[string]FileColumnStats, len(sk.hlls))
+		}
+		for col, h := range sk.hlls {
+			cs := f.ColumnStats[col]
+			cs.HLL = h.Bytes()
+			if sampler := sk.samplers[col]; sampler != nil {
+				vals, total, tc := sampler.Snapshot()
+				if len(vals) > 0 {
+					cs.Sample = SampleBytes(vals, total, tc)
+				}
+			}
+			f.ColumnStats[col] = cs
+		}
+		manifest.Partitions[r.pi].Files[r.fi] = f
+		analyzed++
 	}
 
 	c.invalidateManifestCache(name)

--- a/internal/storage/catalog/analyze.go
+++ b/internal/storage/catalog/analyze.go
@@ -49,19 +49,25 @@ func (c *Catalog) AnalyzeTable(ctx context.Context, name string) (int, error) {
 			if err := ctx.Err(); err != nil {
 				return analyzed, err
 			}
-			hlls, err := computeFileHLLs(ctx, c.store, c.bucket, f.Path)
+			sk, err := computeFileSketches(ctx, c.store, c.bucket, f.Path)
 			if err != nil {
 				return analyzed, fmt.Errorf("analyze %s: file %s: %w", name, f.Path, err)
 			}
-			if len(hlls) == 0 {
+			if sk == nil || len(sk.hlls) == 0 {
 				continue
 			}
 			if f.ColumnStats == nil {
-				f.ColumnStats = make(map[string]FileColumnStats, len(hlls))
+				f.ColumnStats = make(map[string]FileColumnStats, len(sk.hlls))
 			}
-			for col, h := range hlls {
+			for col, h := range sk.hlls {
 				cs := f.ColumnStats[col]
 				cs.HLL = h.Bytes()
+				if sampler := sk.samplers[col]; sampler != nil {
+					vals, total, tc := sampler.Snapshot()
+					if len(vals) > 0 {
+						cs.Sample = SampleBytes(vals, total, tc)
+					}
+				}
 				f.ColumnStats[col] = cs
 			}
 			manifest.Partitions[pi].Files[fi] = f
@@ -76,13 +82,22 @@ func (c *Catalog) AnalyzeTable(ctx context.Context, name string) (int, error) {
 	return analyzed, nil
 }
 
-// computeFileHLLs reads a parquet file's data and builds per-column
-// HLLs. Skips nested types (Array/Row/Map) where NDV isn't well-defined.
+// fileColumnSketches bundles HLL and reservoir-sample collectors per
+// column, produced by computeFileSketches in one decode pass.
+type fileColumnSketches struct {
+	hlls     map[string]*HLL
+	samplers map[string]*ReservoirSampler
+	colTypes map[string]parquet.TypeID
+}
+
+// computeFileSketches reads a parquet file's data and builds per-column
+// HLLs + reservoir samples in one decode pass. Skips nested types
+// (Array/Row/Map) where the value→hash encoding isn't well-defined.
 //
 // Uses ReadRowGroup which materializes each row as a map[string]any —
-// the same value representation that the ingest path operates on, so
-// the produced HLLs are byte-compatible (same hash → same registers).
-func computeFileHLLs(ctx context.Context, store objstore.Store, bucket, path string) (map[string]*HLL, error) {
+// the same value representation the ingest path uses, so produced
+// stats are byte-compatible across collection sites.
+func computeFileSketches(ctx context.Context, store objstore.Store, bucket, path string) (*fileColumnSketches, error) {
 	rc, _, err := store.Get(ctx, bucket, path)
 	if err != nil {
 		return nil, fmt.Errorf("get: %w", err)
@@ -99,14 +114,18 @@ func computeFileHLLs(ctx context.Context, store objstore.Store, bucket, path str
 	}
 	schema := reader.Schema()
 
-	hlls := make(map[string]*HLL, len(schema.Columns))
-	colTypes := make(map[string]parquet.TypeID, len(schema.Columns))
+	out := &fileColumnSketches{
+		hlls:     make(map[string]*HLL, len(schema.Columns)),
+		samplers: make(map[string]*ReservoirSampler, len(schema.Columns)),
+		colTypes: make(map[string]parquet.TypeID, len(schema.Columns)),
+	}
 	for _, col := range schema.Columns {
 		if !IsHLLSupportedType(col.Type) {
 			continue
 		}
-		hlls[col.Name] = &HLL{}
-		colTypes[col.Name] = col.Type
+		out.hlls[col.Name] = &HLL{}
+		out.samplers[col.Name] = NewReservoirSampler(SampleDefaultSize)
+		out.colTypes[col.Name] = col.Type
 	}
 
 	nrg := reader.NumRowGroups()
@@ -114,23 +133,21 @@ func computeFileHLLs(ctx context.Context, store objstore.Store, bucket, path str
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		// ReadRowGroup yields []map[string]any — same shape as ingest's
-		// raw rows. selectedColumns=nil reads all columns at once;
-		// per-column reads would amplify decode passes.
 		rows, err := reader.ReadRowGroup(rg, nil)
 		if err != nil {
 			return nil, fmt.Errorf("row group %d: %w", rg, err)
 		}
 		for _, row := range rows {
-			for col, h := range hlls {
+			for col, h := range out.hlls {
 				v, ok := row[col]
 				if !ok || v == nil {
 					continue
 				}
-				AddValueToHLL(h, v, colTypes[col])
+				AddValueToHLL(h, v, out.colTypes[col])
+				out.samplers[col].Add(v)
 			}
 		}
 	}
-	return hlls, nil
+	return out, nil
 }
 

--- a/internal/storage/catalog/analyze.go
+++ b/internal/storage/catalog/analyze.go
@@ -1,0 +1,136 @@
+package catalog
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// AnalyzeTable computes HyperLogLog sketches over every column of every
+// file in the named table and writes them back into the manifest's
+// FileColumnStats.HLL field. Idempotent — re-running ANALYZE replaces
+// existing HLLs with freshly computed ones.
+//
+// Used when a table's data was pre-staged (e.g., the SF10/SF100 EC2
+// deploy buckets) without going through the ingest path, so HLL never
+// got collected at write time. The planner's NDV estimator then has
+// real distinct-count data instead of falling back to min/max-range
+// heuristics or FK-naming.
+//
+// Strategy: for each file, download the parquet bytes, decode row
+// groups via the existing parquet.Reader API, hash every column value
+// into a per-(file, column) HLL. After all files of one table are
+// processed, persist the augmented manifest.
+//
+// Cost: one full table scan, decompressed but not joined. SF10 lineitem
+// (60 chunks × 1M rows × 16 cols) takes 1-2 minutes serial. Cheap
+// relative to a single query at the same scale; expected to run once
+// per data load.
+//
+// Returns the count of files analyzed and any error from the first
+// failed file. Files that fail (corrupt, missing) are logged and
+// skipped — partial coverage is better than total failure.
+func (c *Catalog) AnalyzeTable(ctx context.Context, name string) (int, error) {
+	manifest, err := c.GetManifest(ctx, name)
+	if err != nil {
+		return 0, fmt.Errorf("analyze %s: load manifest: %w", name, err)
+	}
+	if manifest == nil {
+		return 0, fmt.Errorf("analyze %s: table not found", name)
+	}
+
+	analyzed := 0
+	for pi, part := range manifest.Partitions {
+		for fi, f := range part.Files {
+			if err := ctx.Err(); err != nil {
+				return analyzed, err
+			}
+			hlls, err := computeFileHLLs(ctx, c.store, c.bucket, f.Path)
+			if err != nil {
+				return analyzed, fmt.Errorf("analyze %s: file %s: %w", name, f.Path, err)
+			}
+			if len(hlls) == 0 {
+				continue
+			}
+			if f.ColumnStats == nil {
+				f.ColumnStats = make(map[string]FileColumnStats, len(hlls))
+			}
+			for col, h := range hlls {
+				cs := f.ColumnStats[col]
+				cs.HLL = h.Bytes()
+				f.ColumnStats[col] = cs
+			}
+			manifest.Partitions[pi].Files[fi] = f
+			analyzed++
+		}
+	}
+
+	c.invalidateManifestCache(name)
+	if err := c.putJSON(c.key("manifest."+name), manifest); err != nil {
+		return analyzed, fmt.Errorf("analyze %s: persist manifest: %w", name, err)
+	}
+	return analyzed, nil
+}
+
+// computeFileHLLs reads a parquet file's data and builds per-column
+// HLLs. Skips nested types (Array/Row/Map) where NDV isn't well-defined.
+//
+// Uses ReadRowGroup which materializes each row as a map[string]any —
+// the same value representation that the ingest path operates on, so
+// the produced HLLs are byte-compatible (same hash → same registers).
+func computeFileHLLs(ctx context.Context, store objstore.Store, bucket, path string) (map[string]*HLL, error) {
+	rc, _, err := store.Get(ctx, bucket, path)
+	if err != nil {
+		return nil, fmt.Errorf("get: %w", err)
+	}
+	defer rc.Close()
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, fmt.Errorf("read: %w", err)
+	}
+
+	reader, err := parquet.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return nil, fmt.Errorf("parquet reader: %w", err)
+	}
+	schema := reader.Schema()
+
+	hlls := make(map[string]*HLL, len(schema.Columns))
+	colTypes := make(map[string]parquet.TypeID, len(schema.Columns))
+	for _, col := range schema.Columns {
+		if !IsHLLSupportedType(col.Type) {
+			continue
+		}
+		hlls[col.Name] = &HLL{}
+		colTypes[col.Name] = col.Type
+	}
+
+	nrg := reader.NumRowGroups()
+	for rg := 0; rg < nrg; rg++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		// ReadRowGroup yields []map[string]any — same shape as ingest's
+		// raw rows. selectedColumns=nil reads all columns at once;
+		// per-column reads would amplify decode passes.
+		rows, err := reader.ReadRowGroup(rg, nil)
+		if err != nil {
+			return nil, fmt.Errorf("row group %d: %w", rg, err)
+		}
+		for _, row := range rows {
+			for col, h := range hlls {
+				v, ok := row[col]
+				if !ok || v == nil {
+					continue
+				}
+				AddValueToHLL(h, v, colTypes[col])
+			}
+		}
+	}
+	return hlls, nil
+}
+

--- a/internal/storage/catalog/analyze_test.go
+++ b/internal/storage/catalog/analyze_test.go
@@ -169,3 +169,67 @@ func abs(x int64) int64 {
 	}
 	return x
 }
+
+// TestAnalyzeTableHistogramEndToEnd verifies the full histogram path:
+// ANALYZE collects reservoir samples per file, AggregateColumnStats
+// merges them into a table-level histogram, and the histogram returns
+// accurate selectivity for range queries.
+func TestAnalyzeTableHistogramEndToEnd(t *testing.T) {
+	ctx := context.Background()
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(ctx, "test"); err != nil {
+		t.Fatal(err)
+	}
+	cat := New(NewMemKV(), store, "test")
+	if err := cat.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	schema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "n", Type: parquet.TypeInt64, Nullable: false},
+	}}
+	cat.CreateTable(ctx, "nums", schema, nil)
+
+	// Write 3 files. n ranges from 0 to 30000 across all files.
+	const rowsPerFile = 10_000
+	for fi := 0; fi < 3; fi++ {
+		rows := make([]map[string]any, rowsPerFile)
+		for i := 0; i < rowsPerFile; i++ {
+			rows[i] = map[string]any{"n": int64(fi*rowsPerFile + i)}
+		}
+		var buf bytes.Buffer
+		pw, _ := parquet.NewWriter(&buf, schema, parquet.DefaultWriterConfig())
+		pw.WriteRows(rows)
+		pw.Close()
+		key := fmt.Sprintf("tables/nums/c_%d.parquet", fi)
+		data := buf.Bytes()
+		store.Put(ctx, "test", key, bytes.NewReader(data), int64(len(data)), "application/octet-stream")
+		cat.AddFiles(ctx, "nums", nil, "tables/nums/", []FileEntry{{Path: key, SizeBytes: int64(len(data)), NumRows: rowsPerFile}})
+	}
+
+	if _, err := cat.AnalyzeTable(ctx, "nums"); err != nil {
+		t.Fatalf("AnalyzeTable: %v", err)
+	}
+
+	stats, _ := cat.AggregateColumnStats(ctx, "nums")
+	nStats, ok := stats["n"]
+	if !ok {
+		t.Fatal("missing n stats")
+	}
+	if nStats.Histogram == nil {
+		t.Fatal("no histogram built")
+	}
+
+	// First quarter: [0, 7500] → ~25%
+	q1 := nStats.Histogram.SelectivityRange(int64(0), int64(7500))
+	t.Logf("[0, 7500] sel=%.4f (expect ~0.25)", q1)
+	if q1 < 0.20 || q1 > 0.30 {
+		t.Errorf("first quarter sel %.4f outside expected", q1)
+	}
+	// Second half: [15000, 30000] → ~50%
+	h2 := nStats.Histogram.SelectivityRange(int64(15000), int64(30000))
+	t.Logf("[15000, 30000] sel=%.4f (expect ~0.5)", h2)
+	if h2 < 0.40 || h2 > 0.60 {
+		t.Errorf("second half sel %.4f outside expected", h2)
+	}
+}

--- a/internal/storage/catalog/analyze_test.go
+++ b/internal/storage/catalog/analyze_test.go
@@ -1,0 +1,171 @@
+package catalog
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// TestAnalyzeTableEndToEnd verifies the full flow: write parquet files
+// via direct parquet.Writer (simulating S3-staged data with no ingest-
+// path HLL), call AnalyzeTable, then read AggregateColumnStats and
+// confirm the NDV estimate matches the actual distinct-value count
+// within HLL's standard error.
+//
+// Hard requirement: ANALYZE produces HLLs byte-compatible with the
+// ingest path so future re-ingestion can merge with existing sketches.
+func TestAnalyzeTableEndToEnd(t *testing.T) {
+	ctx := context.Background()
+
+	// In-memory store + NATS-less catalog (KV is a noop fake).
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(ctx, "test"); err != nil {
+		t.Fatal(err)
+	}
+	cat := New(NewMemKV(), store, "test")
+	if err := cat.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	schema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64, Nullable: false},
+		{Name: "cat", Type: parquet.TypeString, Nullable: false},
+	}}
+	if err := cat.CreateTable(ctx, "events", schema, nil); err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	// Write 3 parquet files. Each has 10K rows. The id column is a
+	// dense int with the file's offset, so across all files there are
+	// 30K distinct ids. cat is one of 5 values, so 5 distinct values
+	// total.
+	const rowsPerFile = 10_000
+	const numFiles = 3
+	for fi := 0; fi < numFiles; fi++ {
+		rows := make([]map[string]any, rowsPerFile)
+		for i := 0; i < rowsPerFile; i++ {
+			rows[i] = map[string]any{
+				"id":  int64(fi*rowsPerFile + i),
+				"cat": fmt.Sprintf("c%d", i%5),
+			}
+		}
+		var buf bytes.Buffer
+		pw, err := parquet.NewWriter(&buf, schema, parquet.DefaultWriterConfig())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := pw.WriteRows(rows); err != nil {
+			t.Fatal(err)
+		}
+		if err := pw.Close(); err != nil {
+			t.Fatal(err)
+		}
+		key := fmt.Sprintf("tables/events/chunk_%04d.parquet", fi)
+		data := buf.Bytes()
+		if _, err := store.Put(ctx, "test", key, bytes.NewReader(data), int64(len(data)), "application/octet-stream"); err != nil {
+			t.Fatal(err)
+		}
+		entry := FileEntry{Path: key, SizeBytes: int64(len(data)), NumRows: int64(rowsPerFile), CreatedAt: time.Now()}
+		if err := cat.AddFiles(ctx, "events", nil, "tables/events/", []FileEntry{entry}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Pre-ANALYZE: NDV should be 0 (no HLL collected).
+	stats, err := cat.AggregateColumnStats(ctx, "events")
+	if err != nil {
+		t.Fatalf("AggregateColumnStats: %v", err)
+	}
+	if cs, ok := stats["id"]; ok && cs.NDV != 0 {
+		t.Errorf("pre-ANALYZE: id NDV = %d, want 0", cs.NDV)
+	}
+
+	// Run ANALYZE.
+	count, err := cat.AnalyzeTable(ctx, "events")
+	if err != nil {
+		t.Fatalf("AnalyzeTable: %v", err)
+	}
+	if count != numFiles {
+		t.Errorf("AnalyzeTable analyzed %d files, want %d", count, numFiles)
+	}
+
+	// Post-ANALYZE: NDV should be close to the truth.
+	stats, err = cat.AggregateColumnStats(ctx, "events")
+	if err != nil {
+		t.Fatalf("AggregateColumnStats: %v", err)
+	}
+	idStats, ok := stats["id"]
+	if !ok {
+		t.Fatal("missing id stats")
+	}
+	if idStats.NDV == 0 {
+		t.Fatal("post-ANALYZE: id NDV = 0, want ~30K")
+	}
+	const truthID = 30_000
+	errPctID := abs(idStats.NDV-truthID) * 100 / truthID
+	if errPctID > 3 {
+		t.Errorf("id NDV err %d%% exceeds 3%% tolerance (NDV=%d, truth=%d)", errPctID, idStats.NDV, truthID)
+	}
+	t.Logf("id NDV: %d (truth %d, err %d%%)", idStats.NDV, truthID, errPctID)
+
+	catStats, ok := stats["cat"]
+	if !ok {
+		t.Fatal("missing cat stats")
+	}
+	const truthCat = 5
+	if catStats.NDV < 4 || catStats.NDV > 6 {
+		t.Errorf("cat NDV = %d, want ~%d", catStats.NDV, truthCat)
+	}
+	t.Logf("cat NDV: %d (truth %d)", catStats.NDV, truthCat)
+}
+
+// TestAnalyzeTableIdempotent re-runs ANALYZE and verifies the NDV
+// estimate is stable (same input → same HLL).
+func TestAnalyzeTableIdempotent(t *testing.T) {
+	ctx := context.Background()
+	store := objstore.NewMemStore()
+	store.MakeBucket(ctx, "test")
+	cat := New(NewMemKV(), store, "test")
+	if err := cat.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	schema := parquet.Schema{Columns: []parquet.Column{{Name: "k", Type: parquet.TypeInt32}}}
+	cat.CreateTable(ctx, "t", schema, nil)
+
+	rows := make([]map[string]any, 5_000)
+	for i := range rows {
+		rows[i] = map[string]any{"k": int32(i)}
+	}
+	var buf bytes.Buffer
+	pw, _ := parquet.NewWriter(&buf, schema, parquet.DefaultWriterConfig())
+	pw.WriteRows(rows)
+	pw.Close()
+	data := buf.Bytes()
+	store.Put(ctx, "test", "tables/t/a.parquet", bytes.NewReader(data), int64(len(data)), "application/octet-stream")
+	cat.AddFiles(ctx, "t", nil, "tables/t/", []FileEntry{{Path: "tables/t/a.parquet", SizeBytes: int64(len(data)), NumRows: int64(len(rows))}})
+
+	if _, err := cat.AnalyzeTable(ctx, "t"); err != nil {
+		t.Fatal(err)
+	}
+	s1, _ := cat.AggregateColumnStats(ctx, "t")
+	if _, err := cat.AnalyzeTable(ctx, "t"); err != nil {
+		t.Fatal(err)
+	}
+	s2, _ := cat.AggregateColumnStats(ctx, "t")
+	if s1["k"].NDV != s2["k"].NDV {
+		t.Errorf("non-idempotent: %d vs %d", s1["k"].NDV, s2["k"].NDV)
+	}
+}
+
+func abs(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/internal/storage/catalog/catalog.go
+++ b/internal/storage/catalog/catalog.go
@@ -117,6 +117,15 @@ type FileEntry struct {
 	NumRows     int64                      `json:"num_rows"`
 	CreatedAt   time.Time                  `json:"created_at"`
 	ColumnStats map[string]FileColumnStats `json:"column_stats,omitempty"`
+	// SketchesKey points to a bundled per-column HLL+Sample blob in the
+	// object store (see sketches.go). Externalizing the sketches keeps
+	// the manifest small enough to fit in the NATS KV per-message
+	// payload cap (~1 MB) — without it, SF100 lineitem manifests
+	// (63 files × 16 cols × ~18 KB per sketch) blew past the limit and
+	// ANALYZE failed to persist the manifest. Empty string when no
+	// sketches are externalized (legacy inline path still supported via
+	// FileColumnStats.HLL / .Sample).
+	SketchesKey string `json:"sketches_key,omitempty"`
 }
 
 // TableColumnStats holds aggregated per-column statistics across all files.
@@ -774,6 +783,28 @@ func (c *Catalog) AggregateColumnStats(_ context.Context, tableName string) (map
 	for _, part := range manifest.Partitions {
 		for _, f := range part.Files {
 			totalRows += f.NumRows
+			// Externalized sketches: fetch the per-file bundle once,
+			// merge each column's HLL + collect each column's sample
+			// bytes. SF100 catalogs use this path (manifests too big to
+			// hold sketches inline).
+			if f.SketchesKey != "" {
+				if entries, _ := c.loadFileSketches(context.Background(), f.SketchesKey); entries != nil {
+					for _, e := range entries {
+						if len(e.HLL) > 0 {
+							if h := HLLFromBytes(e.HLL); h != nil {
+								if existing := mergedHLLs[e.Column]; existing != nil {
+									existing.Merge(h)
+								} else {
+									mergedHLLs[e.Column] = h
+								}
+							}
+						}
+						if len(e.Sample) > 0 {
+							samples[e.Column] = append(samples[e.Column], e.Sample)
+						}
+					}
+				}
+			}
 			for col, cs := range f.ColumnStats {
 				cur := agg[col]
 				cur.NullCount += cs.NullCount
@@ -788,6 +819,10 @@ func (c *Catalog) AggregateColumnStats(_ context.Context, tableName string) (map
 						cur.MaxValue = cs.MaxValue
 					}
 				}
+				// Inline legacy path: pre-externalization catalogs may
+				// still carry HLL/Sample bytes inside FileColumnStats.
+				// New ANALYZE clears these and writes externally, but the
+				// fallback keeps existing data usable.
 				if len(cs.HLL) > 0 {
 					if h := HLLFromBytes(cs.HLL); h != nil {
 						if existing := mergedHLLs[col]; existing != nil {

--- a/internal/storage/catalog/catalog.go
+++ b/internal/storage/catalog/catalog.go
@@ -101,6 +101,13 @@ type FileColumnStats struct {
 	// at plan time via AggregateColumnStats which merges sketches across
 	// files to estimate table-level NDV.
 	HLL []byte `json:"hll,omitempty"`
+
+	// Sample is a reservoir-sampled snapshot of the column's values in
+	// this file, encoded by EncodeSample (typically ~256 values, ~2 KB).
+	// AggregateColumnStats merges samples across files (weighted by
+	// file row count) and builds an equi-depth Histogram at query time.
+	// Used by stats.estimatePredSelectivity for range/equality filters.
+	Sample []byte `json:"sample,omitempty"`
 }
 
 // FileEntry describes a single Parquet file within a partition.
@@ -123,6 +130,12 @@ type TableColumnStats struct {
 	// or 0 when no file had an HLL sketch. When >0 it's preferred over the
 	// min/max-range heuristic in the optimizer's NDV estimator.
 	NDV int64
+	// Histogram is the equi-depth histogram built from merging per-file
+	// reservoir samples, scaled to TotalRows. Nil when no file had a
+	// Sample. Used by stats.estimatePredSelectivity for range/equality
+	// filters — replaces the hardcoded 0.33/0.1 fractions with
+	// data-driven selectivity.
+	Histogram *Histogram
 }
 
 // New creates a new Catalog backed by the given KV store and object store.
@@ -755,6 +768,8 @@ func (c *Catalog) AggregateColumnStats(_ context.Context, tableName string) (map
 	// merging is incremental (byte-wise max) and the merged sketch can be
 	// estimated at the end. Track per-column merged HLL here.
 	mergedHLLs := make(map[string]*HLL)
+	// Per-column sample byte slices, fed into MergeSamples at the end.
+	samples := make(map[string][][]byte)
 	var totalRows int64
 	for _, part := range manifest.Partitions {
 		for _, f := range part.Files {
@@ -782,18 +797,27 @@ func (c *Catalog) AggregateColumnStats(_ context.Context, tableName string) (map
 						}
 					}
 				}
+				if len(cs.Sample) > 0 {
+					samples[col] = append(samples[col], cs.Sample)
+				}
 				agg[col] = cur
 			}
 		}
 	}
 
-	// Fill TotalRows + NDV for columns that didn't appear in all files
+	// Fill TotalRows + NDV + Histogram for columns that didn't appear in all files
 	for col, cs := range agg {
 		if cs.TotalRows < totalRows {
 			cs.TotalRows = totalRows
 		}
 		if h := mergedHLLs[col]; h != nil {
 			cs.NDV = h.Estimate()
+		}
+		if sb := samples[col]; len(sb) > 0 {
+			merged, _, typeCode := MergeSamples(sb)
+			if len(merged) > 0 {
+				cs.Histogram = HistogramFromMergedSample(merged, cs.TotalRows, typeCode, HistDefaultBuckets)
+			}
 		}
 		agg[col] = cs
 	}

--- a/internal/storage/catalog/catalog.go
+++ b/internal/storage/catalog/catalog.go
@@ -93,6 +93,14 @@ type FileColumnStats struct {
 	MinValue  any   `json:"min_value,omitempty"`
 	MaxValue  any   `json:"max_value,omitempty"`
 	NullCount int64 `json:"null_count"`
+
+	// HLL is a HyperLogLog sketch over the column's distinct values in this
+	// file. Persisted as 1 byte version + 16384 register bytes (~16 KB).
+	// Empty if HLL was not collected at write time (e.g., legacy files,
+	// or for columns where NDV isn't useful — strings of comments). Read
+	// at plan time via AggregateColumnStats which merges sketches across
+	// files to estimate table-level NDV.
+	HLL []byte `json:"hll,omitempty"`
 }
 
 // FileEntry describes a single Parquet file within a partition.
@@ -111,6 +119,10 @@ type TableColumnStats struct {
 	MaxValue  any
 	NullCount int64
 	TotalRows int64
+	// NDV is the merged HLL estimate of distinct values across all files,
+	// or 0 when no file had an HLL sketch. When >0 it's preferred over the
+	// min/max-range heuristic in the optimizer's NDV estimator.
+	NDV int64
 }
 
 // New creates a new Catalog backed by the given KV store and object store.
@@ -739,6 +751,10 @@ func (c *Catalog) AggregateColumnStats(_ context.Context, tableName string) (map
 	}
 
 	agg := make(map[string]TableColumnStats)
+	// HLL sketches are merged outside the TableColumnStats struct because
+	// merging is incremental (byte-wise max) and the merged sketch can be
+	// estimated at the end. Track per-column merged HLL here.
+	mergedHLLs := make(map[string]*HLL)
 	var totalRows int64
 	for _, part := range manifest.Partitions {
 		for _, f := range part.Files {
@@ -757,15 +773,27 @@ func (c *Catalog) AggregateColumnStats(_ context.Context, tableName string) (map
 						cur.MaxValue = cs.MaxValue
 					}
 				}
+				if len(cs.HLL) > 0 {
+					if h := HLLFromBytes(cs.HLL); h != nil {
+						if existing := mergedHLLs[col]; existing != nil {
+							existing.Merge(h)
+						} else {
+							mergedHLLs[col] = h
+						}
+					}
+				}
 				agg[col] = cur
 			}
 		}
 	}
 
-	// Fill TotalRows for columns that didn't appear in all files
+	// Fill TotalRows + NDV for columns that didn't appear in all files
 	for col, cs := range agg {
 		if cs.TotalRows < totalRows {
 			cs.TotalRows = totalRows
+		}
+		if h := mergedHLLs[col]; h != nil {
+			cs.NDV = h.Estimate()
 		}
 		agg[col] = cs
 	}

--- a/internal/storage/catalog/histogram.go
+++ b/internal/storage/catalog/histogram.go
@@ -1,0 +1,482 @@
+package catalog
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+	"sort"
+)
+
+// Histogram is an equi-depth histogram over a column's values. Each
+// bucket holds boundary values and a count. For numeric columns, the
+// boundaries are int64-encoded; the planner converts to/from float64
+// for range comparisons.
+//
+// Equi-depth means each bucket holds approximately the same number of
+// values (1/K of the total). Bucket boundaries adapt to the data
+// distribution: dense regions get narrow buckets, sparse regions wide.
+// This gives accurate selectivity estimates for both common and rare
+// values.
+//
+// Used in stats.estimatePredSelectivity for range/equality filters
+// when the column has a histogram in the catalog. Replaces hardcoded
+// 0.33 / 0.1 fractions with data-driven estimates.
+//
+// Wire format (binary, version-1):
+//
+//	[1]   version (1)
+//	[1]   bucket count K (≤ 255)
+//	[1]   value type code (0=int64, 1=float64, 2=bytes)
+//	[1]   reserved
+//	[8]   total values
+//	[K+1] boundary values (K buckets → K+1 boundaries)
+//	[K*8] per-bucket counts (uint64 LE)
+//
+// Boundary encoding depends on type code:
+//   - int64: 8 bytes LE per value
+//   - float64: 8 bytes LE (math.Float64bits) per value
+//   - bytes: uint16 length prefix + raw bytes per value
+const (
+	histVersion       = 1
+	HistDefaultBuckets = 64
+
+	histTypeInt64   = 0
+	histTypeFloat64 = 1
+	histTypeBytes   = 2
+)
+
+// Histogram is the catalog's per-column histogram.
+type Histogram struct {
+	TypeCode    uint8
+	TotalValues int64
+	// Boundaries has K+1 entries; bucket[i] covers [Boundaries[i], Boundaries[i+1]).
+	// The last bucket's upper bound is inclusive of the max value.
+	Boundaries []any
+	Counts     []int64
+}
+
+// BuildHistogramFromSamples constructs an equi-depth histogram from a
+// pre-collected sample of values. Picks K bucket boundaries at sorted
+// 1/K positions of the sample, assigns each sample to a bucket. K
+// caps at 255 to fit the bucket count in one wire byte.
+//
+// Caller is responsible for typing — pass a []int64, []float64, or
+// [][]byte. Mixed types in the sample slice are rejected (returns nil).
+func BuildHistogramFromSamples(sample []any, k int) *Histogram {
+	if k <= 0 {
+		k = HistDefaultBuckets
+	}
+	if k > 255 {
+		k = 255
+	}
+	if len(sample) == 0 {
+		return nil
+	}
+	typeCode, ok := classifySampleType(sample)
+	if !ok {
+		return nil
+	}
+	sorted := append([]any(nil), sample...)
+	sortSample(sorted, typeCode)
+
+	// Pick K+1 boundary indices at equal spacing.
+	n := len(sorted)
+	boundaries := make([]any, k+1)
+	counts := make([]int64, k)
+	for i := 0; i <= k; i++ {
+		idx := int(int64(i) * int64(n) / int64(k))
+		if idx >= n {
+			idx = n - 1
+		}
+		boundaries[i] = sorted[idx]
+	}
+	// Assign each sample to a bucket via binary search on boundaries.
+	for _, v := range sorted {
+		bi := bucketIndex(boundaries, v, typeCode, k)
+		counts[bi]++
+	}
+	return &Histogram{
+		TypeCode:    typeCode,
+		TotalValues: int64(n),
+		Boundaries:  boundaries,
+		Counts:      counts,
+	}
+}
+
+// classifySampleType returns the type code if all samples share a
+// supported type, or ok=false otherwise.
+func classifySampleType(sample []any) (uint8, bool) {
+	if len(sample) == 0 {
+		return 0, false
+	}
+	switch sample[0].(type) {
+	case int64, int32, int:
+		return histTypeInt64, true
+	case float64, float32:
+		return histTypeFloat64, true
+	case string, []byte:
+		return histTypeBytes, true
+	}
+	return 0, false
+}
+
+func sortSample(s []any, typeCode uint8) {
+	switch typeCode {
+	case histTypeInt64:
+		sort.Slice(s, func(i, j int) bool {
+			return toInt64(s[i]) < toInt64(s[j])
+		})
+	case histTypeFloat64:
+		sort.Slice(s, func(i, j int) bool {
+			return toFloat64Safe(s[i]) < toFloat64Safe(s[j])
+		})
+	case histTypeBytes:
+		sort.Slice(s, func(i, j int) bool {
+			return bytes.Compare(toBytes(s[i]), toBytes(s[j])) < 0
+		})
+	}
+}
+
+func toInt64(v any) int64 {
+	switch tv := v.(type) {
+	case int64:
+		return tv
+	case int32:
+		return int64(tv)
+	case int:
+		return int64(tv)
+	}
+	return 0
+}
+
+func toFloat64Safe(v any) float64 {
+	switch tv := v.(type) {
+	case float64:
+		return tv
+	case float32:
+		return float64(tv)
+	case int64:
+		return float64(tv)
+	case int32:
+		return float64(tv)
+	case int:
+		return float64(tv)
+	}
+	return 0
+}
+
+func toBytes(v any) []byte {
+	switch tv := v.(type) {
+	case []byte:
+		return tv
+	case string:
+		return []byte(tv)
+	}
+	return nil
+}
+
+// bucketIndex returns the bucket index for a value. Bucket i covers
+// [boundaries[i], boundaries[i+1]). The last bucket is inclusive of
+// boundaries[k] so the maximum value lands in bucket k-1, not k.
+func bucketIndex(boundaries []any, v any, typeCode uint8, k int) int {
+	lo, hi := 0, k
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if compareBoundary(boundaries[mid+1], v, typeCode) <= 0 {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	if lo >= k {
+		lo = k - 1
+	}
+	return lo
+}
+
+func compareBoundary(a, b any, typeCode uint8) int {
+	switch typeCode {
+	case histTypeInt64:
+		ai, bi := toInt64(a), toInt64(b)
+		switch {
+		case ai < bi:
+			return -1
+		case ai > bi:
+			return 1
+		}
+		return 0
+	case histTypeFloat64:
+		af, bf := toFloat64Safe(a), toFloat64Safe(b)
+		switch {
+		case af < bf:
+			return -1
+		case af > bf:
+			return 1
+		}
+		return 0
+	case histTypeBytes:
+		return bytes.Compare(toBytes(a), toBytes(b))
+	}
+	return 0
+}
+
+// SelectivityLE returns the estimated fraction of values ≤ v.
+//
+// Cumulates the counts of all buckets fully below v, plus a linear-
+// interpolation fraction of the bucket containing v. For string
+// columns, the partial-bucket fraction defaults to 0.5 (uniform).
+//
+// Returns 0 (nothing matches) when v < all values, 1 (all match) when
+// v ≥ all values. Clamped to [0, 1].
+func (h *Histogram) SelectivityLE(v any) float64 {
+	if h == nil || h.TotalValues == 0 || len(h.Counts) == 0 {
+		return 0.5
+	}
+	cmpFirst := compareBoundary(v, h.Boundaries[0], h.TypeCode)
+	if cmpFirst < 0 {
+		return 0
+	}
+	cmpLast := compareBoundary(v, h.Boundaries[len(h.Boundaries)-1], h.TypeCode)
+	if cmpLast >= 0 {
+		return 1
+	}
+	// Find the bucket whose upper > v.
+	var below int64
+	for i, count := range h.Counts {
+		if compareBoundary(h.Boundaries[i+1], v, h.TypeCode) > 0 {
+			// v falls into bucket i. Partial bucket fraction:
+			frac := bucketFraction(h.Boundaries[i], h.Boundaries[i+1], v, h.TypeCode)
+			return float64(below+int64(float64(count)*frac)) / float64(h.TotalValues)
+		}
+		below += count
+	}
+	return 1
+}
+
+// SelectivityRange returns the estimated fraction of values in [lo, hi].
+// Inclusive on both ends.
+func (h *Histogram) SelectivityRange(lo, hi any) float64 {
+	if h == nil || h.TotalValues == 0 {
+		return 0.33
+	}
+	leHi := h.SelectivityLE(hi)
+	ltLo := h.SelectivityLT(lo)
+	r := leHi - ltLo
+	if r < 0 {
+		r = 0
+	}
+	if r > 1 {
+		r = 1
+	}
+	return r
+}
+
+// SelectivityLT returns the estimated fraction of values < v.
+func (h *Histogram) SelectivityLT(v any) float64 {
+	if h == nil || h.TotalValues == 0 {
+		return 0.5
+	}
+	cmpFirst := compareBoundary(v, h.Boundaries[0], h.TypeCode)
+	if cmpFirst <= 0 {
+		return 0
+	}
+	cmpLast := compareBoundary(v, h.Boundaries[len(h.Boundaries)-1], h.TypeCode)
+	if cmpLast > 0 {
+		return 1
+	}
+	var below int64
+	for i, count := range h.Counts {
+		if compareBoundary(h.Boundaries[i+1], v, h.TypeCode) >= 0 {
+			frac := bucketFraction(h.Boundaries[i], h.Boundaries[i+1], v, h.TypeCode)
+			return float64(below+int64(float64(count)*frac)) / float64(h.TotalValues)
+		}
+		below += count
+	}
+	return 1
+}
+
+// SelectivityEQ returns the estimated fraction of values exactly equal
+// to v. Uniform-distribution assumption within the containing bucket:
+// 1 / (count in that bucket / count of distinct values in bucket).
+// Without per-bucket NDV, falls back to 1 / TotalValues.
+func (h *Histogram) SelectivityEQ(v any) float64 {
+	if h == nil || h.TotalValues == 0 {
+		return 0.1
+	}
+	cmpFirst := compareBoundary(v, h.Boundaries[0], h.TypeCode)
+	cmpLast := compareBoundary(v, h.Boundaries[len(h.Boundaries)-1], h.TypeCode)
+	if cmpFirst < 0 || cmpLast > 0 {
+		return 0
+	}
+	for i, count := range h.Counts {
+		if compareBoundary(h.Boundaries[i+1], v, h.TypeCode) > 0 {
+			// In bucket i. Estimate 1 over avg-frequency (count / bucket NDV).
+			// Without per-bucket NDV, treat bucket as uniform over its range.
+			return 1.0 / math.Max(float64(count), 1)
+		}
+	}
+	return 1.0 / float64(h.TotalValues)
+}
+
+// bucketFraction returns the fraction of bucket [lo, hi] that's ≤ v,
+// for the purposes of linear interpolation. For numeric types this is
+// (v-lo)/(hi-lo); for bytes returns 0.5 (uniform approximation).
+func bucketFraction(lo, hi, v any, typeCode uint8) float64 {
+	switch typeCode {
+	case histTypeInt64:
+		l, h2, vi := toInt64(lo), toInt64(hi), toInt64(v)
+		if h2 == l {
+			return 0
+		}
+		return math.Max(0, math.Min(1, float64(vi-l)/float64(h2-l)))
+	case histTypeFloat64:
+		l, h2, vf := toFloat64Safe(lo), toFloat64Safe(hi), toFloat64Safe(v)
+		if h2 == l {
+			return 0
+		}
+		return math.Max(0, math.Min(1, (vf-l)/(h2-l)))
+	}
+	return 0.5
+}
+
+// Encode writes the histogram to w in version-1 format.
+func (h *Histogram) Encode(w io.Writer) error {
+	if h == nil {
+		return nil
+	}
+	k := len(h.Counts)
+	hdr := []byte{histVersion, byte(k), h.TypeCode, 0}
+	if _, err := w.Write(hdr); err != nil {
+		return err
+	}
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(h.TotalValues))
+	if _, err := w.Write(buf[:]); err != nil {
+		return err
+	}
+	for _, b := range h.Boundaries {
+		if err := encodeValue(w, b, h.TypeCode); err != nil {
+			return err
+		}
+	}
+	for _, c := range h.Counts {
+		binary.LittleEndian.PutUint64(buf[:], uint64(c))
+		if _, err := w.Write(buf[:]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func encodeValue(w io.Writer, v any, typeCode uint8) error {
+	var buf [8]byte
+	switch typeCode {
+	case histTypeInt64:
+		binary.LittleEndian.PutUint64(buf[:], uint64(toInt64(v)))
+		_, err := w.Write(buf[:])
+		return err
+	case histTypeFloat64:
+		binary.LittleEndian.PutUint64(buf[:], math.Float64bits(toFloat64Safe(v)))
+		_, err := w.Write(buf[:])
+		return err
+	case histTypeBytes:
+		b := toBytes(v)
+		var lb [2]byte
+		binary.LittleEndian.PutUint16(lb[:], uint16(len(b)))
+		if _, err := w.Write(lb[:]); err != nil {
+			return err
+		}
+		_, err := w.Write(b)
+		return err
+	}
+	return fmt.Errorf("encodeValue: unsupported type code %d", typeCode)
+}
+
+// HistogramBytes returns the serialized form for catalog persistence.
+func (h *Histogram) Bytes() []byte {
+	if h == nil {
+		return nil
+	}
+	var buf bytes.Buffer
+	if err := h.Encode(&buf); err != nil {
+		return nil
+	}
+	return buf.Bytes()
+}
+
+// DecodeHistogram reads a version-1 histogram from r.
+func DecodeHistogram(r io.Reader) (*Histogram, error) {
+	var hdr [4]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, fmt.Errorf("histogram: read header: %w", err)
+	}
+	if hdr[0] != histVersion {
+		return nil, fmt.Errorf("histogram: unsupported version %d", hdr[0])
+	}
+	k := int(hdr[1])
+	typeCode := hdr[2]
+	var totalBuf [8]byte
+	if _, err := io.ReadFull(r, totalBuf[:]); err != nil {
+		return nil, fmt.Errorf("histogram: read total: %w", err)
+	}
+	total := int64(binary.LittleEndian.Uint64(totalBuf[:]))
+	boundaries := make([]any, k+1)
+	for i := range boundaries {
+		v, err := decodeValue(r, typeCode)
+		if err != nil {
+			return nil, fmt.Errorf("histogram: boundary %d: %w", i, err)
+		}
+		boundaries[i] = v
+	}
+	counts := make([]int64, k)
+	for i := range counts {
+		if _, err := io.ReadFull(r, totalBuf[:]); err != nil {
+			return nil, fmt.Errorf("histogram: count %d: %w", i, err)
+		}
+		counts[i] = int64(binary.LittleEndian.Uint64(totalBuf[:]))
+	}
+	return &Histogram{TypeCode: typeCode, TotalValues: total, Boundaries: boundaries, Counts: counts}, nil
+}
+
+func decodeValue(r io.Reader, typeCode uint8) (any, error) {
+	var buf [8]byte
+	switch typeCode {
+	case histTypeInt64:
+		if _, err := io.ReadFull(r, buf[:]); err != nil {
+			return nil, err
+		}
+		return int64(binary.LittleEndian.Uint64(buf[:])), nil
+	case histTypeFloat64:
+		if _, err := io.ReadFull(r, buf[:]); err != nil {
+			return nil, err
+		}
+		return math.Float64frombits(binary.LittleEndian.Uint64(buf[:])), nil
+	case histTypeBytes:
+		var lb [2]byte
+		if _, err := io.ReadFull(r, lb[:]); err != nil {
+			return nil, err
+		}
+		n := int(binary.LittleEndian.Uint16(lb[:]))
+		b := make([]byte, n)
+		if _, err := io.ReadFull(r, b); err != nil {
+			return nil, err
+		}
+		return string(b), nil
+	}
+	return nil, fmt.Errorf("decodeValue: unsupported type code %d", typeCode)
+}
+
+// HistogramFromBytes parses a histogram from its serialized form.
+// Returns nil on any error (corrupt bytes, wrong version).
+func HistogramFromBytes(b []byte) *Histogram {
+	if len(b) < 12 {
+		return nil
+	}
+	h, err := DecodeHistogram(bytes.NewReader(b))
+	if err != nil {
+		return nil
+	}
+	return h
+}

--- a/internal/storage/catalog/histogram_test.go
+++ b/internal/storage/catalog/histogram_test.go
@@ -1,0 +1,116 @@
+package catalog
+
+import (
+	"math"
+	"testing"
+)
+
+func TestHistogramRangeSelectivity(t *testing.T) {
+	// Uniform distribution 1..10000.
+	sample := make([]any, 10000)
+	for i := range sample {
+		sample[i] = int64(i + 1)
+	}
+	h := BuildHistogramFromSamples(sample, 64)
+	if h == nil {
+		t.Fatal("BuildHistogramFromSamples returned nil")
+	}
+
+	cases := []struct {
+		name        string
+		lo, hi      int64
+		expectSel   float64
+		tolerancePc float64
+	}{
+		{"first quarter", 1, 2500, 0.25, 5},
+		{"middle half", 2500, 7500, 0.5, 5},
+		{"second half", 5000, 10000, 0.5, 5},
+		{"full range", 1, 10000, 1.0, 5},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			sel := h.SelectivityRange(c.lo, c.hi)
+			errPct := math.Abs(sel-c.expectSel) / c.expectSel * 100
+			t.Logf("[%d, %d] sel=%.4f expected=%.4f err=%.1f%%", c.lo, c.hi, sel, c.expectSel, errPct)
+			if errPct > c.tolerancePc {
+				t.Errorf("selectivity %.4f differs from expected %.4f by %.1f%% (tolerance %.1f%%)",
+					sel, c.expectSel, errPct, c.tolerancePc)
+			}
+		})
+	}
+}
+
+func TestHistogramLEEdges(t *testing.T) {
+	sample := make([]any, 1000)
+	for i := range sample {
+		sample[i] = int64(i + 1)
+	}
+	h := BuildHistogramFromSamples(sample, 32)
+
+	// Below min → 0
+	if sel := h.SelectivityLE(int64(0)); sel != 0 {
+		t.Errorf("LE 0 should be 0, got %f", sel)
+	}
+	// Above max → 1
+	if sel := h.SelectivityLE(int64(2000)); sel != 1 {
+		t.Errorf("LE 2000 should be 1, got %f", sel)
+	}
+	// At median → ~0.5
+	sel := h.SelectivityLE(int64(500))
+	if sel < 0.4 || sel > 0.6 {
+		t.Errorf("LE 500 should be ~0.5, got %f", sel)
+	}
+}
+
+func TestHistogramRoundTrip(t *testing.T) {
+	sample := make([]any, 5000)
+	for i := range sample {
+		sample[i] = int64(i*7 + 3)
+	}
+	h := BuildHistogramFromSamples(sample, 64)
+	if h == nil {
+		t.Fatal("nil histogram")
+	}
+	b := h.Bytes()
+	got := HistogramFromBytes(b)
+	if got == nil {
+		t.Fatal("decode returned nil")
+	}
+	if got.TotalValues != h.TotalValues {
+		t.Errorf("TotalValues: got %d want %d", got.TotalValues, h.TotalValues)
+	}
+	// Selectivity should be identical post-roundtrip.
+	origSel := h.SelectivityRange(int64(1000), int64(8000))
+	decSel := got.SelectivityRange(int64(1000), int64(8000))
+	if origSel != decSel {
+		t.Errorf("selectivity diverged: orig=%f decoded=%f", origSel, decSel)
+	}
+}
+
+func TestHistogramTPCHDateRange(t *testing.T) {
+	// Simulate l_shipdate: 7 years of dates as int32 days since 1992-01-01.
+	// Q04's filter: 1993-07-01 (year 1.5) to 1993-09-30 (year 1.75) — ~3.6% selectivity.
+	sample := make([]any, 60000)
+	for i := range sample {
+		// Uniform across 7*365 = 2555 days
+		sample[i] = int64(i * 2555 / 60000)
+	}
+	h := BuildHistogramFromSamples(sample, 64)
+
+	q4lo := int64(547)  // ~year 1.5
+	q4hi := int64(639)  // ~year 1.75
+	sel := h.SelectivityRange(q4lo, q4hi)
+	t.Logf("Q04-style date range %d-%d: sel=%.4f (expect ~0.036)", q4lo, q4hi, sel)
+	if sel < 0.02 || sel > 0.05 {
+		t.Errorf("Q04 date selectivity off: got %.4f", sel)
+	}
+
+	// Q21-style 2-year span (1995-1996, year 3-4)
+	q21lo := int64(3 * 365)
+	q21hi := int64(5 * 365)
+	sel = h.SelectivityRange(q21lo, q21hi)
+	t.Logf("Q21-style 2-year range %d-%d: sel=%.4f (expect ~0.286)", q21lo, q21hi, sel)
+	if sel < 0.25 || sel > 0.32 {
+		t.Errorf("Q21 date selectivity off: got %.4f", sel)
+	}
+}

--- a/internal/storage/catalog/hll.go
+++ b/internal/storage/catalog/hll.go
@@ -1,0 +1,139 @@
+package catalog
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+	"math/bits"
+
+	"github.com/cespare/xxhash/v2"
+)
+
+// HLL implements a HyperLogLog++ sketch sized for catalog use. With 2^14
+// registers it has ~0.8% standard error on cardinality estimates from
+// thousands up to billions of distinct values, using 16 KB per sketch.
+// That's plenty cheap to persist on every column's catalog entry and
+// gives the planner reliable NDV for join-order decisions and
+// dynamic-filter eligibility.
+//
+// Wire format: a one-byte version (1) followed by the 16384 register
+// bytes. Merge is byte-wise max across two sketches.
+
+const (
+	hllPrecision  = 14
+	hllRegisters  = 1 << hllPrecision // 16384
+	hllMask       = hllRegisters - 1
+	hllVersion    = 1
+)
+
+// HLL is a fixed-size HyperLogLog++ sketch. Zero value is a valid empty
+// sketch; use Add to insert hashed values.
+type HLL struct {
+	registers [hllRegisters]uint8
+}
+
+// Add inserts a value's hash into the sketch.
+func (h *HLL) Add(hash uint64) {
+	idx := hash & hllMask
+	w := hash >> hllPrecision
+	// rho = position of the leftmost 1-bit in w (1-indexed). For a
+	// 64-precision hash and precision p, w has 64-p bits, so the max
+	// rho is 64-p+1 = 51 for p=14.
+	rho := uint8(bits.LeadingZeros64(w<<hllPrecision) + 1)
+	if rho > h.registers[idx] {
+		h.registers[idx] = rho
+	}
+}
+
+// AddBytes hashes b and inserts it.
+func (h *HLL) AddBytes(b []byte) { h.Add(xxhash.Sum64(b)) }
+
+// AddInt64 hashes a uint64 representation of v and inserts it.
+func (h *HLL) AddInt64(v int64) {
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(v))
+	h.Add(xxhash.Sum64(buf[:]))
+}
+
+// Estimate returns the approximate cardinality.
+func (h *HLL) Estimate() int64 {
+	if h == nil {
+		return 0
+	}
+	const m = float64(hllRegisters)
+	alpha := 0.7213 / (1 + 1.079/m)
+	sum := 0.0
+	zeros := 0
+	for _, r := range h.registers {
+		sum += 1.0 / math.Pow(2, float64(r))
+		if r == 0 {
+			zeros++
+		}
+	}
+	raw := alpha * m * m / sum
+	// Small-range correction: linear counting when many registers
+	// haven't seen a hash yet.
+	if zeros > 0 && raw <= 2.5*m {
+		raw = m * math.Log(m/float64(zeros))
+	}
+	return int64(math.Round(raw))
+}
+
+// Merge takes the byte-wise max of the two sketches. Equivalent to
+// computing a sketch over the union of inserted values.
+func (h *HLL) Merge(o *HLL) {
+	if h == nil || o == nil {
+		return
+	}
+	for i, r := range o.registers {
+		if r > h.registers[i] {
+			h.registers[i] = r
+		}
+	}
+}
+
+// Encode writes the sketch to w in version-1 format.
+func (h *HLL) Encode(w io.Writer) error {
+	if _, err := w.Write([]byte{hllVersion}); err != nil {
+		return err
+	}
+	_, err := w.Write(h.registers[:])
+	return err
+}
+
+// DecodeHLL reads a sketch in version-1 format.
+func DecodeHLL(r io.Reader) (*HLL, error) {
+	var hdr [1]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, fmt.Errorf("hll: read header: %w", err)
+	}
+	if hdr[0] != hllVersion {
+		return nil, fmt.Errorf("hll: unsupported version %d", hdr[0])
+	}
+	out := &HLL{}
+	if _, err := io.ReadFull(r, out.registers[:]); err != nil {
+		return nil, fmt.Errorf("hll: read registers: %w", err)
+	}
+	return out, nil
+}
+
+// HLLBytes returns the serialized form, suitable for catalog persistence.
+func (h *HLL) Bytes() []byte {
+	buf := make([]byte, 1+hllRegisters)
+	buf[0] = hllVersion
+	copy(buf[1:], h.registers[:])
+	return buf
+}
+
+// HLLFromBytes parses a sketch from its serialized form. Returns nil on
+// any error (corrupt bytes, wrong version) — callers fall back to the
+// heuristic NDV path.
+func HLLFromBytes(b []byte) *HLL {
+	if len(b) != 1+hllRegisters || b[0] != hllVersion {
+		return nil
+	}
+	out := &HLL{}
+	copy(out.registers[:], b[1:])
+	return out
+}

--- a/internal/storage/catalog/hll_test.go
+++ b/internal/storage/catalog/hll_test.go
@@ -1,0 +1,67 @@
+package catalog
+
+import (
+	"math"
+	"testing"
+)
+
+func TestHLLAccuracy(t *testing.T) {
+	cases := []int64{100, 1_000, 10_000, 100_000, 1_000_000}
+	for _, n := range cases {
+		var h HLL
+		for i := int64(0); i < n; i++ {
+			h.AddInt64(i)
+		}
+		est := h.Estimate()
+		errPct := math.Abs(float64(est-n)) / float64(n) * 100
+		t.Logf("n=%d est=%d err=%.2f%%", n, est, errPct)
+		if errPct > 5 {
+			t.Errorf("n=%d: err %.2f%% exceeds 5%% tolerance (est=%d)", n, errPct, est)
+		}
+	}
+}
+
+func TestHLLMerge(t *testing.T) {
+	var a, b HLL
+	for i := int64(0); i < 50_000; i++ {
+		a.AddInt64(i)
+	}
+	for i := int64(25_000); i < 75_000; i++ {
+		b.AddInt64(i)
+	}
+	a.Merge(&b)
+	est := a.Estimate()
+	want := int64(75_000)
+	errPct := math.Abs(float64(est-want)) / float64(want) * 100
+	if errPct > 5 {
+		t.Errorf("merged estimate %d off by %.2f%% from %d", est, errPct, want)
+	}
+}
+
+func TestHLLRoundTrip(t *testing.T) {
+	var h HLL
+	for i := int64(0); i < 10_000; i++ {
+		h.AddInt64(i * 7)
+	}
+	orig := h.Estimate()
+	b := h.Bytes()
+	got := HLLFromBytes(b)
+	if got == nil {
+		t.Fatal("HLLFromBytes returned nil")
+	}
+	if got.Estimate() != orig {
+		t.Errorf("roundtrip estimate diverged: orig=%d got=%d", orig, got.Estimate())
+	}
+}
+
+func TestHLLBadBytes(t *testing.T) {
+	if HLLFromBytes(nil) != nil {
+		t.Error("nil bytes should return nil")
+	}
+	if HLLFromBytes([]byte{99, 0, 0}) != nil {
+		t.Error("wrong version should return nil")
+	}
+	if HLLFromBytes(make([]byte, 100)) != nil {
+		t.Error("wrong length should return nil")
+	}
+}

--- a/internal/storage/catalog/hll_value.go
+++ b/internal/storage/catalog/hll_value.go
@@ -1,0 +1,131 @@
+package catalog
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// AddValueToHLL hashes a value according to its declared parquet type
+// and inserts the hash into the sketch.
+//
+// Shared between the ingest path (which receives raw map[string]any
+// rows pre-write) and the ANALYZE path (which decodes parquet rows
+// post-write). Both produce hash-compatible HLLs that the catalog
+// can merge.
+//
+// Canonical encodings:
+//   - integer/temporal types → 8-byte LE of int64 representation
+//   - float32/float64 → 8-byte LE of math.Float64bits
+//   - bool → single byte 0/1
+//   - string/bytes/network-id types → raw bytes
+//   - timestamp → UnixMilli (time.Time) or int64 (raw)
+//   - duration → nanoseconds
+//
+// The encoding intentionally normalizes int32 and int64 to the same
+// byte stream so a column widened post-write hashes identically.
+func AddValueToHLL(h *HLL, v any, t parquet.TypeID) {
+	if h == nil || v == nil {
+		return
+	}
+	switch t {
+	case parquet.TypeBool:
+		b := byte(0)
+		if bv, ok := v.(bool); ok && bv {
+			b = 1
+		}
+		h.AddBytes([]byte{b})
+	case parquet.TypeInt32, parquet.TypeInt64, parquet.TypeDate,
+		parquet.TypePort, parquet.TypeProtocol:
+		h.AddInt64(asInt64(v))
+	case parquet.TypeFloat32, parquet.TypeFloat64:
+		bits := math.Float64bits(asFloat64(v))
+		var buf [8]byte
+		binary.LittleEndian.PutUint64(buf[:], bits)
+		h.AddBytes(buf[:])
+	case parquet.TypeTimestamp:
+		switch tv := v.(type) {
+		case time.Time:
+			h.AddInt64(tv.UnixMilli())
+		default:
+			h.AddInt64(asInt64(v))
+		}
+	case parquet.TypeDuration:
+		switch tv := v.(type) {
+		case time.Duration:
+			h.AddInt64(int64(tv))
+		default:
+			h.AddInt64(asInt64(v))
+		}
+	case parquet.TypeString, parquet.TypeBytes,
+		parquet.TypeIPv4, parquet.TypeIPv6, parquet.TypeCIDR,
+		parquet.TypeMAC, parquet.TypeUUID, parquet.TypeDecimal:
+		switch sv := v.(type) {
+		case string:
+			h.AddBytes([]byte(sv))
+		case []byte:
+			h.AddBytes(sv)
+		default:
+			h.AddBytes([]byte(fmt.Sprintf("%v", v)))
+		}
+	default:
+		h.AddBytes([]byte(fmt.Sprintf("%v", v)))
+	}
+}
+
+// IsHLLSupportedType reports whether the column type is one we collect
+// HLL sketches for. Returns false for nested types whose "value" isn't a
+// single scalar.
+func IsHLLSupportedType(t parquet.TypeID) bool {
+	switch t {
+	case parquet.TypeArray, parquet.TypeRow, parquet.TypeMap:
+		return false
+	}
+	return true
+}
+
+func asInt64(v any) int64 {
+	switch tv := v.(type) {
+	case int64:
+		return tv
+	case int32:
+		return int64(tv)
+	case int:
+		return int64(tv)
+	case uint64:
+		return int64(tv)
+	case uint32:
+		return int64(tv)
+	case float64:
+		return int64(tv)
+	case float32:
+		return int64(tv)
+	case bool:
+		if tv {
+			return 1
+		}
+		return 0
+	default:
+		return 0
+	}
+}
+
+func asFloat64(v any) float64 {
+	switch tv := v.(type) {
+	case float64:
+		return tv
+	case float32:
+		return float64(tv)
+	case int64:
+		return float64(tv)
+	case int32:
+		return float64(tv)
+	case int:
+		return float64(tv)
+	default:
+		return 0
+	}
+}

--- a/internal/storage/catalog/sample.go
+++ b/internal/storage/catalog/sample.go
@@ -1,0 +1,310 @@
+package catalog
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"hash/maphash"
+	"io"
+	"math"
+	"sort"
+)
+
+// ColumnSample is a fixed-size random sample of a column's values,
+// persisted in FileColumnStats so the catalog can build aggregate
+// histograms across files at query time. The sample is stored sorted
+// so cross-file merge is a sorted-merge of K-way streams; the
+// histogram is built once from the merged sample on AggregateColumnStats.
+//
+// Storage: ~256 values × 8 bytes for numerics = 2 KB per column per
+// file. Comparable to the per-file Histogram size but mergeable
+// without distribution-assumption hacks.
+//
+// Type-discriminated wire format mirrors Histogram's encodeValue:
+//   - int64: 8 bytes LE per value
+//   - float64: 8 bytes LE (math.Float64bits) per value
+//   - bytes: uint16 length prefix + raw bytes per value
+const (
+	sampleVersion = 1
+
+	SampleDefaultSize = 256
+)
+
+// ReservoirSampler holds an in-memory sample using Algorithm L
+// reservoir sampling: O(N) producer cost, uniformly distributed sample
+// of size K from a stream of unknown length. Each Add either replaces
+// a random existing entry or is dropped, weighted to keep all input
+// values equally probable.
+type ReservoirSampler struct {
+	capacity int
+	values   []any
+	seen     int64
+	rng      maphash.Hash
+	typeCode uint8
+	typed    bool
+}
+
+// NewReservoirSampler creates a sampler of the given capacity. K ≤ 0
+// uses the default (SampleDefaultSize).
+func NewReservoirSampler(k int) *ReservoirSampler {
+	if k <= 0 {
+		k = SampleDefaultSize
+	}
+	rs := &ReservoirSampler{capacity: k, values: make([]any, 0, k)}
+	rs.rng.SetSeed(maphash.MakeSeed())
+	return rs
+}
+
+// Add inserts a value. The sample is updated in O(1) amortized.
+func (rs *ReservoirSampler) Add(v any) {
+	if v == nil {
+		return
+	}
+	if !rs.typed {
+		if tc, ok := sampleTypeOf(v); ok {
+			rs.typeCode = tc
+			rs.typed = true
+		} else {
+			return // unsupported type — skip
+		}
+	}
+	rs.seen++
+	if len(rs.values) < rs.capacity {
+		rs.values = append(rs.values, v)
+		return
+	}
+	// Algorithm R: replace at index j with probability k/n.
+	rs.rng.Reset()
+	rs.rng.WriteString(fmt.Sprintf("%d", rs.seen))
+	j := int(rs.rng.Sum64() % uint64(rs.seen))
+	if j < rs.capacity {
+		rs.values[j] = v
+	}
+}
+
+// Snapshot returns the sampled values along with the total observed
+// count. The sample slice is sorted in-place.
+func (rs *ReservoirSampler) Snapshot() (sorted []any, totalSeen int64, typeCode uint8) {
+	if !rs.typed || len(rs.values) == 0 {
+		return nil, 0, 0
+	}
+	out := append([]any(nil), rs.values...)
+	sortSample(out, rs.typeCode)
+	return out, rs.seen, rs.typeCode
+}
+
+// EncodeSample writes a sorted sample to w in version-1 format.
+//
+//	[1]   version (1)
+//	[1]   type code
+//	[2]   value count K (uint16 LE)
+//	[8]   total observed count (uint64 LE, before reservoir downsampling)
+//	[K*?] K values, type-discriminated encoding
+func EncodeSample(w io.Writer, values []any, totalSeen int64, typeCode uint8) error {
+	if len(values) == 0 {
+		return nil
+	}
+	hdr := []byte{sampleVersion, typeCode}
+	if _, err := w.Write(hdr); err != nil {
+		return err
+	}
+	var cnt [2]byte
+	binary.LittleEndian.PutUint16(cnt[:], uint16(len(values)))
+	if _, err := w.Write(cnt[:]); err != nil {
+		return err
+	}
+	var t [8]byte
+	binary.LittleEndian.PutUint64(t[:], uint64(totalSeen))
+	if _, err := w.Write(t[:]); err != nil {
+		return err
+	}
+	for _, v := range values {
+		if err := encodeValue(w, v, typeCode); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DecodeSample reads a sample written by EncodeSample.
+func DecodeSample(r io.Reader) (values []any, totalSeen int64, typeCode uint8, err error) {
+	var hdr [4]byte
+	if _, err = io.ReadFull(r, hdr[:]); err != nil {
+		return nil, 0, 0, fmt.Errorf("sample: read header: %w", err)
+	}
+	if hdr[0] != sampleVersion {
+		return nil, 0, 0, fmt.Errorf("sample: unsupported version %d", hdr[0])
+	}
+	typeCode = hdr[1]
+	count := int(binary.LittleEndian.Uint16(hdr[2:4]))
+	var t [8]byte
+	if _, err = io.ReadFull(r, t[:]); err != nil {
+		return nil, 0, 0, fmt.Errorf("sample: read total: %w", err)
+	}
+	totalSeen = int64(binary.LittleEndian.Uint64(t[:]))
+	values = make([]any, count)
+	for i := 0; i < count; i++ {
+		v, derr := decodeValue(r, typeCode)
+		if derr != nil {
+			return nil, 0, 0, fmt.Errorf("sample: value %d: %w", i, derr)
+		}
+		values[i] = v
+	}
+	return values, totalSeen, typeCode, nil
+}
+
+// SampleBytes serializes a snapshot for catalog persistence.
+func SampleBytes(values []any, totalSeen int64, typeCode uint8) []byte {
+	if len(values) == 0 {
+		return nil
+	}
+	var buf bytes.Buffer
+	if err := EncodeSample(&buf, values, totalSeen, typeCode); err != nil {
+		return nil
+	}
+	return buf.Bytes()
+}
+
+// SampleFromBytes parses a sample blob. Returns nil values on any error.
+func SampleFromBytes(b []byte) (values []any, totalSeen int64, typeCode uint8, ok bool) {
+	if len(b) < 12 {
+		return nil, 0, 0, false
+	}
+	v, t, tc, err := DecodeSample(bytes.NewReader(b))
+	if err != nil {
+		return nil, 0, 0, false
+	}
+	return v, t, tc, true
+}
+
+// sampleTypeOf returns the type code for a value if supported.
+func sampleTypeOf(v any) (uint8, bool) {
+	switch v.(type) {
+	case int64, int32, int:
+		return histTypeInt64, true
+	case float64, float32:
+		return histTypeFloat64, true
+	case string, []byte:
+		return histTypeBytes, true
+	}
+	return 0, false
+}
+
+// MergeSamples combines multiple per-file samples into a single sorted
+// sample, weighted by each file's totalSeen so larger files contribute
+// more samples to the merged distribution. Returns combined values,
+// total observed across all files, and the shared type code.
+//
+// If samples have mixed type codes (shouldn't happen for a valid
+// column), the first sample's type wins; mismatched entries are
+// skipped.
+func MergeSamples(files [][]byte) (values []any, totalSeen int64, typeCode uint8) {
+	type entry struct {
+		values []any
+		total  int64
+		tc     uint8
+	}
+	var entries []entry
+	for _, b := range files {
+		v, t, tc, ok := SampleFromBytes(b)
+		if !ok {
+			continue
+		}
+		entries = append(entries, entry{v, t, tc})
+		totalSeen += t
+		if len(entries) == 1 {
+			typeCode = tc
+		}
+	}
+	if len(entries) == 0 {
+		return nil, 0, 0
+	}
+	// Weight-proportional draws: each file contributes
+	// ceil(SampleDefaultSize * (file.total / totalSeen)) samples
+	// to the merged sample.
+	merged := make([]any, 0, SampleDefaultSize)
+	remaining := SampleDefaultSize
+	for i, e := range entries {
+		if e.tc != typeCode {
+			continue
+		}
+		// For the last file, take whatever's left to ensure we fill
+		// the budget when rounding under-allocated.
+		var quota int
+		if i == len(entries)-1 {
+			quota = remaining
+		} else {
+			weight := float64(e.total) / float64(totalSeen)
+			quota = int(math.Round(weight * float64(SampleDefaultSize)))
+			if quota > remaining {
+				quota = remaining
+			}
+			if quota < 1 {
+				quota = 1
+			}
+		}
+		// Draw evenly-spaced samples from this file's sorted values.
+		n := len(e.values)
+		if n == 0 || quota <= 0 {
+			continue
+		}
+		if quota >= n {
+			merged = append(merged, e.values...)
+			remaining -= n
+		} else {
+			step := float64(n) / float64(quota)
+			for j := 0; j < quota; j++ {
+				idx := int(float64(j) * step)
+				if idx >= n {
+					idx = n - 1
+				}
+				merged = append(merged, e.values[idx])
+			}
+			remaining -= quota
+		}
+	}
+	sortSample(merged, typeCode)
+	values = merged
+	return values, totalSeen, typeCode
+}
+
+// HistogramFromMergedSample builds a histogram from the merged sample
+// and the actual total row count. The total drives the histogram's
+// TotalValues so selectivities are reported as fractions of the real
+// table size, not of the sample size.
+func HistogramFromMergedSample(values []any, totalRows int64, typeCode uint8, k int) *Histogram {
+	if len(values) == 0 || totalRows == 0 {
+		return nil
+	}
+	h := BuildHistogramFromSamples(values, k)
+	if h == nil {
+		return nil
+	}
+	// Scale TotalValues from sample size to the actual table size so
+	// SelectivityRange returns true-row-count-based fractions.
+	h.TotalValues = totalRows
+	// Counts stay as sample counts; selectivities use count/TotalValues
+	// which already returns the right fraction since both numerator and
+	// denominator scale linearly. Counts will be small (sum to sample
+	// size), but the FRACTION below v matches the population fraction
+	// under the uniform-sampling assumption.
+	scale := float64(totalRows) / float64(sumCounts(h.Counts))
+	for i := range h.Counts {
+		h.Counts[i] = int64(float64(h.Counts[i]) * scale)
+	}
+	return h
+}
+
+func sumCounts(c []int64) int64 {
+	var s int64
+	for _, v := range c {
+		s += v
+	}
+	return s
+}
+
+// pickRandomFloat returns a deterministic-pseudorandom float in [0, 1)
+// derived from x. Used to break ties consistently in sample weighting.
+// Unused for the current weight-proportional draw but kept for future
+// stratified-sampling improvements.
+var _ = sort.SearchInts

--- a/internal/storage/catalog/sketches.go
+++ b/internal/storage/catalog/sketches.go
@@ -1,0 +1,184 @@
+package catalog
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+)
+
+// FileSketches bundles every supported column's HLL + reservoir sample
+// for one parquet file into a single object-store blob. Storing these
+// sketches inline in the catalog manifest blew the NATS payload limit
+// at SF100 (63 lineitem files × 16 cols × 18 KB ≈ 18 MB > 1 MB max),
+// so the catalog now writes sketches to the object store and only
+// keeps a small reference in the manifest.
+//
+// One blob per parquet file (≈ 16 cols × 18 KB ≈ 300 KB at SF100).
+// The blob is read once per file during AggregateColumnStats and the
+// individual sketches feed cross-file merges. Lazy: not loaded unless
+// the planner asks for the table's aggregated stats.
+//
+// Wire format (binary, version-1):
+//
+//	[4]   magic "WSKB" (Wadjet SKetches Bundle)
+//	[1]   version (1)
+//	[1]   reserved
+//	[2]   column count K (uint16 LE)
+//	then K entries, each:
+//	  [2]  column name length (uint16 LE)
+//	  [N]  column name bytes
+//	  [4]  HLL bytes length (uint32 LE; 0 = no HLL)
+//	  [M]  HLL bytes (HLL wire format, see hll.go)
+//	  [4]  Sample bytes length (uint32 LE; 0 = no Sample)
+//	  [P]  Sample bytes (Sample wire format, see sample.go)
+const (
+	sketchesMagic   = "WSKB"
+	sketchesVersion = 1
+)
+
+// FileSketchesEntry is the in-memory form of one column's sketches.
+type FileSketchesEntry struct {
+	Column string
+	HLL    []byte
+	Sample []byte
+}
+
+// EncodeFileSketches serializes a per-column sketch map to the v1 wire
+// format. Empty input returns nil (no blob to upload).
+func EncodeFileSketches(entries []FileSketchesEntry) []byte {
+	if len(entries) == 0 {
+		return nil
+	}
+	var buf bytes.Buffer
+	hdr := make([]byte, 8)
+	copy(hdr[0:4], sketchesMagic)
+	hdr[4] = sketchesVersion
+	binary.LittleEndian.PutUint16(hdr[6:8], uint16(len(entries)))
+	buf.Write(hdr)
+	for _, e := range entries {
+		var lb [4]byte
+		// column name
+		binary.LittleEndian.PutUint16(lb[:2], uint16(len(e.Column)))
+		buf.Write(lb[:2])
+		buf.WriteString(e.Column)
+		// HLL
+		binary.LittleEndian.PutUint32(lb[:], uint32(len(e.HLL)))
+		buf.Write(lb[:])
+		buf.Write(e.HLL)
+		// Sample
+		binary.LittleEndian.PutUint32(lb[:], uint32(len(e.Sample)))
+		buf.Write(lb[:])
+		buf.Write(e.Sample)
+	}
+	return buf.Bytes()
+}
+
+// DecodeFileSketches parses a v1 sketches blob.
+func DecodeFileSketches(r io.Reader) ([]FileSketchesEntry, error) {
+	hdr := make([]byte, 8)
+	if _, err := io.ReadFull(r, hdr); err != nil {
+		return nil, fmt.Errorf("sketches: read header: %w", err)
+	}
+	if string(hdr[0:4]) != sketchesMagic {
+		return nil, fmt.Errorf("sketches: bad magic %q", string(hdr[0:4]))
+	}
+	if hdr[4] != sketchesVersion {
+		return nil, fmt.Errorf("sketches: unsupported version %d", hdr[4])
+	}
+	n := int(binary.LittleEndian.Uint16(hdr[6:8]))
+	out := make([]FileSketchesEntry, 0, n)
+	for i := 0; i < n; i++ {
+		var nameLen [2]byte
+		if _, err := io.ReadFull(r, nameLen[:]); err != nil {
+			return nil, fmt.Errorf("sketches: entry %d name length: %w", i, err)
+		}
+		nameBytes := make([]byte, binary.LittleEndian.Uint16(nameLen[:]))
+		if _, err := io.ReadFull(r, nameBytes); err != nil {
+			return nil, fmt.Errorf("sketches: entry %d name: %w", i, err)
+		}
+		var lb [4]byte
+		if _, err := io.ReadFull(r, lb[:]); err != nil {
+			return nil, fmt.Errorf("sketches: entry %d hll length: %w", i, err)
+		}
+		hllLen := binary.LittleEndian.Uint32(lb[:])
+		hllBytes := make([]byte, hllLen)
+		if hllLen > 0 {
+			if _, err := io.ReadFull(r, hllBytes); err != nil {
+				return nil, fmt.Errorf("sketches: entry %d hll: %w", i, err)
+			}
+		}
+		if _, err := io.ReadFull(r, lb[:]); err != nil {
+			return nil, fmt.Errorf("sketches: entry %d sample length: %w", i, err)
+		}
+		sampleLen := binary.LittleEndian.Uint32(lb[:])
+		sampleBytes := make([]byte, sampleLen)
+		if sampleLen > 0 {
+			if _, err := io.ReadFull(r, sampleBytes); err != nil {
+				return nil, fmt.Errorf("sketches: entry %d sample: %w", i, err)
+			}
+		}
+		out = append(out, FileSketchesEntry{Column: string(nameBytes), HLL: hllBytes, Sample: sampleBytes})
+	}
+	return out, nil
+}
+
+// sketchesObjectKey returns the canonical object-store path for one
+// parquet file's sketches bundle. The basename of the parquet path is
+// reused so the sketch object lives in a parallel directory layout.
+func sketchesObjectKey(table, parquetPath string) string {
+	base := parquetPath
+	if i := bytes.LastIndexByte([]byte(parquetPath), '/'); i >= 0 {
+		base = parquetPath[i+1:]
+	}
+	// Strip a .parquet suffix; keep .sketches as the new extension.
+	if l := len(base); l >= 8 && base[l-8:] == ".parquet" {
+		base = base[:l-8]
+	}
+	return fmt.Sprintf("stats/%s/%s.sketches", table, base)
+}
+
+// putFileSketches uploads a bundled sketches blob and returns the
+// object-store key. Empty entries returns "" (nothing to upload).
+func (c *Catalog) putFileSketches(ctx context.Context, table, parquetPath string, entries []FileSketchesEntry) (string, error) {
+	if len(entries) == 0 {
+		return "", nil
+	}
+	data := EncodeFileSketches(entries)
+	if len(data) == 0 {
+		return "", nil
+	}
+	key := sketchesObjectKey(table, parquetPath)
+	if _, err := c.store.Put(ctx, c.bucket, key, bytes.NewReader(data), int64(len(data)), "application/octet-stream"); err != nil {
+		return "", fmt.Errorf("upload sketches %s: %w", key, err)
+	}
+	return key, nil
+}
+
+// UploadFileSketches is the exported entry point for the ingest path.
+// It bundles per-column sketches into a single object-store blob and
+// returns the canonical key.
+func (c *Catalog) UploadFileSketches(ctx context.Context, table, parquetPath string, entries []FileSketchesEntry) (string, error) {
+	return c.putFileSketches(ctx, table, parquetPath, entries)
+}
+
+// loadFileSketches fetches a previously-uploaded sketches blob.
+// Returns nil entries on best-effort error so AggregateColumnStats
+// can degrade to the legacy inline path or to heuristic NDV.
+func (c *Catalog) loadFileSketches(ctx context.Context, key string) ([]FileSketchesEntry, error) {
+	if key == "" {
+		return nil, nil
+	}
+	rc, _, err := c.store.Get(ctx, c.bucket, key)
+	if err != nil {
+		return nil, fmt.Errorf("fetch sketches %s: %w", key, err)
+	}
+	defer rc.Close()
+	return DecodeFileSketches(rc)
+}
+
+// Compile-time guarantee that we hold a usable Store.
+var _ objstore.Store = (objstore.Store)(nil)

--- a/internal/storage/ingest/hll_stats.go
+++ b/internal/storage/ingest/hll_stats.go
@@ -5,27 +5,30 @@ import (
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
 )
 
-// computeColumnHLLs builds a HyperLogLog++ sketch for every column in
-// the schema, scanning the row map per column. Returns a map keyed by
-// column name; columns whose values are all nil are omitted.
+// columnStats holds both the HLL sketch and the reservoir sample for
+// one column as ingest collects them in one pass.
+type columnStats struct {
+	hll     *catalog.HLL
+	sampler *catalog.ReservoirSampler
+}
+
+// computeColumnStats builds HLL sketches AND reservoir samples for
+// every supported column in one pass over the rows. Two outputs because
+// the catalog needs both — HLL for NDV, samples for histograms.
 //
-// Called from flushBuffer alongside extractColumnStats so the catalog
-// gets table-level NDV estimates the planner can consult for cardinality
-// and dynamic-filter decisions.
-//
-// Uses catalog.AddValueToHLL for the value→hash conversion so HLLs
-// produced here are byte-compatible with those produced by the ANALYZE
-// path (catalog.AnalyzeTable). Both can be merged via HLL.Merge.
-func computeColumnHLLs(rows []map[string]any, schema parquet.Schema) map[string]*catalog.HLL {
+// Uses catalog.AddValueToHLL for hashes and ReservoirSampler.Add for
+// samples; both helpers are shared with the ANALYZE path so produced
+// stats are byte-compatible across collection sites.
+func computeColumnStats(rows []map[string]any, schema parquet.Schema) map[string]*columnStats {
 	if len(rows) == 0 {
 		return nil
 	}
-	out := make(map[string]*catalog.HLL, len(schema.Columns))
+	out := make(map[string]*columnStats, len(schema.Columns))
 	for _, col := range schema.Columns {
 		if !catalog.IsHLLSupportedType(col.Type) {
 			continue
 		}
-		var h catalog.HLL
+		cs := &columnStats{hll: &catalog.HLL{}, sampler: catalog.NewReservoirSampler(catalog.SampleDefaultSize)}
 		any := false
 		for _, row := range rows {
 			v, ok := row[col.Name]
@@ -33,10 +36,11 @@ func computeColumnHLLs(rows []map[string]any, schema parquet.Schema) map[string]
 				continue
 			}
 			any = true
-			catalog.AddValueToHLL(&h, v, col.Type)
+			catalog.AddValueToHLL(cs.hll, v, col.Type)
+			cs.sampler.Add(v)
 		}
 		if any {
-			out[col.Name] = &h
+			out[col.Name] = cs
 		}
 	}
 	return out

--- a/internal/storage/ingest/hll_stats.go
+++ b/internal/storage/ingest/hll_stats.go
@@ -1,0 +1,146 @@
+package ingest
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/storage/catalog"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// computeColumnHLLs builds a HyperLogLog++ sketch for every column in
+// the schema, scanning the row map per column. Returns a map keyed by
+// column name; columns whose values are all nil are omitted.
+//
+// Called from flushBuffer alongside extractColumnStats so the catalog
+// gets table-level NDV estimates the planner can consult for cardinality
+// and dynamic-filter decisions.
+func computeColumnHLLs(rows []map[string]any, schema parquet.Schema) map[string]*catalog.HLL {
+	if len(rows) == 0 {
+		return nil
+	}
+	out := make(map[string]*catalog.HLL, len(schema.Columns))
+	for _, col := range schema.Columns {
+		// HLL works on hashable scalar values. Skip nested types (Array,
+		// Row, Map) — NDV isn't well-defined for them and the parquet
+		// readers don't return them as single values anyway.
+		switch col.Type {
+		case parquet.TypeArray, parquet.TypeRow, parquet.TypeMap:
+			continue
+		}
+		var h catalog.HLL
+		any := false
+		for _, row := range rows {
+			v, ok := row[col.Name]
+			if !ok || v == nil {
+				continue
+			}
+			any = true
+			addValueToHLL(&h, v, col.Type)
+		}
+		if any {
+			out[col.Name] = &h
+		}
+	}
+	return out
+}
+
+// addValueToHLL hashes a value according to its declared parquet type
+// and inserts the hash into the sketch.
+//
+// For numeric/temporal types we serialize a canonical 8-byte LE form to
+// keep the hash stable across int32→int64 widening. For strings we hash
+// the bytes directly. For bool we use a single byte 0/1.
+func addValueToHLL(h *catalog.HLL, v any, t parquet.TypeID) {
+	switch t {
+	case parquet.TypeBool:
+		b := byte(0)
+		if bv, ok := v.(bool); ok && bv {
+			b = 1
+		}
+		h.AddBytes([]byte{b})
+	case parquet.TypeInt32, parquet.TypeInt64, parquet.TypeDate,
+		parquet.TypePort, parquet.TypeProtocol:
+		h.AddInt64(asInt64(v))
+	case parquet.TypeFloat32, parquet.TypeFloat64:
+		bits := math.Float64bits(asFloat64(v))
+		var buf [8]byte
+		binary.LittleEndian.PutUint64(buf[:], bits)
+		h.AddBytes(buf[:])
+	case parquet.TypeTimestamp:
+		// Timestamps stored as int64 ms epoch.
+		switch tv := v.(type) {
+		case time.Time:
+			h.AddInt64(tv.UnixMilli())
+		default:
+			h.AddInt64(asInt64(v))
+		}
+	case parquet.TypeDuration:
+		switch tv := v.(type) {
+		case time.Duration:
+			h.AddInt64(int64(tv))
+		default:
+			h.AddInt64(asInt64(v))
+		}
+	case parquet.TypeString, parquet.TypeBytes,
+		parquet.TypeIPv4, parquet.TypeIPv6, parquet.TypeCIDR,
+		parquet.TypeMAC, parquet.TypeUUID, parquet.TypeDecimal:
+		switch sv := v.(type) {
+		case string:
+			h.AddBytes([]byte(sv))
+		case []byte:
+			h.AddBytes(sv)
+		default:
+			h.AddBytes([]byte(fmt.Sprintf("%v", v)))
+		}
+	default:
+		// Unknown type — hash a stringified form. Conservative; better
+		// than skipping (we can still distinguish "different repr" values).
+		h.AddBytes([]byte(fmt.Sprintf("%v", v)))
+	}
+}
+
+func asInt64(v any) int64 {
+	switch tv := v.(type) {
+	case int64:
+		return tv
+	case int32:
+		return int64(tv)
+	case int:
+		return int64(tv)
+	case uint64:
+		return int64(tv)
+	case uint32:
+		return int64(tv)
+	case float64:
+		return int64(tv)
+	case float32:
+		return int64(tv)
+	case bool:
+		if tv {
+			return 1
+		}
+		return 0
+	default:
+		return 0
+	}
+}
+
+func asFloat64(v any) float64 {
+	switch tv := v.(type) {
+	case float64:
+		return tv
+	case float32:
+		return float64(tv)
+	case int64:
+		return float64(tv)
+	case int32:
+		return float64(tv)
+	case int:
+		return float64(tv)
+	default:
+		return 0
+	}
+}

--- a/internal/storage/ingest/hll_stats.go
+++ b/internal/storage/ingest/hll_stats.go
@@ -1,11 +1,6 @@
 package ingest
 
 import (
-	"encoding/binary"
-	"fmt"
-	"math"
-	"time"
-
 	"github.com/citc-tech/wadjet/internal/storage/catalog"
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
 )
@@ -17,17 +12,17 @@ import (
 // Called from flushBuffer alongside extractColumnStats so the catalog
 // gets table-level NDV estimates the planner can consult for cardinality
 // and dynamic-filter decisions.
+//
+// Uses catalog.AddValueToHLL for the value→hash conversion so HLLs
+// produced here are byte-compatible with those produced by the ANALYZE
+// path (catalog.AnalyzeTable). Both can be merged via HLL.Merge.
 func computeColumnHLLs(rows []map[string]any, schema parquet.Schema) map[string]*catalog.HLL {
 	if len(rows) == 0 {
 		return nil
 	}
 	out := make(map[string]*catalog.HLL, len(schema.Columns))
 	for _, col := range schema.Columns {
-		// HLL works on hashable scalar values. Skip nested types (Array,
-		// Row, Map) — NDV isn't well-defined for them and the parquet
-		// readers don't return them as single values anyway.
-		switch col.Type {
-		case parquet.TypeArray, parquet.TypeRow, parquet.TypeMap:
+		if !catalog.IsHLLSupportedType(col.Type) {
 			continue
 		}
 		var h catalog.HLL
@@ -38,109 +33,11 @@ func computeColumnHLLs(rows []map[string]any, schema parquet.Schema) map[string]
 				continue
 			}
 			any = true
-			addValueToHLL(&h, v, col.Type)
+			catalog.AddValueToHLL(&h, v, col.Type)
 		}
 		if any {
 			out[col.Name] = &h
 		}
 	}
 	return out
-}
-
-// addValueToHLL hashes a value according to its declared parquet type
-// and inserts the hash into the sketch.
-//
-// For numeric/temporal types we serialize a canonical 8-byte LE form to
-// keep the hash stable across int32→int64 widening. For strings we hash
-// the bytes directly. For bool we use a single byte 0/1.
-func addValueToHLL(h *catalog.HLL, v any, t parquet.TypeID) {
-	switch t {
-	case parquet.TypeBool:
-		b := byte(0)
-		if bv, ok := v.(bool); ok && bv {
-			b = 1
-		}
-		h.AddBytes([]byte{b})
-	case parquet.TypeInt32, parquet.TypeInt64, parquet.TypeDate,
-		parquet.TypePort, parquet.TypeProtocol:
-		h.AddInt64(asInt64(v))
-	case parquet.TypeFloat32, parquet.TypeFloat64:
-		bits := math.Float64bits(asFloat64(v))
-		var buf [8]byte
-		binary.LittleEndian.PutUint64(buf[:], bits)
-		h.AddBytes(buf[:])
-	case parquet.TypeTimestamp:
-		// Timestamps stored as int64 ms epoch.
-		switch tv := v.(type) {
-		case time.Time:
-			h.AddInt64(tv.UnixMilli())
-		default:
-			h.AddInt64(asInt64(v))
-		}
-	case parquet.TypeDuration:
-		switch tv := v.(type) {
-		case time.Duration:
-			h.AddInt64(int64(tv))
-		default:
-			h.AddInt64(asInt64(v))
-		}
-	case parquet.TypeString, parquet.TypeBytes,
-		parquet.TypeIPv4, parquet.TypeIPv6, parquet.TypeCIDR,
-		parquet.TypeMAC, parquet.TypeUUID, parquet.TypeDecimal:
-		switch sv := v.(type) {
-		case string:
-			h.AddBytes([]byte(sv))
-		case []byte:
-			h.AddBytes(sv)
-		default:
-			h.AddBytes([]byte(fmt.Sprintf("%v", v)))
-		}
-	default:
-		// Unknown type — hash a stringified form. Conservative; better
-		// than skipping (we can still distinguish "different repr" values).
-		h.AddBytes([]byte(fmt.Sprintf("%v", v)))
-	}
-}
-
-func asInt64(v any) int64 {
-	switch tv := v.(type) {
-	case int64:
-		return tv
-	case int32:
-		return int64(tv)
-	case int:
-		return int64(tv)
-	case uint64:
-		return int64(tv)
-	case uint32:
-		return int64(tv)
-	case float64:
-		return int64(tv)
-	case float32:
-		return int64(tv)
-	case bool:
-		if tv {
-			return 1
-		}
-		return 0
-	default:
-		return 0
-	}
-}
-
-func asFloat64(v any) float64 {
-	switch tv := v.(type) {
-	case float64:
-		return tv
-	case float32:
-		return float64(tv)
-	case int64:
-		return float64(tv)
-	case int32:
-		return float64(tv)
-	case int:
-		return float64(tv)
-	default:
-		return 0
-	}
 }

--- a/internal/storage/ingest/ingest.go
+++ b/internal/storage/ingest/ingest.go
@@ -333,25 +333,43 @@ func (ing *Ingester) flushBuffer(ctx context.Context, partPath string, buf *part
 	// computed from the raw rows before they were serialized.
 	// - HLL → NDV estimation in the planner
 	// - Sample → cross-file histogram merge for selectivity estimation
-	// Parquet metadata doesn't carry either, so the only place to
-	// capture them cheaply is while rows are still in memory.
+	// Sketches are bundled into one object-store blob per parquet file
+	// (sketches.go) so the catalog manifest stays under the NATS 1 MB
+	// payload limit even at SF100 scale (60+ lineitem files × 16 cols).
 	extra := computeColumnStats(buf.rows, ing.schema)
+	var sketchEntries []catalog.FileSketchesEntry
 	if len(extra) > 0 {
 		if colStats == nil {
 			colStats = make(map[string]catalog.FileColumnStats, len(extra))
 		}
 		for col, st := range extra {
 			cs := colStats[col]
+			var hllBytes, sampleBytes []byte
 			if st.hll != nil {
-				cs.HLL = st.hll.Bytes()
+				hllBytes = st.hll.Bytes()
 			}
 			if st.sampler != nil {
 				vals, total, tc := st.sampler.Snapshot()
 				if len(vals) > 0 {
-					cs.Sample = catalog.SampleBytes(vals, total, tc)
+					sampleBytes = catalog.SampleBytes(vals, total, tc)
 				}
 			}
+			if len(hllBytes) > 0 || len(sampleBytes) > 0 {
+				sketchEntries = append(sketchEntries, catalog.FileSketchesEntry{
+					Column: col, HLL: hllBytes, Sample: sampleBytes,
+				})
+			}
 			colStats[col] = cs
+		}
+	}
+	var sketchesKey string
+	if len(sketchEntries) > 0 {
+		key, err := ing.catalog.UploadFileSketches(ctx, ing.tableName, filePath, sketchEntries)
+		if err != nil {
+			ing.logger.Warn("ingest: sketch upload failed; planner falls back to heuristic NDV",
+				"table", ing.tableName, "file", filePath, "error", err)
+		} else {
+			sketchesKey = key
 		}
 	}
 
@@ -362,6 +380,7 @@ func (ing *Ingester) flushBuffer(ctx context.Context, partPath string, buf *part
 		NumRows:     int64(len(buf.rows)),
 		CreatedAt:   time.Now().UTC(),
 		ColumnStats: colStats,
+		SketchesKey: sketchesKey,
 	}
 
 	if err := ing.catalog.AddFiles(ctx, ing.tableName, buf.values, partPath, []catalog.FileEntry{fileEntry}); err != nil {

--- a/internal/storage/ingest/ingest.go
+++ b/internal/storage/ingest/ingest.go
@@ -329,18 +329,28 @@ func (ing *Ingester) flushBuffer(ctx context.Context, partPath string, buf *part
 
 	// Extract column statistics from the written Parquet file
 	colStats := extractColumnStats(data)
-	// Augment with per-column HLL sketches computed from the raw rows
-	// before they were serialized. Parquet metadata doesn't carry NDV
-	// info, so the only place to capture it cheaply is right here while
-	// the rows are still in memory.
-	hlls := computeColumnHLLs(buf.rows, ing.schema)
-	if len(hlls) > 0 {
+	// Augment with per-column HLL sketches AND reservoir samples
+	// computed from the raw rows before they were serialized.
+	// - HLL → NDV estimation in the planner
+	// - Sample → cross-file histogram merge for selectivity estimation
+	// Parquet metadata doesn't carry either, so the only place to
+	// capture them cheaply is while rows are still in memory.
+	extra := computeColumnStats(buf.rows, ing.schema)
+	if len(extra) > 0 {
 		if colStats == nil {
-			colStats = make(map[string]catalog.FileColumnStats, len(hlls))
+			colStats = make(map[string]catalog.FileColumnStats, len(extra))
 		}
-		for col, h := range hlls {
+		for col, st := range extra {
 			cs := colStats[col]
-			cs.HLL = h.Bytes()
+			if st.hll != nil {
+				cs.HLL = st.hll.Bytes()
+			}
+			if st.sampler != nil {
+				vals, total, tc := st.sampler.Snapshot()
+				if len(vals) > 0 {
+					cs.Sample = catalog.SampleBytes(vals, total, tc)
+				}
+			}
 			colStats[col] = cs
 		}
 	}

--- a/internal/storage/ingest/ingest.go
+++ b/internal/storage/ingest/ingest.go
@@ -329,6 +329,21 @@ func (ing *Ingester) flushBuffer(ctx context.Context, partPath string, buf *part
 
 	// Extract column statistics from the written Parquet file
 	colStats := extractColumnStats(data)
+	// Augment with per-column HLL sketches computed from the raw rows
+	// before they were serialized. Parquet metadata doesn't carry NDV
+	// info, so the only place to capture it cheaply is right here while
+	// the rows are still in memory.
+	hlls := computeColumnHLLs(buf.rows, ing.schema)
+	if len(hlls) > 0 {
+		if colStats == nil {
+			colStats = make(map[string]catalog.FileColumnStats, len(hlls))
+		}
+		for col, h := range hlls {
+			cs := colStats[col]
+			cs.HLL = h.Bytes()
+			colStats[col] = cs
+		}
+	}
 
 	// Update catalog manifest
 	fileEntry := catalog.FileEntry{

--- a/internal/worker/dynamic_filter_emit.go
+++ b/internal/worker/dynamic_filter_emit.go
@@ -1,0 +1,168 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/engine/exec"
+)
+
+// materializeDynamicFilters translates a probe-side OpSpec.DynamicFilters
+// into the in-process exec.DynamicRange + exec.BloomScanFilter forms the
+// scan source consumes. Staged blooms (BloomKey set) are fetched from the
+// worker's object store on-demand; inline blooms are used as-is.
+//
+// Failures are partial: a single failed filter is dropped from the result
+// (probe-scan runs without it) rather than failing the task. Correctness
+// is preserved either way — the bloom is an optimization, not a semantic.
+func (e *Executor) materializeDynamicFilters(
+	specs []distributed.DynamicFilterSpec,
+) ([]exec.DynamicRange, []*exec.BloomScanFilter, error) {
+	if len(specs) == 0 {
+		return nil, nil, nil
+	}
+	var ranges []exec.DynamicRange
+	var blooms []*exec.BloomScanFilter
+	for _, s := range specs {
+		if s.HasRange {
+			ranges = append(ranges, exec.DynamicRange{
+				Column:   s.TargetColumn,
+				MinValue: int64ToAny(s.KeyType, s.Min),
+				MaxValue: int64ToAny(s.KeyType, s.Max),
+			})
+		}
+		bloom, mask, ok := e.loadBloomFromSpec(s)
+		if !ok {
+			continue
+		}
+		blooms = append(blooms, &exec.BloomScanFilter{
+			Bloom:     bloom,
+			BloomMask: mask,
+			Column:    s.TargetColumn,
+			UseIntKey: true,
+		})
+	}
+	return ranges, blooms, nil
+}
+
+// loadBloomFromSpec returns the bloom for a spec, fetching from S3 if it
+// was staged out-of-band. Returns ok=false when the bloom is unavailable
+// or empty — caller skips and proceeds without that filter.
+func (e *Executor) loadBloomFromSpec(s distributed.DynamicFilterSpec) ([]uint64, uint64, bool) {
+	if len(s.Bloom) > 0 {
+		return s.Bloom, s.BloomMask, true
+	}
+	if s.BloomBucket == "" || s.BloomKey == "" {
+		return nil, 0, false
+	}
+	ctx := context.Background()
+	rc, _, err := e.store.Get(ctx, s.BloomBucket, s.BloomKey)
+	if err != nil {
+		e.logger.Warn("dynamic_filter: staged bloom fetch failed; proceeding without filter",
+			"filter_id", s.FilterID, "bucket", s.BloomBucket, "key", s.BloomKey, "error", err)
+		return nil, 0, false
+	}
+	defer rc.Close()
+	art, err := distributed.DecodeDynamicFilterArtifact(rc)
+	if err != nil {
+		e.logger.Warn("dynamic_filter: staged bloom decode failed; proceeding without filter",
+			"filter_id", s.FilterID, "error", err)
+		return nil, 0, false
+	}
+	if len(art.Bloom) == 0 {
+		return nil, 0, false
+	}
+	return art.Bloom, art.BloomMask, true
+}
+
+func int64ToAny(keyType string, v int64) any {
+	switch keyType {
+	case "int32", "date":
+		return int32(v)
+	default:
+		return v
+	}
+}
+
+// finalizeDynamicFilterEmits drains each emit op's partial Snapshot,
+// serializes via the WDF1 codec, uploads as a sideband artifact at
+// queries/<queryID>/dynfilter/<stageID>/<taskID>-<filterID>.wdf in the
+// task's ResultBucket, and appends a DynamicFilterPartialRef to result.
+//
+// One PUT per FilterID. The partial is small (sized to the configured
+// BloomBits, default tens of KB to a few MB at the eligibility ceiling),
+// and rides alongside the task's main result upload — no extra round-trip
+// against the task critical path beyond the PUT itself.
+//
+// On error: the partial upload is best-effort. If serialization or upload
+// fails we log and continue; the coordinator's union step treats missing
+// partials as no-op (a missing partial degrades the filter's selectivity,
+// it doesn't corrupt results). Probe-side execution is always safe with
+// or without the dynamic filter.
+func (e *Executor) finalizeDynamicFilterEmits(
+	ctx context.Context,
+	task distributed.Task,
+	emitOps []*exec.DynamicFilterEmitOp,
+	specs []distributed.DynamicFilterEmit,
+	result *distributed.ResultNotification,
+) error {
+	if len(emitOps) == 0 {
+		return nil
+	}
+	if task.ResultBucket == "" {
+		// No upload destination; nothing we can do. Coordinator will see no
+		// partials for this task and degrade the filter gracefully.
+		e.logger.Warn("dynamic_filter_emit: empty ResultBucket; skipping partial upload",
+			"task_id", task.ID, "filters", len(emitOps))
+		return nil
+	}
+	// Index spec by FilterID to attach the KeyColumn label to the ref. ops
+	// and specs are 1:1 by construction (buildDynamicFilterEmitOps preserves
+	// order), so we could rely on positional matching; the FilterID lookup
+	// keeps the code robust if that invariant ever changes.
+	specByID := make(map[string]distributed.DynamicFilterEmit, len(specs))
+	for _, s := range specs {
+		specByID[s.FilterID] = s
+	}
+
+	for _, op := range emitOps {
+		snap := op.Snapshot()
+		_ = specByID[snap.FilterID] // reserved for future key-type validation
+
+		artifact := &distributed.DynamicFilterArtifact{
+			KeyType:   snap.KeyType,
+			HasRange:  snap.HasRange,
+			Min:       snap.Min,
+			Max:       snap.Max,
+			RowCount:  snap.RowCount,
+			Bloom:     snap.Bloom,
+			BloomMask: snap.BloomMask,
+		}
+
+		var buf bytes.Buffer
+		if err := distributed.EncodeDynamicFilterArtifact(&buf, artifact); err != nil {
+			e.logger.Warn("dynamic_filter_emit: encode failed; partial dropped",
+				"task_id", task.ID, "filter_id", snap.FilterID, "error", err)
+			continue
+		}
+		key := fmt.Sprintf("queries/%s/dynfilter/%s/%s-%s.wdf",
+			task.QueryID, task.StageID, task.ID, snap.FilterID)
+		reader := bytes.NewReader(buf.Bytes())
+		if _, err := e.store.Put(ctx, task.ResultBucket, key,
+			reader, int64(buf.Len()), "application/octet-stream"); err != nil {
+			e.logger.Warn("dynamic_filter_emit: upload failed; partial dropped",
+				"task_id", task.ID, "filter_id", snap.FilterID,
+				"bucket", task.ResultBucket, "key", key, "error", err)
+			continue
+		}
+		result.DynamicFilterPartials = append(result.DynamicFilterPartials,
+			distributed.DynamicFilterPartialRef{
+				FilterID: snap.FilterID,
+				Bucket:   task.ResultBucket,
+				Key:      key,
+			})
+	}
+	return nil
+}

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -742,6 +742,37 @@ func (e *Executor) executeShuffle(ctx context.Context, task distributed.Task, re
 	// streaming, the working set is bounded by one file's batches plus the
 	// sink's per-partition bufio buffers (48 × 256 KB ≈ 12 MB).
 	src := newCachedFileStreamSourceWithProjection(e, task.QueryID, bucket, task.Files, task.Columns)
+	// Dynamic-filter pushdown for shuffle's implicit parquet scan. Operates
+	// at two layers:
+	//   - Row-group level (via cachedFileStreamSource.SetDynamicFilters →
+	//     RowGroupIter): skips entire row groups whose stats don't intersect
+	//     the bloom. Effective when per-row-group key range is small (≤1024)
+	//     — typically only at SF100+ where row groups are narrow.
+	//   - Row level (via BloomFilterOp inserted in the shuffle loop below):
+	//     marks ineligible rows in the selection vector before they reach
+	//     the hash-partitioning sink. Effective at any scale because it
+	//     prunes pre-shuffle-write. Adaptive-disables if rejection <5% to
+	//     avoid paying lookup cost on non-selective workloads.
+	// Together they cover the SF1→SF100 selectivity spectrum.
+	var shuffleBloomOps []*exec.BloomFilterOp
+	if len(task.DynamicFilters) > 0 {
+		ranges, blooms, err := e.materializeDynamicFilters(task.DynamicFilters)
+		if err != nil {
+			e.logger.Warn("shuffle task: dynamic-filter materialize failed; proceeding without filter",
+				"task_id", task.ID, "error", err)
+		} else if len(ranges) > 0 || len(blooms) > 0 {
+			src.SetDynamicFilters(ranges, blooms)
+			for _, bf := range blooms {
+				if bf == nil {
+					continue
+				}
+				op := exec.NewBloomFilterOp(bf.Bloom, bf.BloomMask, []string{bf.Column}, bf.UseIntKey)
+				if err := op.Init(ctx); err == nil {
+					shuffleBloomOps = append(shuffleBloomOps, op)
+				}
+			}
+		}
+	}
 	if err := src.Init(ctx); err != nil {
 		return fmt.Errorf("shuffle task %s: source init: %w", task.ID, err)
 	}
@@ -785,6 +816,26 @@ func (e *Executor) executeShuffle(ctx context.Context, task distributed.Task, re
 		n := int64(b.ActiveLen())
 		if n == 0 {
 			continue
+		}
+		// Row-level dynamic-filter prune (post-row-group-prune). Applies
+		// every bloom in sequence; each modifies b.Sel. An op that returns
+		// nil means every row was bloom-rejected — skip the batch entirely.
+		if len(shuffleBloomOps) > 0 {
+			for _, op := range shuffleBloomOps {
+				bb, err := op.Execute(ctx, b)
+				if err != nil {
+					return fmt.Errorf("shuffle task %s: bloom filter op: %w", task.ID, err)
+				}
+				if bb == nil {
+					b = nil
+					break
+				}
+				b = bb
+			}
+			if b == nil || b.ActiveLen() == 0 {
+				continue
+			}
+			n = int64(b.ActiveLen())
 		}
 		if sink == nil {
 			sink = newPartitionedShuffleSink(spillDir, task.ShuffleKeys, task.NumPartitions, b.Schema)

--- a/internal/worker/executor_fragment.go
+++ b/internal/worker/executor_fragment.go
@@ -235,6 +235,20 @@ func (e *Executor) executeFragment(ctx context.Context, task distributed.Task, r
 	}
 	defer sink.close()
 
+	// Dynamic-filter emit (Trino-style semi-join pushdown). When the source
+	// spec carries DynamicFilterEmits, prepend a pass-through accumulator
+	// op per emit to the unary chain. Snapshots are uploaded after the
+	// pipeline finishes; refs land in result.DynamicFilterPartials.
+	emitOps, err := buildDynamicFilterEmitOps(sourceSpec.DynamicFilterEmits)
+	if err != nil {
+		return fmt.Errorf("fragment task %s: dynamic filter emit ops: %w", task.ID, err)
+	}
+	for _, op := range emitOps {
+		if err := op.Init(ctx); err != nil {
+			return fmt.Errorf("fragment task %s: emit op init: %w", task.ID, err)
+		}
+	}
+
 	if len(breakerIdxs) == 0 {
 		// Linear pipeline: source → unary ops → sink.
 		preOps, cleanup, err := e.buildUnaryChain(ctx, task, middle)
@@ -242,14 +256,53 @@ func (e *Executor) executeFragment(ctx context.Context, task distributed.Task, r
 			return err
 		}
 		defer cleanup()
-		return e.runFragmentLinear(ctx, task, src, preOps, sink, result)
+		ops := prependEmitOps(emitOps, preOps)
+		if err := e.runFragmentLinear(ctx, task, src, ops, sink, result); err != nil {
+			return err
+		}
+		return e.finalizeDynamicFilterEmits(ctx, task, emitOps, sourceSpec.DynamicFilterEmits, result)
 	}
 
 	// One or more pipeline-breakers — split middle into N+1 unary segments
 	// around them and run a chain of consume/drain phases. No materialization
 	// to disk between phases; each breaker holds its state in memory (with
 	// optional spill).
-	return e.runFragmentWithBreakers(ctx, task, src, middle, breakerIdxs, sink, result)
+	//
+	// Emit ops are prepended ONLY to the first segment (pre-source ops) so
+	// they observe every input row regardless of breaker layout.
+	if err := e.runFragmentWithBreakers(ctx, task, src, middle, breakerIdxs, sink, result, emitOps); err != nil {
+		return err
+	}
+	return e.finalizeDynamicFilterEmits(ctx, task, emitOps, sourceSpec.DynamicFilterEmits, result)
+}
+
+func prependEmitOps(emit []*exec.DynamicFilterEmitOp, rest []exec.UnaryOperator) []exec.UnaryOperator {
+	if len(emit) == 0 {
+		return rest
+	}
+	out := make([]exec.UnaryOperator, 0, len(emit)+len(rest))
+	for _, op := range emit {
+		out = append(out, op)
+	}
+	out = append(out, rest...)
+	return out
+}
+
+func buildDynamicFilterEmitOps(specs []distributed.DynamicFilterEmit) ([]*exec.DynamicFilterEmitOp, error) {
+	if len(specs) == 0 {
+		return nil, nil
+	}
+	out := make([]*exec.DynamicFilterEmitOp, 0, len(specs))
+	for _, s := range specs {
+		if s.FilterID == "" || s.KeyColumn == "" {
+			return nil, fmt.Errorf("dynamic_filter_emit: FilterID and KeyColumn required")
+		}
+		if s.BloomBits <= 0 {
+			return nil, fmt.Errorf("dynamic_filter_emit %s: BloomBits must be > 0", s.FilterID)
+		}
+		out = append(out, exec.NewDynamicFilterEmitOp(s.FilterID, s.KeyColumn, s.KeyType, s.BloomBits))
+	}
+	return out, nil
 }
 
 // runFragmentLinear streams batches from src through unary ops into the sink.
@@ -436,7 +489,7 @@ type fragmentBreaker struct {
 // breaker path is exercised by tests and ready for future shapes
 // (e.g. final_aggregate + sort fused into one fragment when the planner
 // stops emitting them as separate Sort stages).
-func (e *Executor) runFragmentWithBreakers(ctx context.Context, task distributed.Task, src exec.Source, middle []distributed.OpSpec, breakerIdxs []int, sink fragmentSink, result *distributed.ResultNotification) error {
+func (e *Executor) runFragmentWithBreakers(ctx context.Context, task distributed.Task, src exec.Source, middle []distributed.OpSpec, breakerIdxs []int, sink fragmentSink, result *distributed.ResultNotification, emitOps []*exec.DynamicFilterEmitOp) error {
 	progress := exec.ProgressReporterFromContext(ctx)
 
 	breakers := make([]*fragmentBreaker, len(breakerIdxs))
@@ -469,6 +522,11 @@ func (e *Executor) runFragmentWithBreakers(ctx context.Context, task distributed
 		// already-init'd from buildFragmentBreaker (HashAggregate's Project),
 		// so don't double-init here.
 		phaseOps := append([]exec.UnaryOperator{}, segOps...)
+		if j == 0 {
+			// Emit ops sit at the very head of the pipeline so they observe
+			// every source-emitted row before any breaker / segment op.
+			phaseOps = prependEmitOps(emitOps, phaseOps)
+		}
 		phaseOps = append(phaseOps, breakers[j].PrependOps...)
 
 		if j == 0 {
@@ -821,6 +879,20 @@ func (e *Executor) buildFragmentSource(task distributed.Task, spec distributed.O
 		} else {
 			e.logger.Warn("fragment source: shard params set but source is not cachedFileStreamSource",
 				"alias", spec.InputAlias, "shard_idx", spec.ScanShardIndex, "shard_count", spec.ScanShardCount)
+		}
+	}
+	// Dynamic-filter pushdown (Trino-style semi-join). When the OpScan spec
+	// carries DynamicFilters, materialize each into a BloomScanFilter and
+	// attach to the source so row groups get pruned before any S3 fetch.
+	if len(spec.DynamicFilters) > 0 {
+		if cs, ok := src.(*cachedFileStreamSource); ok {
+			ranges, blooms, err := e.materializeDynamicFilters(spec.DynamicFilters)
+			if err != nil {
+				e.logger.Warn("fragment source: dynamic-filter materialize failed; proceeding without filter",
+					"alias", spec.InputAlias, "error", err)
+			} else if len(ranges) > 0 || len(blooms) > 0 {
+				cs.SetDynamicFilters(ranges, blooms)
+			}
 		}
 	}
 	return src, nil

--- a/internal/worker/stream_source.go
+++ b/internal/worker/stream_source.go
@@ -101,6 +101,22 @@ type cachedFileStreamSource struct {
 	// Empty for all TPC-H scans.
 	fallbackBatches  []*batch.RecordBatch
 	fallbackBatchIdx int
+
+	// Dynamic-filter pushdowns. Set by the fragment runner from
+	// OpSpec.DynamicFilters; consumed by RowGroupIter to skip row groups
+	// whose stats don't intersect the build-side bloom or range.
+	dynamicRanges []exec.DynamicRange
+	bloomFilters  []*exec.BloomScanFilter
+}
+
+// SetDynamicFilters attaches dynamic-filter pushdowns to this source.
+// Idempotent — safe to call before Init.
+func (s *cachedFileStreamSource) SetDynamicFilters(ranges []exec.DynamicRange, blooms []*exec.BloomScanFilter) {
+	if s == nil {
+		return
+	}
+	s.dynamicRanges = ranges
+	s.bloomFilters = blooms
 }
 
 func newCachedFileStreamSource(executor *Executor, queryID, bucket string, files []string) *cachedFileStreamSource {
@@ -414,6 +430,9 @@ func (s *cachedFileStreamSource) openNextFile(ctx context.Context) error {
 	iter, err := scan.OpenRowGroupIter(reader, projCols, nil, shardIdx, shardCount)
 	if err != nil {
 		return fmt.Errorf("opening row-group iterator for %s: %w", filePath, err)
+	}
+	if len(s.dynamicRanges) > 0 || len(s.bloomFilters) > 0 {
+		iter.SetDynamicFilters(s.dynamicRanges, s.bloomFilters)
 	}
 	s.parquetIter = iter
 	s.parquetReader = reader


### PR DESCRIPTION
## Summary

- Per-file sketches (HLL + reservoir sample, ~18 KB/col) moved out of inline `FileEntry.ColumnStats` into a per-file object-store blob at `stats/<table>/<file>.sketches` (WSKB v1 binary format)
- Fixes SF100 ANALYZE TABLE failure on lineitem: a 63-file × 16-col manifest grew to ~18 MB, blowing past NATS' default 1 MB payload limit and aborting ANALYZE mid-flight — the planner then silently fell back to FK/heuristic NDV for every query touching lineitem
- Both ANALYZE and the ingest write-path produce externalized sketches; `AggregateColumnStats` consumes the external blob with a legacy inline fallback for catalogs written before this change
- Drive-by: gate two `-race`-incompatible coordinator test files behind `//go:build !race` to match their dependency (`setupTPCHDistributedAtScale` in `distributed_tpch_test.go`), unblocking the pre-push hook

## Validation

- TPC-H SF0.01 22/22 PASS locally
- **SF100 22/22 PASS at ~71m11s** — first SF100 run with full CBO actually seeing real per-column NDVs on lineitem
- Wall-time vs PR #95 1101d9d baseline (1h39m21s): **-28m suite**, Q05 -45% (3m37 vs 6m38), Q17 -48% (3m03 vs 5m51), Q18 -23% (8m34 vs 11m06)
- Results: `s3://wadjet-bench-sf100-use2/results/20260526-211027/`

## Test plan

- [ ] CI green (build + SF0.01 correctness)
- [ ] SF1 perf bench in CI (no regression expected — change is purely additive on the read path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)