### PR TITLE
perf(exec): unify HashJoin on partition-on-arrival, retire flat path, enable SF100 mc=4

### DIFF
--- a/deploy/benchmark/terraform/sf100-distributed.tfvars
+++ b/deploy/benchmark/terraform/sf100-distributed.tfvars
@@ -14,26 +14,22 @@ data_prefix               = ""              # SF100 data at root (lineitem/, ord
 generate_data             = false           # data is pre-staged; do not regenerate
 skip_queries              = ""
 query_timeout             = "30m"           # SF100 heavy queries need >10m default; mirrors sf10-distributed
-# 2026-05-07 Q17 investigation: 4 concurrent stage tasks each with ~5-6 GB
-# live working set overwhelmed the 21.6 GB GOMEMLIMIT, GC thrashed,
-# heartbeats starved, coord reaped. Lowered to 3.
-#
-# 2026-05-09 SF100 deploy of 7a8c0d6 (PR #90 groupstate-soa-split) at
-# max_concurrent=4: Q17 PASSED in 22m18s (the =4 unblock goal), but the
-# suite did not complete — a query post-Q17 (Q18 or Q21 based on staged
-# shuffle outputs `final_aggregate-13` + `join-16`) hit a separate
-# memory bottleneck and the run never reached the S3 upload step. Q17
-# was +5m13s vs the =3 baseline (17m5s). The refactor is correct but
-# =4 across the whole 22Q suite remains memory-bound on a different
-# code path. Stay at =3 until the post-Q17 bottleneck (likely
-# drainSimpleAggsToPartialGroups peak, ~749 MB at SF10) is addressed.
-# 2026-05-10 deploy of db4feab (PR #91 + #92 typed-keyvals) at mc=4:
-# Q01-Q04 PASSED (Q03 -53s vs 7m18 baseline, Q04 -1m49 vs 8m57). Q05
-# (5-way customer/orders/lineitem/supplier/nation/region join) stalled
-# after ~16 min: worker reaped (1m43s no heartbeat with 2 in-flight
-# tasks), then ~10 min no stage completions. Different signature than
-# PR #90's post-Q17 stall — this is a hash-join build/probe memory
-# pressure at SF100, NOT the drain path. Production stays at mc=3 until
-# the Q05-shape HashJoin peak is addressed. Cost of this attempt ~$1.55.
-max_concurrent            = 3
+# max_concurrent history (chronological):
+# - 2026-05-07: lowered 4->3 after the Q17 investigation (4 concurrent
+#   tasks x ~5-6 GB live overwhelmed the 21.6 GB GOMEMLIMIT, GC thrashed,
+#   heartbeats starved, coord reaped).
+# - 2026-05-09 (PR #90) and 2026-05-10 (db4feab, PR #91/#92) mc=4 attempts
+#   each failed: PR #90 completed Q17 but the suite died post-Q17 on the
+#   Q18/Q21 drain; db4feab stalled at Q05 (a hash-join build/probe memory
+#   pressure, NOT the drain path) — worker reaped, ~10 min no stage
+#   completions. Production pinned at mc=3.
+# - 2026-06-03 (d5997af, HashJoin flat-path retirement / partition-on-arrival
+#   unification): mc=4 now PASSES the full suite. SF100 22/22 byte-identical
+#   to the mc=3 baseline (results/20260603-174555), total 1h6m vs ~71m at
+#   mc=3 — FASTER and complete. Both prior death points cleared: Q05 (3m35s)
+#   and the Q17->Q18 drain (Q18 7m16s vs 10m8s at mc=3). The fix makes the
+#   HashJoin build spill O(partition) instead of doing a reactive O(total)
+#   repartition+rebuild under pressure, which is what OOM'd mc=4 before.
+#   Raised to 4 — the concurrency payoff the engine was always targeting.
+max_concurrent            = 4
 data_plane                = "grpc" # Phase C+D+E gRPC data-plane (task dispatch + results + gather + TaskProgress). NATS retained for heartbeats + cancellation + KV only. SF100 is where the design was actually targeted — Q17 dispatch-stall + NATS lock-contention pathologies.

--- a/internal/engine/batch/batch.go
+++ b/internal/engine/batch/batch.go
@@ -115,6 +115,21 @@ func (b *RecordBatch) MemBytes() int64 {
 	return size
 }
 
