### PR TITLE
perf(worker): pool s2.Writer/s2.Reader on shuffle codec hot path

### DIFF
--- a/internal/coordinator/distributed_tpch_race_stub_test.go
+++ b/internal/coordinator/distributed_tpch_race_stub_test.go
@@ -1,0 +1,29 @@
+//go:build race
+
+// distributed_tpch_test.go is gated with //go:build !race because the
+// embedded nats-server v2.12.6 has a known upstream data race that fires
+// in JetStream's concurrent CreateOrUpdateConsumer / Fetch / Ack path
+// (see the header comment in that file). The helper
+// setupTPCHDistributedAtScale lives there, so consumer test files
+// (dynamic_filter_e2e_test.go, q07_sf10_repro_test.go) lose their
+// symbol under -race builds.
+//
+// This stub keeps those consumer tests compiling under -race by
+// declaring the symbol; at runtime they t.Skip before exercising the
+// racy NATS path. Remove this file once nats-server is upgraded past
+// the fix and the !race gate is removed from distributed_tpch_test.go.
+
+package coordinator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/citc-tech/wadjet/benchmarks/tpch"
+)
+
+func setupTPCHDistributedAtScale(t *testing.T, _ tpch.ScaleFactor) (context.Context, *Coordinator) {
+	t.Helper()
+	t.Skip("setupTPCHDistributedAtScale unavailable under -race (nats-server v2.12.6 upstream race)")
+	return nil, nil
+}

--- a/internal/worker/shuffle_codec_pool.go
+++ b/internal/worker/shuffle_codec_pool.go
@@ -1,0 +1,56 @@
+package worker
+
+import (
+	"io"
+	"sync"
+
+	"github.com/klauspost/compress/s2"
+)
+
+// s2.Writer / s2.Reader carry sizable internal buffers (the encoder block
+// buffer is ~64 KB; the decoder maintains its own scratch). Allocating a
+// fresh codec for every shuffle compress/decompress call shows up at the
+// top of the SF100 22Q profile — Q18 in particular spent ~25 % of CPU in
+// shuffle-write under s2.encodeBlockGo plus its surrounding allocator
+// pressure (see project_q18_cpu_profile_sf100_2026-05-22). The codec's
+// own Reset(io.Writer)/Reset(io.Reader) APIs already let us recycle the
+// internal state across calls; this pool puts the recycling in front of
+// every caller in the shuffle hot path.
+
+var (
+	s2WriterPool = sync.Pool{New: func() any { return s2.NewWriter(nil) }}
+	s2ReaderPool = sync.Pool{New: func() any { return s2.NewReader(nil) }}
+)
+
+// acquireS2Writer returns a pooled *s2.Writer attached to dst. The writer's
+// internal block buffer is reused across calls, eliminating per-call
+// allocation for the hot shuffle-write path. The caller MUST call Close
+// before releaseS2Writer — Close flushes the final block; without it the
+// produced stream is truncated.
+func acquireS2Writer(dst io.Writer) *s2.Writer {
+	w := s2WriterPool.Get().(*s2.Writer)
+	w.Reset(dst)
+	return w
+}
+
+// releaseS2Writer returns w to the pool after detaching it from its
+// destination (Reset(nil)) so the pool never holds a reference to a
+// caller's now-closed io.Writer. Safe to call after w.Close().
+func releaseS2Writer(w *s2.Writer) {
+	w.Reset(nil)
+	s2WriterPool.Put(w)
+}
+
+// acquireS2Reader returns a pooled *s2.Reader attached to src. The reader's
+// decompression scratch is reused across calls.
+func acquireS2Reader(src io.Reader) *s2.Reader {
+	r := s2ReaderPool.Get().(*s2.Reader)
+	r.Reset(src)
+	return r
+}
+
+// releaseS2Reader returns r to the pool after detaching it from src.
+func releaseS2Reader(r *s2.Reader) {
+	r.Reset(nil)
+	s2ReaderPool.Put(r)
+}

