### PR TITLE
fix(exec): loop cooperative spill until reservable (fixes flaky TestConcurrentBuildSharedTracker)

### DIFF
--- a/internal/engine/exec/join_partition_arrival.go
+++ b/internal/engine/exec/join_partition_arrival.go
@@ -573,20 +573,42 @@ func (h *HashJoin) spillUntilCanReserve(needed int64) error {
 		return nil
 	}
 	// Cooperative spill: ask the worker's advisor to evict from any other
-	// concurrent operator. Skip if no SpillManager (test paths), no other
-	// operators (single-operator path), or the budget hasn't been crossed.
+	// concurrent operator. Skip if no SpillManager (test paths, single-operator
+	// path). We LOOP rather than make a single request: the advisor evicts one
+	// victim partition per call and may free less than the gap in one round,
+	// and a concurrent build on the same pool can add between rounds. A single
+	// round that comes up a few bytes short would otherwise bubble a spurious
+	// "memory budget exceeded" up to the caller even though the combined
+	// unspillable footprint fits the budget. Keep requesting relief (and
+	// re-checking our own self-spill, in case an open accumulator became
+	// spillable meanwhile) until we fit or a full round frees nothing anywhere.
 	if h.Spill == nil {
 		return nil
 	}
-	gap := h.MemTracker.Used() + needed - h.MemTracker.Budget()
-	// h.mu is held — release before calling cross-operator advisory. A
-	// concurrent operator's SpillSome takes ITS mu, never ours, but we
-	// shouldn't pin our partitioning loop while another operator does its
-	// own potentially-large spill.
-	h.mu.Unlock()
-	_, err := h.Spill.RequestRelief(gap)
-	h.mu.Lock()
-	return err
+	for h.MemTracker.Used()+needed > h.MemTracker.Budget() {
+		gap := h.MemTracker.Used() + needed - h.MemTracker.Budget()
+		// h.mu is held — release before calling cross-operator advisory. A
+		// concurrent operator's SpillSome takes ITS mu, never ours, so this is
+		// deadlock-free; we just shouldn't pin our partitioning loop while
+		// another operator does its own potentially-large spill.
+		h.mu.Unlock()
+		relieved, err := h.Spill.RequestRelief(gap)
+		h.mu.Lock()
+		if err != nil {
+			return err
+		}
+		selfFreed, err := h.spillOneInMemoryPartition()
+		if err != nil {
+			return err
+		}
+		if relieved == 0 && selfFreed == 0 {
+			// Neither we nor any peer has anything left to evict; the build
+			// genuinely cannot fit. Return nil and let the caller's Reserve
+			// surface the real over-budget error with full context.
+			return nil
+		}
+	}
+	return nil
 }
 
 // Inspect implements memory.AccountedOperator. OwnedBytes includes the hash


### PR DESCRIPTION
## Problem

The post-merge CI run for #105 failed on `TestConcurrentBuildSharedTracker` (it passed locally + on the PR check) — a timing flake:

```
Join A Build failed: memory budget exceeded (used=1448974, requested=151828, budget=1600000)
```

Failed by **802 bytes**.

## Root cause

`spillUntilCanReserve` self-spilled its own partitions in a loop, then made a **single** `RequestRelief` call before returning — leaving the caller one Reserve retry. Under concurrent builds on a tight shared pool, that one round can come up a few bytes short:
- `RequestRelief` returns partial when a peer gets cooled down for delivering less than it claimed, or
- a concurrent build re-reserves between the relief call and the caller's retry.

Either way it bubbles a spurious "memory budget exceeded" even though the combined **unspillable** footprint (hash arena/index, ~700KB for the two builds) fits comfortably under the 1.6MB budget. The function's name promises "spill *until* can reserve" but it gave up after one cooperative round.

This is a pathological tight-pool micro-case (hash overhead ~44% of budget). The engine is correct at scale — the SF100 mc=4 validation in #105 ran 22/22 with zero Reserve failures.

## Fix

Loop the cooperative path: keep requesting relief (and re-checking our own self-spill, in case an open accumulator became spillable) until we fit or a full round frees nothing anywhere. Converges because the combined unspillable footprint is under budget; the "nothing freed" break + `RequestRelief`'s per-operator cooldown bound any spin.

## Validation

- `go build ./...`; full `./internal/...`; `exec -race -count=3`; **SF0.01 byte-identical**; local harness **25/25**.
- The two concurrent shared-tracker tests (`TestConcurrentBuildSharedTracker`, `TestPartitionOnArrival_ConcurrentBuildsSharedPool`) under **`-race -count=30`** — previously flaky, now solid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)