+// EnsureCapacity grows every column so positions [0, n) are addressable for
+// in-place writes, preserving existing data, and sets Len to n. Used by
+// append-style builders (e.g. the hash-join per-partition accumulator) that
+// grow a batch across many source batches rather than pre-sizing to a
+// worst-case capacity. See Vector.EnsureLen for per-type behavior and the
+// nested-type caveat.
+func (b *RecordBatch) EnsureCapacity(n int) {
+	for _, col := range b.Columns {
+		col.EnsureLen(n)
+	}
+	if n > b.Len {
+		b.Len = n
+	}
+}
+
 // Reset clears the batch for reuse, keeping allocated memory.
 func (b *RecordBatch) Reset(numRows int) {
 	b.Len = numRows

--- a/internal/engine/batch/bitmap.go
+++ b/internal/engine/batch/bitmap.go
@@ -35,6 +35,40 @@ func NewBitmapAllNull(n int) Bitmap {
 	return Bitmap{data: make([]uint64, words), len: n, hasNulls: hn}
 }
 
+// EnsureLen grows the bitmap to at least n bits, defaulting any newly added
+// bits to non-null (1) to match NewBitmap. Existing bits are preserved. Used by
+// append-style builders that grow a column across many source batches instead
+// of pre-sizing to a worst-case capacity.
+func (b *Bitmap) EnsureLen(n int) {
+	if n <= b.len {
+		return
+	}
+	words := (n + 63) / 64
+	if words > cap(b.data) {
+		// Grow the word array geometrically (at least double) so repeated
+		// EnsureLen calls amortize to O(1) per row instead of reallocating
+		// every 64 rows.
+		newCap := cap(b.data)
+		if newCap == 0 {
+			newCap = words
+		}
+		for newCap < words {
+			newCap *= 2
+		}
+		grown := make([]uint64, words, newCap)
+		copy(grown, b.data)
+		b.data = grown
+	} else if words > len(b.data) {
+		b.data = b.data[:words]
+	}
+	// Default new bits [b.len, n) to non-null (1). Each bit is set at most once
+	// across successive grows (b.len only advances), so total work is O(rows).
+	for i := b.len; i < n; i++ {
+		b.data[i/64] |= 1 << uint(i%64)
+	}
+	b.len = n
+}
+
 // IsNull returns true if the bit at position i is 0 (null).
 // Includes bounds checking for safety at API boundaries.
 func (b *Bitmap) IsNull(i int) bool {

--- a/internal/engine/batch/ensurelen_test.go
+++ b/internal/engine/batch/ensurelen_test.go
@@ -1,0 +1,139 @@
+package batch
+
+import (
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// TestBitmapEnsureLen_DefaultsNonNullAndPreserves verifies that growing a
+// bitmap defaults the new bits to non-null (1) while preserving existing null
+// state, across word boundaries.
+func TestBitmapEnsureLen_DefaultsNonNullAndPreserves(t *testing.T) {
+	b := NewBitmap(0)
+	b.EnsureLen(3)
+	b.SetNull(1)
+
+	// Grow well past a 64-bit word boundary.
+	b.EnsureLen(200)
+
+	if !b.IsNull(1) {
+		t.Fatal("existing null bit at index 1 not preserved after grow")
+	}
+	for _, i := range []int{0, 2, 63, 64, 65, 128, 199} {
+		if b.IsNull(i) {
+			t.Fatalf("bit %d should default to non-null after grow", i)
+		}
+	}
+	// Out-of-range still reads as null (defensive bounds).
+	if !b.IsNull(200) {
+		t.Fatal("index 200 is out of range and should read null")
+	}
+
+	// A null set after growth must stick, and HasNulls must reflect it.
+	b.SetNull(150)
+	if !b.IsNull(150) {
+		t.Fatal("null set after grow not recorded")
+	}
+	if !b.HasNulls() {
+		t.Fatal("HasNulls should be true after a SetNull")
+	}
+}
+
+// TestBitmapEnsureLen_Idempotent confirms shrinking-or-equal requests are no-ops.
+func TestBitmapEnsureLen_Idempotent(t *testing.T) {
+	b := NewBitmap(0)
+	b.EnsureLen(100)
+	b.SetNull(50)
+	b.EnsureLen(40) // <= len: no-op
+	if !b.IsNull(50) {
+		t.Fatal("EnsureLen with smaller n must not disturb existing bits")
+	}
+}
+
+// TestVectorEnsureLen_FixedWidth grows a fixed-width vector incrementally,
+// writing through both the realloc and the reslice-within-cap paths, and
+// verifies values + nulls survive growth.
+func TestVectorEnsureLen_FixedWidth(t *testing.T) {
+	v := NewVector(TypeInt64, 0)
+	// Write 5 values across two grows (forces at least one realloc).
+	v.EnsureLen(3)
+	for i := 0; i < 3; i++ {
+		v.Int64Data[i] = int64(i + 1)
+	}
+	v.EnsureLen(5)
+	v.Int64Data[3] = 40
+	v.Nulls.SetNull(4) // leave index 4 data zero, marked null
+
+	if v.Len != 5 {
+		t.Fatalf("Len = %d, want 5", v.Len)
+	}
+	want := []int64{1, 2, 3, 40, 0}
+	for i, w := range want {
+		if v.Int64Data[i] != w {
+			t.Fatalf("Int64Data[%d] = %d, want %d (data not preserved across grow)", i, v.Int64Data[i], w)
+		}
+	}
+	for i := 0; i < 4; i++ {
+		if v.Nulls.IsNull(i) {
+			t.Fatalf("index %d unexpectedly null", i)
+		}
+	}
+	if !v.Nulls.IsNull(4) {
+		t.Fatal("index 4 should be null")
+	}
+}
+
+// TestVectorEnsureLen_Bytes grows a string vector and verifies sequential
+// SetFrom-style appends keep offset continuity after growth.
+func TestVectorEnsureLen_Bytes(t *testing.T) {
+	src := NewVector(TypeString, 2)
+	src.BytesData.Set(0, []byte("alpha"))
+	src.BytesData.Set(1, []byte("beta"))
+
+	dst := NewVector(TypeString, 0)
+	dst.EnsureLen(1)
+	dst.BytesData.SetFrom(0, &src.BytesData, 0) // "alpha"
+	dst.EnsureLen(2)
+	dst.BytesData.SetFrom(1, &src.BytesData, 1) // "beta"
+
+	if got := string(dst.BytesData.Value(0)); got != "alpha" {
+		t.Fatalf("value 0 = %q, want alpha", got)
+	}
+	if got := string(dst.BytesData.Value(1)); got != "beta" {
+		t.Fatalf("value 1 = %q, want beta", got)
+	}
+}
+
+// TestRecordBatchEnsureCapacity_GrowsAllColumnsAndLen builds a batch row-by-row
+// purely through EnsureCapacity growth (no pre-sizing) and checks the result is
+// a well-formed batch.
+func TestRecordBatchEnsureCapacity_GrowsAllColumnsAndLen(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "name", Type: parquet.TypeString},
+	}
+	b := NewRecordBatch(schema, 0)
+
+	const n = 100
+	for i := 0; i < n; i++ {
+		b.EnsureCapacity(i + 1)
+		b.Columns[0].Int64Data[i] = int64(i * 10)
+		b.Columns[1].BytesData.Set(i, []byte{byte('a' + i%26)})
+	}
+
+	if b.Len != n {
+		t.Fatalf("Len = %d, want %d", b.Len, n)
+	}
+	if len(b.Columns[0].Int64Data) < n {
+		t.Fatalf("id column len %d < %d", len(b.Columns[0].Int64Data), n)
+	}
+	for i := 0; i < n; i++ {
+		if b.Columns[0].Int64Data[i] != int64(i*10) {
+			t.Fatalf("id[%d] = %d, want %d", i, b.Columns[0].Int64Data[i], i*10)
+		}
+		if got := string(b.Columns[1].BytesData.Value(i)); got != string(rune('a'+i%26)) {
+			t.Fatalf("name[%d] = %q, want %q", i, got, string(rune('a'+i%26)))
+		}
+	}
+}

--- a/internal/engine/batch/vector.go
+++ b/internal/engine/batch/vector.go
@@ -283,6 +283,122 @@ func NewVectorWithScale(typ TypeID, length int, scale int) *Vector {
 	return v
 }
 
+// EnsureLen grows the vector's backing storage so positions [0, n) are
+// addressable for in-place writes (Set / index-assign), preserving existing
+// values, defaulting new fixed-width slots to zero and new null bits to
+// non-null. Backing arrays grow geometrically (via append) for amortized O(1)
+// appends, so an append-style builder can grow a column across many source
+// batches instead of pre-sizing to a worst-case capacity. Sets Len to n.
+//
+// Scalar, bytes, decimal and fixed-dim VECTOR columns are fully supported.
+// Nested ARRAY/MAP element storage and ROW children are NOT grown here (their
+// element storage is appended by SetValue); callers that build nested columns
+// should use pre-sized batches. The hash-join accumulator path that relies on
+// EnsureLen guards nested schemas to a pre-sized path for this reason.
+func (v *Vector) EnsureLen(n int) {
+	if n <= v.Len {
+		return
+	}
+	v.Nulls.EnsureLen(n)
+	switch v.Type {
+	case TypeBool:
+		if cap(v.BoolData) >= n {
+			v.BoolData = v.BoolData[:n]
+		} else {
+			g := make([]bool, n, growCap(cap(v.BoolData), n))
+			copy(g, v.BoolData)
+			v.BoolData = g
+		}
+	case TypeInt32, TypePort, TypeProtocol, TypeDate:
+		if cap(v.Int32Data) >= n {
+			v.Int32Data = v.Int32Data[:n]
+		} else {
+			g := make([]int32, n, growCap(cap(v.Int32Data), n))
+			copy(g, v.Int32Data)
+			v.Int32Data = g
+		}
+	case TypeInt64, TypeTimestamp, TypeIPv4, TypeMAC, TypeDuration:
+		if cap(v.Int64Data) >= n {
+			v.Int64Data = v.Int64Data[:n]
+		} else {
+			g := make([]int64, n, growCap(cap(v.Int64Data), n))
+			copy(g, v.Int64Data)
+			v.Int64Data = g
+		}
+	case TypeFloat32:
+		if cap(v.Float32Data) >= n {
+			v.Float32Data = v.Float32Data[:n]
+		} else {
+			g := make([]float32, n, growCap(cap(v.Float32Data), n))
+			copy(g, v.Float32Data)
+			v.Float32Data = g
+		}
+	case TypeFloat64:
+		if cap(v.Float64Data) >= n {
+			v.Float64Data = v.Float64Data[:n]
+		} else {
+			g := make([]float64, n, growCap(cap(v.Float64Data), n))
+			copy(g, v.Float64Data)
+			v.Float64Data = g
+		}
+	case TypeString, TypeBytes, TypeIPv6, TypeCIDR, TypeUUID:
+		// Offsets need length n+1 (one trailing offset). Data grows separately
+		// via Set/SetFrom appends.
+		if cap(v.BytesData.Offsets) >= n+1 {
+			v.BytesData.Offsets = v.BytesData.Offsets[:n+1]
+		} else {
+			g := make([]uint32, n+1, growCap(cap(v.BytesData.Offsets), n+1))
+			copy(g, v.BytesData.Offsets)
+			v.BytesData.Offsets = g
+		}
+	case TypeDecimal:
+		if cap(v.DecimalData.Data) >= n {
+			v.DecimalData.Data = v.DecimalData.Data[:n]
+		} else {
+			g := make([]Int128, n, growCap(cap(v.DecimalData.Data), n))
+			copy(g, v.DecimalData.Data)
+			v.DecimalData.Data = g
+		}
+	case TypeVector:
+		if v.VectorDim > 0 {
+			need := n * v.VectorDim
+			if cap(v.Float32Data) >= need {
+				v.Float32Data = v.Float32Data[:need]
+			} else {
+				g := make([]float32, need, growCap(cap(v.Float32Data), need))
+				copy(g, v.Float32Data)
+				v.Float32Data = g
+			}
+		}
+	case TypeArray, TypeMap:
+		if cap(v.Offsets) >= n+1 {
+			v.Offsets = v.Offsets[:n+1]
+		} else {
+			g := make([]int32, n+1, growCap(cap(v.Offsets), n+1))
+			copy(g, v.Offsets)
+			v.Offsets = g
+		}
+	case TypeRow:
+		for _, c := range v.Children {
+			c.EnsureLen(n)
+		}
+	}
+	v.Len = n
+}
+
+// growCap returns a new capacity >= need, at least doubling the old capacity so
+// repeated EnsureLen growth amortizes to O(1) per appended row.
+func growCap(old, need int) int {
+	c := old
+	if c == 0 {
+		c = need
+	}
+	for c < need {
+		c *= 2
+	}
+	return c
+}
+
 // NewVectorVector creates a new VECTOR column with fixed dimensionality.
 // Storage: Float32Data of length * dim, where row i occupies [i*dim, (i+1)*dim).
 func NewVectorVector(length, dim int) *Vector {

--- a/internal/engine/exec/join.go
+++ b/internal/engine/exec/join.go
@@ -140,16 +140,6 @@ type HashJoin struct {
 	// output schema. Only set when spillState is non-nil.
 	spillOutputFilter map[string]bool
 	spillLeftSchema   []parquet.Column
-
-	// PartitionOnArrival makes Build allocate spillState upfront and partition
-	// every batch as it arrives, so memory pressure can be relieved by evicting
-	// a single partition (O(partition_size)) instead of redistributing the
-	// entire flat hash table on first spill (O(total_size) plus a hash-table
-	// reset and rebuild). When false, Build uses the legacy flat path and only
-	// converts to partitioned representation reactively on first spill. The
-	// production worker path enables this; standalone embeddings without a
-	// shared memory pool keep the legacy path.
-	PartitionOnArrival bool
 }
 
 // BloomPushdownOp returns a UnaryOperator that pre-filters probe batches using
@@ -678,14 +668,9 @@ func (h *HashJoin) Build(ctx context.Context, source Source) error {
 	}
 
 	// Cooperative-spill registration: when the join has both a Spill manager
-	// and a MemTracker, register as a Spillable so the worker's
-	// SpillManager.RequestRelief can target this operator's partitions when
-	// another task hits Reserve failure. Registering at Build entry (rather
-	// than only in buildPartitioned) covers the legacy-flat-path-then-
-	// reactively-converted case: the operator starts with spillState=nil
-	// (SpillFootprint returns 0, RequestRelief skips it), and once
-	// spillBuildBatches reactively allocates spillState mid-build, the
-	// operator becomes a viable target without any additional registration.
+	// and a MemTracker (so it dispatches to buildPartitioned below), register as
+	// a Spillable so the worker's SpillManager.RequestRelief can target this
+	// operator's in-memory partitions when another task hits Reserve failure.
 	if h.Spill != nil && h.MemTracker != nil && !h.SemiAntiKeyOnly {
 		// Register with the relief registry for the duration of Build (the
 		// spill-eligible phase).
@@ -698,29 +683,25 @@ func (h *HashJoin) Build(ctx context.Context, source Source) error {
 		}()
 	}
 
-	// Partition-on-arrival path: when both MemTracker and Spill are
-	// configured (the production worker config) and the caller opted in via
-	// PartitionOnArrival, bypass the legacy flat-then-reactively-partition
-	// path. Spill becomes O(partition) instead of O(total), which is the
-	// architectural primitive that the SF10 lineitem broadcast-join "8 min
-	// per join" memory pressure was hitting.
-	//
-	// The CALLER (worker stage hash join, in production) decides whether to
-	// set this flag — it sees the shared pool state at task entry and only
-	// turns the flag on when pressure is already high enough to make the
-	// per-partition allocation cost worth paying. Below pressure, the worker
-	// leaves the flag false and we run the legacy flat path; if pressure
-	// rises mid-build, spillBuildBatches reactively converts to partitioned
-	// representation at that point. Tests that need to validate partition-
-	// on-arrival behavior set the flag unconditionally.
-	if h.PartitionOnArrival && h.Spill != nil && h.MemTracker != nil && !h.SemiAntiKeyOnly {
+	// Spill-eligible builds (MemTracker + Spill both configured — the
+	// production worker config) always partition on arrival. Spill is then
+	// O(partition) instead of O(total): each pressure event evicts one
+	// partition rather than freezing, repartitioning, and rebuilding the whole
+	// flat state. There is no at-entry pressure heuristic — partitioning is
+	// unconditional for spill-eligible builds, so a build that mispredicts its
+	// pressure can never get stuck on a flat path with no cheap spill (the
+	// Q17/Q18 mc=4 failure mode). The flat path below runs only for callers
+	// without a tracker/spill (embedded queries, tests, spill-replay rebuilds),
+	// where it is a pure in-memory build that never spills.
+	if h.Spill != nil && h.MemTracker != nil && !h.SemiAntiKeyOnly {
 		return h.buildPartitioned(ctx, source)
 	}
 
-	// Full builds use serial insertion. buildParallel creates per-worker
-	// local tables then merges them, but the merge re-inserts every key
-	// and costs as much as the parallel insertion saved (~9s for 60M rows).
-	// Serial without spill is a tight loop at ~0.6s/60M rows.
+	// No-spill flat build: serial insertion. A per-worker parallel build was
+	// removed in the flat-path retirement — its local-table merge re-inserted
+	// every key and cost as much as the parallel insertion saved (~9s/60M rows),
+	// while serial is a tight ~0.6s/60M-row loop. (Spill-eligible builds use
+	// buildPartitioned; semi/anti key-only builds use buildParallelKeyOnly.)
 
 	// Report build-side row consumption to the per-task progress reporter.
 	// Without this, a long broadcast_join build phase (minutes for SF10
@@ -861,43 +842,19 @@ func (h *HashJoin) Build(ctx context.Context, source Source) error {
 			continue
 		}
 
-		// Spill to disk if memory pressure is high
-		if h.Spill != nil && h.Spill.ShouldSpillFor(memory.SpillCheap) && (len(h.buildBatches) > 0 || h.spillState != nil) {
-			if err := h.spillBuildBatches(0); err != nil {
-				h.mu.Unlock()
-				return fmt.Errorf("spilling build side: %w", err)
-			}
-		}
-
-		// Track memory if budget is set
+		// Track memory if a budget is set. This flat path runs only for callers
+		// without a configured Spill manager (embedded queries, tests, the
+		// spill-replay tmpJoin rebuild) — see Build's dispatch above — so a
+		// Reserve failure has no spill recourse and fails loudly rather than
+		// silently over-committing. Spill-eligible builds use buildPartitioned.
 		if h.MemTracker != nil {
 			cost := hashBuildBytes(b)
 			if err := h.MemTracker.Reserve(cost); err != nil {
-				// Try spilling before giving up
-				if h.Spill != nil {
-					if spillErr := h.spillBuildBatches(cost); spillErr == nil {
-						// After spill, this join's trackedMem was reduced. Try again.
-						if err2 := h.MemTracker.Reserve(cost); err2 != nil {
-							h.mu.Unlock()
-							return fmt.Errorf("hash join build: %w (build_rows=%d, batches=%d)",
-								err2, h.buildRows, len(h.buildBatches))
-						}
-					}
-				} else {
-					h.mu.Unlock()
-					return fmt.Errorf("hash join build: %w (build_rows=%d, batches=%d)",
-						err, h.buildRows, len(h.buildBatches))
-				}
+				h.mu.Unlock()
+				return fmt.Errorf("hash join build (no spill configured): %w (build_rows=%d, batches=%d)",
+					err, h.buildRows, len(h.buildBatches))
 			}
 			h.trackedMem += cost
-		}
-
-		// If spill state is active, route new batches through partitioning
-		if h.spillState != nil {
-			b.Detach()
-			h.partitionBuildBatch(b)
-			h.mu.Unlock()
-			continue
 		}
 
 		// Collect min/max for dynamic filter pushdown before key indexing.
@@ -1016,13 +973,8 @@ func (h *HashJoin) Build(ctx context.Context, source Source) error {
 		h.mu.Unlock()
 	}
 
-	// When Grace Hash Join is active, rebuild hash table from in-memory partitions only.
-	// Spilled partitions will be processed one at a time during probe flush.
-	if h.spillState != nil {
-		if err := h.reloadInMemoryPartitions(); err != nil {
-			return fmt.Errorf("rebuilding in-memory partitions: %w", err)
-		}
-	}
+	// This flat path is no-spill (spillState is always nil here): spill-eligible
+	// builds run buildPartitioned, which indexes per-partition on arrival.
 
 	// Allocate matched bitmap for right/full outer join and right semi/anti tracking
 	if (h.JoinType == RightJoin || h.JoinType == FullOuterJoin ||
@@ -1041,148 +993,6 @@ func (h *HashJoin) Build(ctx context.Context, source Source) error {
 	// the per-batch tracking loop. Charge them to the memory tracker.
 	h.reconcileHashMemory()
 
-	h.buildDone = true
-	return nil
-}
-
-// localBuild accumulates hash table state for one parallel build worker.
-// Each worker builds into its own local hash table and arena to avoid
-// contention. After all workers finish, locals are merged into the main
-// HashJoin state.
-type localBuild struct {
-	batches   []*batch.RecordBatch
-	arena     []buildRef
-	arenaNext []int32
-	intIndex  *intHashTable
-	strIndex  *strHashTable
-	keyBuf    []byte
-	buildRows int64
-}
-
-func (lb *localBuild) appendInt(key int64, ref buildRef) {
-	idx := int32(len(lb.arena))
-	lb.arena = append(lb.arena, ref)
-	if prev, ok := lb.intIndex.PutNoGrow(key, idx); ok {
-		lb.arenaNext = append(lb.arenaNext, prev)
-	} else {
-		lb.arenaNext = append(lb.arenaNext, -1)
-	}
-}
-
-func (lb *localBuild) appendStr(ref buildRef, key []byte) {
-	idx := int32(len(lb.arena))
-	lb.arena = append(lb.arena, ref)
-	if prev, ok := lb.strIndex.PutNoGrow(key, idx); ok {
-		lb.arenaNext = append(lb.arenaNext, prev)
-	} else {
-		lb.arenaNext = append(lb.arenaNext, -1)
-	}
-}
-
-// buildParallel uses per-worker local hash tables for concurrent build.
-// Each worker reads batches (serialized by mutex), inserts into its local
-// table (no contention, fits in L2 cache), then all locals are merged.
-func (h *HashJoin) buildParallel(ctx context.Context, source Source, workers int) error {
-	if err := ctx.Err(); err != nil {
-		return fmt.Errorf("join build cancelled: %w", err)
-	}
-
-	// Read first batch to initialize schema, key indices, and hash type.
-	first, err := source.Next(ctx)
-	if err != nil {
-		return fmt.Errorf("build source next: %w", err)
-	}
-	if first == nil {
-		h.buildDone = true
-		return nil
-	}
-
-	h.buildSchema = first.Schema
-	h.buildKeyIdx = make([]int, len(h.RightKeys))
-	for i, col := range h.RightKeys {
-		h.buildKeyIdx[i] = first.ColumnIndex(col)
-	}
-	h.tryEnableIntKey(first)
-
-	// Create per-worker local accumulators.
-	hint := 64
-	if h.BuildRowHint > 0 {
-		hint = int(h.BuildRowHint) / workers
-		if hint < 64 {
-			hint = 64
-		}
-	}
-	locals := make([]*localBuild, workers)
-	for i := range locals {
-		lb := &localBuild{
-			keyBuf: make([]byte, 0, 128),
-		}
-		if h.useIntKey || h.useDualIntKey {
-			lb.intIndex = newIntHashTable(hint)
-		} else {
-			lb.strIndex = newStrHashTable(hint)
-		}
-		if h.BuildRowHint > 0 {
-			lb.arena = make([]buildRef, 0, hint)
-			lb.arenaNext = make([]int32, 0, hint)
-		}
-		locals[i] = lb
-	}
-
-	// Process first batch in worker 0's local.
-	h.processLocalBatch(locals[0], first)
-
-	// Launch workers.
-	var sourceMu sync.Mutex
-	var wg sync.WaitGroup
-	var firstErr atomic.Value
-
-	for i := 0; i < workers; i++ {
-		wg.Add(1)
-		go func(lb *localBuild) {
-			defer wg.Done()
-			for {
-				if ctx.Err() != nil {
-					return
-				}
-				sourceMu.Lock()
-				b, err := source.Next(ctx)
-				if b != nil && b.Sel != nil {
-					// Snapshot selection vector — filter operators reuse a
-					// shared buffer that the next source.Next() overwrites.
-					sel := make([]uint32, len(b.Sel))
-					copy(sel, b.Sel)
-					b.Sel = sel
-				}
-				sourceMu.Unlock()
-				if err != nil {
-					firstErr.CompareAndSwap(nil, fmt.Errorf("build source next: %w", err))
-					return
-				}
-				if b == nil {
-					return
-				}
-				h.processLocalBatch(lb, b)
-			}
-		}(locals[i])
-	}
-	wg.Wait()
-
-	if v := firstErr.Load(); v != nil {
-		return v.(error)
-	}
-
-	// Merge all local builds into the main hash join state.
-	h.mergeLocalBuilds(locals)
-
-	// Allocate matched bitmap for right/full outer join tracking.
-	if (h.JoinType == RightJoin || h.JoinType == FullOuterJoin) && len(h.arena) > 0 {
-		h.arenaMatched = make([]bool, len(h.arena))
-	}
-
-	h.consolidateBuild()
-
-	h.buildBloom()
 	h.buildDone = true
 	return nil
 }
@@ -1444,207 +1254,6 @@ func (h *HashJoin) insertKeyOnlyBatch(lk *localKeyBuild, b *batch.RecordBatch) {
 	lk.rows += int64(b.ActiveLen())
 }
 
-// processLocalBatch inserts one batch into a worker-local build accumulator.
-// Caller must not hold any locks — this function is lock-free per worker.
-func (h *HashJoin) processLocalBatch(lb *localBuild, b *batch.RecordBatch) {
-	b.Detach()
-	batchIdx := int32(len(lb.batches))
-	lb.batches = append(lb.batches, b)
-
-	// Pre-grow for this batch.
-	batchRows := b.ActiveLen()
-	if h.useIntKey || h.useDualIntKey {
-		lb.intIndex.EnsureCapacity(batchRows)
-	} else if lb.strIndex != nil {
-		lb.strIndex.EnsureCapacity(batchRows)
-	}
-
-	if h.useIntKey {
-		col := b.Columns[h.buildKeyIdx[0]]
-		if b.Sel != nil {
-			for _, si := range b.Sel {
-				key, ok := intKeyFromVector(col, int(si))
-				if !ok {
-					continue
-				}
-				lb.appendInt(key, buildRef{batchIdx: batchIdx, rowIdx: int32(si)})
-				lb.buildRows++
-			}
-		} else if !col.Nulls.HasNulls() {
-			switch col.Type {
-			case batch.TypeInt32, batch.TypePort, batch.TypeProtocol, batch.TypeDate:
-				data := col.Int32Data
-				for rowIdx := 0; rowIdx < b.Len; rowIdx++ {
-					lb.appendInt(int64(data[rowIdx]), buildRef{batchIdx: batchIdx, rowIdx: int32(rowIdx)})
-				}
-			default:
-				data := col.Int64Data
-				for rowIdx := 0; rowIdx < b.Len; rowIdx++ {
-					lb.appendInt(data[rowIdx], buildRef{batchIdx: batchIdx, rowIdx: int32(rowIdx)})
-				}
-			}
-			lb.buildRows += int64(b.Len)
-		} else {
-			for rowIdx := 0; rowIdx < b.Len; rowIdx++ {
-				key, ok := intKeyFromVector(col, rowIdx)
-				if !ok {
-					continue
-				}
-				lb.appendInt(key, buildRef{batchIdx: batchIdx, rowIdx: int32(rowIdx)})
-				lb.buildRows++
-			}
-		}
-	} else if h.useDualIntKey {
-		col0, col1 := b.Columns[h.buildKeyIdx[0]], b.Columns[h.buildKeyIdx[1]]
-		if b.Sel != nil {
-			for _, si := range b.Sel {
-				a, bb, ok := dualIntKeyFromVectors(col0, col1, int(si))
-				if !ok {
-					continue
-				}
-				lb.appendInt(dualIntHash(a, bb), buildRef{batchIdx: batchIdx, rowIdx: int32(si)})
-				lb.buildRows++
-			}
-		} else {
-			for rowIdx := 0; rowIdx < b.Len; rowIdx++ {
-				a, bb, ok := dualIntKeyFromVectors(col0, col1, rowIdx)
-				if !ok {
-					continue
-				}
-				lb.appendInt(dualIntHash(a, bb), buildRef{batchIdx: batchIdx, rowIdx: int32(rowIdx)})
-				lb.buildRows++
-			}
-		}
-	} else {
-		if lb.strIndex == nil {
-			lb.strIndex = newStrHashTable(64)
-		}
-		if b.Sel != nil {
-			for _, si := range b.Sel {
-				lb.keyBuf = lb.keyBuf[:0]
-				for _, idx := range h.buildKeyIdx {
-					if idx < 0 {
-						lb.keyBuf = append(lb.keyBuf, 1)
-						continue
-					}
-					v := b.Columns[idx]
-					if v.Nulls.IsNullFast(int(si)) {
-						lb.keyBuf = append(lb.keyBuf, 1)
-					} else {
-						lb.keyBuf = append(lb.keyBuf, 0)
-						lb.keyBuf = appendColumnValue(lb.keyBuf, v, int(si), v.Type)
-					}
-				}
-				lb.appendStr(buildRef{batchIdx: batchIdx, rowIdx: int32(si)}, lb.keyBuf)
-				lb.buildRows++
-			}
-		} else {
-			for rowIdx := 0; rowIdx < b.Len; rowIdx++ {
-				lb.keyBuf = lb.keyBuf[:0]
-				for _, idx := range h.buildKeyIdx {
-					if idx < 0 {
-						lb.keyBuf = append(lb.keyBuf, 1)
-						continue
-					}
-					v := b.Columns[idx]
-					if v.Nulls.IsNullFast(rowIdx) {
-						lb.keyBuf = append(lb.keyBuf, 1)
-					} else {
-						lb.keyBuf = append(lb.keyBuf, 0)
-						lb.keyBuf = appendColumnValue(lb.keyBuf, v, rowIdx, v.Type)
-					}
-				}
-				lb.appendStr(buildRef{batchIdx: batchIdx, rowIdx: int32(rowIdx)}, lb.keyBuf)
-				lb.buildRows++
-			}
-		}
-	}
-	// Deferred growth check after batch.
-	if h.useIntKey || h.useDualIntKey {
-		lb.intIndex.CheckGrow()
-	} else if lb.strIndex != nil {
-		lb.strIndex.CheckGrow()
-	}
-}
-
-// mergeLocalBuilds combines per-worker local accumulators into the main
-// HashJoin state. Concatenates batches and arenas, then re-inserts hash
-// table entries with adjusted indices. O(distinct_keys) hash work, not
-// O(total_rows), since each key appears once per local table.
-func (h *HashJoin) mergeLocalBuilds(locals []*localBuild) {
-	// Count totals for pre-allocation.
-	var totalArena, totalBatches int
-	for _, lb := range locals {
-		totalArena += len(lb.arena)
-		totalBatches += len(lb.batches)
-		h.buildRows += lb.buildRows
-	}
-
-	h.buildBatches = make([]*batch.RecordBatch, 0, totalBatches)
-	h.arena = make([]buildRef, 0, totalArena)
-	h.arenaNext = make([]int32, 0, totalArena)
-
-	// Pre-size the merged hash table for the total row count.
-	if h.useIntKey || h.useDualIntKey {
-		h.intIndex = newIntHashTable(int(h.buildRows))
-	} else {
-		h.strIndex = newStrHashTable(int(h.buildRows))
-	}
-
-	for _, lb := range locals {
-		batchOffset := int32(len(h.buildBatches))
-		arenaOffset := int32(len(h.arena))
-
-		// Append batches.
-		h.buildBatches = append(h.buildBatches, lb.batches...)
-
-		// Bulk-copy arena and adjust batchIdx in-place (sequential write
-		// is more cache-friendly than per-element struct creation).
-		arenaStart := len(h.arena)
-		h.arena = append(h.arena, lb.arena...)
-		for i := arenaStart; i < len(h.arena); i++ {
-			h.arena[i].batchIdx += batchOffset
-		}
-
-		// Bulk-copy arenaNext and adjust chain links in-place.
-		nextStart := len(h.arenaNext)
-		h.arenaNext = append(h.arenaNext, lb.arenaNext...)
-		for i := nextStart; i < len(h.arenaNext); i++ {
-			if h.arenaNext[i] >= 0 {
-				h.arenaNext[i] += arenaOffset
-			}
-		}
-
-		// Re-insert hash entries with adjusted arena indices.
-		// Uses Put directly (returns old value) instead of Get+Put,
-		// saving one hash table probe per key during merge.
-		if h.useIntKey || h.useDualIntKey {
-			lb.intIndex.ForEach(func(key int64, localHead int32) {
-				adjustedHead := localHead + arenaOffset
-				if existingHead, existed := h.intIndex.Put(key, adjustedHead); existed {
-					// Link local chain tail to existing merged chain head.
-					tail := adjustedHead
-					for h.arenaNext[tail] >= 0 {
-						tail = h.arenaNext[tail]
-					}
-					h.arenaNext[tail] = existingHead
-				}
-			})
-		} else if lb.strIndex != nil {
-			lb.strIndex.ForEachWithValue(func(key []byte, localHead int32) {
-				adjustedHead := localHead + arenaOffset
-				if existingHead, existed := h.strIndex.Put(key, adjustedHead); existed {
-					tail := adjustedHead
-					for h.arenaNext[tail] >= 0 {
-						tail = h.arenaNext[tail]
-					}
-					h.arenaNext[tail] = existingHead
-				}
-			})
-		}
-	}
-}
-
 // buildBloom populates the bloom filter from the build-side hash table keys.
 // Uses a 64-bit-per-slot bloom with 2 hash functions. The filter size is
 // chosen to give ~1% false positive rate for the number of distinct keys.
@@ -1871,144 +1480,6 @@ func bloomHashBytes(key []byte) uint64 {
 		h *= 16777619
 	}
 	return h ^ (h >> 32)
-}
-
-// spillBuildBatches partitions current build batches by hash and spills the
-// largest partition(s) to disk. Must be called with h.mu held.
-// neededBytes is the amount of additional memory needed (0 = just reduce to
-// under 80% threshold). When non-zero, partitions are spilled until
-// in-memory usage + neededBytes fits within budget.
-func (h *HashJoin) spillBuildBatches(neededBytes int64) error {
-	ss := h.spillState
-	if ss == nil {
-		// First spill: initialize partition state and redistribute existing
-		// batches. Drop each batch from h.buildBatches as soon as its rows
-		// have been copied into a partition so the original column data is
-		// GC-eligible during the redistribution loop. Without this drop the
-		// peak heap during spill includes BOTH the full flat build state
-		// AND the new partition data — at SF100 that's an extra ~3 GB of
-		// transient pressure that pushes workers over GOMEMLIMIT during
-		// the very moment they're trying to relieve memory pressure.
-		dir := h.Spill.SpillDir()
-		ss = newSpillState(dir, h.buildSchema)
-		h.spillState = ss
-
-		// Reset hash table state BEFORE redistribution so the partition
-		// path gets a clean intIndex/strIndex to insert into. Set the
-		// arena/arenaNext slices to nil rather than [:0] so the backing
-		// arrays become GC-eligible — at SF100 the flat arena before the
-		// first spill can hold 1 GB+ of buildRefs and we don't want to
-		// carry that capacity forward when the partitioned path uses its
-		// own per-partition state.
-		h.arena = nil
-		h.arenaNext = nil
-		if h.useIntKey || h.useDualIntKey {
-			h.intIndex = newIntHashTable(64)
-		} else {
-			h.strIndex = newStrHashTable(64)
-		}
-		h.buildRows = 0
-
-		// Redistribute existing build batches into partitions, dropping
-		// each from the flat slice as it's consumed so peak heap during
-		// the redistribution loop is bounded by (partitions in flight)
-		// rather than (full flat state + full partition state).
-		flat := h.buildBatches
-		h.buildBatches = nil
-		for i := range flat {
-			b := flat[i]
-			flat[i] = nil
-			h.partitionBuildBatch(b)
-		}
-	}
-
-	// Spill largest partition(s) until memory pressure is resolved
-	for {
-		// Re-sync tracker: release only what THIS join freed by spilling.
-		// Other concurrent builds' tracked memory must not be disturbed.
-		var inMem int64
-		for p, mem := range ss.partMemory {
-			if !ss.spilledParts[p] {
-				inMem += mem
-			}
-		}
-		if h.MemTracker != nil && h.trackedMem > inMem {
-			h.MemTracker.Release(h.trackedMem - inMem)
-			h.trackedMem = inMem
-		}
-
-		// Check if we've freed enough
-		if neededBytes > 0 {
-			// Spill until there's room for the incoming batch
-			if h.MemTracker == nil || inMem+neededBytes <= h.MemTracker.Budget() {
-				break
-			}
-		} else {
-			// Proactive spill: stop when under 80% threshold
-			if h.MemTracker == nil || !h.Spill.ShouldSpillFor(memory.SpillCheap) {
-				break
-			}
-		}
-
-		partID := ss.largestInMemoryPartition()
-		if partID < 0 {
-			break // nothing left to spill
-		}
-		if _, err := ss.spillBuildPartition(partID); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// reloadInMemoryPartitions rebuilds the hash table from in-memory partitions only.
-// Spilled partitions are NOT loaded — they'll be processed one at a time during probe.
-func (h *HashJoin) reloadInMemoryPartitions() error {
-	ss := h.spillState
-	if ss == nil {
-		return nil
-	}
-
-	// Count in-memory rows for pre-allocation
-	var totalRows int
-	for partID, batches := range ss.partBuildBatches {
-		if ss.spilledParts[partID] {
-			continue
-		}
-		for _, b := range batches {
-			totalRows += b.Len
-		}
-	}
-
-	// Reset build state
-	h.buildBatches = nil
-	h.buildRows = 0
-	h.arena = make([]buildRef, 0, totalRows)
-	h.arenaNext = make([]int32, 0, totalRows)
-	if h.useIntKey || h.useDualIntKey {
-		h.intIndex = newIntHashTable(totalRows)
-	} else {
-		h.strIndex = newStrHashTable(totalRows)
-	}
-
-	// Rebuild hash table from in-memory partitions
-	for partID, batches := range ss.partBuildBatches {
-		if ss.spilledParts[partID] {
-			continue
-		}
-		for _, b := range batches {
-			batchIdx := int32(len(h.buildBatches))
-			h.buildBatches = append(h.buildBatches, b)
-			if h.SemiAntiKeyOnly {
-				h.indexBuildBatchKeyOnly(b)
-			} else {
-				h.indexBuildBatch(b, batchIdx)
-			}
-		}
-	}
-
-	return nil
 }
 
 // PruneBuildColumns removes non-essential columns from the build-side batches.

--- a/internal/engine/exec/join_partition_arrival.go
+++ b/internal/engine/exec/join_partition_arrival.go
@@ -21,6 +21,15 @@ import (
 // when the pool is mostly empty. Tune via SF10/SF100 deploys.
 const PartitionOnArrivalThresholdPercent = 30
 
+// accumFlushRows is the row count at which an open per-partition build
+// accumulator is frozen (indexed into the hash table and handed to
+// buildBatches) and a fresh one is started. Bounding accumulators at
+// batch.DefaultBatchSize keeps per-batch index growth (EnsureCapacity +
+// CheckGrow) on its tuned path and caps any single buildBatches entry to one
+// arrival batch's worth. Accumulators grow on demand toward this bound rather
+// than pre-allocating it, so a sparsely-filled partition stays small.
+const accumFlushRows = batch.DefaultBatchSize
+
 // SharedPoolUnderPressure reports whether the shared tracker is at or above
 // PartitionOnArrivalThresholdPercent of its budget. Returns false when no
 // budget is configured (test paths, embedded callers without a memory pool).
@@ -159,6 +168,16 @@ func (h *HashJoin) buildPartitioned(ctx context.Context, source Source) error {
 		h.mu.Unlock()
 	}
 
+	// Freeze any remaining open per-partition accumulators so their buffered
+	// rows are indexed and joined into the build side before probe begins. This
+	// extends the arena, so it must run before arenaMatched is sized below.
+	h.mu.Lock()
+	if err := h.freezeAllOpenAccums(); err != nil {
+		h.mu.Unlock()
+		return fmt.Errorf("freezing accumulators at build end: %w", err)
+	}
+	h.mu.Unlock()
+
 	// Allocate matched bitmap for right/full outer join and right semi/anti tracking
 	if (h.JoinType == RightJoin || h.JoinType == FullOuterJoin ||
 		h.JoinType == RightSemiJoin || h.JoinType == RightAntiJoin) && len(h.arena) > 0 {
@@ -187,29 +206,42 @@ func (h *HashJoin) buildPartitioned(ctx context.Context, source Source) error {
 // Caller must hold h.mu.
 func (h *HashJoin) partitionAndIndexBatch(b *batch.RecordBatch) error {
 	ss := h.spillState
-	partRows := computeBuildPartitionRows(h, b)
 
-	for partID, rows := range partRows {
+	if !ss.accumChecked {
+		ss.accumEligible = accumEligibleSchema(b)
+		ss.accumChecked = true
+	}
+
+	// Reset the reusable per-partition scatter scratch (capacity retained) and
+	// scatter this arrival batch's rows into it — no per-batch map allocation.
+	for p := range ss.partRowScratch {
+		ss.partRowScratch[p] = ss.partRowScratch[p][:0]
+	}
+	computeBuildPartitionRows(h, b, &ss.partRowScratch)
+
+	for partID := 0; partID < numSpillPartitions; partID++ {
+		rows := ss.partRowScratch[partID]
 		if len(rows) == 0 {
 			continue
 		}
-		partBatch := compactBatchForRows(b, rows)
-		partBytes := hashBuildBytes(partBatch)
 
+		// Already spilling to disk: write a transient compacted batch straight
+		// out. Spilled partitions are never indexed or accumulated, so there is
+		// no live ref and no accumulator involved.
 		if ss.spilledParts[partID] {
+			partBatch := compactBatchForRows(b, rows)
+			partBytes := hashBuildBytes(partBatch)
 			if err := ss.writeBuildBatch(partID, partBatch); err != nil {
 				return fmt.Errorf("writing build batch for spilled partition %d: %w", partID, err)
 			}
-			// Release the cost portion that this batch contributed to the
-			// arrival batch's Reserve(cost). The rows just went to disk —
-			// the corresponding bytes are no longer charged against the
-			// in-memory budget, and there's no in-memory partition to spill
-			// later that would otherwise release them. Without this, every
-			// arrival batch processed after partitions start spilling
-			// drifts the tracker upward by the to-disk fraction, eventually
-			// outrunning the recoverable partMemory pool — which is the
-			// failure mode TestPartitionOnArrival_BasicSpill exposed before
-			// this release.
+			// Release the cost portion that these rows contributed to the
+			// arrival batch's Reserve(cost). They just went to disk, so the
+			// corresponding bytes are no longer charged against the in-memory
+			// budget, and there's no in-memory partition to spill later that
+			// would otherwise release them. Without this, every arrival batch
+			// processed after partitions start spilling drifts the tracker
+			// upward by the to-disk fraction — the failure mode
+			// TestPartitionOnArrival_BasicSpill exposed before this release.
 			if h.MemTracker != nil && partBytes > 0 {
 				h.MemTracker.Release(partBytes)
 				h.trackedMem -= partBytes
@@ -220,46 +252,199 @@ func (h *HashJoin) partitionAndIndexBatch(b *batch.RecordBatch) error {
 			continue
 		}
 
-		partBatch.Detach() // build retains references; batch must not be recycled
-		batchIdx := int32(len(h.buildBatches))
-		h.buildBatches = append(h.buildBatches, partBatch)
-		ss.batchPartID = append(ss.batchPartID, partID)
-		ss.partBuildBatches[partID] = append(ss.partBuildBatches[partID], partBatch)
-		ss.partMemory[partID] += partBytes
-
-		// Pre-grow hash table for this partition's rows so PutNoGrow won't
-		// overflow during indexing. Mirrors the legacy flat path's per-batch
-		// EnsureCapacity + CheckGrow pattern.
-		batchRows := partBatch.ActiveLen()
-		if h.useIntKey || h.useDualIntKey {
-			if h.intIndex == nil {
-				h.intIndex = newIntHashTable(batchRows)
+		// In-memory partition. Eligible (scalar/bytes/decimal) schemas append
+		// into a reusable growable per-partition accumulator; nested-column
+		// schemas index one tightly-sized batch per arrival (append-grow can't
+		// extend nested element storage).
+		if ss.accumEligible {
+			if err := h.appendToAccum(b, partID, rows); err != nil {
+				return err
 			}
-			h.intIndex.EnsureCapacity(batchRows)
-		} else if h.strIndex != nil {
-			h.strIndex.EnsureCapacity(batchRows)
 		} else {
-			h.strIndex = newStrHashTable(batchRows)
+			h.freezeTightForPartition(partID, b, rows)
 		}
+	}
+	return nil
+}
 
-		h.indexBuildBatch(partBatch, batchIdx)
+// accumEligibleSchema reports whether every column of b can be grown in place by
+// Vector.EnsureLen (scalar, bytes, or decimal). Nested ARRAY/MAP/ROW/VECTOR
+// columns cannot, so such schemas use the tight per-arrival path.
+func accumEligibleSchema(b *batch.RecordBatch) bool {
+	for _, col := range b.Columns {
+		switch col.Type {
+		case batch.TypeArray, batch.TypeMap, batch.TypeRow, batch.TypeVector:
+			return false
+		}
+	}
+	return true
+}
 
-		if h.useIntKey || h.useDualIntKey {
-			h.intIndex.CheckGrow()
-		} else if h.strIndex != nil {
-			h.strIndex.CheckGrow()
+// freezeTightForPartition indexes one tightly-sized batch of an in-memory
+// partition's rows directly into the build side (no accumulator reuse). Used
+// for nested-column schemas and oversized arrival contributions. partMemory is
+// charged the batch's true MemBytes (its capacity equals its row count).
+// Caller must hold h.mu.
+func (h *HashJoin) freezeTightForPartition(partID int, b *batch.RecordBatch, rows []int) {
+	ss := h.spillState
+	tight := compactBatchForRows(b, rows)
+	tight.Detach()
+	ss.partMemory[partID] += tight.MemBytes() + int64(len(rows))*40
+	h.registerFrozen(partID, tight)
+}
+
+// appendToAccum appends b's selected rows for an in-memory partition into that
+// partition's open accumulator, freezing it first if the rows would overflow
+// accumFlushRows. partMemory is charged with the TIGHT byte footprint of the
+// appended rows (independent of the accumulator's physical capacity), keeping
+// the spill accounting balanced against the arrival batch's Reserve(cost) and
+// making an open accumulator's rows visible to spill selection before freeze.
+//
+// Caller must hold h.mu.
+func (h *HashJoin) appendToAccum(b *batch.RecordBatch, partID int, rows []int) error {
+	ss := h.spillState
+
+	// Defensive: an arrival batch never exceeds DefaultBatchSize, so a fresh
+	// accumulator always fits one partition's slice within accumFlushRows. If a
+	// future caller delivers an oversized batch, freeze any partial accumulator
+	// (to preserve arrival order within the partition) and index the oversized
+	// slice as one tight batch rather than overflowing the freeze bound.
+	if len(rows) > accumFlushRows {
+		if err := h.freezeAccum(partID); err != nil {
+			return err
+		}
+		h.freezeTightForPartition(partID, b, rows)
+		return nil
+	}
+
+	acc := ss.openAccum[partID]
+	if acc != nil && acc.Len+len(rows) > accumFlushRows {
+		if err := h.freezeAccum(partID); err != nil {
+			return err
+		}
+		acc = nil
+	}
+	if acc == nil {
+		// Mint empty; the backing arrays grow on demand via EnsureCapacity so a
+		// partition that receives few rows never pre-commits an accumFlushRows-
+		// sized buffer (which would over-allocate 64 partitions on a tight pool
+		// and starve concurrent builds — the regime this path exists to serve).
+		acc = batch.NewRecordBatch(b.Schema, 0)
+		acc.Detach() // build retains references; batch must not be recycled
+		ss.openAccum[partID] = acc
+	}
+	dstStart := acc.Len
+	acc.EnsureCapacity(dstStart + len(rows)) // grows backing arrays; sets acc.Len
+	dataBytes := appendRows(acc, b, rows, dstStart)
+	ss.partMemory[partID] += dataBytes + int64(len(rows))*40
+	ss.openAccumData[partID] += dataBytes
+	return nil
+}
+
+// freezeAccum finalizes partID's open accumulator: it sets the batch's logical
+// length, indexes it into the global hash table, and appends it to buildBatches
+// (after which it backs live buildRefs and must never be mutated or Reset).
+// openAccum[partID] is cleared. No-op when there is no open accumulator.
+//
+// Caller must hold h.mu.
+func (h *HashJoin) freezeAccum(partID int) error {
+	ss := h.spillState
+	acc := ss.openAccum[partID]
+	if acc == nil {
+		return nil
+	}
+	ss.openAccum[partID] = nil
+	if acc.Len == 0 {
+		ss.openAccumData[partID] = 0
+		return nil
+	}
+	// Ensure each column's logical length matches the filled row count so the
+	// frozen batch is structurally a normal compacted batch (EnsureCapacity
+	// already set these during the last append; this is defensive).
+	for _, col := range acc.Columns {
+		col.Len = acc.Len
+	}
+	// Reconcile the accumulator's fixed-capacity overhead. Its arrays were
+	// allocated for accumFlushRows rows regardless of fill, so MemBytes() (which
+	// counts slice length + Data capacity) exceeds the tight per-row data
+	// charged at append. Charge the difference to partMemory AND the shared
+	// tracker so the resident-but-unfilled capacity is accounted: undercounting
+	// it would let the shared pool over-commit to concurrent tasks — the OOM
+	// risk this path exists to remove. On spill, partMemory[partID] (now
+	// inclusive) is released, balancing this charge; Close releases the rest.
+	if excess := acc.MemBytes() - ss.openAccumData[partID]; excess > 0 {
+		ss.partMemory[partID] += excess
+		if h.MemTracker != nil {
+			h.MemTracker.ForceReserve(excess)
+			h.trackedMem += excess
+		}
+	}
+	ss.openAccumData[partID] = 0
+	h.registerFrozen(partID, acc)
+	return nil
+}
+
+// registerFrozen indexes a finalized in-memory partition batch into the hash
+// table and records it in buildBatches plus the per-partition bookkeeping. The
+// batch must be Detached, dense (Sel==nil), and have its logical Len set.
+// partMemory is charged by the caller (tightly, at append time), so this does
+// not touch it. Caller must hold h.mu.
+func (h *HashJoin) registerFrozen(partID int, frozen *batch.RecordBatch) {
+	ss := h.spillState
+	batchIdx := int32(len(h.buildBatches))
+	h.buildBatches = append(h.buildBatches, frozen)
+	ss.batchPartID = append(ss.batchPartID, partID)
+	ss.partBuildBatches[partID] = append(ss.partBuildBatches[partID], frozen)
+
+	// Pre-grow the hash table for this batch's rows so PutNoGrow won't overflow
+	// during indexing. Mirrors the legacy flat path's EnsureCapacity+CheckGrow.
+	batchRows := frozen.ActiveLen()
+	if h.useIntKey || h.useDualIntKey {
+		if h.intIndex == nil {
+			h.intIndex = newIntHashTable(batchRows)
+		}
+		h.intIndex.EnsureCapacity(batchRows)
+	} else if h.strIndex != nil {
+		h.strIndex.EnsureCapacity(batchRows)
+	} else {
+		h.strIndex = newStrHashTable(batchRows)
+	}
+
+	h.indexBuildBatch(frozen, batchIdx)
+
+	if h.useIntKey || h.useDualIntKey {
+		h.intIndex.CheckGrow()
+	} else if h.strIndex != nil {
+		h.strIndex.CheckGrow()
+	}
+}
+
+// freezeAllOpenAccums freezes every open per-partition accumulator. Called once
+// at build end so the final partial accumulators are indexed before probe.
+// Caller must hold h.mu.
+func (h *HashJoin) freezeAllOpenAccums() error {
+	ss := h.spillState
+	if ss == nil {
+		return nil
+	}
+	for partID := 0; partID < numSpillPartitions; partID++ {
+		if ss.openAccum[partID] != nil {
+			if err := h.freezeAccum(partID); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
 }
 
 // computeBuildPartitionRows assigns each row of b to a hash partition based
-// on the join's key encoding (int / dual-int / string). Rows whose key is
-// null are routed to partition 0 and will produce no hash-table match — but
-// keeping them grouped means the same partition holds all keys that hash to
-// it, including a probe-side null lookup that hits this same partition.
-func computeBuildPartitionRows(h *HashJoin, b *batch.RecordBatch) map[int][]int {
-	partRows := make(map[int][]int)
+// on the join's key encoding (int / dual-int / string), appending the row
+// index into out[partition]. The caller owns out and must truncate each
+// out[p] to [:0] before the call. Rows whose key is null are routed to
+// partition 0 and will produce no hash-table match — but keeping them grouped
+// means the same partition holds all keys that hash to it, including a
+// probe-side null lookup that hits this same partition.
+func computeBuildPartitionRows(h *HashJoin, b *batch.RecordBatch, out *[numSpillPartitions][]int) {
 	switch {
 	case h.useIntKey:
 		col := b.Columns[h.buildKeyIdx[0]]
@@ -268,21 +453,21 @@ func computeBuildPartitionRows(h *HashJoin, b *batch.RecordBatch) map[int][]int 
 				row := int(si)
 				key, ok := intKeyFromVector(col, row)
 				if !ok {
-					partRows[0] = append(partRows[0], row)
+					out[0] = append(out[0], row)
 					continue
 				}
 				p := spillPartition(key)
-				partRows[p] = append(partRows[p], row)
+				out[p] = append(out[p], row)
 			}
 		} else {
 			for i := 0; i < b.Len; i++ {
 				key, ok := intKeyFromVector(col, i)
 				if !ok {
-					partRows[0] = append(partRows[0], i)
+					out[0] = append(out[0], i)
 					continue
 				}
 				p := spillPartition(key)
-				partRows[p] = append(partRows[p], i)
+				out[p] = append(out[p], i)
 			}
 		}
 	case h.useDualIntKey:
@@ -292,21 +477,21 @@ func computeBuildPartitionRows(h *HashJoin, b *batch.RecordBatch) map[int][]int 
 				row := int(si)
 				a, bb, ok := dualIntKeyFromVectors(col0, col1, row)
 				if !ok {
-					partRows[0] = append(partRows[0], row)
+					out[0] = append(out[0], row)
 					continue
 				}
 				p := spillPartition(dualIntHash(a, bb))
-				partRows[p] = append(partRows[p], row)
+				out[p] = append(out[p], row)
 			}
 		} else {
 			for i := 0; i < b.Len; i++ {
 				a, bb, ok := dualIntKeyFromVectors(col0, col1, i)
 				if !ok {
-					partRows[0] = append(partRows[0], i)
+					out[0] = append(out[0], i)
 					continue
 				}
 				p := spillPartition(dualIntHash(a, bb))
-				partRows[p] = append(partRows[p], i)
+				out[p] = append(out[p], i)
 			}
 		}
 	default:
@@ -315,17 +500,16 @@ func computeBuildPartitionRows(h *HashJoin, b *batch.RecordBatch) map[int][]int 
 				row := int(si)
 				h.buildKeyFromBatch(b, row)
 				p := spillPartitionBytes(h.keyBuf)
-				partRows[p] = append(partRows[p], row)
+				out[p] = append(out[p], row)
 			}
 		} else {
 			for i := 0; i < b.Len; i++ {
 				h.buildKeyFromBatch(b, i)
 				p := spillPartitionBytes(h.keyBuf)
-				partRows[p] = append(partRows[p], i)
+				out[p] = append(out[p], i)
 			}
 		}
 	}
-	return partRows
 }
 
 // spillOneInMemoryPartition picks the largest in-memory partition, writes its
@@ -348,6 +532,15 @@ func (h *HashJoin) spillOneInMemoryPartition() (int64, error) {
 	partID := ss.largestInMemoryPartition()
 	if partID < 0 {
 		return 0, nil
+	}
+
+	// Freeze this partition's open accumulator (if any) so its buffered rows
+	// become a writable, indexed batch in buildBatches before we evict. Those
+	// rows are already counted in partMemory[partID] (charged at append), so
+	// largestInMemoryPartition could have selected this partition on their
+	// account and the freed total below stays correct.
+	if err := h.freezeAccum(partID); err != nil {
+		return 0, err
 	}
 
 	// Mark spilled BEFORE writing, so any concurrent (re-entry-safe) callers

--- a/internal/engine/exec/join_partition_arrival.go
+++ b/internal/engine/exec/join_partition_arrival.go
@@ -8,19 +8,6 @@ import (
 	"github.com/citc-tech/wadjet/internal/engine/memory"
 )
 
-// PartitionOnArrivalThresholdPercent is the shared-pool used percentage at
-// or above which the worker should turn on partition-on-arrival for new
-// HashJoin builds. Below this threshold, the legacy flat path is cheaper:
-// it skips the per-batch compactBatchForRows × 64 allocations that pure
-// partition-on-arrival paid upfront. Above the threshold, eager
-// partitioning is worth it because spill is likely and the partition-on-
-// arrival path makes spill O(partition) instead of O(total).
-//
-// 30% is heuristic: chosen so concurrent builds on a shared pool start
-// partitioning before the pool fills, but don't pay the allocation tax
-// when the pool is mostly empty. Tune via SF10/SF100 deploys.
-const PartitionOnArrivalThresholdPercent = 30
-
 // accumFlushRows is the row count at which an open per-partition build
 // accumulator is frozen (indexed into the hash table and handed to
 // buildBatches) and a fresh one is started. Bounding accumulators at
@@ -29,25 +16,6 @@ const PartitionOnArrivalThresholdPercent = 30
 // arrival batch's worth. Accumulators grow on demand toward this bound rather
 // than pre-allocating it, so a sparsely-filled partition stays small.
 const accumFlushRows = batch.DefaultBatchSize
-
-// SharedPoolUnderPressure reports whether the shared tracker is at or above
-// PartitionOnArrivalThresholdPercent of its budget. Returns false when no
-// budget is configured (test paths, embedded callers without a memory pool).
-//
-// Worker callers use this to decide whether to enable HashJoin.PartitionOnArrival
-// at task entry — the Build path itself doesn't read pressure dynamically;
-// it trusts the caller's flag and runs the partitioned path unconditionally
-// when set.
-func SharedPoolUnderPressure(t *memory.Tracker) bool {
-	if t == nil {
-		return false
-	}
-	budget := t.Budget()
-	if budget <= 0 {
-		return false
-	}
-	return t.Used()*100 >= budget*PartitionOnArrivalThresholdPercent
-}
 
 // buildPartitioned is the partition-on-arrival build path. Instead of
 // accumulating every batch flat and reactively switching to partitioned-spill

--- a/internal/engine/exec/join_partition_arrival_test.go
+++ b/internal/engine/exec/join_partition_arrival_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/citc-tech/wadjet/internal/engine/batch"
 	"github.com/citc-tech/wadjet/internal/engine/memory"
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
 )
@@ -403,6 +404,152 @@ func TestPartitionOnArrival_StringKeySpill(t *testing.T) {
 	}
 	if len(sink.Rows) != expected {
 		t.Fatalf("expected %d rows, got %d", expected, len(sink.Rows))
+	}
+}
+
+// TestPartitionOnArrival_MultiBatchAccumulatorFill is the buildRef-integrity
+// regression for the reusable per-partition accumulator. It feeds the build
+// side as MANY tiny arrival batches, so every partition's accumulator spans
+// multiple arrival batches (appends at dstStart > 0) and fills/freezes more
+// than once (buildN > accumFlushRows). Each build row carries a UNIQUE payload,
+// so any error in the accumulator's row offset — a wrong appendRows dstStart, a
+// wrong frozen Len, or a Reset/overwrite of a still-live accumulator — would
+// return the wrong payload for a probed key and fail the per-key assertion
+// below. Duplicate keys spread across distinct arrival batches exercise match
+// chains that cross accumulator-freeze boundaries. The spill subcase forces
+// partially-filled accumulators to be frozen and evicted mid-build.
+func TestPartitionOnArrival_MultiBatchAccumulatorFill(t *testing.T) {
+	rightSchema := []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "val", Type: parquet.TypeString},
+	}
+	const (
+		buildN       = 6000 // > accumFlushRows (2048): accumulators freeze and refill
+		dupKeys      = 200   // ids 0..dupKeys-1 appear twice with distinct payloads
+		arrivalBatch = 37    // tiny: forces many partial per-partition appends
+	)
+
+	rightRows := make([]map[string]any, 0, buildN+dupKeys)
+	for i := 0; i < buildN; i++ {
+		rightRows = append(rightRows, map[string]any{
+			"id":  int64(i),
+			"val": fmt.Sprintf("val-%d", i),
+		})
+	}
+	// Duplicate keys 0..dupKeys-1 with a distinct payload, appended last so they
+	// land in much later arrival batches than the originals — the resulting
+	// 2-entry match chains straddle accumulator freezes.
+	for i := 0; i < dupKeys; i++ {
+		rightRows = append(rightRows, map[string]any{
+			"id":  int64(i),
+			"val": fmt.Sprintf("dup-%d", i),
+		})
+	}
+
+	makeBatches := func() []*batch.RecordBatch {
+		var out []*batch.RecordBatch
+		for i := 0; i < len(rightRows); i += arrivalBatch {
+			end := i + arrivalBatch
+			if end > len(rightRows) {
+				end = len(rightRows)
+			}
+			out = append(out, batch.FromRows(rightSchema, rightRows[i:end]))
+		}
+		return out
+	}
+
+	leftSchema := []parquet.Column{{Name: "id", Type: parquet.TypeInt64}}
+	leftRows := make([]map[string]any, buildN)
+	for i := 0; i < buildN; i++ {
+		leftRows[i] = map[string]any{"id": int64(i)}
+	}
+
+	cases := []struct {
+		name      string
+		budget    int64
+		wantSpill bool
+	}{
+		{"no-spill", 64 << 20, false},
+		{"spill", 150_000, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			tracker := memory.NewTracker("test", tc.budget)
+			sm, err := memory.NewSpillManager(tmpDir, tracker)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer sm.Cleanup()
+
+			hj := NewHashJoin(InnerJoin, []string{"id"}, []string{"id"})
+			hj.Spill = sm
+			hj.MemTracker = tracker
+			hj.PartitionOnArrival = true
+
+			if err := hj.Build(context.Background(), NewBatchSource(makeBatches())); err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+			if hj.spillState == nil {
+				t.Fatal("partition-on-arrival must allocate spillState")
+			}
+			spilled := len(hj.spillState.spilledParts)
+			if tc.wantSpill && spilled == 0 {
+				t.Fatalf("expected at least one spilled partition at budget %d", tc.budget)
+			}
+			if !tc.wantSpill && spilled != 0 {
+				t.Fatalf("did not expect spill at budget %d, got %d spilled", tc.budget, spilled)
+			}
+
+			probe := hj.Probe()
+			sink := &CollectSink{}
+			pipe := &Pipeline{
+				Source: NewSliceSource(leftSchema, leftRows),
+				Ops:    []UnaryOperator{probe},
+				Sink:   sink,
+			}
+			if err := pipe.Run(context.Background()); err != nil {
+				t.Fatalf("Pipeline failed: %v", err)
+			}
+
+			// Gather build payloads per probed key. id i<dupKeys matches two
+			// build rows (val-i and dup-i); id i>=dupKeys matches exactly one.
+			got := make(map[int64][]string, buildN)
+			for _, row := range sink.Rows {
+				id, ok := row["id"].(int64)
+				if !ok {
+					t.Fatalf("expected int64 id, got %T", row["id"])
+				}
+				val, ok := row["val"].(string)
+				if !ok {
+					t.Fatalf("expected string val for id %d, got %T", id, row["val"])
+				}
+				got[id] = append(got[id], val)
+			}
+
+			totalExpected := 0
+			for i := 0; i < buildN; i++ {
+				want := map[string]bool{fmt.Sprintf("val-%d", i): true}
+				if i < dupKeys {
+					want[fmt.Sprintf("dup-%d", i)] = true
+				}
+				totalExpected += len(want)
+
+				gotVals := got[int64(i)]
+				if len(gotVals) != len(want) {
+					t.Fatalf("id %d: got %d matches %v, want %d", i, len(gotVals), gotVals, len(want))
+				}
+				for _, g := range gotVals {
+					if !want[g] {
+						t.Fatalf("id %d: wrong payload %q (a corrupt accumulator offset would surface here); got=%v",
+							i, g, gotVals)
+					}
+				}
+			}
+			if len(sink.Rows) != totalExpected {
+				t.Fatalf("expected %d output rows, got %d", totalExpected, len(sink.Rows))
+			}
+		})
 	}
 }
 

--- a/internal/engine/exec/join_partition_arrival_test.go
+++ b/internal/engine/exec/join_partition_arrival_test.go
@@ -55,7 +55,6 @@ func TestPartitionOnArrival_BasicSpill(t *testing.T) {
 	hj := NewHashJoin(InnerJoin, []string{"id"}, []string{"id"})
 	hj.Spill = sm
 	hj.MemTracker = tracker
-	hj.PartitionOnArrival = true
 
 	if err := hj.Build(context.Background(), NewSliceSource(rightSchema, rightRows)); err != nil {
 		t.Fatalf("Build failed: %v", err)
@@ -162,7 +161,6 @@ func TestPartitionOnArrival_NoSpillStillCorrect(t *testing.T) {
 	hj := NewHashJoin(InnerJoin, []string{"id"}, []string{"id"})
 	hj.Spill = sm
 	hj.MemTracker = tracker
-	hj.PartitionOnArrival = true
 
 	if err := hj.Build(context.Background(), NewSliceSource(rightSchema, rightRows)); err != nil {
 		t.Fatalf("Build failed: %v", err)
@@ -246,7 +244,6 @@ func TestPartitionOnArrival_ConcurrentBuildsSharedPool(t *testing.T) {
 		hj := NewHashJoin(InnerJoin, []string{"id"}, []string{"id"})
 		hj.Spill = sm
 		hj.MemTracker = sharedTracker
-		hj.PartitionOnArrival = true
 		return hj
 	}
 	hjA := makeJoin()
@@ -373,7 +370,6 @@ func TestPartitionOnArrival_StringKeySpill(t *testing.T) {
 	hj := NewHashJoin(InnerJoin, []string{"k"}, []string{"k"})
 	hj.Spill = sm
 	hj.MemTracker = tracker
-	hj.PartitionOnArrival = true
 
 	if err := hj.Build(context.Background(), NewSliceSource(rightSchema, rightRows)); err != nil {
 		t.Fatalf("Build failed: %v", err)
@@ -485,7 +481,6 @@ func TestPartitionOnArrival_MultiBatchAccumulatorFill(t *testing.T) {
 			hj := NewHashJoin(InnerJoin, []string{"id"}, []string{"id"})
 			hj.Spill = sm
 			hj.MemTracker = tracker
-			hj.PartitionOnArrival = true
 
 			if err := hj.Build(context.Background(), NewBatchSource(makeBatches())); err != nil {
 				t.Fatalf("Build failed: %v", err)

--- a/internal/engine/exec/join_partition_bench_test.go
+++ b/internal/engine/exec/join_partition_bench_test.go
@@ -9,19 +9,21 @@ import (
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
 )
 
-// BenchmarkHashJoinBuildNoSpill is the Option A gate for HashJoin partial-drain.
+// BenchmarkHashJoinBuildNoSpill measures the permanent no-spill build cost of
+// the two surviving build paths after the flat-path unification:
+//   - "flat": a no-spill in-memory build (no MemTracker/Spill — embedded
+//     queries, tests, spill-replay rebuilds). Zero-copy: indexes arriving
+//     batches in place.
+//   - "partitioned": buildPartitioned, taken by every spill-eligible build
+//     (MemTracker + Spill set). It scatters rows into growable per-partition
+//     accumulators (one physical copy per row), the cost of making spill
+//     O(partition) and cooperative relief always available.
 //
-// It measures build-side cost of the legacy flat path (PartitionOnArrival=false)
-// vs the partition-on-arrival path (true) in the NO-SPILL regime — the regime
-// the flat "fast path" exists to optimize. Partition-on-arrival is already the
-// correct partial-drain path (O(partition) eviction, cooperative relief); the
-// only thing keeping the legacy flat path alive is the hypothesis that its
-// per-batch scatter is too expensive when no spill happens. If the overhead
-// here is within noise, the flat path — and its reactive O(total) repartition +
-// full hash-table rebuild (the Q17/Q18 mc=4 killer) — can be retired.
-//
-// Both paths get MemTracker+Spill with a budget far above the working set, so
-// nothing spills and the only variable is PartitionOnArrival.
+// The "partitioned" arm is given an 8 GiB budget so nothing spills — the
+// measured delta is the per-row copy floor that spill-eligible builds now pay
+// unconditionally (the accepted tax for retiring the reactive O(total)
+// repartition that was the Q17/Q18 mc=4 killer). Guards against regressing
+// either path's no-spill cost.
 func BenchmarkHashJoinBuildNoSpill(b *testing.B) {
 	const buildN = 200_000
 	schema := []parquet.Column{
@@ -61,6 +63,10 @@ func BenchmarkHashJoinBuildNoSpill(b *testing.B) {
 
 	tmpDir := b.TempDir() // unused target: no spill at this budget
 
+	// Path selection is driven by spill-eligibility: a build with a
+	// MemTracker + Spill manager partitions on arrival; one without takes the
+	// no-spill flat path. (The PartitionOnArrival flag was retired with the
+	// flat-path unification.)
 	for _, partition := range []bool{false, true} {
 		name := "flat"
 		if partition {
@@ -71,15 +77,18 @@ func BenchmarkHashJoinBuildNoSpill(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
 				batches := freshBatches()
-				tracker := memory.NewTracker("bench", 8<<30) // 8 GiB: no spill
-				sm, err := memory.NewSpillManager(tmpDir, tracker)
-				if err != nil {
-					b.Fatal(err)
-				}
 				hj := NewHashJoin(InnerJoin, []string{"id"}, []string{"id"})
-				hj.Spill = sm
-				hj.MemTracker = tracker
-				hj.PartitionOnArrival = partition
+				var sm *memory.SpillManager
+				if partition {
+					tracker := memory.NewTracker("bench", 8<<30) // 8 GiB: no spill
+					var err error
+					sm, err = memory.NewSpillManager(tmpDir, tracker)
+					if err != nil {
+						b.Fatal(err)
+					}
+					hj.Spill = sm
+					hj.MemTracker = tracker
+				}
 				src := NewBatchSource(batches)
 				b.StartTimer()
 
@@ -89,7 +98,9 @@ func BenchmarkHashJoinBuildNoSpill(b *testing.B) {
 
 				b.StopTimer()
 				_ = hj.Close()
-				sm.Cleanup()
+				if sm != nil {
+					sm.Cleanup()
+				}
 				b.StartTimer()
 			}
 		})

--- a/internal/engine/exec/join_partition_bench_test.go
+++ b/internal/engine/exec/join_partition_bench_test.go
@@ -1,0 +1,97 @@
+package exec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/engine/memory"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// BenchmarkHashJoinBuildNoSpill is the Option A gate for HashJoin partial-drain.
+//
+// It measures build-side cost of the legacy flat path (PartitionOnArrival=false)
+// vs the partition-on-arrival path (true) in the NO-SPILL regime — the regime
+// the flat "fast path" exists to optimize. Partition-on-arrival is already the
+// correct partial-drain path (O(partition) eviction, cooperative relief); the
+// only thing keeping the legacy flat path alive is the hypothesis that its
+// per-batch scatter is too expensive when no spill happens. If the overhead
+// here is within noise, the flat path — and its reactive O(total) repartition +
+// full hash-table rebuild (the Q17/Q18 mc=4 killer) — can be retired.
+//
+// Both paths get MemTracker+Spill with a budget far above the working set, so
+// nothing spills and the only variable is PartitionOnArrival.
+func BenchmarkHashJoinBuildNoSpill(b *testing.B) {
+	const buildN = 200_000
+	schema := []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "val", Type: parquet.TypeString},
+	}
+	rows := make([]map[string]any, buildN)
+	for i := range rows {
+		rows[i] = map[string]any{
+			"id":  int64(i),
+			"val": "lineitem-ish-string-payload-row",
+		}
+	}
+
+	ctx := context.Background()
+
+	// Convert rows -> fresh batches (untimed). A fresh set each iteration so
+	// neither build path can observe state left by the previous one.
+	freshBatches := func() []*batch.RecordBatch {
+		src := NewSliceSource(schema, rows)
+		if err := src.Init(ctx); err != nil {
+			b.Fatal(err)
+		}
+		var out []*batch.RecordBatch
+		for {
+			rb, err := src.Next(ctx)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if rb == nil {
+				break
+			}
+			out = append(out, rb)
+		}
+		return out
+	}
+
+	tmpDir := b.TempDir() // unused target: no spill at this budget
+
+	for _, partition := range []bool{false, true} {
+		name := "flat"
+		if partition {
+			name = "partitioned"
+		}
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				batches := freshBatches()
+				tracker := memory.NewTracker("bench", 8<<30) // 8 GiB: no spill
+				sm, err := memory.NewSpillManager(tmpDir, tracker)
+				if err != nil {
+					b.Fatal(err)
+				}
+				hj := NewHashJoin(InnerJoin, []string{"id"}, []string{"id"})
+				hj.Spill = sm
+				hj.MemTracker = tracker
+				hj.PartitionOnArrival = partition
+				src := NewBatchSource(batches)
+				b.StartTimer()
+
+				if err := hj.Build(ctx, src); err != nil {
+					b.Fatal(err)
+				}
+
+				b.StopTimer()
+				_ = hj.Close()
+				sm.Cleanup()
+				b.StartTimer()
+			}
+		})
+	}
+}

--- a/internal/engine/exec/join_pressure_aware_test.go
+++ b/internal/engine/exec/join_pressure_aware_test.go
@@ -2,152 +2,21 @@ package exec
 
 import (
 	"context"
-	"runtime"
 	"testing"
 
 	"github.com/citc-tech/wadjet/internal/engine/memory"
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
 )
 
-// TestSharedPoolUnderPressure covers the helper used by worker code to decide
-// whether to enable PartitionOnArrival at task entry.
-func TestSharedPoolUnderPressure(t *testing.T) {
-	tests := []struct {
-		name   string
-		used   int64
-		budget int64
-		want   bool
-	}{
-		{"nil_tracker", 0, 0, false},
-		{"no_budget", 100, 0, false},
-		{"empty_pool", 0, 1000, false},
-		{"below_threshold", 299, 1000, false},
-		{"at_threshold", 300, 1000, true},
-		{"above_threshold", 500, 1000, true},
-		{"full", 1000, 1000, true},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			var tracker *memory.Tracker
-			if tc.budget > 0 {
-				tracker = memory.NewTracker("test", tc.budget)
-				if tc.used > 0 {
-					_ = tracker.Reserve(tc.used)
-				}
-			}
-			if got := SharedPoolUnderPressure(tracker); got != tc.want {
-				t.Errorf("used=%d budget=%d: got %v, want %v", tc.used, tc.budget, got, tc.want)
-			}
-		})
-	}
-}
-
-// TestPartitionOnArrival_LowPressureFlatPath_NoAllocBlowup is the regression
-// gate for the SF10 join-8 OOM observed on the 277152c deploy. Before the
-// pressure-aware switch, PartitionOnArrival=true unconditionally fired the
-// per-batch partitioning path even when the shared pool was nearly empty,
-// running compactBatchForRows × 64 partitions on every source batch. For a
-// modest-sized supplier-class build, that meant thousands of small batch
-// allocations the GC then had to clean up — enough to starve the worker's
-// heartbeat goroutine and trigger a stale-worker reap + OOM-kill cascade.
-//
-// The fix: worker code only sets PartitionOnArrival when SharedPoolUnderPressure
-// is true at task entry. This test asserts:
-//   - With the worker's flag off (SharedPoolUnderPressure=false because
-//     tracker is empty), Build runs the legacy flat path.
-//   - The build completes correctly without the per-partition allocation
-//     storm, measured by an HeapAlloc delta upper bound.
-//   - With the flag explicitly forced on (test setup), the partitioned
-//     path runs as before — the flag still works for tests / pressure-
-//     aware callers that detect a hot pool.
-func TestPartitionOnArrival_LowPressureFlatPath_NoAllocBlowup(t *testing.T) {
-	rightSchema := []parquet.Column{
-		{Name: "id", Type: parquet.TypeInt64},
-		{Name: "v", Type: parquet.TypeString},
-	}
-	const buildN = 50_000 // ~25 source batches at default 2048
-	rightRows := make([]map[string]any, buildN)
-	for i := range rightRows {
-		rightRows[i] = map[string]any{
-			"id": int64(i),
-			"v":  "padding-supplier-row-data-for-test",
-		}
-	}
-
-	leftSchema := []parquet.Column{{Name: "id", Type: parquet.TypeInt64}}
-	leftRows := []map[string]any{{"id": int64(0)}, {"id": int64(100)}, {"id": int64(1000)}}
-
-	tmpDir := t.TempDir()
-	// Large budget so the worker's pressure check would return false.
-	tracker := memory.NewTracker("test", 1<<30) // 1 GB
-	sm, err := memory.NewSpillManager(tmpDir, tracker)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer sm.Cleanup()
-
-	if SharedPoolUnderPressure(tracker) {
-		t.Fatal("test setup: tracker should be empty — pressure check must be false")
-	}
-
-	// Mimic the worker's setup: shared spill + tracker, but PartitionOnArrival
-	// LEFT FALSE because pressure check returned false. This is the path the
-	// 277152c deploy regressed: pre-fix it was unconditionally true.
-	hj := NewHashJoin(InnerJoin, []string{"id"}, []string{"id"})
-	hj.Spill = sm
-	hj.MemTracker = tracker
-	hj.PartitionOnArrival = false // worker would set this from SharedPoolUnderPressure(tracker)
-
-	runtime.GC() // baseline before allocation
-	var msBefore runtime.MemStats
-	runtime.ReadMemStats(&msBefore)
-
-	if err := hj.Build(context.Background(), NewSliceSource(rightSchema, rightRows)); err != nil {
-		t.Fatalf("Build failed: %v", err)
-	}
-
-	var msAfter runtime.MemStats
-	runtime.ReadMemStats(&msAfter)
-
-	// Critical invariant: legacy flat path stores one batch per source
-	// arrival, NOT 64 partition mini-batches per arrival.
-	if hj.spillState != nil {
-		t.Errorf("legacy flat path must not allocate spillState upfront; got non-nil")
-	}
-	// 50K rows in 2048-row source batches → ~25 source batches → ~25 entries
-	// in buildBatches. With 64-partition partition-on-arrival it would be
-	// ~1,600 entries.
-	if got := len(hj.buildBatches); got > 50 {
-		t.Errorf("legacy flat path should have one buildBatches entry per source batch (~25); got %d (suggests partition-on-arrival fired)", got)
-	}
-
-	// Probe to confirm correctness: 3 probe rows × 1 match each = 3 rows.
-	probe := hj.Probe()
-	sink := &CollectSink{}
-	pipe := &Pipeline{
-		Source: NewSliceSource(leftSchema, leftRows),
-		Ops:    []UnaryOperator{probe},
-		Sink:   sink,
-	}
-	if err := pipe.Run(context.Background()); err != nil {
-		t.Fatalf("Pipeline failed: %v", err)
-	}
-	if got := len(sink.Rows); got != 3 {
-		t.Fatalf("expected 3 output rows, got %d", got)
-	}
-
-	// Smoke: number of buildBatches at completion is a proxy for the per-
-	// partition allocation storm. Stronger heap deltas vary by GC schedule
-	// so we keep this assertion tied to the structural invariant above.
-	t.Logf("buildBatches=%d, heapAllocDelta=%d KB",
-		len(hj.buildBatches), int64(msAfter.HeapAlloc-msBefore.HeapAlloc)/1024)
-}
-
-// TestPartitionOnArrival_ForcedAllocatesSpillState confirms that explicit
-// PartitionOnArrival=true still routes through the partitioned path
-// regardless of pressure — the flag remains a force-on for tests and for
-// pressure-aware callers that have detected a hot pool.
-func TestPartitionOnArrival_ForcedAllocatesSpillState(t *testing.T) {
+// TestPartitionOnArrival_SpillEligibleAllocatesSpillState confirms that any
+// spill-eligible build (MemTracker + Spill both set) routes through the
+// partition-on-arrival path and allocates spillState upfront. There is no
+// at-entry pressure heuristic any more — partitioning is unconditional for
+// spill-eligible builds, so the flat path is reached only by callers without a
+// tracker/spill. (Replaces the retired TestSharedPoolUnderPressure and
+// TestPartitionOnArrival_LowPressureFlatPath_NoAllocBlowup, whose
+// low-pressure-stays-flat guarantee is now structural rather than heuristic.)
+func TestPartitionOnArrival_SpillEligibleAllocatesSpillState(t *testing.T) {
 	schema := []parquet.Column{
 		{Name: "id", Type: parquet.TypeInt64},
 	}
@@ -167,12 +36,11 @@ func TestPartitionOnArrival_ForcedAllocatesSpillState(t *testing.T) {
 	hj := NewHashJoin(InnerJoin, []string{"id"}, []string{"id"})
 	hj.Spill = sm
 	hj.MemTracker = tracker
-	hj.PartitionOnArrival = true // force the path
 
 	if err := hj.Build(context.Background(), NewSliceSource(schema, rows)); err != nil {
 		t.Fatalf("Build failed: %v", err)
 	}
 	if hj.spillState == nil {
-		t.Fatal("forced PartitionOnArrival must allocate spillState upfront")
+		t.Fatal("spill-eligible build must partition on arrival and allocate spillState upfront")
 	}
 }

--- a/internal/engine/exec/join_spill.go
+++ b/internal/engine/exec/join_spill.go
@@ -81,6 +81,39 @@ type spillState struct {
 	// nil under the legacy reactive-spill path, which never needs this lookup.
 	batchPartID []int
 
+	// --- Partition-on-arrival reusable build scatter state ---
+	// partRowScratch[p] holds the row indices of the CURRENT arrival batch that
+	// hash to partition p. Reused across arrival batches: each is truncated to
+	// [:0] (capacity retained) at the top of partitionAndIndexBatch. This
+	// replaces the per-batch map[int][]int + 64 fresh []int allocations.
+	partRowScratch [numSpillPartitions][]int
+
+	// openAccum[p] is the in-progress per-partition accumulator batch. Rows are
+	// appended into it across arrival batches; when it fills to accumFlushRows
+	// (or at build end / before its partition spills) it is "frozen": indexed
+	// into the hash table, appended to buildBatches, and openAccum[p] cleared so
+	// the next arrival batch mints a fresh one. A frozen accumulator backs live
+	// buildRefs and is NEVER mutated or Reset while reachable from buildBatches.
+	// partMemory is charged tightly at append time, so an open accumulator's
+	// rows are already counted for spill selection before the freeze.
+	openAccum [numSpillPartitions]*batch.RecordBatch
+
+	// openAccumData[p] accumulates the appendRows data-byte charges (the
+	// MemBytes-comparable portion, excluding null-bitmap words) made into
+	// partition p's open accumulator. At freeze it is reconciled against the
+	// accumulator's true MemBytes() so the growable accumulator's residual
+	// capacity slack (bitmap words + bytes-arena cap) is charged and later
+	// released honestly rather than undercounted.
+	openAccumData [numSpillPartitions]int64
+
+	// accumEligible reports whether the build schema is composed only of column
+	// types whose storage EnsureLen can grow in place (scalar/bytes/decimal).
+	// Schemas with nested ARRAY/MAP/ROW/VECTOR build columns fall back to one
+	// tightly-sized indexed batch per arrival, since append-grow cannot extend
+	// nested element storage. Computed once from the first arrival batch.
+	accumEligible bool
+	accumChecked  bool
+
 	schema []parquet.Column // build-side schema
 }
 
@@ -1248,75 +1281,114 @@ func (p *HashJoinProbe) probePartition(in *batch.RecordBatch, row int) int {
 	return spillPartitionBytes(p.keyBuf)
 }
 
-// compactBatchForRows creates a new batch containing only the specified rows.
+// compactBatchForRows creates a new dense batch containing only the specified
+// rows. It is a thin wrapper over appendRows that mints a tightly-sized
+// destination; callers that reuse a destination across many source batches use
+// appendRows directly (see the partition-on-arrival accumulator path).
 func compactBatchForRows(in *batch.RecordBatch, rows []int) *batch.RecordBatch {
 	out := batch.NewRecordBatch(in.Schema, len(rows))
-	for j, col := range in.Columns {
-		dst := out.Columns[j]
+	appendRows(out, in, rows, 0)
+	return out
+}
+
+// appendRows copies src's rows[di] into dst at positions [dstStart, dstStart+len(rows)).
+// It returns the data-byte footprint of the copied rows (matching Vector.MemBytes
+// per-type sizing, summed over just these rows, excluding null-bitmap words and
+// the per-row hash overhead) so callers can charge a TIGHT memory figure that is
+// independent of dst's physical capacity — required when dst is a reused
+// accumulator sized larger than its logical row count.
+//
+// Preconditions the caller MUST satisfy:
+//   - dst.Sel == nil and dst's fixed-width column slices have length >=
+//     dstStart+len(rows).
+//   - dst.Nulls is pre-cleared to all-valid over [dstStart, dstStart+len(rows))
+//     (true for a freshly NewRecordBatch'd or Reset() batch); appendRows only
+//     ever sets nulls, never clears them.
+//   - For BytesColumn columns, rows are appended in strictly increasing dst
+//     position with dst.BytesData.Offsets[dstStart] == len(dst.BytesData.Data)
+//     (true at dstStart==0 after Reset, and maintained as the tail grows).
+//
+// appendRows does NOT update dst.Len; the caller owns the logical row count.
+func appendRows(dst, src *batch.RecordBatch, rows []int, dstStart int) int64 {
+	n := int64(len(rows))
+	var dataBytes int64
+	for j, col := range src.Columns {
+		d := dst.Columns[j]
 		switch col.Type {
 		case batch.TypeBool:
 			for di, si := range rows {
 				if col.Nulls.IsNullFast(si) {
-					dst.Nulls.SetNull(di)
+					d.Nulls.SetNull(dstStart + di)
 				} else {
-					dst.BoolData[di] = col.BoolData[si]
+					d.BoolData[dstStart+di] = col.BoolData[si]
 				}
 			}
+			dataBytes += n
 		case batch.TypeInt32, batch.TypePort, batch.TypeProtocol, batch.TypeDate:
 			for di, si := range rows {
 				if col.Nulls.IsNullFast(si) {
-					dst.Nulls.SetNull(di)
+					d.Nulls.SetNull(dstStart + di)
 				} else {
-					dst.Int32Data[di] = col.Int32Data[si]
+					d.Int32Data[dstStart+di] = col.Int32Data[si]
 				}
 			}
+			dataBytes += n * 4
 		case batch.TypeInt64, batch.TypeTimestamp, batch.TypeIPv4, batch.TypeMAC, batch.TypeDuration:
 			for di, si := range rows {
 				if col.Nulls.IsNullFast(si) {
-					dst.Nulls.SetNull(di)
+					d.Nulls.SetNull(dstStart + di)
 				} else {
-					dst.Int64Data[di] = col.Int64Data[si]
+					d.Int64Data[dstStart+di] = col.Int64Data[si]
 				}
 			}
+			dataBytes += n * 8
 		case batch.TypeFloat32:
 			for di, si := range rows {
 				if col.Nulls.IsNullFast(si) {
-					dst.Nulls.SetNull(di)
+					d.Nulls.SetNull(dstStart + di)
 				} else {
-					dst.Float32Data[di] = col.Float32Data[si]
+					d.Float32Data[dstStart+di] = col.Float32Data[si]
 				}
 			}
+			dataBytes += n * 4
 		case batch.TypeFloat64:
 			for di, si := range rows {
 				if col.Nulls.IsNullFast(si) {
-					dst.Nulls.SetNull(di)
+					d.Nulls.SetNull(dstStart + di)
 				} else {
-					dst.Float64Data[di] = col.Float64Data[si]
+					d.Float64Data[dstStart+di] = col.Float64Data[si]
 				}
 			}
+			dataBytes += n * 8
 		case batch.TypeString, batch.TypeBytes, batch.TypeIPv6, batch.TypeCIDR, batch.TypeUUID:
 			for di, si := range rows {
 				if col.Nulls.IsNullFast(si) {
-					dst.Nulls.SetNull(di)
-					dst.BytesData.Set(di, nil) // maintain offset continuity
+					d.Nulls.SetNull(dstStart + di)
+					d.BytesData.Set(dstStart+di, nil) // maintain offset continuity
 				} else {
-					dst.BytesData.SetFrom(di, &col.BytesData, si)
+					start := col.BytesData.Offsets[si]
+					end := col.BytesData.Offsets[si+1]
+					dataBytes += int64(end - start)
+					d.BytesData.SetFrom(dstStart+di, &col.BytesData, si)
 				}
 			}
+			dataBytes += n * 4 // offsets, one uint32 per row
 		case batch.TypeDecimal:
 			for di, si := range rows {
 				if col.Nulls.IsNullFast(si) {
-					dst.Nulls.SetNull(di)
+					d.Nulls.SetNull(dstStart + di)
 				} else {
-					dst.DecimalData.Data[di] = col.DecimalData.Data[si]
+					d.DecimalData.Data[dstStart+di] = col.DecimalData.Data[si]
 				}
 			}
+			dataBytes += n * 16
 		default:
-			// Fallback via GetValue/SetValue
+			// Fallback via GetValue/SetValue (nested ARRAY/ROW/MAP/VECTOR).
 			for di, si := range rows {
-				dst.SetValue(di, col.GetValue(si))
+				d.SetValue(dstStart+di, col.GetValue(si))
 			}
+			dataBytes += n * 8 // coarse estimate; nested types are off the join hot path
 		}
 	}
-	return out
+	return dataBytes
 }

--- a/internal/engine/exec/join_spill.go
+++ b/internal/engine/exec/join_spill.go
@@ -180,28 +180,6 @@ func (s *spillState) largestInMemoryPartition() int {
 	return bestPart
 }
 
-// spillBuildPartition writes a partition's build batches to disk and frees memory.
-// Returns the number of bytes freed.
-func (s *spillState) spillBuildPartition(partID int) (int64, error) {
-	batches := s.partBuildBatches[partID]
-	if len(batches) == 0 {
-		s.spilledParts[partID] = true
-		return 0, nil
-	}
-
-	path, err := writeSpillBatches(s.dir, batches)
-	if err != nil {
-		return 0, fmt.Errorf("spilling partition %d: %w", partID, err)
-	}
-
-	s.partBuildFiles[partID] = append(s.partBuildFiles[partID], path)
-	freed := s.partMemory[partID]
-	delete(s.partBuildBatches, partID)
-	delete(s.partMemory, partID)
-	s.spilledParts[partID] = true
-	return freed, nil
-}
-
 // writeProbeRow buffers a probe batch for a spilled partition.
 // Thread-safe: called concurrently from parallel pipeline workers.
 func (s *spillState) writeProbeRow(partID int, b *batch.RecordBatch) error {
@@ -245,60 +223,6 @@ func (s *spillState) cleanup() {
 		for _, f := range files {
 			os.Remove(f)
 		}
-	}
-}
-
-// partitionBuildBatch assigns rows from a build batch to partitions.
-// The batch is split by partition ID and stored in the partition's build list.
-func (h *HashJoin) partitionBuildBatch(b *batch.RecordBatch) {
-	ss := h.spillState
-
-	// Compute partition for each row
-	partRows := make(map[int][]int) // partID → row indices
-
-	if h.useIntKey {
-		col := b.Columns[h.buildKeyIdx[0]]
-		for i := 0; i < b.Len; i++ {
-			key, ok := intKeyFromVector(col, i)
-			if !ok {
-				partRows[0] = append(partRows[0], i)
-				continue
-			}
-			p := spillPartition(key)
-			partRows[p] = append(partRows[p], i)
-		}
-	} else if h.useDualIntKey {
-		col0, col1 := b.Columns[h.buildKeyIdx[0]], b.Columns[h.buildKeyIdx[1]]
-		for i := 0; i < b.Len; i++ {
-			a, bb, ok := dualIntKeyFromVectors(col0, col1, i)
-			if !ok {
-				partRows[0] = append(partRows[0], i)
-				continue
-			}
-			p := spillPartition(dualIntHash(a, bb))
-			partRows[p] = append(partRows[p], i)
-		}
-	} else {
-		for i := 0; i < b.Len; i++ {
-			h.buildKeyFromBatch(b, i)
-			p := spillPartitionBytes(h.keyBuf)
-			partRows[p] = append(partRows[p], i)
-		}
-	}
-
-	// Create per-partition batches
-	for partID, rows := range partRows {
-		if ss.spilledParts[partID] {
-			// This partition is already spilled — append to its long-lived
-			// writer so a run of post-spill batches concatenates into a
-			// single file instead of fragmenting into one file per batch.
-			partBatch := compactBatchForRows(b, rows)
-			_ = ss.writeBuildBatch(partID, partBatch) // best-effort
-			continue
-		}
-		partBatch := compactBatchForRows(b, rows)
-		ss.partBuildBatches[partID] = append(ss.partBuildBatches[partID], partBatch)
-		ss.partMemory[partID] += hashBuildBytes(partBatch)
 	}
 }
 

--- a/internal/engine/exec/join_spill_test.go
+++ b/internal/engine/exec/join_spill_test.go
@@ -415,9 +415,15 @@ func TestGraceHashJoinSpill_Parallel(t *testing.T) {
 }
 
 // TestConcurrentBuildSharedTracker verifies that two hash joins sharing a single
-// MemTracker don't corrupt each other's accounting when one spills. Previously,
-// spillBuildBatches() called tracker.Reset() which zeroed ALL concurrent builds'
-// tracked memory, causing unchecked allocation and OOM in multi-way joins (Q21).
+// MemTracker keep their accounting balanced (tracker.Used == sum of per-join
+// trackedMem) when one spills under concurrent build. The original regression
+// was the legacy flat path's spillBuildBatches() calling tracker.Reset(), which
+// zeroed ALL concurrent builds' tracked memory → unchecked allocation and OOM in
+// multi-way joins (Q21). That path is retired; spill-eligible builds now use
+// partition-on-arrival (buildPartitioned), whose spillOneInMemoryPartition only
+// Releases its own partition bytes and never touches the shared tracker's total,
+// so the invariant holds structurally. This test now guards that invariant under
+// buildPartitioned's cooperative cross-operator spill.
 func TestConcurrentBuildSharedTracker(t *testing.T) {
 	schema := []parquet.Column{
 		{Name: "id", Type: parquet.TypeInt64},
@@ -442,11 +448,14 @@ func TestConcurrentBuildSharedTracker(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	// Shared tracker: each build produces ~980KB (5 batches × 196KB).
-	// Budget of 1.4MB lets both builds get at least 2 batches before
-	// combined usage triggers spill (80% of 1.4MB = 1.12MB threshold),
-	// even if one build monopolizes early scheduling.
-	budget := int64(1_400_000)
+	// Shared budget that forces at least one build to spill while leaving
+	// headroom for buildPartitioned's residual hash-table overhead, which (for
+	// partition-on-arrival) stays in the tracker for spilled partitions until
+	// Close rather than being dropped by a flat-path arena rebuild. 1.6MB is
+	// the calibrated minimum for two concurrent 10K-row builds (matching
+	// TestPartitionOnArrival_ConcurrentBuildsSharedPool); the legacy flat path's
+	// 1.4MB was tuned to its smaller reactively-rebuilt arena.
+	budget := int64(1_600_000)
 	sharedTracker := memory.NewTracker("shared", budget)
 	sm, err := memory.NewSpillManager(tmpDir, sharedTracker)
 	if err != nil {

--- a/internal/worker/executor_fragment.go
+++ b/internal/worker/executor_fragment.go
@@ -965,15 +965,13 @@ func (e *Executor) buildFragmentJoinProbe(ctx context.Context, task distributed.
 			hj.SemiAntiFilter = physical.BuildSemiAntiFilter(spec.JoinFilter)
 		}
 		if e.sharedSpill != nil {
+			// Wiring a Spill manager + tracker makes Build partition on arrival
+			// unconditionally (O(partition) spill). There is no at-entry
+			// pressure heuristic: the stale 30% snapshot used to leave shuffle
+			// builds on the flat path, which could then need an O(total)
+			// reactive repartition under pressure (the Q17/Q18 mc=4 killer).
 			hj.Spill = e.sharedSpill
 			hj.MemTracker = e.sharedTracker
-			// Broadcast probes always force partition-on-arrival to bound peak
-			// heap; shuffle-side probes opt in based on observed pool pressure.
-			if spec.Type == distributed.OpBroadcastProbe {
-				hj.PartitionOnArrival = true
-			} else {
-				hj.PartitionOnArrival = exec.SharedPoolUnderPressure(e.sharedTracker)
-			}
 		}
 		if err := hj.Build(ctx, src); err != nil {
 			return nil, fmt.Errorf("building hash table: %w", err)

--- a/internal/worker/executor_fragment_test.go
+++ b/internal/worker/executor_fragment_test.go
@@ -443,9 +443,9 @@ func makeProbeWshf(t *testing.T, rows []struct {
 // drove probes through exec.Pipeline which already includes flushSpilledOps;
 // the fragment runner did not.
 //
-// This test forces the build's hash partition to spill (tiny shared budget +
-// PartitionOnArrival via OpBroadcastProbe) and asserts every matching
-// probe→build pair appears in the joined output.
+// This test forces the build's hash partition to spill (tiny shared budget;
+// the shared Spill+tracker make Build partition on arrival) and asserts every
+// matching probe→build pair appears in the joined output.
 func TestExecuteFragment_HashJoinProbe_FlushesSpilledPartitions(t *testing.T) {
 	ctx := context.Background()
 	const bucket = "test-fragment-hj-flush"
@@ -455,7 +455,7 @@ func TestExecuteFragment_HashJoinProbe_FlushesSpilledPartitions(t *testing.T) {
 	// triggers spillUntilCanReserve, which evicts the largest in-memory
 	// partition. Subsequent batches scattered to that partition write
 	// directly to disk; probe rows hashing there route through the spill
-	// flush path. PartitionOnArrival=true is forced by OpBroadcastProbe.
+	// flush path. The shared Spill manager makes the build partition on arrival.
 	const numBuildFiles = 4
 	const rowsPerFile = 2048
 	const buildN = numBuildFiles * rowsPerFile
@@ -524,8 +524,8 @@ func TestExecuteFragment_HashJoinProbe_FlushesSpilledPartitions(t *testing.T) {
 				InputBucket: bucket,
 			},
 			{
-				// OpBroadcastProbe forces PartitionOnArrival=true on the
-				// HashJoin (see buildFragmentJoinProbe). The tight shared
+				// The shared Spill manager makes this HashJoin partition on
+				// arrival (see buildFragmentJoinProbe). The tight shared
 				// budget triggers a spill once the second build batch
 				// arrives, putting probe-routing rows on disk.
 				Type:        distributed.OpBroadcastProbe,


### PR DESCRIPTION
## Summary

Unifies the HashJoin build onto the **partition-on-arrival** path and retires the legacy flat build path, eliminating the reactive O(total) repartition+rebuild that was the documented Q17/Q18 SF100 `max_concurrent=4` OOM killer. Validated end-to-end with an SF100 mc=4 deploy: **22/22 byte-identical, faster than mc=3, and it actually completes** (mc=4 previously couldn't). Production knob raised 3→4.

## Commits

1. **`d915ad2` test(exec)** — flat-vs-partitioned build gate benchmark (`BenchmarkHashJoinBuildNoSpill`).
2. **`0a26cf2` perf(exec)** — cheap **growable per-partition accumulators**. Replaces the per-(partition×arrival-batch) batch mint + per-batch `map[int][]int` with a reusable `[64][]int` scatter scratch and accumulator batches that grow to fit (new `batch.RecordBatch.EnsureCapacity` / `Vector.EnsureLen` / `Bitmap.EnsureLen` primitives, reslice + geometric realloc). No-spill partitioned build went **2.24×→~1.6× flat wall, 135K→7K allocs/op (19× fewer)**. `partMemory` is charged tight at append and reconciled to the accumulator's true `MemBytes` at freeze so resident capacity is accounted honestly (under-counting would let the shared pool over-commit = OOM risk). Adds a mutation-tested buildRef-integrity regression test + batch-primitive unit tests.
3. **`d5997af` perf(exec)** — **retire the legacy flat path** (−756 lines). Every spill-eligible build (MemTracker+Spill set) now partitions on arrival unconditionally — no at-entry pressure heuristic. Deleted `spillBuildBatches`/`reloadInMemoryPartitions` (the reactive converter), the dead `buildParallel` cluster, `partitionBuildBatch`/`spillBuildPartition`, `SharedPoolUnderPressure`+threshold, and the `PartitionOnArrival` flag. **Flat survives as a pure no-spill build** for callers without a tracker/spill (embedded `wadjet.DB`, spill-replay rebuild, ~40 tests) — guard `Spill!=nil && MemTracker!=nil` is load-bearing.
4. **`b4ec2f0` perf(worker)** — raise SF100 `max_concurrent` 3→4 (the retired knob).

## Why it's correct

`buildRef.rowIdx` keys on the per-partition batch's dense offset; appends only extend the tail and growth reallocs only *open* (un-indexed) accumulators, so frozen rows' refs stay valid. Nested-column build schemas fall back to a tight per-arrival batch (`EnsureLen` can't grow nested element storage).

## Validation

- **Local:** `go build ./...`, full `./internal/...`, `exec`+`worker` `-race`, `exec -count=5` (concurrent stability), **TPC-H SF0.01 byte-identical**, local harness **25/25**.
- **SF100 mc=4 deploy** (`d5997af`, on-demand, results/20260603-174555):
  - **22/22 PASS, every row count byte-identical to the mc=3 baseline.**
  - **Total 1h6m vs ~71m at mc=3 — faster AND complete.**
  - Both prior mc=4 death points cleared: **Q05** (hash-join build/probe pressure) 3m35s; **Q17→Q18 drain** Q18 7m16s (vs 10m8s, −2m52s), Q21 8m10s (−1m30s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)