--- a/internal/worker/shuffle_codec_pool_test.go
+++ b/internal/worker/shuffle_codec_pool_test.go
@@ -1,0 +1,145 @@
+package worker
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io"
+	"sync"
+	"testing"
+)
+
+// TestS2WriterPoolRoundTrip confirms the writer pool produces output that
+// round-trips through the reader pool, across many sequential reuses of
+// the same pooled instance. Catches any state bleed across Reset boundaries.
+func TestS2WriterPoolRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		size int
+	}{
+		{"small_1KB", 1024},
+		{"medium_64KB", 64 * 1024},
+		{"large_4MB", 4 * 1024 * 1024},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			for iter := 0; iter < 5; iter++ {
+				src := make([]byte, tc.size)
+				if _, err := rand.Read(src); err != nil {
+					t.Fatalf("rand: %v", err)
+				}
+
+				var enc bytes.Buffer
+				w := acquireS2Writer(&enc)
+				if _, err := w.Write(src); err != nil {
+					t.Fatalf("write iter %d: %v", iter, err)
+				}
+				if err := w.Close(); err != nil {
+					t.Fatalf("close iter %d: %v", iter, err)
+				}
+				releaseS2Writer(w)
+
+				r := acquireS2Reader(bytes.NewReader(enc.Bytes()))
+				got, err := io.ReadAll(r)
+				if err != nil {
+					t.Fatalf("decode iter %d: %v", iter, err)
+				}
+				releaseS2Reader(r)
+
+				if !bytes.Equal(got, src) {
+					t.Fatalf("iter %d: round-trip mismatch (%d → %d → %d bytes)",
+						iter, tc.size, enc.Len(), len(got))
+				}
+			}
+		})
+	}
+}
+
+// TestS2PoolConcurrent exercises the pool from many goroutines simultaneously
+// to confirm a worker holding one instance never observes another's state.
+func TestS2PoolConcurrent(t *testing.T) {
+	const goroutines = 16
+	const itersPerG = 32
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines)
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(seed byte) {
+			defer wg.Done()
+			payload := bytes.Repeat([]byte{seed}, 8192)
+			for i := 0; i < itersPerG; i++ {
+				var buf bytes.Buffer
+				w := acquireS2Writer(&buf)
+				if _, err := w.Write(payload); err != nil {
+					errs <- err
+					return
+				}
+				if err := w.Close(); err != nil {
+					errs <- err
+					return
+				}
+				releaseS2Writer(w)
+
+				r := acquireS2Reader(bytes.NewReader(buf.Bytes()))
+				got, err := io.ReadAll(r)
+				releaseS2Reader(r)
+				if err != nil {
+					errs <- err
+					return
+				}
+				if !bytes.Equal(got, payload) {
+					errs <- io.ErrUnexpectedEOF
+					return
+				}
+			}
+		}(byte(g + 1))
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent round-trip: %v", err)
+		}
+	}
+}
+
+// BenchmarkCompressShuffleDataPool measures the steady-state allocation
+// reduction from the pool on the hot shuffle-write path. Compare before/
+// after a pool change with `benchstat`.
+func BenchmarkCompressShuffleDataPool(b *testing.B) {
+	src := make([]byte, 1<<20) // 1 MB compressible payload
+	for i := range src {
+		src[i] = byte(i % 251)
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		out := CompressShuffleData(src)
+		if len(out) == 0 {
+			b.Fatal("empty output")
+		}
+	}
+}
+
+// BenchmarkDecompressShuffleDataPool measures the decompress side.
+func BenchmarkDecompressShuffleDataPool(b *testing.B) {
+	src := make([]byte, 1<<20)
+	for i := range src {
+		src[i] = byte(i % 251)
+	}
+	compressed := CompressShuffleData(src)
+	if string(compressed[:4]) != "WSHC" {
+		b.Fatalf("input not compressed (skipped threshold); got magic %q", compressed[:4])
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		out, err := DecompressShuffleData(compressed)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(out) != len(src) {
+			b.Fatalf("len mismatch: got %d want %d", len(out), len(src))
+		}
+	}
+}

--- a/internal/worker/shuffle_format.go
+++ b/internal/worker/shuffle_format.go
@@ -9,8 +9,6 @@ import (
 	"os"
 	"unsafe"
 
-	"github.com/klauspost/compress/s2"
-
 	"github.com/citc-tech/wadjet/internal/engine/batch"
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
 )
