### PR TITLE
fix(exec): make Sort/Window spill genuinely out-of-core via sorted-run external merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ SQL text
 - **Selection vectors**: Filtering marks indices instead of copying rows
 - **Push-based pipelines**: Source → UnaryOperator chain → Sink
 - **Pipeline breakers**: Aggregate, Sort, Window act as SinkSource (consume all, then produce)
+- **Spill-to-disk**: All pipeline breakers degrade gracefully past memory — HashJoin (grace partition-on-arrival), HashAggregate (partial-state k-way merge), Sort and Window (sorted-run external merge, streaming k-way). Residuals that still materialize fully: window specs with empty PARTITION BY, nested-type (Array/Map/Row) schemas in Sort/Window (legacy row spill).
 - **Batch pooling**: `BatchPool` for zero-alloc batch reuse
 
 ### Core Interfaces
@@ -115,8 +116,8 @@ Network-native types (IPv4, IPv6, CIDR, MAC, Port, Protocol) are first-class wit
 ### Distribution
 
 - **Modes**: `standalone` (all-in-one), `coordinator` (plan+dispatch), `worker` (execute)
-- **Pipeline-only execution**: All queries run as full SQL pipelines on workers. No inter-stage S3 shuffles.
-- **Probe-split**: Partition the largest table's files across workers, each runs the full query, coordinator merges partial results (re-aggregation, sort, dedup).
+- **Stage-DAG execution**: Distributed queries run as a multi-stage DAG. Every stage's output **materializes to S3** (`queries/<id>/...`) and is read back by the next stage — structurally like Trino's fault-tolerant execution with exchange spooling, not like its streaming mode. `exchange-repartition` stages hash-partition `.wshf` shuffle files; large-build joins (> `shuffleBuildThreshold`) take this path by default.
+- **Broadcast + probe-split**: Builds under `BroadcastBytesThreshold` replicate to all workers; the probe side's files are split across workers, each runs the full join, coordinator merges partial results (re-aggregation, sort, dedup).
 - **NATS JetStream**: Task queues with request/reply result delivery, metadata KV
 - **Federation**: NATS leaf nodes connect edge clusters to central
 

--- a/internal/engine/exec/join_spill.go
+++ b/internal/engine/exec/join_spill.go
@@ -505,6 +505,23 @@ func writeColumnData(w *bufio.Writer, v *batch.Vector, n int, buf []byte) error 
 			binary.LittleEndian.PutUint64(buf[:8], uint64(d.Hi))
 			w.Write(buf[:8])
 		}
+
+	case batch.TypeVector:
+		// [dim:u32] then n*dim float32s. dim is per-column metadata that the
+		// Vector carries outside the schema, so it must ride in the file.
+		binary.LittleEndian.PutUint32(buf[:4], uint32(v.VectorDim))
+		w.Write(buf[:4])
+		total := n * v.VectorDim
+		for i := 0; i < total; i++ {
+			binary.LittleEndian.PutUint32(buf[:4], math.Float32bits(v.Float32Data[i]))
+			w.Write(buf[:4])
+		}
+
+	default:
+		// Nested types (Array/Map/Row) have no columnar spill encoding.
+		// Writing nothing here would silently corrupt data on read-back, so
+		// fail loudly — callers gate on columnarSpillableSchema.
+		return fmt.Errorf("columnar spill: unsupported column type %v", v.Type)
 	}
 	return nil
 }
@@ -671,6 +688,23 @@ func readColumnData(r *bufio.Reader, v *batch.Vector, n int, buf []byte) error {
 			hi := int64(binary.LittleEndian.Uint64(buf[:8]))
 			v.DecimalData.Data[i] = batch.Int128{Lo: lo, Hi: hi}
 		}
+
+	case batch.TypeVector:
+		if _, err := io.ReadFull(r, buf[:4]); err != nil {
+			return err
+		}
+		dim := int(binary.LittleEndian.Uint32(buf[:4]))
+		v.VectorDim = dim
+		v.Float32Data = make([]float32, n*dim)
+		for i := range v.Float32Data {
+			if _, err := io.ReadFull(r, buf[:4]); err != nil {
+				return err
+			}
+			v.Float32Data[i] = math.Float32frombits(binary.LittleEndian.Uint32(buf[:4]))
+		}
+
+	default:
+		return fmt.Errorf("columnar spill: unsupported column type %v", v.Type)
 	}
 	return nil
 }

