### PR TITLE
perf(parquet): pool zstd decompress output buffers on page-read hot path

### DIFF
--- a/internal/engine/scan/columnar_native.go
+++ b/internal/engine/scan/columnar_native.go
@@ -243,6 +243,7 @@ func readColumnNative(vec *batch.Vector, fr *pqt.FileReader, rgIdx, colIdx, numR
 		if defLevels == nil || !hasNulls {
 			if coerce {
 				if err := copyNativeCoercedDirect(vec, offset, data, pageRows, fileType, catalogType); err != nil {
+					page.Release()
 					return err
 				}
 			} else {
@@ -251,6 +252,7 @@ func readColumnNative(vec *batch.Vector, fr *pqt.FileReader, rgIdx, colIdx, numR
 		} else {
 			if coerce {
 				if err := copyNativeCoercedScatter(vec, offset, data, defLevels, int32(maxDefLevel), pageRows, fileType, catalogType); err != nil {
+					page.Release()
 					return err
 				}
 			} else {
@@ -259,6 +261,7 @@ func readColumnNative(vec *batch.Vector, fr *pqt.FileReader, rgIdx, colIdx, numR
 		}
 
 		offset += pageRows
+		page.Release()
 	}
 
 	return nil

--- a/internal/storage/parquet/decompress.go
+++ b/internal/storage/parquet/decompress.go
@@ -51,12 +51,23 @@ func init() {
 }
 
 func decompressZstd(data []byte, size int) ([]byte, error) {
-	dst := make([]byte, 0, size)
+	dst := getZstdBuf(size)
 	dst, err := zstdDecoder.DecodeAll(data, dst)
 	if err != nil {
+		putZstdBuf(dst)
 		return nil, fmt.Errorf("zstd decompress: %w", err)
 	}
 	return dst, nil
+}
+
+// ReleaseDecompressed returns the slice returned by Decompress to its pool,
+// if it came from one. Safe to call with any slice — non-pooled buffers are
+// dropped to GC. Only the zstd path is currently pooled; other codecs are
+// no-ops.
+func ReleaseDecompressed(codec CompressionCodec, buf []byte) {
+	if codec == CodecZstd {
+		putZstdBuf(buf)
+	}
 }
 
 func decompressGzip(data []byte, size int) ([]byte, error) {

--- a/internal/storage/parquet/decompress_pool.go
+++ b/internal/storage/parquet/decompress_pool.go
@@ -1,0 +1,49 @@
+package parquet
+
+import "sync"
+
+// zstd.DecodeAll always allocates a fresh output slice when its dst arg can't
+// hold the decompressed payload. Every parquet page goes through this path,
+// and the SF100 22Q worker CPU profile after PR #103 (s2 codec pool) ranked
+// `zstd.sequenceDecs.decodeSync` at 14.3 % cum — roughly 2× the residual s2
+// share. This pool reuses the output buffer across decompress calls so the
+// per-page allocation falls off the profile.
+//
+// Lifetime contract: the caller of Decompress receives a slice whose backing
+// array MAY come from this pool. PageData records the buffer and exposes
+// Release() so the per-page consumer loop can return it after the values have
+// been copied into their destination Vector. If Release is not called, the
+// buffer is simply GC'd — correctness is preserved, the perf win is lost.
+
+var zstdBufPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, 0, 64*1024)
+		return &b
+	},
+}
+
+// Cap pool-resident buffers at 4 MiB. Parquet pages are typically <=1 MiB; a
+// runaway page that exceeds this stays out of the pool so a single outlier
+// can't pin a multi-megabyte buffer indefinitely.
+const zstdBufPoolMaxCap = 4 * 1024 * 1024
+
+func getZstdBuf(size int) []byte {
+	bp := zstdBufPool.Get().(*[]byte)
+	b := (*bp)[:0]
+	if cap(b) < size {
+		// Pool entry too small — let zstd.DecodeAll grow the slice itself
+		// (it picks a sensible growth factor). Return the small one to the
+		// pool so it stays usable for smaller pages.
+		zstdBufPool.Put(bp)
+		return make([]byte, 0, size)
+	}
+	return b
+}
+
+func putZstdBuf(b []byte) {
+	if cap(b) == 0 || cap(b) > zstdBufPoolMaxCap {
+		return
+	}
+	b = b[:0]
+	zstdBufPool.Put(&b)
+}

--- a/internal/storage/parquet/decompress_pool_test.go
+++ b/internal/storage/parquet/decompress_pool_test.go
@@ -1,0 +1,148 @@
+package parquet
+
+import (
+	"bytes"
+	"math/rand"
+	"sync"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+func zstdEncode(t testing.TB, src []byte) []byte {
+	t.Helper()
+	enc, err := zstd.NewWriter(nil)
+	if err != nil {
+		t.Fatalf("zstd.NewWriter: %v", err)
+	}
+	defer enc.Close()
+	return enc.EncodeAll(src, nil)
+}
+
+// Pooled zstd decompress must produce bit-identical output to a fresh
+// allocation, including across repeated calls that hit / miss the pool size
+// class. Mirrors the round-trip invariant validated for PR #103's s2 pool.
+func TestZstdBufPool_RoundTrip(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	sizes := []int{0, 1, 32, 1024, 4096, 64*1024, 256*1024, 1024*1024}
+
+	for _, size := range sizes {
+		src := make([]byte, size)
+		rng.Read(src)
+		enc := zstdEncode(t, src)
+
+		for i := 0; i < 4; i++ {
+			got, err := decompressZstd(enc, size)
+			if err != nil {
+				t.Fatalf("size=%d iter=%d: %v", size, i, err)
+			}
+			if !bytes.Equal(got, src) {
+				t.Fatalf("size=%d iter=%d: output mismatch", size, i)
+			}
+			putZstdBuf(got)
+		}
+	}
+}
+
+// Concurrent decompresses must not see cross-pollution from sibling
+// goroutines' output buffers. This is the regression guard for the case where
+// two callers Get the same backing array from the pool.
+func TestZstdBufPool_Concurrent(t *testing.T) {
+	const workers = 16
+	const iters = 64
+
+	payloads := make([][]byte, workers)
+	encoded := make([][]byte, workers)
+	rng := rand.New(rand.NewSource(42))
+	for i := range payloads {
+		size := 1024 + rng.Intn(64*1024)
+		payloads[i] = make([]byte, size)
+		rng.Read(payloads[i])
+		encoded[i] = zstdEncode(t, payloads[i])
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				got, err := decompressZstd(encoded[i], len(payloads[i]))
+				if err != nil {
+					errs <- err
+					return
+				}
+				if !bytes.Equal(got, payloads[i]) {
+					errs <- &mismatchErr{worker: i, iter: j}
+					putZstdBuf(got)
+					return
+				}
+				putZstdBuf(got)
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for e := range errs {
+		t.Fatal(e)
+	}
+}
+
+type mismatchErr struct{ worker, iter int }
+
+func (e *mismatchErr) Error() string {
+	return "concurrent decompress mismatch"
+}
+
+func BenchmarkDecompressZstd(b *testing.B) {
+	// 64 KiB random-ish payload (compresses moderately) — roughly mid-range
+	// for TPC-H parquet pages.
+	rng := rand.New(rand.NewSource(7))
+	src := make([]byte, 64*1024)
+	for i := range src {
+		src[i] = byte(rng.Intn(64))
+	}
+	enc := zstdEncode(b, src)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		got, err := decompressZstd(enc, len(src))
+		if err != nil {
+			b.Fatal(err)
+		}
+		putZstdBuf(got)
+	}
+}
+
+// putZstdBuf must drop oversized buffers so a single anomalous page can't
+// pin a huge allocation in the pool indefinitely.
+func TestZstdBufPool_RejectsOversized(t *testing.T) {
+	huge := make([]byte, 0, zstdBufPoolMaxCap+1)
+	putZstdBuf(huge) // must not panic, must not retain
+
+	// Drain the pool a few times; we expect the new function (64 KB) to win
+	// out, never the huge one.
+	for i := 0; i < 8; i++ {
+		bp := zstdBufPool.Get().(*[]byte)
+		if cap(*bp) > zstdBufPoolMaxCap {
+			t.Fatalf("oversized buffer leaked into pool: cap=%d", cap(*bp))
+		}
+		zstdBufPool.Put(bp)
+	}
+}
+
+// PageData.Release must be safe to call multiple times and on a zero value.
+func TestPageDataRelease_Idempotent(t *testing.T) {
+	var p *PageData
+	p.Release() // nil receiver
+
+	p = &PageData{}
+	p.Release() // no rawBuf
+
+	buf := getZstdBuf(1024)
+	p = &PageData{rawBuf: buf, codec: CodecZstd}
+	p.Release()
+	p.Release() // double-release must not double-put
+}

--- a/internal/storage/parquet/decompress_pool_test.go
+++ b/internal/storage/parquet/decompress_pool_test.go
@@ -2,7 +2,9 @@ package parquet
 
 import (
 	"bytes"
+	"fmt"
 	"math/rand"
+	"reflect"
 	"sync"
 	"testing"
 
@@ -145,4 +147,162 @@ func TestPageDataRelease_Idempotent(t *testing.T) {
 	p = &PageData{rawBuf: buf, codec: CodecZstd}
 	p.Release()
 	p.Release() // double-release must not double-put
+}
+
+// deepCopyForSnapshot makes a value safe to retain across a pool poison: any
+// reference type that *could* alias a pooled decompression buffer is copied so
+// the snapshot is immune to later corruption. Scalars are returned as-is.
+func deepCopyForSnapshot(v any) any {
+	switch t := v.(type) {
+	case []byte:
+		cp := make([]byte, len(t))
+		copy(cp, t)
+		return cp
+	case string:
+		return string([]byte(t))
+	case []int64:
+		cp := make([]int64, len(t))
+		copy(cp, t)
+		return cp
+	case []float64:
+		cp := make([]float64, len(t))
+		copy(cp, t)
+		return cp
+	default:
+		return v
+	}
+}
+
+// TestZstdPoolPoison_ReaderAlias is the premature-release regression guard for
+// the zstd decompress-buffer pool. It reads a zstd-compressed parquet file
+// fully via the public reader, snapshots every value, then deterministically
+// poisons the pool by overwriting the full capacity of every released buffer
+// with 0xFF. If any consumer retained a slice that still aliases a pooled
+// buffer past page.Release(), its bytes now read sentinel and the snapshot
+// comparison fails. On correct (copy-out) code the snapshot is unchanged.
+//
+// This lives in the parquet package on purpose: only here can the test reach
+// zstdBufPool directly to force a deterministic poison, and ReadRows runs
+// single-goroutine so every released page buffer is resident in one pool when
+// poisonPool drains it — no scheduling or sync.Pool timing luck.
+func TestZstdPoolPoison_ReaderAlias(t *testing.T) {
+	const nRows = 5000
+	schema := Schema{
+		Columns: []Column{
+			{Name: "id", Type: TypeInt64},       // PLAIN INT64 — Int64() unsafe-aliases rawBuf
+			{Name: "i32", Type: TypeInt32},      // PLAIN INT32 — Int32() unsafe-aliases rawBuf
+			{Name: "amount", Type: TypeFloat64}, // PLAIN DOUBLE — Double() aliases rawBuf
+			{Name: "name", Type: TypeString},    // BYTE_ARRAY — exercises the string path
+		},
+	}
+	rows := make([]map[string]any, nRows)
+	for i := 0; i < nRows; i++ {
+		rows[i] = map[string]any{
+			"id":     int64(i)*1_000_003 + 7,
+			"i32":    int32(i*31 - 5),
+			"amount": float64(i) * 1.5,
+			"name":   fmt.Sprintf("row-%08d-payload-value", i),
+		}
+	}
+
+	// Force zstd compression and a small page buffer so the columns span
+	// several pages — each page is its own decompress + Release cycle.
+	cfg := DefaultWriterConfig()
+	cfg.Compression = CompressionZstd
+	cfg.PageBufferSize = 8 * 1024
+	cfg.RowGroupSize = 1 << 20
+
+	var buf bytes.Buffer
+	pw, err := NewWriter(&buf, schema, cfg)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	if err := pw.WriteRows(rows); err != nil {
+		t.Fatalf("WriteRows: %v", err)
+	}
+	if err := pw.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	data := buf.Bytes()
+
+	reader, err := NewReaderFromBytes(data)
+	if err != nil {
+		t.Fatalf("NewReaderFromBytes: %v", err)
+	}
+	got, err := reader.ReadRows(nil)
+	if err != nil {
+		t.Fatalf("ReadRows: %v", err)
+	}
+	if len(got) != nRows {
+		t.Fatalf("row count = %d, want %d", len(got), nRows)
+	}
+
+	// Snapshot every value with a deep copy, BEFORE poisoning the pool.
+	snap := make([]map[string]any, len(got))
+	for i, r := range got {
+		m := make(map[string]any, len(r))
+		for k, v := range r {
+			m[k] = deepCopyForSnapshot(v)
+		}
+		snap[i] = m
+	}
+
+	poisonPool(t)
+
+	for i := range got {
+		if !reflect.DeepEqual(got[i], snap[i]) {
+			t.Fatalf("row %d corrupted after pool poison — a consumer retained a "+
+				"pool-aliased reference past Release:\n got=%#v\nwant=%#v",
+				i, got[i], snap[i])
+		}
+	}
+
+	// A clean re-read must also match the snapshot (the file itself is intact).
+	reader2, err := NewReaderFromBytes(data)
+	if err != nil {
+		t.Fatalf("NewReaderFromBytes (reread): %v", err)
+	}
+	reread, err := reader2.ReadRows(nil)
+	if err != nil {
+		t.Fatalf("ReadRows (reread): %v", err)
+	}
+	for i := range snap {
+		if !reflect.DeepEqual(reread[i], snap[i]) {
+			t.Fatalf("row %d differs on clean re-read: got=%#v want=%#v",
+				i, reread[i], snap[i])
+		}
+	}
+}
+
+// poisonPool deterministically clobbers every buffer resident in zstdBufPool:
+// it drains the pool, fills each buffer's full capacity with 0xFF, then returns
+// them. Any slice still aliasing a released buffer now reads sentinel bytes.
+func poisonPool(t *testing.T) {
+	t.Helper()
+	const drainLimit = 8192
+	drained := make([]*[]byte, 0, 128)
+	fresh := 0
+	for i := 0; i < drainLimit; i++ {
+		bp := zstdBufPool.Get().(*[]byte)
+		b := *bp
+		full := b[:cap(b)]
+		for j := range full {
+			full[j] = 0xFF
+		}
+		drained = append(drained, bp)
+		// Pool.New mints empty 64 KiB buffers; once we've pulled a short streak
+		// of those we've drained all real (payload-bearing) entries.
+		if cap(b) == 64*1024 {
+			fresh++
+			if fresh >= 16 {
+				break
+			}
+		} else {
+			fresh = 0
+		}
+	}
+	for _, bp := range drained {
+		b := (*bp)[:0]
+		zstdBufPool.Put(&b)
+	}
 }

--- a/internal/storage/parquet/page_reader.go
+++ b/internal/storage/parquet/page_reader.go
@@ -7,12 +7,30 @@ import (
 
 // PageData holds the decoded contents of a single Parquet data page.
 type PageData struct {
-	NumValues       int
-	NumRows         int
-	NumNulls        int
-	Data            Values  // decoded column values (non-null values only)
+	NumValues        int
+	NumRows          int
+	NumNulls         int
+	Data             Values  // decoded column values (non-null values only)
 	DefinitionLevels []int32 // nil if column is required (no nulls)
 	RepetitionLevels []int32 // nil for flat schemas (no nesting)
+
+	// rawBuf is the decompressed page buffer that backs Data when the page
+	// values alias the decompress output (PLAIN-encoded numeric/fixed-len
+	// columns). nil when no pooled buffer needs to be returned (uncompressed
+	// pages, dictionary-indexed pages, or codecs without a buffer pool).
+	rawBuf []byte
+	codec  CompressionCodec
+}
+
+// Release returns any pooled decompression buffer backing this page to its
+// pool. Must be called once the page's values have been copied into their
+// destination Vector — subsequent use of p.Data is undefined.
+func (p *PageData) Release() {
+	if p == nil || p.rawBuf == nil {
+		return
+	}
+	ReleaseDecompressed(p.codec, p.rawBuf)
+	p.rawBuf = nil
 }
 
 // DictionaryData holds the decoded contents of a dictionary page.
@@ -204,6 +222,8 @@ func (r *ColumnPageReader) decodeDataPageV1(ph *PageHeader, compressed []byte) (
 		Data:             vals,
 		DefinitionLevels: defLevels,
 		RepetitionLevels: repLevels,
+		rawBuf:           pageData,
+		codec:            r.codec,
 	}, nil
 }
 
@@ -249,17 +269,20 @@ func (r *ColumnPageReader) decodeDataPageV2(ph *PageHeader, compressed []byte) (
 
 	// Decompress the data section (levels were NOT compressed in v2).
 	dataSection := compressed[off:]
+	var rawBuf []byte
 	if dph.IsCompressed {
 		decompressed, err := Decompress(r.codec, dataSection, int(ph.UncompressedPageSize)-repLen-defLen)
 		if err != nil {
 			return nil, fmt.Errorf("decompressing v2 data: %w", err)
 		}
 		dataSection = decompressed
+		rawBuf = decompressed
 	}
 
 	nonNullCount := numValues - numNulls
 	vals, err := r.decodeValues(dataSection, nonNullCount, dph.Encoding)
 	if err != nil {
+		ReleaseDecompressed(r.codec, rawBuf)
 		return nil, fmt.Errorf("decoding v2 data: %w", err)
 	}
 
@@ -270,6 +293,8 @@ func (r *ColumnPageReader) decodeDataPageV2(ph *PageHeader, compressed []byte) (
 		Data:             vals,
 		DefinitionLevels: defLevels,
 		RepetitionLevels: repLevels,
+		rawBuf:           rawBuf,
+		codec:            r.codec,
 	}, nil
 }
 

--- a/internal/storage/parquet/page_reader.go
+++ b/internal/storage/parquet/page_reader.go
@@ -209,6 +209,9 @@ func (r *ColumnPageReader) decodeDataPageV1(ph *PageHeader, compressed []byte) (
 
 	vals, err := r.decodeValues(valuesData, nonNullCount, dph.Encoding)
 	if err != nil {
+		// Return the pooled decompress buffer on the error path (mirrors the
+		// v2 path); nothing references it once decode failed.
+		ReleaseDecompressed(r.codec, pageData)
 		return nil, fmt.Errorf("decoding v1 data: %w", err)
 	}
 

--- a/internal/storage/parquet/reader.go
+++ b/internal/storage/parquet/reader.go
@@ -267,6 +267,7 @@ func readLeafColumn(fr *FileReader, rgIdx, colIdx int) (leafColumnData, error) {
 		// Decode non-null values.
 		pageVals := decodePageValues(data, lcd.maxDef, page.DefinitionLevels, typeID)
 		lcd.values = append(lcd.values, pageVals...)
+		page.Release()
 	}
 
 	return lcd, nil
@@ -715,6 +716,7 @@ func readColumnToAny(fr *FileReader, rgIdx, colIdx, numRows int, typeID TypeID) 
 			unpackWithNulls(values, offset, data, page.DefinitionLevels, maxDef, n, typeID)
 		}
 		offset += n
+		page.Release()
 	}
 	return values, nil
 }


### PR DESCRIPTION
## Summary

Pools the per-page zstd decompression output buffer in the parquet page-read hot path. Previously every data page allocated a fresh `make([]byte, 0, size)` for `zstd.DecodeAll`; the SF100 22Q worker CPU profile after #103 ranked `zstd.sequenceDecs.decodeSync` at **14.3% cum** (~2× the residual s2 share). A `sync.Pool` of output buffers (`getZstdBuf`/`putZstdBuf`) reuses the allocation across calls; `PageData.Release()` returns the buffer once the page's values have been copied into their destination.

## Lifetime contract

`PageData.rawBuf` records the decompress buffer; consumers call `page.Release()` **after** copying values out. The three release sites are `readColumnNative` (scan hot path), `readLeafColumn`, and `readColumnToAny`. Non-pooled codecs and fresh-copy paths are no-ops. If `Release` is never called the buffer simply GCs — correctness preserved, perf win lost.

## Safety review (critical parquet infra)

A pooled-buffer change here risks silent corruption if any decoded value *aliases* `rawBuf` and survives past `Release()`. Verified — by source review and a 4-lens adversarial audit — that every aliasing type is fully materialized before release:

- **PLAIN numerics** alias `rawBuf` → consumers `copy()` values out first.
- **PLAIN ByteArray** is already a fresh `packed` copy → never aliases.
- **FIXED_LEN / INT96 / DELTA_LENGTH_BYTE_ARRAY** alias `rawBuf` → consumers materialize via `BytesColumn` append-copy, `string()`, `make+copy`, or value conversion (`decimalBytesToInt64`) before release.
- **Dictionary** data pages carry fresh RLE indices; resolved values alias the (never-pooled) dictionary buffer.
- **Def/rep levels** are freshly allocated by the RLE decoders (and in v2 come from the uncompressed input), never aliasing `rawBuf`.
- **Pool mechanics**: no double-put (Release zeroes `rawBuf`), oversized (>4 MiB) and zero-cap buffers dropped, `DecodeAll` realloc handled, length reset on put.

## Hardening added on top of the original commit

- **`fix(parquet)`**: release the pooled buffer on the v1 decode-error path too (the v2 path already did) — error-path only, no behavior change otherwise.
- **`test(parquet)`**: `TestZstdPoolPoison_ReaderAlias` — a *deterministic* premature-release regression guard. Reads a zstd parquet file, snapshots every value, then drains `zstdBufPool` and overwrites each resident buffer with `0xFF`. Any retained pool-alias surfaces as a snapshot mismatch with no `sync.Pool` timing luck (the reader is single-goroutine). **Verified to have teeth**: injecting a one-line `rawBuf` alias in `unpackAllPresent` fails the test; the real copy-out code passes.

## Validation

- SF100 22/22 **byte-identical** when this branch was first validated (Q19 −27%, Q05 −5%, suite flat-at-noise; kept per the no-revert-on-serial-clog rule — the alloc reduction is the signal, wall-flat is not a regression).
- Rebased onto current `main` (mc=4 baseline); `decompress.go` unchanged underneath. Local gates green: `go build ./...`, parquet/scan/exec/batch unit tests, `-race` on parquet/scan/exec, and the **TPC-H SF0.01 22/22 correctness gate** (mandated for any parquet change).

## Commits
1. `perf(parquet)` — the pool itself (original, SF100-validated).
2. `fix(parquet)` — v1 decode-error release symmetry.
3. `test(parquet)` — deterministic poison-pool regression guard.