@@ -656,13 +654,16 @@ func CompressShuffleData(data []byte) []byte {
 	var buf bytes.Buffer
 	buf.Grow(len(data)/2 + 4)
 	buf.Write(compressedMagic[:])
-	w := s2.NewWriter(&buf)
+	w := acquireS2Writer(&buf)
 	if _, err := w.Write(data); err != nil {
+		releaseS2Writer(w)
 		return data
 	}
 	if err := w.Close(); err != nil {
+		releaseS2Writer(w)
 		return data
 	}
+	releaseS2Writer(w)
 	// Only use compression if it saves at least 10%
 	if buf.Len() >= len(data)*9/10 {
 		return data
@@ -707,16 +708,19 @@ func CompressShuffleFile(srcPath, dstPath string) (compressedSize int64, useComp
 		dst.Close()
 		return 0, false, fmt.Errorf("write WSHC magic: %w", err)
 	}
-	w := s2.NewWriter(dst)
+	w := acquireS2Writer(dst)
 	if _, err := io.Copy(w, src); err != nil {
 		w.Close()
+		releaseS2Writer(w)
 		dst.Close()
 		return 0, false, fmt.Errorf("s2 stream copy: %w", err)
 	}
 	if err := w.Close(); err != nil {
+		releaseS2Writer(w)
 		dst.Close()
 		return 0, false, fmt.Errorf("s2 close: %w", err)
 	}
+	releaseS2Writer(w)
 	outInfo, err := dst.Stat()
 	if err != nil {
 		dst.Close()
@@ -741,7 +745,8 @@ func CompressShuffleFile(srcPath, dstPath string) (compressedSize int64, useComp
 // by the build-cache stream source to transcode WSHC payloads to WSHF on disk
 // without first materializing the entire compressed body in memory.
 func streamDecompressShuffle(src io.Reader, dst io.Writer) error {
-	r := s2.NewReader(src)
+	r := acquireS2Reader(src)
+	defer releaseS2Reader(r)
 	if _, err := io.Copy(dst, r); err != nil {
 		return fmt.Errorf("decompressing shuffle stream: %w", err)
 	}
@@ -758,7 +763,8 @@ func DecompressShuffleData(data []byte) ([]byte, error) {
 		data[2] != compressedMagic[2] || data[3] != compressedMagic[3] {
 		return data, nil // not compressed
 	}
-	r := s2.NewReader(bytes.NewReader(data[4:]))
+	r := acquireS2Reader(bytes.NewReader(data[4:]))
+	defer releaseS2Reader(r)
 	decoded, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("decompressing shuffle data: %w", err)


### PR DESCRIPTION
## Summary

- Q18 SF100 CPU profile attributed ~25% of total CPU to shuffle-write (`s2.encodeBlockGo` + surrounding allocator pressure), with a long tail on the decompress side
- Every `CompressShuffleData` / `CompressShuffleFile` / `streamDecompressShuffle` / `DecompressShuffleData` call was constructing a fresh `s2.Writer` / `s2.Reader`, each carrying a sizable internal scratch buffer (~64 KB writer block)
- `s2` already exposes `Reset(io.Writer)` and `Reset(io.Reader)`; wrap both in `sync.Pool` and reroute the four hot-path call sites in `shuffle_format.go` through the pool
- Drive-by: stub `setupTPCHDistributedAtScale` under `//go:build race` so the coordinator test binary still compiles when the pre-push hook runs `-race`

## Micro-bench (1 MB compressible payload, 3 runs)

| | Before | After | Δ |
|---|---|---|---|
| Compress wall | 417 µs | 312 µs | **-25%** |
| Compress bytes | 2.64 MB | 0.73 MB | **-72%** |
| Compress allocs | 14 | 8 | -43% |
| Decompress wall | 1.63 ms | 1.05 ms | **-36%** |
| Decompress bytes | 4.33 MB | 2.26 MB | **-48%** |
| Decompress allocs | 28 | 25 | -11% |

## Local validation

- Round-trip + concurrent unit tests (`TestS2WriterPoolRoundTrip`, `TestS2PoolConcurrent`) confirm no state bleed across `Reset` boundaries
- TPC-H SF0.01 22/22 PASS
- Full `internal/worker` test suite green
- Local distributed harness (`cmd/tpch-harness --mode=local`) PASS
- Coordinator test binary builds clean under `-race`

## Test plan

- [ ] CI green (build + SF0.01 correctness + SF1 bench)
- [ ] SF100 deploy to confirm shuffle-write CPU share drops vs prior profile (defer until next session per current handoff — no deploys overnight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)