--- a/internal/engine/exec/sort.go
+++ b/internal/engine/exec/sort.go
@@ -1,7 +1,6 @@
 package exec
 
 import (
-	"container/heap"
 	"context"
 	"sort"
 	"strconv"
@@ -9,7 +8,6 @@ import (
 	"sync/atomic"
 
 	"github.com/citc-tech/wadjet/internal/engine/batch"
-	"github.com/citc-tech/wadjet/internal/engine/exec/kernel"
 	"github.com/citc-tech/wadjet/internal/engine/memory"
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
 )
@@ -42,10 +40,16 @@ type Sort struct {
 	mu         sync.Mutex
 	batches    []*batch.RecordBatch // columnar storage
 	totalRows  int
-	trackedMem int64 // memory reserved from shared tracker by this operator
-	spillFiles []string
+	trackedMem int64                // memory reserved from shared tracker by this operator
+	spillFiles []string             // legacy row-oriented spill (schemas the columnar run format can't carry)
+	runFiles   []string             // sorted columnar runs (external-merge path)
 	sorted     []*batch.RecordBatch // materialized sorted results
 	pos        int
+	// External-merge stream state (set by finalizeExternalMerge; drained by Next).
+	merger    *runMerger
+	mergeRuns []string // run files to delete once the merge drains
+	mergeEmit int      // rows emitted so far (Limit enforcement)
+	mergeDone bool
 	// AccountedOperator (Phase 2) state — see HashAggregate for the contract.
 	accInstanceID       uint64
 	accState            atomic.Int32
@@ -64,6 +68,10 @@ func (s *Sort) Init(_ context.Context) error {
 	s.totalRows = 0
 	s.sorted = nil
 	s.pos = 0
+	s.merger = nil
+	s.mergeRuns = nil
+	s.mergeEmit = 0
+	s.mergeDone = false
 	return nil
 }
 
@@ -96,23 +104,57 @@ func (s *Sort) Consume(_ context.Context, b *batch.RecordBatch) error {
 		}
 	}
 
-	// Spill to disk if memory pressure is high
+	// Spill to disk if memory pressure is high. The columnar run path
+	// accumulates at least minSortRunBytes before flushing so runs stay
+	// merge-friendly; the legacy row path (nested-type schemas) keeps the
+	// old flush-on-pressure behavior. Peer relief (SpillSome) bypasses the
+	// floor.
 	if s.Spill != nil && s.Spill.ShouldSpillFor(memory.SpillCheap) && len(s.batches) > 0 {
+		if !columnarSpillableSchema(s.schema) || s.trackedMem >= minSortRunBytes {
+			if _, err := s.flushSpillLocked(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// flushSpillLocked drains all buffered batches to disk and releases their
+// tracking, returning the bytes freed. Columnar-spillable schemas write a
+// SORTED run (the external-merge unit); nested-type schemas fall back to the
+// legacy row-oriented spill file. Caller holds s.mu.
+func (s *Sort) flushSpillLocked() (int64, error) {
+	if len(s.batches) == 0 || s.trackedMem == 0 {
+		return 0, nil
+	}
+	if columnarSpillableSchema(s.schema) {
+		path, err := sortBatchesToRun(s.Spill.SpillDir(), s.schema, s.batches, s.totalRows, s.Keys, s.Limit)
+		if err != nil {
+			return 0, err
+		}
+		if path != "" {
+			s.runFiles = append(s.runFiles, path)
+		}
+	} else {
 		var rows []map[string]any
 		for _, sb := range s.batches {
 			rows = append(rows, sb.ToRows()...)
 		}
 		path, err := s.Spill.SpillRows(rows)
 		if err != nil {
-			return err
+			return 0, err
 		}
 		s.spillFiles = append(s.spillFiles, path)
-		s.batches = s.batches[:0]
-		s.totalRows = 0
-		s.Spill.ReleaseTracking(s.trackedMem)
-		s.trackedMem = 0
 	}
-	return nil
+	s.batches = s.batches[:0]
+	s.totalRows = 0
+	freed := s.trackedMem
+	s.Spill.ReleaseTracking(freed)
+	s.trackedMem = 0
+	if s.accInstanceID != 0 {
+		s.Spill.Tracker().PublishOwned(s.accInstanceID, 0)
+	}
+	return freed, nil
 }
 
 func (s *Sort) Finalize(_ context.Context) error {
@@ -131,7 +173,80 @@ func (s *Sort) Finalize(_ context.Context) error {
 	if len(s.spillFiles) > 0 {
 		return s.finalizeWithSpill()
 	}
+	if len(s.runFiles) > 0 {
+		return s.finalizeExternalMerge()
+	}
 	return s.finalizeColumnar()
+}
+
+// finalizeExternalMerge sets up the streaming k-way merge over sorted runs
+// plus the in-memory remainder. Nothing is materialized here — Next() pulls
+// one merged batch at a time, so finalize-phase memory is bounded by one
+// buffered batch per run regardless of input size.
+func (s *Sort) finalizeExternalMerge() error {
+	runs := s.runFiles
+	s.runFiles = nil
+
+	// Multi-level pre-merge keeps the final fan-in (and its one-batch-per-run
+	// buffer cost) bounded. Reserve one slot for the in-memory cursor.
+	runs, err := preMergeRuns(s.Spill.SpillDir(), s.schema, s.Keys, runs, maxMergeFanIn-1, s.Limit)
+	if err != nil {
+		return err
+	}
+
+	cursors := make([]*runCursor, 0, len(runs)+1)
+	for ord, p := range runs {
+		c, err := newFileRunCursor(p)
+		if err != nil {
+			for _, prev := range cursors {
+				prev.close()
+			}
+			return err
+		}
+		c.ord = ord
+		cursors = append(cursors, c)
+	}
+
+	// In-memory remainder participates as the last cursor: sorted entries
+	// gathered lazily, no run write needed. It arrived after every spilled
+	// run, so it ties last — consistent with the stable in-memory sort.
+	if len(s.batches) > 0 {
+		entries := buildSortEntries(s.batches, s.totalRows)
+		resolved := resolveSortKeysForBatches(s.Keys, s.batches)
+		entries = selectSortedEntries(entries, sortEntriesLessFunc(resolved, s.batches), s.Limit)
+		c, err := newMemRunCursor(s.schema, s.batches, entries)
+		if err != nil {
+			for _, prev := range cursors {
+				prev.close()
+			}
+			return err
+		}
+		c.ord = len(runs)
+		cursors = append(cursors, c)
+	}
+
+	s.merger = newRunMerger(s.schema, s.Keys, cursors)
+	s.mergeRuns = runs
+	return nil
+}
+
+// finishMergeLocked tears down the external merge: closes cursors, deletes
+// run files, releases the reservation still held for the in-memory remainder,
+// and drops batch references.
+func (s *Sort) finishMergeLocked() {
+	if s.merger != nil {
+		s.merger.close()
+		s.merger = nil
+	}
+	removeRunFiles(s.mergeRuns)
+	s.mergeRuns = nil
+	s.batches = nil
+	s.totalRows = 0
+	if s.Spill != nil && s.trackedMem > 0 {
+		s.Spill.ReleaseTracking(s.trackedMem)
+		s.trackedMem = 0
+	}
+	s.mergeDone = true
 }
 
 // finalizeWithSpill falls back to row-oriented sort when spill files exist.
@@ -204,149 +319,24 @@ type sortEntry struct {
 }
 
 // finalizeColumnar sorts using typed column comparisons on an index array.
+// The entry-building / key-resolution / top-K machinery is shared with the
+// external-merge run writer (sort_external.go).
 func (s *Sort) finalizeColumnar() error {
 	if len(s.batches) == 0 {
 		return nil
 	}
 
-	// Build index entries for all active rows
-	entries := make([]sortEntry, 0, s.totalRows)
-	for bi, b := range s.batches {
-		if b.Sel != nil {
-			for _, idx := range b.Sel {
-				entries = append(entries, sortEntry{batchIdx: uint32(bi), rowIdx: idx})
-			}
-		} else {
-			for i := 0; i < b.Len; i++ {
-				entries = append(entries, sortEntry{batchIdx: uint32(bi), rowIdx: uint32(i)})
-			}
-		}
-	}
-
-	// Resolve sort key column indices and pre-resolve typed comparison kernels.
-	// Null ordering (NULLS FIRST vs NULLS LAST) is baked into the kernel selection,
-	// so the comparison loop has no per-row null checks.
-	type resolvedKey struct {
-		colIdx  int
-		order   SortOrder
-		compare kernel.SortCompareKernel
-	}
-	firstBatch := s.batches[0]
-	resolved := make([]resolvedKey, len(s.Keys))
-	for i, key := range s.Keys {
-		idx := firstBatch.ColumnIndex(key.Column)
-		if idx >= len(firstBatch.Columns) {
-			idx = -1 // schema/column count mismatch — skip this key
-		}
-		var cmp kernel.SortCompareKernel
-		if idx >= 0 {
-			colType := firstBatch.Columns[idx].Type
-			// Check if this column is null-free across all batches.
-			allNullFree := true
-			for _, b := range s.batches {
-				if idx >= len(b.Columns) || b.Columns[idx].Nulls.HasNulls() {
-					allNullFree = false
-					break
-				}
-			}
-			if allNullFree {
-				// No nulls: skip null bitmap checks entirely.
-				cmp = kernel.ResolveSortCompareNoNulls(colType)
-			} else if key.NullsLast {
-				// Has nulls with NULLS LAST: null > non-null baked into kernel.
-				cmp = kernel.ResolveSortCompareNullsLast(colType)
-			} else {
-				// Has nulls with NULLS FIRST (default): null < non-null.
-				cmp = kernel.ResolveSortCompare(colType)
-			}
-		}
-		resolved[i] = resolvedKey{colIdx: idx, order: key.Order, compare: cmp}
-	}
-
-	// Sort comparison function used by both full sort and TopN heap.
-	// Null ordering is fully handled by the selected kernel — no post-hoc checks needed.
-	batches := s.batches
-	lessFunc := func(ei, ej sortEntry) bool {
-		bi, bj := batches[ei.batchIdx], batches[ej.batchIdx]
-		ri, rj := int(ei.rowIdx), int(ej.rowIdx)
-		for _, key := range resolved {
-			if key.colIdx < 0 || key.colIdx >= len(bi.Columns) || key.colIdx >= len(bj.Columns) {
-				continue
-			}
-			cmp := key.compare(bi.Columns[key.colIdx], ri, bj.Columns[key.colIdx], rj)
-			if cmp == 0 {
-				continue
-			}
-			if key.order == Descending {
-				return cmp > 0
-			}
-			return cmp < 0
-		}
-		return false
-	}
-
-	// When Limit is small relative to total rows, use a bounded heap
-	// to find the top Limit entries in O(n log k) instead of O(n log n).
-	if s.Limit > 0 && s.Limit < len(entries)/2 {
-		k := s.Limit
-		// Build a max-heap of size k where the root is the WORST entry
-		// (the one we'd evict first). "Worse" = sorts LATER = inverse of lessFunc.
-		h := &topNHeap{
-			entries: make([]sortEntry, k),
-			less:    lessFunc,
-		}
-		copy(h.entries, entries[:k])
-		heap.Init(h)
-
-		for _, e := range entries[k:] {
-			// If this entry is better than the worst in the heap, replace
-			if lessFunc(e, h.entries[0]) {
-				h.entries[0] = e
-				heap.Fix(h, 0)
-			}
-		}
-
-		// Sort the heap entries to get final order
-		entries = h.entries
-		sort.SliceStable(entries, func(i, j int) bool {
-			return lessFunc(entries[i], entries[j])
-		})
-	} else {
-		// Full sort for unlimited or large-limit queries
-		sort.SliceStable(entries, func(i, j int) bool {
-			return lessFunc(entries[i], entries[j])
-		})
-	}
+	entries := buildSortEntries(s.batches, s.totalRows)
+	resolved := resolveSortKeysForBatches(s.Keys, s.batches)
+	entries = selectSortedEntries(entries, sortEntriesLessFunc(resolved, s.batches), s.Limit)
 
 	// Materialize sorted batches using typed column copies.
-	// When Limit > 0, only materialize the top Limit rows (Top-K).
-	materializeN := len(entries)
-	if s.Limit > 0 && s.Limit < materializeN {
-		materializeN = s.Limit
-	}
-	for pos := 0; pos < materializeN; {
+	for pos := 0; pos < len(entries); {
 		end := pos + batch.DefaultBatchSize
-		if end > materializeN {
-			end = materializeN
+		if end > len(entries) {
+			end = len(entries)
 		}
-		chunk := entries[pos:end]
-		out := batch.NewRecordBatch(s.schema, len(chunk))
-		// Column-first iteration for better cache locality on destination arrays.
-		for j := range s.schema {
-			// Verify all source batches have this column; if any don't,
-			// the output column stays zero-valued (null-filled on demand).
-			allHaveCol := true
-			for _, e := range chunk {
-				if j >= len(batches[e.batchIdx].Columns) {
-					allHaveCol = false
-					break
-				}
-			}
-			if allHaveCol {
-				gatherSortVector(out.Columns[j], j, chunk, batches)
-			}
-		}
-		s.sorted = append(s.sorted, out)
+		s.sorted = append(s.sorted, gatherEntriesBatch(s.schema, s.batches, entries[pos:end]))
 		pos = end
 	}
 
@@ -356,6 +346,15 @@ func (s *Sort) finalizeColumnar() error {
 
 // Truncate keeps only the first n rows of sorted output (Top-K).
 func (s *Sort) Truncate(n int) {
+	// External-merge path: nothing is materialized — cap the stream instead.
+	// Callers (fragment PostFinalize, sortSourceAdapter) invoke Truncate once
+	// between Finalize and the first Next, before any rows are emitted.
+	if s.merger != nil || s.mergeDone {
+		if s.Limit == 0 || n < s.Limit {
+			s.Limit = n
+		}
+		return
+	}
 	remaining := n
 	for i, b := range s.sorted {
 		if remaining <= 0 {
@@ -414,12 +413,20 @@ func (s *Sort) Close() error {
 		s.unregisterAccounted()
 		s.unregisterAccounted = nil
 	}
+	s.mu.Lock()
+	if s.merger != nil || len(s.mergeRuns) > 0 {
+		// Early cancel mid-merge: close cursors and delete run scratch.
+		s.finishMergeLocked()
+	}
+	removeRunFiles(s.runFiles)
+	s.runFiles = nil
 	if s.Spill != nil && s.trackedMem > 0 {
 		s.Spill.ReleaseTracking(s.trackedMem)
 		s.trackedMem = 0
 	}
 	s.batches = nil
 	s.totalRows = 0
+	s.mu.Unlock()
 	return nil
 }
 
@@ -464,47 +471,67 @@ func (s *Sort) EstimateRelief(target int64) int64 {
 	return s.spillableBytesLocked()
 }
 
-// SpillSome drains accumulated input batches to a raw-row spill file and
-// releases the freed bytes. Sort uses raw-row spill (not partial state)
-// because input batches are pre-sort — there's no partial sorted state to
-// preserve until finalizeWithSpill runs the global merge.
+// SpillSome drains accumulated input batches to disk and releases the freed
+// bytes — a sorted columnar run on the external-merge path, a raw-row file on
+// the nested-type fallback. All-or-nothing either way: input batches are
+// pre-sort, so there's no partial state to keep.
 //
 // Implements memory.Spillable and memory.AccountedOperator.
-func (s *Sort) SpillSome(target int64) (int64, error) {
+func (s *Sort) SpillSome(_ int64) (int64, error) {
 	s.accState.Store(int32(memory.OpSpilling))
 	defer s.accState.CompareAndSwap(int32(memory.OpSpilling), int32(memory.OpActive))
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.Spill == nil || s.trackedMem == 0 || len(s.batches) == 0 {
+	if s.Spill == nil || s.finalized {
 		return 0, nil
 	}
-	var rows []map[string]any
-	for _, sb := range s.batches {
-		rows = append(rows, sb.ToRows()...)
-	}
-	path, err := s.Spill.SpillRows(rows)
-	if err != nil {
-		return 0, err
-	}
-	s.spillFiles = append(s.spillFiles, path)
-	s.batches = s.batches[:0]
-	s.totalRows = 0
-	freed := s.trackedMem
-	s.Spill.ReleaseTracking(freed)
-	s.trackedMem = 0
-	if s.accInstanceID != 0 {
-		s.Spill.Tracker().PublishOwned(s.accInstanceID, 0)
-	}
-	return freed, nil
+	return s.flushSpillLocked()
 }
 
-// Next returns sorted results in batches.
+// Next returns sorted results in batches. On the external-merge path it
+// streams from the k-way run merger; otherwise it drains the materialized
+// s.sorted list.
 func (s *Sort) Next(_ context.Context) (*batch.RecordBatch, error) {
+	if s.merger != nil || s.mergeDone {
+		return s.nextMerged()
+	}
 	if s.pos >= len(s.sorted) {
 		return nil, nil
 	}
 	b := s.sorted[s.pos]
 	s.pos++
+	return b, nil
+}
+
+// nextMerged pulls the next batch from the external merge, enforcing Limit
+// and tearing the merge down (cursors, run files, reservations) at EOF.
+func (s *Sort) nextMerged() (*batch.RecordBatch, error) {
+	if s.mergeDone {
+		return nil, nil
+	}
+	b, err := s.merger.Next()
+	if err != nil {
+		return nil, err
+	}
+	if b == nil {
+		s.mu.Lock()
+		s.finishMergeLocked()
+		s.mu.Unlock()
+		return nil, nil
+	}
+	if s.Limit > 0 {
+		remaining := s.Limit - s.mergeEmit
+		if remaining <= 0 {
+			s.mu.Lock()
+			s.finishMergeLocked()
+			s.mu.Unlock()
+			return nil, nil
+		}
+		if b.Len > remaining {
+			b.Len = remaining
+		}
+	}
+	s.mergeEmit += b.Len
 	return b, nil
 }
 

--- a/internal/engine/exec/sort_external.go
+++ b/internal/engine/exec/sort_external.go
@@ -1,0 +1,530 @@
+package exec
+
+import (
+	"container/heap"
+	"os"
+	"sort"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/engine/exec/kernel"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// ---- External sort: sorted-run generation + streaming k-way merge ----
+//
+// Sort and Window used to spill raw unsorted rows and read EVERYTHING back at
+// finalize for one in-memory sort over boxed []map[string]any — spill deferred
+// peak memory instead of bounding it (the finalize working set was the whole
+// input, in a representation several times larger than columnar). The external
+// path bounds memory for real: each spill sorts the buffered batches with the
+// typed kernels and writes a sorted columnar run; finalize streams a k-way
+// merge over the runs, holding one batch per run.
+
+// minSortRunBytes is the floor on buffered bytes before Sort/Window self-spill
+// a sorted run under SpillCheap pressure. Without a floor, sustained pressure
+// makes every Consume flush a single-batch run — thousands of tiny files and a
+// huge merge fan-in. 64 MiB matches memory.minOperatorBytes (the boot
+// invariant's per-task progress floor) and HashAggregate's
+// spillFileTargetBytes. Peer-demanded relief (SpillSome) ignores the floor —
+// EstimateRelief promises the full buffer, so SpillSome must deliver it.
+// Package var so tests can force tiny runs.
+var minSortRunBytes int64 = 64 << 20
+
+// maxMergeFanIn caps how many runs a single k-way merge holds open at once
+// (one buffered batch each). Beyond the cap, runs are pre-merged in groups
+// into longer runs (classic multi-level external merge), bounding merge
+// memory at maxMergeFanIn × batch size. Package var so tests can force the
+// multi-level path with few runs.
+var maxMergeFanIn = 64
+
+// columnarSpillableSchema reports whether every column type round-trips
+// through the columnar spill format (writeColumnarBatch/readColumnarBatch).
+// Nested types do not — schemas containing them fall back to the legacy
+// row-oriented spill path, which boxes but is correct.
+func columnarSpillableSchema(schema []parquet.Column) bool {
+	for _, c := range schema {
+		switch c.Type {
+		case parquet.TypeArray, parquet.TypeMap, parquet.TypeRow:
+			return false
+		}
+	}
+	return true
+}
+
+// resolvedSortKey is a sort key resolved against a concrete batch set: column
+// index plus the typed comparison kernel with null ordering baked in.
+type resolvedSortKey struct {
+	colIdx  int
+	order   SortOrder
+	compare kernel.SortCompareKernel
+}
+
+// resolveSortKeysForBatches resolves key columns and picks comparison kernels.
+// Null ordering (NULLS FIRST vs NULLS LAST) is baked into kernel selection;
+// the null-free fast kernel is used only when no batch has nulls in the column.
+func resolveSortKeysForBatches(keys []SortKey, batches []*batch.RecordBatch) []resolvedSortKey {
+	resolved := make([]resolvedSortKey, len(keys))
+	if len(batches) == 0 {
+		for i, key := range keys {
+			resolved[i] = resolvedSortKey{colIdx: -1, order: key.Order}
+		}
+		return resolved
+	}
+	firstBatch := batches[0]
+	for i, key := range keys {
+		idx := firstBatch.ColumnIndex(key.Column)
+		if idx >= len(firstBatch.Columns) {
+			idx = -1 // schema/column count mismatch — skip this key
+		}
+		var cmp kernel.SortCompareKernel
+		if idx >= 0 {
+			colType := firstBatch.Columns[idx].Type
+			allNullFree := true
+			for _, b := range batches {
+				if idx >= len(b.Columns) || b.Columns[idx].Nulls.HasNulls() {
+					allNullFree = false
+					break
+				}
+			}
+			if allNullFree {
+				cmp = kernel.ResolveSortCompareNoNulls(colType)
+			} else if key.NullsLast {
+				cmp = kernel.ResolveSortCompareNullsLast(colType)
+			} else {
+				cmp = kernel.ResolveSortCompare(colType)
+			}
+		}
+		resolved[i] = resolvedSortKey{colIdx: idx, order: key.Order, compare: cmp}
+	}
+	return resolved
+}
+
+// buildSortEntries flattens the active rows of batches into sort entries.
+func buildSortEntries(batches []*batch.RecordBatch, totalRows int) []sortEntry {
+	entries := make([]sortEntry, 0, totalRows)
+	for bi, b := range batches {
+		if b.Sel != nil {
+			for _, idx := range b.Sel {
+				entries = append(entries, sortEntry{batchIdx: uint32(bi), rowIdx: idx})
+			}
+		} else {
+			for i := 0; i < b.Len; i++ {
+				entries = append(entries, sortEntry{batchIdx: uint32(bi), rowIdx: uint32(i)})
+			}
+		}
+	}
+	return entries
+}
+
+// sortEntriesLessFunc builds the multi-key comparison closure over a batch set.
+func sortEntriesLessFunc(resolved []resolvedSortKey, batches []*batch.RecordBatch) func(ei, ej sortEntry) bool {
+	return func(ei, ej sortEntry) bool {
+		bi, bj := batches[ei.batchIdx], batches[ej.batchIdx]
+		ri, rj := int(ei.rowIdx), int(ej.rowIdx)
+		for _, key := range resolved {
+			if key.colIdx < 0 || key.colIdx >= len(bi.Columns) || key.colIdx >= len(bj.Columns) {
+				continue
+			}
+			cmp := key.compare(bi.Columns[key.colIdx], ri, bj.Columns[key.colIdx], rj)
+			if cmp == 0 {
+				continue
+			}
+			if key.order == Descending {
+				return cmp > 0
+			}
+			return cmp < 0
+		}
+		return false
+	}
+}
+
+// selectSortedEntries sorts entries; when 0 < limit < len/2 it uses the
+// bounded heap to find the top limit entries in O(n log k), and in all
+// limited cases truncates the result to limit (rows past limit in a sorted
+// run can never appear in the global top-K).
+func selectSortedEntries(entries []sortEntry, less func(a, b sortEntry) bool, limit int) []sortEntry {
+	if limit > 0 && limit < len(entries)/2 {
+		k := limit
+		h := &topNHeap{
+			entries: make([]sortEntry, k),
+			less:    less,
+		}
+		copy(h.entries, entries[:k])
+		heap.Init(h)
+		for _, e := range entries[k:] {
+			if less(e, h.entries[0]) {
+				h.entries[0] = e
+				heap.Fix(h, 0)
+			}
+		}
+		entries = h.entries
+		sort.SliceStable(entries, func(i, j int) bool {
+			return less(entries[i], entries[j])
+		})
+		return entries
+	}
+	sort.SliceStable(entries, func(i, j int) bool {
+		return less(entries[i], entries[j])
+	})
+	if limit > 0 && limit < len(entries) {
+		entries = entries[:limit]
+	}
+	return entries
+}
+
+// gatherEntriesBatch materializes entries[from:to] into a fresh batch using
+// the typed gather kernels. Columns missing from any source batch stay
+// zero-valued, matching finalizeColumnar's tolerance for schema drift.
+func gatherEntriesBatch(schema []parquet.Column, batches []*batch.RecordBatch, entries []sortEntry) *batch.RecordBatch {
+	out := batch.NewRecordBatch(schema, len(entries))
+	for j := range schema {
+		allHaveCol := true
+		for _, e := range entries {
+			if j >= len(batches[e.batchIdx].Columns) {
+				allHaveCol = false
+				break
+			}
+		}
+		if allHaveCol {
+			gatherSortVector(out.Columns[j], j, entries, batches)
+		}
+	}
+	return out
+}
+
+// writeSortedRun gathers entries (already sorted) into DefaultBatchSize
+// chunks and writes them as one columnar run file. Returns "" when entries
+// is empty.
+func writeSortedRun(dir string, schema []parquet.Column, batches []*batch.RecordBatch, entries []sortEntry) (string, error) {
+	if len(entries) == 0 {
+		return "", nil
+	}
+	sw, err := newSpillBatchWriter(dir, "sort-run")
+	if err != nil {
+		return "", err
+	}
+	for pos := 0; pos < len(entries); {
+		end := pos + batch.DefaultBatchSize
+		if end > len(entries) {
+			end = len(entries)
+		}
+		if err := sw.writeBatch(gatherEntriesBatch(schema, batches, entries[pos:end])); err != nil {
+			sw.close()
+			return "", err
+		}
+		pos = end
+	}
+	return sw.close()
+}
+
+// sortBatchesToRun sorts the active rows of batches by keys and writes them
+// as one sorted run file. limit > 0 truncates the run to its top limit rows.
+func sortBatchesToRun(dir string, schema []parquet.Column, batches []*batch.RecordBatch, totalRows int, keys []SortKey, limit int) (string, error) {
+	entries := buildSortEntries(batches, totalRows)
+	resolved := resolveSortKeysForBatches(keys, batches)
+	entries = selectSortedEntries(entries, sortEntriesLessFunc(resolved, batches), limit)
+	return writeSortedRun(dir, schema, batches, entries)
+}
+
+// ---- Run cursors ----
+
+// runCursor walks one sorted run — either a spill file (streamed one batch at
+// a time) or the operator's in-memory remainder (sorted entries gathered
+// lazily in DefaultBatchSize chunks). cur==nil means exhausted.
+type runCursor struct {
+	// file-backed run
+	reader *spillBatchReader
+	path   string
+
+	// in-memory run
+	memSchema  []parquet.Column
+	memBatches []*batch.RecordBatch
+	memEntries []sortEntry
+	memPos     int
+
+	cur *batch.RecordBatch
+	row int
+	ord int // arrival order of the run; merge tie-break for determinism
+}
+
+func newFileRunCursor(path string) (*runCursor, error) {
+	r, err := openSpillBatchReader(path)
+	if err != nil {
+		return nil, err
+	}
+	c := &runCursor{reader: r, path: path}
+	if err := c.loadNext(); err != nil {
+		c.close()
+		return nil, err
+	}
+	return c, nil
+}
+
+func newMemRunCursor(schema []parquet.Column, batches []*batch.RecordBatch, entries []sortEntry) (*runCursor, error) {
+	c := &runCursor{memSchema: schema, memBatches: batches, memEntries: entries}
+	if err := c.loadNext(); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func (c *runCursor) loadNext() error {
+	c.row = 0
+	if c.reader != nil {
+		b, err := c.reader.Next()
+		if err != nil {
+			return err
+		}
+		c.cur = b
+		return nil
+	}
+	if c.memPos >= len(c.memEntries) {
+		c.cur = nil
+		return nil
+	}
+	end := c.memPos + batch.DefaultBatchSize
+	if end > len(c.memEntries) {
+		end = len(c.memEntries)
+	}
+	c.cur = gatherEntriesBatch(c.memSchema, c.memBatches, c.memEntries[c.memPos:end])
+	c.memPos = end
+	return nil
+}
+
+// advance moves to the next row, loading the next batch at a batch boundary.
+func (c *runCursor) advance() error {
+	c.row++
+	if c.cur != nil && c.row < c.cur.Len {
+		return nil
+	}
+	return c.loadNext()
+}
+
+func (c *runCursor) close() {
+	if c.reader != nil {
+		c.reader.Close()
+		c.reader = nil
+	}
+	c.memBatches = nil
+	c.memEntries = nil
+	c.cur = nil
+}
+
+// ---- K-way merge ----
+
+// mergeHeap orders cursors by their current row using the resolved keys;
+// ties break on run arrival order so equal keys keep input order (matching
+// the stable in-memory sort).
+type mergeHeap struct {
+	cursors  []*runCursor
+	resolved []resolvedSortKey
+}
+
+func (h *mergeHeap) Len() int { return len(h.cursors) }
+
+func (h *mergeHeap) Less(i, j int) bool {
+	a, b := h.cursors[i], h.cursors[j]
+	for _, key := range h.resolved {
+		if key.colIdx < 0 || key.colIdx >= len(a.cur.Columns) || key.colIdx >= len(b.cur.Columns) {
+			continue
+		}
+		cmp := key.compare(a.cur.Columns[key.colIdx], a.row, b.cur.Columns[key.colIdx], b.row)
+		if cmp == 0 {
+			continue
+		}
+		if key.order == Descending {
+			return cmp > 0
+		}
+		return cmp < 0
+	}
+	return a.ord < b.ord
+}
+
+func (h *mergeHeap) Swap(i, j int) { h.cursors[i], h.cursors[j] = h.cursors[j], h.cursors[i] }
+func (h *mergeHeap) Push(x any)    { h.cursors = append(h.cursors, x.(*runCursor)) }
+func (h *mergeHeap) Pop() any {
+	old := h.cursors
+	n := len(old)
+	x := old[n-1]
+	h.cursors = old[:n-1]
+	return x
+}
+
+// runMerger streams a k-way merge over sorted runs, one output batch at a
+// time. Memory held: one buffered batch per live cursor.
+type runMerger struct {
+	h      *mergeHeap
+	schema []parquet.Column
+}
+
+// newRunMerger builds a merger over the cursors. Comparison kernels are
+// resolved from the first live cursor's batch (all runs share the schema);
+// always null-aware because per-run null-freedom isn't tracked across files.
+func newRunMerger(schema []parquet.Column, keys []SortKey, cursors []*runCursor) *runMerger {
+	live := make([]*runCursor, 0, len(cursors))
+	for _, c := range cursors {
+		if c.cur != nil {
+			live = append(live, c)
+		} else {
+			c.close()
+		}
+	}
+	resolved := make([]resolvedSortKey, len(keys))
+	for i, key := range keys {
+		resolved[i] = resolvedSortKey{colIdx: -1, order: key.Order}
+		if len(live) == 0 {
+			continue
+		}
+		first := live[0].cur
+		idx := first.ColumnIndex(key.Column)
+		if idx >= len(first.Columns) {
+			continue
+		}
+		var cmp kernel.SortCompareKernel
+		if key.NullsLast {
+			cmp = kernel.ResolveSortCompareNullsLast(first.Columns[idx].Type)
+		} else {
+			cmp = kernel.ResolveSortCompare(first.Columns[idx].Type)
+		}
+		resolved[i] = resolvedSortKey{colIdx: idx, order: key.Order, compare: cmp}
+	}
+	h := &mergeHeap{cursors: live, resolved: resolved}
+	heap.Init(h)
+	return &runMerger{h: h, schema: schema}
+}
+
+// mergeRef pins one merged output row: the source batch stays alive until the
+// rows referencing it are materialized.
+type mergeRef struct {
+	b   *batch.RecordBatch
+	row int
+}
+
+// Next returns the next merged batch (up to DefaultBatchSize rows), or
+// (nil, nil) when all runs are exhausted.
+func (m *runMerger) Next() (*batch.RecordBatch, error) {
+	if m.h.Len() == 0 {
+		return nil, nil
+	}
+	refs := make([]mergeRef, 0, batch.DefaultBatchSize)
+	for len(refs) < batch.DefaultBatchSize && m.h.Len() > 0 {
+		c := m.h.cursors[0]
+		refs = append(refs, mergeRef{b: c.cur, row: c.row})
+		if err := c.advance(); err != nil {
+			return nil, err
+		}
+		if c.cur == nil {
+			c.close()
+			heap.Pop(m.h)
+		} else {
+			heap.Fix(m.h, 0)
+		}
+	}
+	out := batch.NewRecordBatch(m.schema, len(refs))
+	for j := range m.schema {
+		dst := out.Columns[j]
+		for di, r := range refs {
+			if j >= len(r.b.Columns) {
+				continue
+			}
+			copyVectorValue(dst, di, r.b.Columns[j], r.row)
+		}
+	}
+	return out, nil
+}
+
+func (m *runMerger) close() {
+	for _, c := range m.h.cursors {
+		c.close()
+	}
+	m.h.cursors = nil
+}
+
+// preMergeRuns reduces the run count to at most maxRuns by merging groups of
+// maxMergeFanIn runs into longer runs (multi-level external merge). Consumed
+// run files are deleted. limit > 0 truncates intermediate runs (sorted, so
+// rows past limit cannot reach the global top-K).
+func preMergeRuns(dir string, schema []parquet.Column, keys []SortKey, runs []string, maxRuns, limit int) ([]string, error) {
+	for len(runs) > maxRuns {
+		next := make([]string, 0, (len(runs)+maxMergeFanIn-1)/maxMergeFanIn)
+		for i := 0; i < len(runs); i += maxMergeFanIn {
+			end := i + maxMergeFanIn
+			if end > len(runs) {
+				end = len(runs)
+			}
+			group := runs[i:end]
+			if len(group) == 1 {
+				next = append(next, group[0])
+				continue
+			}
+			path, err := mergeRunsToFile(dir, schema, keys, group, limit)
+			if err != nil {
+				return nil, err
+			}
+			for _, p := range group {
+				os.Remove(p)
+			}
+			if path != "" {
+				next = append(next, path)
+			}
+		}
+		runs = next
+	}
+	return runs, nil
+}
+
+// mergeRunsToFile merges the given runs into one new run file.
+func mergeRunsToFile(dir string, schema []parquet.Column, keys []SortKey, runs []string, limit int) (string, error) {
+	cursors := make([]*runCursor, 0, len(runs))
+	closeAll := func() {
+		for _, c := range cursors {
+			c.close()
+		}
+	}
+	for ord, p := range runs {
+		c, err := newFileRunCursor(p)
+		if err != nil {
+			closeAll()
+			return "", err
+		}
+		c.ord = ord
+		cursors = append(cursors, c)
+	}
+	m := newRunMerger(schema, keys, cursors)
+	defer m.close()
+
+	sw, err := newSpillBatchWriter(dir, "sort-merge")
+	if err != nil {
+		return "", err
+	}
+	written := 0
+	for {
+		b, err := m.Next()
+		if err != nil {
+			sw.close()
+			return "", err
+		}
+		if b == nil {
+			break
+		}
+		if limit > 0 && written+b.Len > limit {
+			b.Len = limit - written // safe: columnar format writes b.Len rows
+		}
+		if err := sw.writeBatch(b); err != nil {
+			sw.close()
+			return "", err
+		}
+		written += b.Len
+		if limit > 0 && written >= limit {
+			break
+		}
+	}
+	return sw.close()
+}
+
+// removeRunFiles best-effort deletes run files (spill scratch).
+func removeRunFiles(paths []string) {
+	for _, p := range paths {
+		os.Remove(p)
+	}
+}

--- a/internal/engine/exec/sort_external_test.go
+++ b/internal/engine/exec/sort_external_test.go
@@ -1,0 +1,422 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"sort"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/engine/memory"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// forceTinyRuns lowers the sorted-run floor so unit-scale budgets exercise
+// the external-merge path; restores on cleanup.
+func forceTinyRuns(tb testing.TB) {
+	tb.Helper()
+	oldRun := minSortRunBytes
+	minSortRunBytes = 1
+	tb.Cleanup(func() { minSortRunBytes = oldRun })
+}
+
+// newSortSpillHarness builds a Sort with a tracker budget small enough that
+// SpillCheap pressure fires after a few batches.
+func newSortSpillHarness(tb testing.TB, keys []SortKey, budget int64) *Sort {
+	tb.Helper()
+	tracker := memory.NewTracker("sort-ext-test", budget)
+	sm, err := memory.NewSpillManager(tb.TempDir(), tracker)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	s := NewSort(keys)
+	s.Spill = sm
+	if err := s.Init(context.Background()); err != nil {
+		tb.Fatal(err)
+	}
+	return s
+}
+
+func drainSortRows(tb testing.TB, s *Sort) []map[string]any {
+	tb.Helper()
+	var rows []map[string]any
+	for {
+		b, err := s.Next(context.Background())
+		if err != nil {
+			tb.Fatalf("Next: %v", err)
+		}
+		if b == nil {
+			return rows
+		}
+		rows = append(rows, b.ToRows()...)
+	}
+}
+
+// TestSortExternalMerge_StringsNullsDesc pushes string-keyed rows with nulls
+// through the run-spill path and verifies the merged stream matches an
+// in-memory reference sort: DESC with NULLS LAST plus an int tiebreaker.
+func TestSortExternalMerge_StringsNullsDesc(t *testing.T) {
+	forceTinyRuns(t)
+	schema := []parquet.Column{
+		{Name: "name", Type: parquet.TypeString, Nullable: true},
+		{Name: "id", Type: parquet.TypeInt64},
+	}
+	keys := []SortKey{
+		{Column: "name", Order: Descending, NullsLast: true},
+		{Column: "id", Order: Ascending},
+	}
+
+	rng := rand.New(rand.NewSource(42))
+	var allRows []map[string]any
+	const numBatches, rowsPerBatch = 12, 16
+	for i := 0; i < numBatches*rowsPerBatch; i++ {
+		var name any
+		if rng.Intn(8) == 0 {
+			name = nil
+		} else {
+			name = fmt.Sprintf("name-%02d", rng.Intn(20))
+		}
+		allRows = append(allRows, map[string]any{"name": name, "id": int64(i)})
+	}
+
+	// Reference: in-memory Sort (no Spill) over the same data.
+	ref := NewSort(keys)
+	if err := ref.Init(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	// Spilling Sort with a budget tiny enough that every batch crosses
+	// SpillCheap (40% of 512B).
+	s := newSortSpillHarness(t, keys, 512)
+
+	ctx := context.Background()
+	for i := 0; i < numBatches; i++ {
+		rows := allRows[i*rowsPerBatch : (i+1)*rowsPerBatch]
+		if err := ref.Consume(ctx, batch.FromRows(schema, rows)); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Consume(ctx, batch.FromRows(schema, rows)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(s.runFiles) == 0 {
+		t.Fatal("run-spill path was never exercised; budget/floor setup is wrong")
+	}
+	runPaths := append([]string(nil), s.runFiles...)
+
+	if err := ref.Finalize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Finalize(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	want := drainSortRows(t, ref)
+	got := drainSortRows(t, s)
+	if len(got) != len(want) {
+		t.Fatalf("row count: got %d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if fmt.Sprint(got[i]["name"]) != fmt.Sprint(want[i]["name"]) || got[i]["id"] != want[i]["id"] {
+			t.Fatalf("row %d: got %v want %v", i, got[i], want[i])
+		}
+	}
+
+	// Run scratch must be deleted once the merge drains.
+	for _, p := range runPaths {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("run file %s not cleaned up after drain", p)
+		}
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestSortExternalMerge_TopK verifies Limit enforcement across spilled runs:
+// each run is truncated to Limit at write time and the merged stream stops at
+// exactly Limit rows.
+func TestSortExternalMerge_TopK(t *testing.T) {
+	forceTinyRuns(t)
+	schema := []parquet.Column{{Name: "val", Type: parquet.TypeInt64}}
+	keys := []SortKey{{Column: "val", Order: Ascending}}
+
+	s := newSortSpillHarness(t, keys, 512)
+	s.Limit = 7
+
+	ctx := context.Background()
+	const total = 200
+	perm := rand.New(rand.NewSource(7)).Perm(total)
+	for i := 0; i < total; i += 10 {
+		rows := make([]map[string]any, 0, 10)
+		for j := i; j < i+10; j++ {
+			rows = append(rows, map[string]any{"val": int64(perm[j])})
+		}
+		if err := s.Consume(ctx, batch.FromRows(schema, rows)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(s.runFiles) == 0 {
+		t.Fatal("run-spill path was never exercised")
+	}
+	if err := s.Finalize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	got := drainSortRows(t, s)
+	if len(got) != 7 {
+		t.Fatalf("Top-K: got %d rows, want 7", len(got))
+	}
+	for i, r := range got {
+		if r["val"] != int64(i) {
+			t.Fatalf("Top-K row %d: got %v want %d", i, r["val"], i)
+		}
+	}
+}
+
+// TestSortExternalMerge_MultiLevel forces the multi-level pre-merge by
+// capping fan-in at 2 with many runs, verifying correctness end-to-end.
+func TestSortExternalMerge_MultiLevel(t *testing.T) {
+	forceTinyRuns(t)
+	oldFan := maxMergeFanIn
+	maxMergeFanIn = 2
+	t.Cleanup(func() { maxMergeFanIn = oldFan })
+
+	schema := []parquet.Column{{Name: "val", Type: parquet.TypeInt64}}
+	s := newSortSpillHarness(t, []SortKey{{Column: "val", Order: Ascending}}, 256)
+
+	ctx := context.Background()
+	const total = 300
+	perm := rand.New(rand.NewSource(11)).Perm(total)
+	for i := 0; i < total; i += 5 {
+		rows := make([]map[string]any, 0, 5)
+		for j := i; j < i+5; j++ {
+			rows = append(rows, map[string]any{"val": int64(perm[j])})
+		}
+		if err := s.Consume(ctx, batch.FromRows(schema, rows)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(s.runFiles) < 3 {
+		t.Fatalf("need ≥3 runs to exercise multi-level merge, got %d", len(s.runFiles))
+	}
+	if err := s.Finalize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	got := drainSortRows(t, s)
+	if len(got) != total {
+		t.Fatalf("row count: got %d want %d", len(got), total)
+	}
+	for i, r := range got {
+		if r["val"] != int64(i) {
+			t.Fatalf("row %d: got %v want %d", i, r["val"], i)
+		}
+	}
+}
+
+// TestSortTruncate_ExternalMergePath covers the fragment-executor contract:
+// Sort built WITHOUT Limit, spills, Finalize, then Truncate(n) runs once
+// before the first Next — the merged stream must stop at n rows.
+func TestSortTruncate_ExternalMergePath(t *testing.T) {
+	forceTinyRuns(t)
+	schema := []parquet.Column{{Name: "val", Type: parquet.TypeInt64}}
+	s := newSortSpillHarness(t, []SortKey{{Column: "val", Order: Ascending}}, 512)
+
+	ctx := context.Background()
+	const total = 100
+	perm := rand.New(rand.NewSource(3)).Perm(total)
+	for i := 0; i < total; i += 10 {
+		rows := make([]map[string]any, 0, 10)
+		for j := i; j < i+10; j++ {
+			rows = append(rows, map[string]any{"val": int64(perm[j])})
+		}
+		if err := s.Consume(ctx, batch.FromRows(schema, rows)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(s.runFiles) == 0 {
+		t.Fatal("run-spill path was never exercised")
+	}
+	if err := s.Finalize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	s.Truncate(5)
+	got := drainSortRows(t, s)
+	if len(got) != 5 {
+		t.Fatalf("Truncate(5) on merge path: got %d rows", len(got))
+	}
+	for i, r := range got {
+		if r["val"] != int64(i) {
+			t.Fatalf("row %d: got %v want %d", i, r["val"], i)
+		}
+	}
+}
+
+// TestSortSpillSome_ReliefContract verifies the AccountedOperator contract on
+// the run path: EstimateRelief's claim is delivered by SpillSome, and the
+// sort still produces correct output afterward.
+func TestSortSpillSome_ReliefContract(t *testing.T) {
+	forceTinyRuns(t)
+	schema := []parquet.Column{{Name: "val", Type: parquet.TypeInt64}}
+	// Large budget: no self-spill; SpillSome is the only spill trigger.
+	s := newSortSpillHarness(t, []SortKey{{Column: "val", Order: Ascending}}, 1<<30)
+
+	ctx := context.Background()
+	for i := 0; i < 10; i++ {
+		rows := make([]map[string]any, 0, 10)
+		for j := 0; j < 10; j++ {
+			rows = append(rows, map[string]any{"val": int64(100 - (i*10 + j))})
+		}
+		if err := s.Consume(ctx, batch.FromRows(schema, rows)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	claimed := s.EstimateRelief(1 << 20)
+	if claimed == 0 {
+		t.Fatal("EstimateRelief claimed 0 with buffered batches")
+	}
+	freed, err := s.SpillSome(1 << 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if freed != claimed {
+		t.Fatalf("SpillSome freed %d, EstimateRelief claimed %d", freed, claimed)
+	}
+	if len(s.runFiles) == 0 {
+		t.Fatal("SpillSome did not produce a run file")
+	}
+	if err := s.Finalize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	got := drainSortRows(t, s)
+	if len(got) != 100 {
+		t.Fatalf("row count: got %d want 100", len(got))
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i]["val"].(int64) < got[i-1]["val"].(int64) {
+			t.Fatalf("not sorted at %d", i)
+		}
+	}
+}
+
+// TestColumnarSpillVectorRoundTrip locks the new TypeVector encoding in the
+// columnar spill format: dim + values + nulls must round-trip exactly.
+func TestColumnarSpillVectorRoundTrip(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "emb", Type: parquet.TypeVector, Nullable: true, Dimension: 3},
+	}
+	const n = 5
+	b := batch.NewRecordBatch(schema, n)
+	for i := 0; i < n; i++ {
+		b.Columns[0].Int64Data[i] = int64(i)
+		for d := 0; d < 3; d++ {
+			b.Columns[1].Float32Data[i*3+d] = float32(i*10 + d)
+		}
+	}
+	b.Columns[1].Nulls.SetNull(2)
+
+	path, err := writeSpillBatches(t.TempDir(), []*batch.RecordBatch{b})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(path)
+	got, err := readSpillBatches(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Len != n {
+		t.Fatalf("read back %d batches, first len %d", len(got), got[0].Len)
+	}
+	v := got[0].Columns[1]
+	if v.VectorDim != 3 {
+		t.Fatalf("VectorDim: got %d want 3", v.VectorDim)
+	}
+	for i := 0; i < n; i++ {
+		if i == 2 {
+			if !v.Nulls.IsNull(i) {
+				t.Fatalf("row 2 should be null")
+			}
+			continue
+		}
+		for d := 0; d < 3; d++ {
+			if v.Float32Data[i*3+d] != float32(i*10+d) {
+				t.Fatalf("row %d dim %d: got %v want %v", i, d, v.Float32Data[i*3+d], float32(i*10+d))
+			}
+		}
+	}
+}
+
+// TestColumnarSpillNestedTypeError locks the fail-loudly contract: nested
+// types have no columnar encoding and must error instead of silently
+// corrupting (the pre-change behavior wrote nothing and read garbage).
+func TestColumnarSpillNestedTypeError(t *testing.T) {
+	schema := []parquet.Column{{Name: "arr", Type: parquet.TypeArray}}
+	b := batch.NewRecordBatch(schema, 1)
+	if _, err := writeSpillBatches(t.TempDir(), []*batch.RecordBatch{b}); err == nil {
+		t.Fatal("writeSpillBatches on Array column should error, got nil")
+	}
+}
+
+// TestSortExternalFallback_NestedSchema verifies nested-type schemas route to
+// the legacy row spill (correct, if memory-hungry) instead of columnar runs.
+func TestSortExternalFallback_NestedSchema(t *testing.T) {
+	if columnarSpillableSchema([]parquet.Column{{Name: "a", Type: parquet.TypeArray}}) {
+		t.Fatal("Array schema must not be columnar-spillable")
+	}
+	if columnarSpillableSchema([]parquet.Column{{Name: "m", Type: parquet.TypeMap}}) {
+		t.Fatal("Map schema must not be columnar-spillable")
+	}
+	if columnarSpillableSchema([]parquet.Column{{Name: "r", Type: parquet.TypeRow}}) {
+		t.Fatal("Row schema must not be columnar-spillable")
+	}
+	if !columnarSpillableSchema([]parquet.Column{
+		{Name: "v", Type: parquet.TypeVector, Dimension: 4},
+		{Name: "s", Type: parquet.TypeString},
+	}) {
+		t.Fatal("Vector+String schema should be columnar-spillable")
+	}
+}
+
+// TestSortExternalMerge_Determinism: two identical spilling sorts must emit
+// byte-identical row order (run-ordinal tie-break), the property distributed
+// re-runs rely on.
+func TestSortExternalMerge_Determinism(t *testing.T) {
+	forceTinyRuns(t)
+	schema := []parquet.Column{
+		{Name: "k", Type: parquet.TypeInt64},
+		{Name: "tag", Type: parquet.TypeString},
+	}
+	keys := []SortKey{{Column: "k", Order: Ascending}}
+	run := func() []map[string]any {
+		s := newSortSpillHarness(t, keys, 512)
+		ctx := context.Background()
+		// Many duplicate keys so the tie-break actually decides ordering.
+		for i := 0; i < 10; i++ {
+			rows := make([]map[string]any, 0, 10)
+			for j := 0; j < 10; j++ {
+				rows = append(rows, map[string]any{"k": int64(j % 3), "tag": fmt.Sprintf("b%02d-r%02d", i, j)})
+			}
+			if err := s.Consume(ctx, batch.FromRows(schema, rows)); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := s.Finalize(ctx); err != nil {
+			t.Fatal(err)
+		}
+		return drainSortRows(t, s)
+	}
+	a, b := run(), run()
+	if len(a) != len(b) {
+		t.Fatalf("row counts differ: %d vs %d", len(a), len(b))
+	}
+	for i := range a {
+		if a[i]["k"] != b[i]["k"] || a[i]["tag"] != b[i]["tag"] {
+			t.Fatalf("row %d differs between identical runs: %v vs %v", i, a[i], b[i])
+		}
+	}
+	// Keys must still be sorted.
+	if !sort.SliceIsSorted(a, func(i, j int) bool { return a[i]["k"].(int64) < a[j]["k"].(int64) }) {
+		t.Fatal("output not sorted by key")
+	}
+}

--- a/internal/engine/exec/sort_spill_test.go
+++ b/internal/engine/exec/sort_spill_test.go
@@ -9,19 +9,19 @@ import (
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
 )
 
-// TestSortSpill_FinalizeMergesSpilledRows exercises the finalizeWithSpill
-// path: low memory budget triggers spill in Consume, then Finalize must read
-// every spilled file back, merge with any in-memory residue, and produce a
-// globally sorted result.
+// TestSortSpill_FinalizeMergesSpilledRows exercises the external-merge spill
+// path: low memory budget triggers sorted-run spill in Consume, then Finalize
+// sets up a streaming k-way merge that Next drains into a globally sorted
+// result.
 //
-// Why this test matters: Sort.spillFiles is populated by Consume when
-// SpillManager.ShouldSpillFor(SpillCheap) trips, but no prior test exercised
-// finalizeWithSpill end-to-end. SF100 sort-heavy workloads (Q21, Q18)
-// hit this path under memory pressure; without coverage it could regress
-// silently. Mirrors HashAggregate's TestHashAggregateSpillBatching
+// Why this test matters: Sort.runFiles is populated by Consume when
+// SpillManager.ShouldSpillFor(SpillCheap) trips. SF100 sort-heavy workloads
+// (Q21, Q18) hit this path under memory pressure; without coverage it could
+// regress silently. Mirrors HashAggregate's TestHashAggregateSpillBatching
 // philosophy — set a tiny budget, push enough rows to force spill, verify
 // the final output is correct.
 func TestSortSpill_FinalizeMergesSpilledRows(t *testing.T) {
+	forceTinyRuns(t)
 	schema := []parquet.Column{
 		{Name: "val", Type: parquet.TypeInt64},
 	}
@@ -62,8 +62,8 @@ func TestSortSpill_FinalizeMergesSpilledRows(t *testing.T) {
 		}
 	}
 
-	// Sanity check: spill path actually fired.
-	if len(s.spillFiles) == 0 {
+	// Sanity check: spill path actually fired (sorted columnar runs).
+	if len(s.runFiles) == 0 {
 		t.Fatal("spill path was never exercised; tracker/budget setup is wrong")
 	}
 
@@ -71,9 +71,10 @@ func TestSortSpill_FinalizeMergesSpilledRows(t *testing.T) {
 		t.Fatalf("Finalize: %v", err)
 	}
 
-	// Spill files cleaned up by finalizeWithSpill.
-	if len(s.spillFiles) != 0 {
-		t.Errorf("Finalize should clear spillFiles, got %d remaining", len(s.spillFiles))
+	// Finalize hands runs to the streaming merger; nothing should remain in
+	// the pre-finalize run list.
+	if len(s.runFiles) != 0 {
+		t.Errorf("Finalize should hand off runFiles to the merger, got %d remaining", len(s.runFiles))
 	}
 
 	// Drain the sorted output and verify ascending order across every row.
@@ -112,6 +113,7 @@ func TestSortSpill_FinalizeMergesSpilledRows(t *testing.T) {
 // after the most recent spill flush — finalizeWithSpill must merge both
 // in-memory and spilled rows.
 func TestSortSpill_MixedInMemoryAndSpilled(t *testing.T) {
+	forceTinyRuns(t)
 	schema := []parquet.Column{
 		{Name: "val", Type: parquet.TypeInt64},
 	}
@@ -151,7 +153,7 @@ func TestSortSpill_MixedInMemoryAndSpilled(t *testing.T) {
 		}
 	}
 
-	if len(s.spillFiles) == 0 {
+	if len(s.runFiles) == 0 {
 		t.Fatal("spill path was never exercised")
 	}
 

--- a/internal/engine/exec/window.go
+++ b/internal/engine/exec/window.go
@@ -76,7 +76,10 @@ type Window struct {
 	totalRows  int
 	trackedMem int64 // memory reserved from shared tracker by this operator
 	schema     []parquet.Column
-	spillFiles []string
+	spillFiles []string // legacy row-oriented spill (schemas the columnar run format can't carry)
+	runFiles   []string // sorted columnar runs (external partition-at-a-time path)
+	groups     []windowSpecGroup
+	ext        *windowExtState // final-pass streaming state, drained by Next
 
 	result  []*batch.RecordBatch
 	pos     int
@@ -104,6 +107,8 @@ func (w *Window) Init(_ context.Context) error {
 	w.pos = 0
 	w.emitted = false
 	w.finalized = false
+	w.groups = groupWindowSpecs(w.Columns)
+	w.ext = nil
 	// Register with the relief registry up front: Window self-spills during
 	// Consume, so it must be visible to RequestRelief before any batch arrives.
 	// A zero footprint at registration is fine (Inspect reports OwnedBytes==0).
@@ -135,23 +140,63 @@ func (w *Window) Consume(_ context.Context, b *batch.RecordBatch) error {
 		}
 	}
 
-	// Spill to disk if memory pressure is high
+	// Spill to disk if memory pressure is high. The columnar run path
+	// accumulates at least minSortRunBytes before flushing (merge-friendly
+	// runs); the legacy row path keeps the old flush-on-pressure behavior.
+	// Peer relief (SpillSome) bypasses the floor.
 	if w.Spill != nil && w.Spill.ShouldSpillFor(memory.SpillCheap) && len(w.batches) > 0 {
+		if !w.useColumnarRuns() || w.trackedMem >= minSortRunBytes {
+			if _, err := w.flushSpillLocked(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// useColumnarRuns reports whether spill goes through the external
+// partition-at-a-time path: every column type must round-trip the columnar
+// run format and there must be a window spec to sort runs by.
+func (w *Window) useColumnarRuns() bool {
+	return len(w.groups) > 0 && columnarSpillableSchema(w.schema)
+}
+
+// flushSpillLocked drains all buffered batches to disk and releases their
+// tracking, returning the bytes freed. The external path writes a run sorted
+// by the first spec group's (PARTITION BY, ORDER BY); the fallback writes the
+// legacy row-oriented file. Caller holds w.mu.
+func (w *Window) flushSpillLocked() (int64, error) {
+	if len(w.batches) == 0 || w.trackedMem == 0 {
+		return 0, nil
+	}
+	if w.useColumnarRuns() {
+		path, err := sortBatchesToRun(w.Spill.SpillDir(), w.schema, w.batches, w.totalRows, w.groups[0].sortKeys, 0)
+		if err != nil {
+			return 0, err
+		}
+		if path != "" {
+			w.runFiles = append(w.runFiles, path)
+		}
+	} else {
 		var rows []map[string]any
 		for _, sb := range w.batches {
 			rows = append(rows, sb.ToRows()...)
 		}
 		path, err := w.Spill.SpillRows(rows)
 		if err != nil {
-			return err
+			return 0, err
 		}
 		w.spillFiles = append(w.spillFiles, path)
-		w.batches = w.batches[:0]
-		w.totalRows = 0
-		w.Spill.ReleaseTracking(w.trackedMem)
-		w.trackedMem = 0
 	}
-	return nil
+	w.batches = w.batches[:0]
+	w.totalRows = 0
+	freed := w.trackedMem
+	w.Spill.ReleaseTracking(freed)
+	w.trackedMem = 0
+	if w.accInstanceID != 0 {
+		w.Spill.Tracker().PublishOwned(w.accInstanceID, 0)
+	}
+	return freed, nil
 }
 
 func (w *Window) Finalize(_ context.Context) error {
@@ -166,7 +211,77 @@ func (w *Window) Finalize(_ context.Context) error {
 	if len(w.spillFiles) > 0 {
 		return w.finalizeWithSpill()
 	}
+	if len(w.runFiles) > 0 {
+		return w.finalizeExternal()
+	}
 	return w.finalizeColumnar()
+}
+
+// finalizeExternal prepares the partition-at-a-time stream over sorted runs.
+// Non-final spec groups run disk-to-disk passes here (each bounded by the
+// largest partition plus the merge fan-in); the final group streams through
+// Next(), so finalize never materializes the dataset.
+func (w *Window) finalizeExternal() error {
+	// The in-memory remainder joins the runs as one more sorted run; the
+	// multi-pass flow then has a single uniform input.
+	w.mu.Lock()
+	_, ferr := w.flushSpillLocked()
+	runs := w.runFiles
+	w.runFiles = nil
+	w.mu.Unlock()
+	if ferr != nil {
+		return ferr
+	}
+	dir := w.Spill.SpillDir()
+	passSchema := w.schema
+
+	// charge surfaces per-partition accumulation to the tracker so a
+	// pathologically large partition is visible to the pressure breaker.
+	charge := func(delta int64) {
+		if delta >= 0 {
+			w.Spill.TrackBatch(delta)
+		} else {
+			w.Spill.ReleaseTracking(-delta)
+		}
+	}
+
+	var err error
+	for gi := 0; gi < len(w.groups)-1; gi++ {
+		if gi > 0 {
+			runs, err = resortRunsByKeys(dir, passSchema, runs, w.groups[gi].sortKeys)
+			if err != nil {
+				return err
+			}
+		}
+		runs, passSchema, err = windowDiskPass(dir, passSchema, runs, w.groups[gi], charge)
+		if err != nil {
+			removeRunFiles(runs)
+			return err
+		}
+	}
+
+	last := w.groups[len(w.groups)-1]
+	if len(w.groups) > 1 {
+		runs, err = resortRunsByKeys(dir, passSchema, runs, last.sortKeys)
+		if err != nil {
+			return err
+		}
+	}
+	merger, runs, err := openRunMerger(dir, passSchema, last.sortKeys, runs)
+	if err != nil {
+		removeRunFiles(runs)
+		return err
+	}
+	w.ext = &windowExtState{
+		walker:    newPartitionWalker(merger, last.partitionBy, charge),
+		merger:    merger,
+		schema:    passSchema,
+		group:     last,
+		reorder:   buildWindowReorder(len(w.schema), w.groups, len(w.Columns)),
+		outSchema: w.buildOutputSchema(),
+		runs:      runs,
+	}
+	return nil
 }
 
 // Inspect implements memory.AccountedOperator.
@@ -208,33 +323,17 @@ func (w *Window) EstimateRelief(target int64) int64 {
 }
 
 // SpillSome implements memory.AccountedOperator: drains all buffered input
-// batches to a raw-row spill file and releases the freed bytes.
+// batches to disk and releases the freed bytes — a sorted columnar run on
+// the external path, a raw-row file on the nested-type fallback.
 func (w *Window) SpillSome(_ int64) (int64, error) {
 	w.accState.Store(int32(memory.OpSpilling))
 	defer w.accState.CompareAndSwap(int32(memory.OpSpilling), int32(memory.OpActive))
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	if w.Spill == nil || w.trackedMem == 0 || len(w.batches) == 0 {
+	if w.Spill == nil || w.finalized {
 		return 0, nil
 	}
-	var rows []map[string]any
-	for _, sb := range w.batches {
-		rows = append(rows, sb.ToRows()...)
-	}
-	path, err := w.Spill.SpillRows(rows)
-	if err != nil {
-		return 0, err
-	}
-	w.spillFiles = append(w.spillFiles, path)
-	w.batches = w.batches[:0]
-	w.totalRows = 0
-	freed := w.trackedMem
-	w.Spill.ReleaseTracking(freed)
-	w.trackedMem = 0
-	if w.accInstanceID != 0 {
-		w.Spill.Tracker().PublishOwned(w.accInstanceID, 0)
-	}
-	return freed, nil
+	return w.flushSpillLocked()
 }
 
 // finalizeColumnar is the fast path when no spill occurred — operates entirely
@@ -351,6 +450,13 @@ func (w *Window) buildOutputSchema() []parquet.Column {
 // not reached (early cancel).
 func (w *Window) Close() error {
 	w.mu.Lock()
+	if w.ext != nil {
+		// Early cancel mid-stream: close cursors and delete run scratch.
+		w.ext.cleanup()
+		w.ext = nil
+	}
+	removeRunFiles(w.runFiles)
+	w.runFiles = nil
 	if w.Spill != nil && w.trackedMem > 0 {
 		w.Spill.ReleaseTracking(w.trackedMem)
 		w.trackedMem = 0
@@ -364,14 +470,50 @@ func (w *Window) Close() error {
 	return nil
 }
 
-// Next returns windowed results in batches.
+// Next returns windowed results in batches. On the external path it streams
+// one partition at a time from the final pass's merge.
 func (w *Window) Next(_ context.Context) (*batch.RecordBatch, error) {
+	if w.ext != nil {
+		return w.nextExternal()
+	}
 	if w.pos >= len(w.result) {
 		return nil, nil
 	}
 	b := w.result[w.pos]
 	w.pos++
 	return b, nil
+}
+
+// nextExternal drains the chunk queue, refilling it one computed partition at
+// a time; at stream EOF it tears down cursors and deletes run scratch.
+func (w *Window) nextExternal() (*batch.RecordBatch, error) {
+	e := w.ext
+	for {
+		if e.qpos < len(e.queue) {
+			b := e.queue[e.qpos]
+			e.qpos++
+			return b, nil
+		}
+		if e.done {
+			return nil, nil
+		}
+		parts, bytes, err := e.walker.nextPartition()
+		if err != nil {
+			return nil, err
+		}
+		if parts == nil {
+			e.cleanup()
+			return nil, nil
+		}
+		combined := computeWindowPartition(parts, e.schema, e.group)
+		e.walker.releasePartition(bytes)
+		if combined == nil {
+			continue
+		}
+		out := reorderBatchColumns(combined, e.reorder, e.outSchema)
+		e.queue = chunkBatch(out, batch.DefaultBatchSize)
+		e.qpos = 0
+	}
 }
 
 // --- Columnar helpers ---
@@ -424,7 +566,12 @@ func windowCopyVectorRange(dst, src *batch.Vector, dstOff, srcOff, count int) {
 			dst.BytesData.BulkCopy(dstOff, &src.BytesData, srcOff, count)
 		} else {
 			for i := 0; i < count; i++ {
-				if !src.Nulls.IsNullFast(srcOff + i) {
+				if src.Nulls.IsNullFast(srcOff + i) {
+					// BytesColumn writes must be sequential: a null row still
+					// needs its offset slot advanced or every later row in
+					// this column reads back as concatenated garbage.
+					dst.BytesData.Set(dstOff+i, nil)
+				} else {
 					dst.BytesData.SetFrom(dstOff+i, &src.BytesData, srcOff+i)
 				}
 			}

--- a/internal/engine/exec/window_external.go
+++ b/internal/engine/exec/window_external.go
@@ -1,0 +1,514 @@
+package exec
+
+import (
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/engine/exec/kernel"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// ---- External window: partition-at-a-time over externally sorted runs ----
+//
+// The legacy spill path read every spilled row back into []map[string]any and
+// computed row-oriented — peak finalize memory was the whole input, boxed.
+// The external path sorts spilled runs by (PARTITION BY, ORDER BY), streams a
+// k-way merge, and materializes ONE partition at a time: peak memory is the
+// largest partition plus one buffered batch per run. Window columns with an
+// empty PARTITION BY form a single partition spanning the input — that case
+// (like DuckDB's holistic aggregates) still materializes fully; partitioned
+// windows degrade gracefully.
+//
+// Window columns are grouped by identical (PartitionBy, OrderBy). Each group
+// is one pass: re-sort runs by the group's keys (skipped for the first group,
+// whose runs were written pre-sorted at spill time), merge, walk partitions,
+// compute the group's columns, and either write augmented runs for the next
+// pass or stream final batches out of Next().
+
+// windowSpecGroup is a set of window columns sharing one sort order.
+type windowSpecGroup struct {
+	partitionBy []string
+	orderBy     []SortKey
+	sortKeys    []SortKey // partitionBy (ascending) then orderBy — the pass's sort order
+	cols        []WindowColumn
+	origIdx     []int // positions in Window.Columns, for output-schema ordering
+}
+
+func sameSortKeys(a, b []SortKey) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func sameStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// groupWindowSpecs buckets window columns by identical (PartitionBy, OrderBy),
+// preserving first-occurrence order.
+func groupWindowSpecs(cols []WindowColumn) []windowSpecGroup {
+	var groups []windowSpecGroup
+	for k, wc := range cols {
+		found := -1
+		for gi := range groups {
+			if sameStrings(groups[gi].partitionBy, wc.PartitionBy) && sameSortKeys(groups[gi].orderBy, wc.OrderBy) {
+				found = gi
+				break
+			}
+		}
+		if found < 0 {
+			sk := make([]SortKey, 0, len(wc.PartitionBy)+len(wc.OrderBy))
+			for _, pc := range wc.PartitionBy {
+				sk = append(sk, SortKey{Column: pc, Order: Ascending})
+			}
+			sk = append(sk, wc.OrderBy...)
+			groups = append(groups, windowSpecGroup{
+				partitionBy: wc.PartitionBy,
+				orderBy:     wc.OrderBy,
+				sortKeys:    sk,
+			})
+			found = len(groups) - 1
+		}
+		groups[found].cols = append(groups[found].cols, wc)
+		groups[found].origIdx = append(groups[found].origIdx, k)
+	}
+	return groups
+}
+
+// ---- Partition walker ----
+
+// partitionWalker segments a sorted merge stream at PARTITION BY boundaries.
+// Each yielded partition is a list of selection-vector views over the
+// merger's output batches. charge, when set, receives byte deltas as
+// partition segments accumulate; the caller releases via releasePartition —
+// this makes a pathologically large partition visible to the memory tracker.
+type partitionWalker struct {
+	m           *runMerger
+	partitionBy []string
+	partIdxs    []int
+	compare     []kernel.SortCompareKernel
+	charge      func(delta int64)
+
+	cur      []*batch.RecordBatch // segments of the partition being accumulated
+	curBytes int64
+	lastB    *batch.RecordBatch // last row of the previous segment (boundary compare)
+	lastRow  int
+
+	pending    *batch.RecordBatch // batch with rows left to scan after a boundary
+	pendingPos int
+	resolved   bool
+	eof        bool
+}
+
+func newPartitionWalker(m *runMerger, partitionBy []string, charge func(delta int64)) *partitionWalker {
+	w := &partitionWalker{m: m, partitionBy: partitionBy, charge: charge}
+	w.partIdxs = make([]int, len(partitionBy))
+	for i := range w.partIdxs {
+		w.partIdxs[i] = -1
+	}
+	w.compare = make([]kernel.SortCompareKernel, len(partitionBy))
+	return w
+}
+
+// resolve binds partition column indices and comparison kernels against the
+// first batch's schema. Null-aware kernels report null==null as 0, so
+// all-null key runs group into one partition (sameColumnar semantics).
+func (w *partitionWalker) resolve(b *batch.RecordBatch) {
+	for i, name := range w.partitionBy {
+		idx := b.ColumnIndex(name)
+		if idx >= len(b.Columns) {
+			continue
+		}
+		w.partIdxs[i] = idx
+		w.compare[i] = kernel.ResolveSortCompare(b.Columns[idx].Type)
+	}
+	w.resolved = true
+}
+
+// sameRow reports whether two rows agree on every partition column.
+func (w *partitionWalker) sameRow(ba *batch.RecordBatch, ra int, bb *batch.RecordBatch, rb int) bool {
+	for i, idx := range w.partIdxs {
+		if idx < 0 || w.compare[i] == nil {
+			continue
+		}
+		if w.compare[i](ba.Columns[idx], ra, bb.Columns[idx], rb) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// appendSegment adds rows [from, to) of b to the current partition as a
+// selection-vector view over b's columns.
+func (w *partitionWalker) appendSegment(b *batch.RecordBatch, from, to int) {
+	if to <= from {
+		return
+	}
+	sel := make([]uint32, to-from)
+	for i := range sel {
+		sel[i] = uint32(from + i)
+	}
+	seg := &batch.RecordBatch{Columns: b.Columns, Schema: b.Schema, Len: b.Len, Sel: sel}
+	w.cur = append(w.cur, seg)
+	w.lastB = b
+	w.lastRow = to - 1
+	if w.charge != nil {
+		// Approximate: charge the backing batch's bytes per segment. Segments
+		// of one batch share backing arrays, but the case needing visibility
+		// — one partition spanning many batches — is charged accurately.
+		cost := b.MemBytes()
+		w.curBytes += cost
+		w.charge(cost)
+	}
+}
+
+func (w *partitionWalker) takeCurrent() ([]*batch.RecordBatch, int64) {
+	parts, bytes := w.cur, w.curBytes
+	w.cur = nil
+	w.curBytes = 0
+	w.lastB = nil
+	return parts, bytes
+}
+
+// releasePartition returns a finished partition's charge to the tracker.
+func (w *partitionWalker) releasePartition(bytes int64) {
+	if w.charge != nil && bytes > 0 {
+		w.charge(-bytes)
+	}
+}
+
+// nextPartition returns the segments of the next complete partition and their
+// charged bytes, or (nil, 0, nil) when the stream is exhausted. With no
+// partition columns the whole input is one partition.
+func (w *partitionWalker) nextPartition() ([]*batch.RecordBatch, int64, error) {
+	for {
+		var b *batch.RecordBatch
+		var start int
+		switch {
+		case w.pending != nil:
+			b, start = w.pending, w.pendingPos
+			w.pending = nil
+		case !w.eof:
+			nb, err := w.m.Next()
+			if err != nil {
+				return nil, 0, err
+			}
+			if nb == nil {
+				w.eof = true
+				continue
+			}
+			if nb.Len == 0 {
+				continue
+			}
+			if !w.resolved {
+				w.resolve(nb)
+			}
+			b, start = nb, 0
+		default:
+			// EOF: flush the final open partition.
+			if len(w.cur) > 0 {
+				parts, bytes := w.takeCurrent()
+				return parts, bytes, nil
+			}
+			return nil, 0, nil
+		}
+
+		// Does this batch continue the open partition?
+		if w.lastB != nil && len(w.partIdxs) > 0 && !w.sameRow(w.lastB, w.lastRow, b, start) {
+			parts, bytes := w.takeCurrent()
+			w.pending, w.pendingPos = b, start
+			return parts, bytes, nil
+		}
+
+		if len(w.partIdxs) == 0 {
+			// No PARTITION BY — single partition, no boundaries to find.
+			w.appendSegment(b, start, b.Len)
+			continue
+		}
+
+		boundary := -1
+		for i := start + 1; i < b.Len; i++ {
+			if !w.sameRow(b, i-1, b, i) {
+				boundary = i
+				break
+			}
+		}
+		if boundary < 0 {
+			w.appendSegment(b, start, b.Len)
+			continue
+		}
+		w.appendSegment(b, start, boundary)
+		parts, bytes := w.takeCurrent()
+		w.pending, w.pendingPos = b, boundary
+		return parts, bytes, nil
+	}
+}
+
+// ---- Window passes over runs ----
+
+// resortRunsByKeys rewrites runs sorted by a new key set: stream every run,
+// buffer batches up to minSortRunBytes, sort each buffer with the typed
+// kernels, and write it as a new run. Consumed runs are deleted. Memory is
+// bounded by one buffer regardless of total spilled bytes.
+func resortRunsByKeys(dir string, schema []parquet.Column, runs []string, keys []SortKey) ([]string, error) {
+	var out []string
+	var buf []*batch.RecordBatch
+	var bufRows int
+	var bufBytes int64
+	flush := func() error {
+		if len(buf) == 0 {
+			return nil
+		}
+		p, err := sortBatchesToRun(dir, schema, buf, bufRows, keys, 0)
+		if err != nil {
+			return err
+		}
+		if p != "" {
+			out = append(out, p)
+		}
+		buf, bufRows, bufBytes = nil, 0, 0
+		return nil
+	}
+	for _, rp := range runs {
+		r, err := openSpillBatchReader(rp)
+		if err != nil {
+			removeRunFiles(out)
+			return nil, err
+		}
+		for {
+			b, err := r.Next()
+			if err != nil {
+				r.Close()
+				removeRunFiles(out)
+				return nil, err
+			}
+			if b == nil {
+				break
+			}
+			buf = append(buf, b)
+			bufRows += b.Len
+			bufBytes += b.MemBytes()
+			if bufBytes >= minSortRunBytes {
+				if err := flush(); err != nil {
+					r.Close()
+					removeRunFiles(out)
+					return nil, err
+				}
+			}
+		}
+		r.Close()
+	}
+	if err := flush(); err != nil {
+		removeRunFiles(out)
+		return nil, err
+	}
+	removeRunFiles(runs)
+	return out, nil
+}
+
+// openRunMerger pre-merges runs down to the fan-in cap and returns a merger
+// over file cursors, plus the (possibly rewritten) run list for cleanup.
+func openRunMerger(dir string, schema []parquet.Column, keys []SortKey, runs []string) (*runMerger, []string, error) {
+	runs, err := preMergeRuns(dir, schema, keys, runs, maxMergeFanIn, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	cursors := make([]*runCursor, 0, len(runs))
+	for ord, p := range runs {
+		c, err := newFileRunCursor(p)
+		if err != nil {
+			for _, prev := range cursors {
+				prev.close()
+			}
+			return nil, nil, err
+		}
+		c.ord = ord
+		cursors = append(cursors, c)
+	}
+	return newRunMerger(schema, keys, cursors), runs, nil
+}
+
+// computeWindowPartition concatenates one partition's segments, appends the
+// group's window output columns, and computes them. The input is already
+// sorted by (partitionBy, orderBy), so no per-column re-sort happens — the
+// stream order IS the window order.
+func computeWindowPartition(parts []*batch.RecordBatch, schema []parquet.Column, g windowSpecGroup) *batch.RecordBatch {
+	combined := windowConcatBatches(parts, schema)
+	if combined == nil || combined.Len == 0 {
+		return nil
+	}
+	n := combined.Len
+	base := len(schema)
+
+	// Copy the schema before appending: combined.Schema aliases the pass
+	// schema slice and appending in place could clobber its backing array.
+	outSchema := make([]parquet.Column, base, base+len(g.cols))
+	copy(outSchema, schema)
+	for _, wc := range g.cols {
+		vec := batch.NewVector(wc.OutputType, n)
+		vec.Nulls = batch.NewBitmapAllNull(n)
+		combined.Columns = append(combined.Columns, vec)
+		outSchema = append(outSchema, parquet.Column{
+			Name:     wc.OutputCol,
+			Type:     wc.OutputType,
+			Nullable: true,
+		})
+	}
+	combined.Schema = outSchema
+
+	for i, wc := range g.cols {
+		inputIdx := -1
+		if wc.InputCol != "" {
+			inputIdx = combined.ColumnIndex(wc.InputCol)
+		}
+		orderIdxs := make([]int, len(wc.OrderBy))
+		for j, key := range wc.OrderBy {
+			orderIdxs[j] = combined.ColumnIndex(key.Column)
+		}
+		computePartitionColumnar(combined, combined.Columns[base+i], 0, n, wc, inputIdx, orderIdxs)
+	}
+	return combined
+}
+
+// chunkBatch splits a batch into DefaultBatchSize pieces so a huge partition
+// doesn't travel the pipeline (or the spill format) as one giant batch.
+func chunkBatch(b *batch.RecordBatch, size int) []*batch.RecordBatch {
+	if b.Len <= size {
+		return []*batch.RecordBatch{b}
+	}
+	out := make([]*batch.RecordBatch, 0, (b.Len+size-1)/size)
+	for pos := 0; pos < b.Len; {
+		end := pos + size
+		if end > b.Len {
+			end = b.Len
+		}
+		n := end - pos
+		chunk := batch.NewRecordBatch(b.Schema, n)
+		for j := range b.Schema {
+			windowCopyVectorRange(chunk.Columns[j], b.Columns[j], 0, pos, n)
+		}
+		out = append(out, chunk)
+		pos = end
+	}
+	return out
+}
+
+// windowDiskPass runs one non-final spec group: merge the (sorted) runs, walk
+// partitions, compute the group's columns, and write the augmented stream as
+// a single new run (the pass preserves the merge's sort order). Consumed runs
+// are deleted. Returns the new run list and the augmented schema.
+func windowDiskPass(dir string, schema []parquet.Column, runs []string, g windowSpecGroup, charge func(int64)) ([]string, []parquet.Column, error) {
+	merger, runs, err := openRunMerger(dir, schema, g.sortKeys, runs)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer merger.close()
+	walker := newPartitionWalker(merger, g.partitionBy, charge)
+
+	outSchema := make([]parquet.Column, len(schema), len(schema)+len(g.cols))
+	copy(outSchema, schema)
+	for _, wc := range g.cols {
+		outSchema = append(outSchema, parquet.Column{Name: wc.OutputCol, Type: wc.OutputType, Nullable: true})
+	}
+
+	sw, err := newSpillBatchWriter(dir, "window-pass")
+	if err != nil {
+		return nil, nil, err
+	}
+	for {
+		parts, bytes, err := walker.nextPartition()
+		if err != nil {
+			sw.close()
+			return nil, nil, err
+		}
+		if parts == nil {
+			break
+		}
+		combined := computeWindowPartition(parts, schema, g)
+		walker.releasePartition(bytes)
+		if combined == nil {
+			continue
+		}
+		for _, chunk := range chunkBatch(combined, batch.DefaultBatchSize) {
+			if err := sw.writeBatch(chunk); err != nil {
+				sw.close()
+				return nil, nil, err
+			}
+		}
+	}
+	path, err := sw.close()
+	if err != nil {
+		return nil, nil, err
+	}
+	removeRunFiles(runs)
+	if path == "" {
+		return nil, outSchema, nil
+	}
+	return []string{path}, outSchema, nil
+}
+
+// buildWindowReorder maps the final pass's combined column order
+// (original schema, then each group's columns in pass order) back to the
+// declared output order (original schema, then Window.Columns order).
+// reorder[outPos] = combined column index.
+func buildWindowReorder(numOrigCols int, groups []windowSpecGroup, numWindowCols int) []int {
+	reorder := make([]int, numOrigCols+numWindowCols)
+	for i := 0; i < numOrigCols; i++ {
+		reorder[i] = i
+	}
+	offset := numOrigCols
+	for _, g := range groups {
+		for pi, k := range g.origIdx {
+			reorder[numOrigCols+k] = offset + pi
+		}
+		offset += len(g.cols)
+	}
+	return reorder
+}
+
+// reorderBatchColumns produces a batch whose columns follow outSchema's
+// order, sharing the source vectors (no copy).
+func reorderBatchColumns(b *batch.RecordBatch, reorder []int, outSchema []parquet.Column) *batch.RecordBatch {
+	cols := make([]*batch.Vector, len(reorder))
+	for outPos, srcIdx := range reorder {
+		cols[outPos] = b.Columns[srcIdx]
+	}
+	return &batch.RecordBatch{Columns: cols, Schema: outSchema, Len: b.Len, Sel: b.Sel}
+}
+
+// windowExtState is the final group's streaming state, driven by Next().
+type windowExtState struct {
+	walker    *partitionWalker
+	merger    *runMerger
+	schema    []parquet.Column // input schema of the final pass
+	group     windowSpecGroup
+	reorder   []int
+	outSchema []parquet.Column
+	runs      []string // run files to delete once drained
+	queue     []*batch.RecordBatch
+	qpos      int
+	done      bool
+}
+
+func (e *windowExtState) cleanup() {
+	if e.merger != nil {
+		e.merger.close()
+		e.merger = nil
+	}
+	removeRunFiles(e.runs)
+	e.runs = nil
+	e.queue = nil
+	e.done = true
+}

--- a/internal/engine/exec/window_external_test.go
+++ b/internal/engine/exec/window_external_test.go
@@ -1,0 +1,274 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sort"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/engine/memory"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// newWindowSpillHarness builds a Window whose tracker budget forces the
+// run-spill path within a few batches.
+func newWindowSpillHarness(tb testing.TB, cols []WindowColumn, budget int64) *Window {
+	tb.Helper()
+	tracker := memory.NewTracker("window-ext-test", budget)
+	sm, err := memory.NewSpillManager(tb.TempDir(), tracker)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	w := NewWindow(cols)
+	w.Spill = sm
+	if err := w.Init(context.Background()); err != nil {
+		tb.Fatal(err)
+	}
+	return w
+}
+
+func drainWindowRows(tb testing.TB, w *Window) []map[string]any {
+	tb.Helper()
+	var rows []map[string]any
+	for {
+		b, err := w.Next(context.Background())
+		if err != nil {
+			tb.Fatalf("Next: %v", err)
+		}
+		if b == nil {
+			return rows
+		}
+		rows = append(rows, b.ToRows()...)
+	}
+}
+
+// canonicalRows sorts rows by their full string representation. Window output
+// row ORDER is not part of the operator contract (the planner adds an ORDER
+// BY when one is required), and the external path emits in partition-sorted
+// order while the in-memory path emits in the last window column's order —
+// so equivalence is on the row multiset.
+func canonicalRows(rows []map[string]any, cols []string) []string {
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		s := ""
+		for _, c := range cols {
+			s += fmt.Sprintf("%s=%v;", c, r[c])
+		}
+		out[i] = s
+	}
+	sort.Strings(out)
+	return out
+}
+
+// runWindowBothPaths feeds identical batches through an in-memory Window and
+// a spilling Window and asserts the row multisets match exactly.
+func runWindowBothPaths(t *testing.T, schema []parquet.Column, cols []WindowColumn, allRows []map[string]any, rowsPerBatch int, compareCols []string) {
+	t.Helper()
+	forceTinyRuns(t)
+	ctx := context.Background()
+
+	ref := NewWindow(cols)
+	if err := ref.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	w := newWindowSpillHarness(t, cols, 512)
+
+	for i := 0; i < len(allRows); i += rowsPerBatch {
+		end := i + rowsPerBatch
+		if end > len(allRows) {
+			end = len(allRows)
+		}
+		if err := ref.Consume(ctx, batch.FromRows(schema, allRows[i:end])); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Consume(ctx, batch.FromRows(schema, allRows[i:end])); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(w.runFiles) == 0 {
+		t.Fatal("window run-spill path was never exercised; budget/floor setup is wrong")
+	}
+	if err := ref.Finalize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Finalize(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	want := canonicalRows(drainWindowRows(t, ref), compareCols)
+	got := canonicalRows(drainWindowRows(t, w), compareCols)
+	if len(got) != len(want) {
+		t.Fatalf("row count: got %d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("row %d differs:\n got  %s\n want %s", i, got[i], want[i])
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestWindowExternal_MatchesInMemory: one spec group covering ranking,
+// running aggregate, and whole-partition aggregate, with enough duplicate
+// partition keys that partitions span batch boundaries in the merged stream.
+func TestWindowExternal_MatchesInMemory(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "grp", Type: parquet.TypeInt64},
+		{Name: "ts", Type: parquet.TypeInt64},
+		{Name: "amount", Type: parquet.TypeFloat64},
+	}
+	cols := []WindowColumn{
+		{Func: WinRowNumber, OutputCol: "rn", OutputType: parquet.TypeInt64,
+			PartitionBy: []string{"grp"}, OrderBy: []SortKey{{Column: "ts", Order: Ascending}}},
+		{Func: WinSum, InputCol: "amount", OutputCol: "running_sum", OutputType: parquet.TypeFloat64,
+			PartitionBy: []string{"grp"}, OrderBy: []SortKey{{Column: "ts", Order: Ascending}}},
+	}
+	rng := rand.New(rand.NewSource(99))
+	var rows []map[string]any
+	for i := 0; i < 240; i++ {
+		rows = append(rows, map[string]any{
+			"grp":    int64(rng.Intn(7)),
+			"ts":     int64(i), // unique → deterministic running values
+			"amount": float64(rng.Intn(100)),
+		})
+	}
+	runWindowBothPaths(t, schema, cols, rows, 16,
+		[]string{"grp", "ts", "amount", "rn", "running_sum"})
+}
+
+// TestWindowExternal_MultiSpecGroups: two different (PARTITION BY, ORDER BY)
+// specs force a disk-to-disk pass plus a re-sort between groups, and the
+// output columns must come back in declared order.
+func TestWindowExternal_MultiSpecGroups(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "a", Type: parquet.TypeInt64},
+		{Name: "b", Type: parquet.TypeInt64},
+		{Name: "v", Type: parquet.TypeFloat64},
+	}
+	cols := []WindowColumn{
+		{Func: WinRank, OutputCol: "rank_a", OutputType: parquet.TypeInt64,
+			PartitionBy: []string{"a"}, OrderBy: []SortKey{{Column: "v", Order: Descending}}},
+		{Func: WinCount, OutputCol: "cnt_b", OutputType: parquet.TypeInt64,
+			PartitionBy: []string{"b"}},
+		{Func: WinMax, InputCol: "v", OutputCol: "max_a", OutputType: parquet.TypeFloat64,
+			PartitionBy: []string{"a"}, OrderBy: []SortKey{{Column: "v", Order: Descending}}},
+	}
+	rng := rand.New(rand.NewSource(5))
+	var rows []map[string]any
+	for i := 0; i < 200; i++ {
+		rows = append(rows, map[string]any{
+			"a": int64(rng.Intn(5)),
+			"b": int64(rng.Intn(4)),
+			"v": float64(i), // unique → deterministic rank/max
+		})
+	}
+	runWindowBothPaths(t, schema, cols, rows, 16,
+		[]string{"a", "b", "v", "rank_a", "cnt_b", "max_a"})
+}
+
+// TestWindowExternal_EmptyPartitionBy: no PARTITION BY means one partition
+// spanning the whole input — the documented full-materialization residual.
+// Must still be correct.
+func TestWindowExternal_EmptyPartitionBy(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "ts", Type: parquet.TypeInt64},
+		{Name: "v", Type: parquet.TypeFloat64},
+	}
+	cols := []WindowColumn{
+		{Func: WinRowNumber, OutputCol: "rn", OutputType: parquet.TypeInt64,
+			OrderBy: []SortKey{{Column: "ts", Order: Ascending}}},
+	}
+	var rows []map[string]any
+	for i := 0; i < 150; i++ {
+		rows = append(rows, map[string]any{"ts": int64(150 - i), "v": float64(i)})
+	}
+	runWindowBothPaths(t, schema, cols, rows, 10, []string{"ts", "v", "rn"})
+}
+
+// TestWindowExternal_NullPartitionKeys: null partition keys must group into
+// one partition on the external path (kernel null==null compares equal),
+// matching the in-memory path's sameColumnar semantics.
+func TestWindowExternal_NullPartitionKeys(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "grp", Type: parquet.TypeString, Nullable: true},
+		{Name: "ts", Type: parquet.TypeInt64},
+	}
+	cols := []WindowColumn{
+		{Func: WinCount, OutputCol: "cnt", OutputType: parquet.TypeInt64,
+			PartitionBy: []string{"grp"}},
+		{Func: WinRowNumber, OutputCol: "rn", OutputType: parquet.TypeInt64,
+			PartitionBy: []string{"grp"}, OrderBy: []SortKey{{Column: "ts", Order: Ascending}}},
+	}
+	rng := rand.New(rand.NewSource(13))
+	var rows []map[string]any
+	for i := 0; i < 160; i++ {
+		var g any
+		if rng.Intn(3) == 0 {
+			g = nil
+		} else {
+			g = fmt.Sprintf("g%d", rng.Intn(3))
+		}
+		rows = append(rows, map[string]any{"grp": g, "ts": int64(i)})
+	}
+	runWindowBothPaths(t, schema, cols, rows, 12, []string{"grp", "ts", "cnt", "rn"})
+}
+
+// TestWindowConcat_NullableStringCorruption is the regression test for a
+// windowCopyVectorRange bug found while building the external path: the
+// nullable-bytes branch skipped null rows without advancing the BytesColumn
+// offset slot, so every row AFTER a null in a concatenated batch read back as
+// concatenated garbage ("g0g1g2..."), silently corrupting partition keys and
+// window results on the NO-SPILL path. Multiple small batches with a nullable
+// string partition column reproduce it; fails before the Set(di, nil) fix.
+func TestWindowConcat_NullableStringCorruption(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "grp", Type: parquet.TypeString, Nullable: true},
+		{Name: "ts", Type: parquet.TypeInt64},
+	}
+	cols := []WindowColumn{
+		{Func: WinCount, OutputCol: "cnt", OutputType: parquet.TypeInt64,
+			PartitionBy: []string{"grp"}},
+	}
+	ctx := context.Background()
+	w := NewWindow(cols) // no SpillManager: pure in-memory columnar path
+	if err := w.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	// Three batches, each with a leading null — the desync trigger.
+	groups := []string{"a", "b"}
+	want := map[string]int64{"<nil>": 3, "a": 6, "b": 6}
+	for b := 0; b < 3; b++ {
+		rows := []map[string]any{{"grp": nil, "ts": int64(b * 10)}}
+		for j := 0; j < 4; j++ {
+			rows = append(rows, map[string]any{
+				"grp": groups[j%2],
+				"ts":  int64(b*10 + j + 1),
+			})
+		}
+		if err := w.Consume(ctx, batch.FromRows(schema, rows)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.Finalize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]int64{}
+	seen := map[string]bool{}
+	for _, r := range drainWindowRows(t, w) {
+		g := fmt.Sprint(r["grp"])
+		got[g] = r["cnt"].(int64)
+		seen[g] = true
+	}
+	if len(seen) != len(want) {
+		t.Fatalf("partition keys corrupted: got %v", got)
+	}
+	for g, n := range want {
+		if got[g] != n {
+			t.Fatalf("count for %q: got %d want %d (full: %v)", g, got[g], n, got)
+		}
+	}
+}

--- a/internal/engine/exec/window_test.go
+++ b/internal/engine/exec/window_test.go
@@ -313,6 +313,7 @@ func TestWindowPartitionCount(t *testing.T) {
 // TestWindowSpillToDisk verifies that the Window operator correctly spills
 // input batches to disk under memory pressure and produces correct results.
 func TestWindowSpillToDisk(t *testing.T) {
+	forceTinyRuns(t)
 	schema := []parquet.Column{
 		{Name: "dept", Type: parquet.TypeString},
 		{Name: "id", Type: parquet.TypeInt64},
@@ -366,12 +367,12 @@ func TestWindowSpillToDisk(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Verify spill was triggered
-	spilledFiles := sm.SpilledFiles()
-	if len(spilledFiles) == 0 {
-		t.Fatal("expected spill to trigger, but no spill files were created")
+	// Verify spill was triggered: the external path leaves the final-pass
+	// streaming state armed after Finalize (run files are operator-managed,
+	// not registered with the SpillManager).
+	if win.ext == nil {
+		t.Fatal("expected spill to trigger, but the external window path was never armed")
 	}
-	t.Logf("spilled %d files", len(spilledFiles))
 
 	// Collect all output batches
 	var allRows []map[string]any
@@ -437,6 +438,7 @@ func TestWindowSpillToDisk(t *testing.T) {
 // TestWindowSpillRunningSum verifies spill correctness with an aggregate
 // window function (SUM with ORDER BY → running total).
 func TestWindowSpillRunningSum(t *testing.T) {
+	forceTinyRuns(t)
 	schema := []parquet.Column{
 		{Name: "id", Type: parquet.TypeInt64},
 		{Name: "val", Type: parquet.TypeFloat64},
@@ -489,8 +491,8 @@ func TestWindowSpillRunningSum(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(sm.SpilledFiles()) == 0 {
-		t.Fatal("expected spill to trigger")
+	if win.ext == nil {
+		t.Fatal("expected spill to trigger, but the external window path was never armed")
 	}
 
 	// Collect results


### PR DESCRIPTION
## Why

Investigation into never-OOM stability (the new top priority) found that Sort and Window spill was **fake out-of-core**: both spilled raw unsorted rows, then `finalizeWithSpill` read *everything* back into `[]map[string]any` boxed row-maps for one in-memory `sort.SliceStable`. Spill deferred peak memory instead of bounding it — and the boxed representation is several times larger than columnar, so a sort whose input exceeded memory OOM'd at finalize *regardless of how much it spilled*. This was the #1 architectural OOM vector in the engine (HashJoin and HashAggregate already degrade properly).

## What

**External sort (Sort)**
- Spill sorts buffered batches with the existing typed kernels and writes a **sorted columnar run** (64 MiB floor under `SpillCheap` pressure to keep runs merge-friendly; peer-relief `SpillSome` bypasses the floor and keeps the `EstimateRelief` contract).
- Finalize arms a **streaming k-way merge** (runs + in-memory remainder as cursors); `Next()` emits one merged batch at a time. Finalize-phase memory = one buffered batch per run; multi-level pre-merge caps fan-in at `maxMergeFanIn`.
- Top-K: runs truncate to `Limit` at write; merge stops at `Limit`; `Truncate()` on the merge path caps the stream (fragment `PostFinalize` / `sortSourceAdapter` contracts preserved).
- Equal keys tie-break on run ordinal → deterministic output across identical runs (byte-identical distributed re-runs).

**External window (Window)**
- Runs are written sorted by the first spec group's `(PARTITION BY, ORDER BY)`; finalize streams a k-way merge and materializes **one partition at a time** (largest-partition bound, charged to the tracker). Multi-spec plans run disk-to-disk passes with re-sort between groups; the final group streams through `Next()`. Empty `PARTITION BY` remains a documented full-materialization residual (DuckDB has the same holistic limitation).

**Columnar spill format** (shared with HashJoin spill)
- `TypeVector` now round-trips (dim + values). Previously Vector/Array/Map/Row columns were **silently dropped on write** and read back as garbage — now nested types fail loudly, and Sort/Window route nested-type schemas to the legacy row-spill path (correct, if memory-hungry).

## Bonus: latent wrong-results bug fixed

The new path-equivalence tests caught a **pre-existing no-spill bug**: `windowCopyVectorRange` skipped null rows in nullable bytes columns without advancing the BytesColumn offset slot, so every row after a null in a concatenated batch read back as concatenated garbage (`"g0g1g2..."`) — corrupting partition keys and window results whenever a nullable string/bytes column crossed batch concat. One-line fix + teeth-verified regression test (`TestWindowConcat_NullableStringCorruption`).

## Testing

- New: run-merge correctness vs in-memory reference (strings/nulls/DESC/NULLS LAST), Top-K under spill, multi-level merge (fan-in 2), `Truncate`-after-Finalize contract, `SpillSome` relief contract, determinism across identical runs, TypeVector round-trip, nested-type fail-loud, window spill-vs-no-spill equivalence (single spec, multi-spec, empty PARTITION BY, null partition keys).
- Updated: existing Sort/Window spill tests to the new mechanics (`forceTinyRuns` override; run files are operator-managed, deleted after drain).
- Gates: full `./internal/...` tree, `-race`, TPC-H SF0.01 22/22, `tpch-harness --mode=local` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)