### PR TITLE
feat(coordinator): bounded task retry + gRPC dispatch memory admission gate

### DIFF
--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -733,10 +733,10 @@ func (c *Coordinator) dispatchShuffleStage(
 	}
 	// Synthesize a source stage for runShuffleSide.
 	synthetic := physical.Stage{
-		ID:         stage.ID + "-src",
-		Type:       physical.StageScan,
-		ScanFiles:  sourceFiles,
-		TableName:  stage.TableName, // may be empty for chained shuffles; worker falls back to generic scan
+		ID:        stage.ID + "-src",
+		Type:      physical.StageScan,
+		ScanFiles: sourceFiles,
+		TableName: stage.TableName, // may be empty for chained shuffles; worker falls back to generic scan
 	}
 	numParts := stage.Exchange.Count
 	if numParts == 0 {
@@ -1221,15 +1221,15 @@ func (c *Coordinator) dispatchScanAggregateStage(
 	tasks := make([]distributed.Task, 0, actualTasks)
 	for shardIdx, files := range fileSets {
 		t := distributed.Task{
-			ID:           uuid.New().String()[:8],
-			QueryID:      queryID,
-			StageID:      stage.ID,
-			Type:         distributed.TaskTypeStage,
-			StageType:    "aggregate",
-			TableName:    stage.TableName,
-			Columns:      stage.Columns,
-			GroupByCols:  stage.FusedAggGroupBy,
-			Aggregates:   aggs,
+			ID:          uuid.New().String()[:8],
+			QueryID:     queryID,
+			StageID:     stage.ID,
+			Type:        distributed.TaskTypeStage,
+			StageType:   "aggregate",
+			TableName:   stage.TableName,
+			Columns:     stage.Columns,
+			GroupByCols: stage.FusedAggGroupBy,
+			Aggregates:  aggs,
 			// Propagate scan-pushed WHERE fragments. Without this the worker
 			// aggregates every row in the file slice and ignores the query's
 			// predicate — group counts match legacy but aggregate VALUES are
@@ -1850,27 +1850,27 @@ func (c *Coordinator) dispatchComputeStage(
 			})
 		}
 		t := distributed.Task{
-			ID:              uuid.New().String()[:8],
-			QueryID:         queryID,
-			StageID:         stage.ID,
-			Type:            distributed.TaskTypeStage,
-			StageType:       stage.Type,
-			JoinType:        stage.JoinType,
-			JoinLeftKeys:    stage.JoinLeftKeys,
-			JoinRightKeys:   stage.JoinRightKeys,
+			ID:                  uuid.New().String()[:8],
+			QueryID:             queryID,
+			StageID:             stage.ID,
+			Type:                distributed.TaskTypeStage,
+			StageType:           stage.Type,
+			JoinType:            stage.JoinType,
+			JoinLeftKeys:        stage.JoinLeftKeys,
+			JoinRightKeys:       stage.JoinRightKeys,
 			BuildTableAlias:     stage.BuildTableAlias,
 			QualifyAllBuildCols: stage.QualifyAllBuildCols,
 			JoinFilter:          stage.JoinFilter,
-			FusedJoins:      wireFused,
-			GroupByCols:     stage.GroupByCols,
-			Aggregates:      aggs,
-			SortKeys:        sorts,
-			Limit:           stage.Limit,
-			Inputs:          taskInputs,
-			DataBucket:      c.config.ResultBucket,
-			ResultBucket:    c.config.ResultBucket,
-			ResultPrefix:    resultPrefix,
-			CreatedAt:       time.Now(),
+			FusedJoins:          wireFused,
+			GroupByCols:         stage.GroupByCols,
+			Aggregates:          aggs,
+			SortKeys:            sorts,
+			Limit:               stage.Limit,
+			Inputs:              taskInputs,
+			DataBucket:          c.config.ResultBucket,
+			ResultBucket:        c.config.ResultBucket,
+			ResultPrefix:        resultPrefix,
+			CreatedAt:           time.Now(),
 			// Output column projection for hash_join / broadcast_join stages.
 			// The worker applies these as the probe operator's OutputFilter so
 			// the join emits only the columns the downstream stage consumes,
@@ -2022,40 +2022,41 @@ func (c *Coordinator) dispatchComputeStage(
 	defer c.tracker.Delete(stageQueryID)
 
 	subject := distributed.QueryResultSubject(stageQueryID)
-	type taskResult struct {
-		files []string
-		err   string
-	}
 	for i := range tasks {
 		tasks[i].QueryID = stageQueryID
+		tasks[i].Attempt = 1
 	}
-	collected := make([]taskResult, 0, len(tasks))
-	var mu sync.Mutex
 	done := make(chan struct{}, 1)
 	progress := make(chan struct{}, len(tasks))
 	// Register with the per-query progress bridge so worker-emitted
 	// TaskProgress messages also count as forward progress for this
 	// stage's idle detection.
 	defer stageProgressBridgeFromContext(ctx).Register(stage.ID, progress)()
+	// Task retry: failed tasks are re-dispatched up to maxTaskAttempts
+	// (deterministic durable inputs + overwrite-safe outputs make this
+	// sound). DISABLED for gather-fused stages — those stream rows to the
+	// client mid-task, so a retried task would duplicate streamed output.
+	retrier := newTaskRetrier(tasks, fusion == nil, func(t distributed.Task) {
+		if ctx.Err() != nil {
+			return
+		}
+		if pubErr := c.scheduler.PublishTasks(ctx, []distributed.Task{t}); pubErr != nil {
+			c.logger.Error("task retry publish failed",
+				"stage_id", stage.ID, "task_id", t.ID, "error", pubErr)
+		}
+	}, c.logger, stage.ID)
 	sub, err := c.nc.Subscribe(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
 		if err := distributed.Unmarshal(msg.Data, &r); err != nil {
 			return
 		}
 		c.workers.MarkWorkerSeen(r.WorkerID)
-		mu.Lock()
-		if r.Success {
-			collected = append(collected, taskResult{files: r.ResultFiles})
-		} else {
-			collected = append(collected, taskResult{err: r.Error})
-		}
-		got := len(collected)
-		mu.Unlock()
+		allDone := retrier.Observe(r)
 		select {
 		case progress <- struct{}{}:
 		default:
 		}
-		if got >= len(tasks) {
+		if allDone {
 			select {
 			case done <- struct{}{}:
 			default:
@@ -2084,23 +2085,14 @@ func (c *Coordinator) dispatchComputeStage(
 	}
 
 	if err := awaitStageProgress(ctx, done, progress, "compute "+stage.ID); err != nil {
-		mu.Lock()
-		got := len(collected)
-		mu.Unlock()
-		return StageOutput{}, fmt.Errorf("stage %s with %d/%d results: %w", stage.ID, got, len(tasks), err)
+		return StageOutput{}, fmt.Errorf("stage %s with %d/%d results: %w", stage.ID, retrier.Terminal(), len(tasks), err)
 	}
 	c.logger.Info("compute stage complete", "stage_id", stage.ID, "tasks", len(tasks))
 
-	mu.Lock()
-	results := make([]taskResult, len(collected))
-	copy(results, collected)
-	mu.Unlock()
-
-	for _, r := range results {
-		if r.err != "" {
-			return StageOutput{}, fmt.Errorf("stage %s: task failed: %s", stage.ID, r.err)
-		}
+	if taskID, errMsg, failed := retrier.FirstError(); failed {
+		return StageOutput{}, fmt.Errorf("stage %s: task %s failed after %d attempts: %s", stage.ID, taskID, maxTaskAttempts, errMsg)
 	}
+	resultFiles := retrier.Files()
 	// Fused join + downstream exchange-sender: each task produced N partition
 	// files at "<prefix>partition=NNNN/<task>.wshf" (worker's executeFragment
 	// → fragmentExchangeSink). Bucket all files across all tasks by partition
@@ -2110,8 +2102,8 @@ func (c *Coordinator) dispatchComputeStage(
 		(stage.Type == physical.StageHashJoin || stage.Type == physical.StageBroadcastJoin) {
 		numParts := stage.Exchange.Count
 		shardFiles := make([][]string, numParts)
-		for _, r := range results {
-			for _, f := range r.files {
+		for _, taskFiles := range resultFiles {
+			for _, f := range taskFiles {
 				p, parseErr := parsePartitionFromPath(f)
 				if parseErr != nil {
 					return StageOutput{}, fmt.Errorf("stage %s: parsing partition from %q: %w", stage.ID, f, parseErr)
@@ -2128,10 +2120,9 @@ func (c *Coordinator) dispatchComputeStage(
 			Files:         shardFiles,
 		}, nil
 	}
-	files := make([][]string, len(tasks))
-	for i, r := range results {
-		files[i] = r.files
-	}
+	// resultFiles is in dispatch order (taskRetrier keys results by task ID),
+	// which is deterministic — an improvement over the old arrival-order slice.
+	files := resultFiles
 	// Kind reflects what the planner said this stage produces. Single-
 	// task Singleton stages label their output OutputSinglePart so
 	// downstream consumers (partitionFilesForWorker) return the full file

--- a/internal/coordinator/orchestrate_repartition.go
+++ b/internal/coordinator/orchestrate_repartition.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/citc-tech/wadjet/internal/distributed"
@@ -194,15 +193,49 @@ func (c *Coordinator) runShuffleSide(
 	c.tracker.Start(shuffleQueryID)
 	defer c.tracker.Delete(shuffleQueryID)
 
-	// Subscribe for results before publishing to avoid the race.
+	// Build tasks first (the retrier needs them registered), then subscribe
+	// BEFORE publishing to avoid the result race.
 	subject := distributed.QueryResultSubject(shuffleQueryID)
-	type taskResult struct {
-		files []string
-		err   string
-	}
-	collected := make([]taskResult, 0, actualTasks)
-	var mu sync.Mutex
 	done := make(chan struct{}, 1)
+
+	tasks := make([]distributed.Task, actualTasks)
+	for i, files := range fileSets {
+		t := distributed.Task{
+			ID:             uuid.New().String()[:8],
+			QueryID:        shuffleQueryID,
+			StageID:        stageID,
+			Type:           distributed.TaskTypeShuffle,
+			TableName:      sourceStage.TableName,
+			Files:          files,
+			Columns:        cols,
+			ShuffleKeys:    keys,
+			NumPartitions:  numParts,
+			DataBucket:     c.config.ResultBucket,
+			ResultBucket:   c.config.ResultBucket,
+			ResultPrefix:   resultPrefix,
+			CreatedAt:      time.Now(),
+			DynamicFilters: dynamicFilters,
+		}
+		if clusterID := c.catalog.ClusterID(); clusterID != "" {
+			t.ClusterID = clusterID
+		}
+		t.Attempt = 1
+		tasks[i] = t
+	}
+
+	// Shuffle tasks are never gather-fused (their outputs are partition
+	// files), so retry is always safe here: deterministic inputs, and a
+	// retry overwrites the failed attempt's identically-named, identically-
+	// contented partition files.
+	retrier := newTaskRetrier(tasks, true, func(t distributed.Task) {
+		if ctx.Err() != nil {
+			return
+		}
+		if pubErr := c.scheduler.PublishTasks(ctx, []distributed.Task{t}); pubErr != nil {
+			c.logger.Error("shuffle task retry publish failed",
+				"side", sideName, "task_id", t.ID, "error", pubErr)
+		}
+	}, c.logger, stageID)
 
 	sub, err := c.nc.Subscribe(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
@@ -210,15 +243,7 @@ func (c *Coordinator) runShuffleSide(
 			return
 		}
 		c.workers.MarkWorkerSeen(r.WorkerID)
-		mu.Lock()
-		if !r.Success {
-			collected = append(collected, taskResult{err: r.Error})
-		} else {
-			collected = append(collected, taskResult{files: r.ResultFiles})
-		}
-		got := len(collected)
-		mu.Unlock()
-		if got >= actualTasks {
+		if retrier.Observe(r) {
 			select {
 			case done <- struct{}{}:
 			default:
@@ -229,31 +254,6 @@ func (c *Coordinator) runShuffleSide(
 		return nil, fmt.Errorf("subscribing for shuffle-%s results: %w", sideName, err)
 	}
 	defer sub.Unsubscribe()
-
-	// Build and publish all tasks at once.
-	tasks := make([]distributed.Task, actualTasks)
-	for i, files := range fileSets {
-		t := distributed.Task{
-			ID:           uuid.New().String()[:8],
-			QueryID:      shuffleQueryID,
-			StageID:      stageID,
-			Type:         distributed.TaskTypeShuffle,
-			TableName:    sourceStage.TableName,
-			Files:        files,
-			Columns:      cols,
-			ShuffleKeys:  keys,
-			NumPartitions: numParts,
-			DataBucket:   c.config.ResultBucket,
-			ResultBucket: c.config.ResultBucket,
-			ResultPrefix: resultPrefix,
-			CreatedAt:    time.Now(),
-			DynamicFilters: dynamicFilters,
-		}
-		if clusterID := c.catalog.ClusterID(); clusterID != "" {
-			t.ClusterID = clusterID
-		}
-		tasks[i] = t
-	}
 
 	if err := c.scheduler.PublishTasks(ctx, tasks); err != nil {
 		return nil, fmt.Errorf("publishing shuffle-%s tasks: %w", sideName, err)
@@ -266,16 +266,9 @@ func (c *Coordinator) runShuffleSide(
 		return nil, fmt.Errorf("shuffle-%s timed out after %s: %w", sideName, shuffleStageTimeout, ctx.Err())
 	}
 
-	// Check for any task failures.
-	mu.Lock()
-	results := make([]taskResult, len(collected))
-	copy(results, collected)
-	mu.Unlock()
-
-	for _, r := range results {
-		if r.err != "" {
-			return nil, fmt.Errorf("shuffle-%s task failed: %s", sideName, r.err)
-		}
+	// Check for any task failures (terminal: retries exhausted).
+	if taskID, errMsg, failed := retrier.FirstError(); failed {
+		return nil, fmt.Errorf("shuffle-%s task %s failed after %d attempts: %s", sideName, taskID, maxTaskAttempts, errMsg)
 	}
 
 	// Bucket result files by partition. Each file has a path like:
@@ -283,8 +276,8 @@ func (c *Coordinator) runShuffleSide(
 	// We parse the partition number from the "partition=NNNN" path segment.
 	// This format is fixed by the worker's executeShuffle (partitionedShuffleSink).
 	shardFiles := make([][]string, numParts)
-	for _, r := range results {
-		for _, f := range r.files {
+	for _, taskFiles := range retrier.Files() {
+		for _, f := range taskFiles {
 			p, parseErr := parsePartitionFromPath(f)
 			if parseErr != nil {
 				return nil, fmt.Errorf("shuffle-%s: parsing partition from %q: %w", sideName, f, parseErr)
@@ -377,14 +370,14 @@ func buildShufflePipelineTasks(
 			probeFiles = append(probeFiles, layout.ProbeShardFiles[p]...)
 		}
 		tasks = append(tasks, distributed.Task{
-			ID:           uuid.New().String()[:8],
-			QueryID:      queryID,
-			StageID:      "pipeline-0",
-			Type:         distributed.TaskTypePipeline,
-			SQLText:      sql,
-			DataBucket:   resultBucket,
-			ResultBucket: resultBucket,
-			ResultPrefix: resultPrefix,
+			ID:               uuid.New().String()[:8],
+			QueryID:          queryID,
+			StageID:          "pipeline-0",
+			Type:             distributed.TaskTypePipeline,
+			SQLText:          sql,
+			DataBucket:       resultBucket,
+			ResultBucket:     resultBucket,
+			ResultPrefix:     resultPrefix,
 			PartialAggregate: true,
 			PreScannedInputs: map[string][]string{
 				layout.BuildAlias: buildFiles,
@@ -421,4 +414,3 @@ func findShuffleScanStages(stages []physical.Stage, cand physical.ShuffleCandida
 	}
 	return build, probe, nil
 }
-

--- a/internal/coordinator/task_retry.go
+++ b/internal/coordinator/task_retry.go
@@ -1,0 +1,151 @@
+package coordinator
+
+import (
+	"log/slog"
+	"sync"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+)
+
+// maxTaskAttempts caps total executions of one task (first attempt +
+// retries). Stage inputs are durable, deterministic S3 files and task
+// outputs are overwrite-safe (same TaskID → same S3 key; collection uses
+// the successful attempt's ResultNotification), so re-running a failed
+// task is semantically safe. Mirrors Trino FTE's bounded task retry.
+const maxTaskAttempts = 3
+
+// taskRetrier tracks per-task terminal state for one stage dispatch and
+// re-dispatches failed tasks up to maxTaskAttempts. It replaces the
+// append-only result slice in the stage dispatchers, which also fixes a
+// latent duplicate-delivery hazard: the worker's result publish retries up
+// to 3x, and a duplicate notification could double-count in the old slice
+// and complete the stage early with a task still outstanding.
+//
+// Retry policy v1: every failure is considered retriable and simply
+// re-dispatched (round-robin lands it elsewhere); deterministic failures
+// burn the attempt cap and then fail the stage. Two hard exclusions, both
+// the caller's responsibility via the retry flag:
+//   - gather-fused stages: workers stream rows to the client mid-task, so a
+//     retried task would duplicate streamed output.
+//   - cancelled queries: the dispatcher stops observing on ctx cancel.
+type taskRetrier struct {
+	mu       sync.Mutex
+	states   map[string]*taskAttemptState
+	tasks    map[string]distributed.Task
+	order    []string // task IDs in dispatch order, for deterministic output assembly
+	terminal int
+
+	retryEnabled bool
+	republish    func(distributed.Task)
+	logger       *slog.Logger
+	stageID      string
+}
+
+type taskAttemptState struct {
+	files    []string
+	errMsg   string
+	attempts int
+	terminal bool
+}
+
+// newTaskRetrier registers the dispatched tasks. republish re-dispatches a
+// single task; it is invoked on the caller-provided function asynchronously
+// (from the NATS subscription goroutine) and must not block long.
+func newTaskRetrier(tasks []distributed.Task, retryEnabled bool, republish func(distributed.Task), logger *slog.Logger, stageID string) *taskRetrier {
+	tr := &taskRetrier{
+		states:       make(map[string]*taskAttemptState, len(tasks)),
+		tasks:        make(map[string]distributed.Task, len(tasks)),
+		order:        make([]string, 0, len(tasks)),
+		retryEnabled: retryEnabled && republish != nil,
+		republish:    republish,
+		logger:       logger,
+		stageID:      stageID,
+	}
+	for _, t := range tasks {
+		tr.states[t.ID] = &taskAttemptState{attempts: 1}
+		tr.tasks[t.ID] = t
+		tr.order = append(tr.order, t.ID)
+	}
+	return tr
+}
+
+// Observe processes one ResultNotification and returns true when every task
+// has reached a terminal state (success, or failure with retries exhausted).
+// Unknown task IDs and duplicates after a terminal result are ignored.
+func (tr *taskRetrier) Observe(r distributed.ResultNotification) (allDone bool) {
+	tr.mu.Lock()
+	st, ok := tr.states[r.TaskID]
+	if !ok || st.terminal {
+		done := tr.terminal >= len(tr.order)
+		tr.mu.Unlock()
+		return done
+	}
+	if r.Success {
+		st.files = r.ResultFiles
+		st.errMsg = ""
+		st.terminal = true
+		tr.terminal++
+		done := tr.terminal >= len(tr.order)
+		tr.mu.Unlock()
+		return done
+	}
+	// Failure: retry if attempts remain, else terminal failure.
+	if tr.retryEnabled && st.attempts < maxTaskAttempts {
+		st.attempts++
+		task := tr.tasks[r.TaskID]
+		task.Attempt = st.attempts
+		tr.mu.Unlock()
+		if tr.logger != nil {
+			tr.logger.Warn("retrying failed task",
+				"stage_id", tr.stageID, "task_id", r.TaskID,
+				"attempt", task.Attempt, "max_attempts", maxTaskAttempts,
+				"failed_on", r.WorkerID, "error", r.Error)
+		}
+		// Re-dispatch off the subscription goroutine; the scheduler's
+		// publish path flushes the NATS connection.
+		go tr.republish(task)
+		return false
+	}
+	st.errMsg = r.Error
+	st.terminal = true
+	tr.terminal++
+	done := tr.terminal >= len(tr.order)
+	tr.mu.Unlock()
+	if tr.logger != nil {
+		tr.logger.Error("task failed terminally",
+			"stage_id", tr.stageID, "task_id", r.TaskID,
+			"attempts", st.attempts, "error", r.Error)
+	}
+	return done
+}
+
+// Terminal returns how many tasks have reached a terminal state.
+func (tr *taskRetrier) Terminal() int {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	return tr.terminal
+}
+
+// FirstError returns the first terminal failure in dispatch order, if any.
+func (tr *taskRetrier) FirstError() (taskID, errMsg string, failed bool) {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	for _, id := range tr.order {
+		if st := tr.states[id]; st.terminal && st.errMsg != "" {
+			return id, st.errMsg, true
+		}
+	}
+	return "", "", false
+}
+
+// Files returns per-task result files in dispatch order. Only meaningful
+// after all tasks are terminal and FirstError reports none.
+func (tr *taskRetrier) Files() [][]string {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	out := make([][]string, len(tr.order))
+	for i, id := range tr.order {
+		out[i] = tr.states[id].files
+	}
+	return out
+}

--- a/internal/coordinator/task_retry_test.go
+++ b/internal/coordinator/task_retry_test.go
@@ -1,0 +1,214 @@
+package coordinator
+
+import (
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+)
+
+func retryTestTasks(n int) []distributed.Task {
+	tasks := make([]distributed.Task, n)
+	for i := range tasks {
+		tasks[i] = distributed.Task{ID: string(rune('a' + i)), QueryID: "q", StageID: "s", Attempt: 1}
+	}
+	return tasks
+}
+
+func okResult(taskID string, files ...string) distributed.ResultNotification {
+	return distributed.ResultNotification{TaskID: taskID, Success: true, ResultFiles: files}
+}
+
+func failResult(taskID, msg string) distributed.ResultNotification {
+	return distributed.ResultNotification{TaskID: taskID, Success: false, Error: msg}
+}
+
+// collectingRepublisher records re-dispatched tasks thread-safely.
+type collectingRepublisher struct {
+	mu    sync.Mutex
+	tasks []distributed.Task
+}
+
+func (c *collectingRepublisher) republish(t distributed.Task) {
+	c.mu.Lock()
+	c.tasks = append(c.tasks, t)
+	c.mu.Unlock()
+}
+
+func (c *collectingRepublisher) snapshot() []distributed.Task {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]distributed.Task, len(c.tasks))
+	copy(out, c.tasks)
+	return out
+}
+
+// waitRepublished polls until the republisher has seen n tasks (republish is
+// invoked on a goroutine from Observe).
+func waitRepublished(t *testing.T, c *collectingRepublisher, n int) []distributed.Task {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		got := c.snapshot()
+		if len(got) >= n {
+			return got
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("republished %d tasks, want %d", len(got), n)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func TestTaskRetrier_AllSucceedFirstTry(t *testing.T) {
+	rep := &collectingRepublisher{}
+	tr := newTaskRetrier(retryTestTasks(3), true, rep.republish, slog.Default(), "s")
+	if tr.Observe(okResult("a", "f-a")) {
+		t.Fatal("done after 1/3")
+	}
+	if tr.Observe(okResult("b", "f-b")) {
+		t.Fatal("done after 2/3")
+	}
+	if !tr.Observe(okResult("c", "f-c")) {
+		t.Fatal("not done after 3/3")
+	}
+	if _, _, failed := tr.FirstError(); failed {
+		t.Fatal("unexpected failure")
+	}
+	files := tr.Files()
+	want := []string{"f-a", "f-b", "f-c"}
+	for i, w := range want {
+		if len(files[i]) != 1 || files[i][0] != w {
+			t.Fatalf("files[%d] = %v, want [%s] (dispatch order)", i, files[i], w)
+		}
+	}
+	if len(rep.snapshot()) != 0 {
+		t.Fatal("nothing should have been republished")
+	}
+}
+
+func TestTaskRetrier_FailThenRetrySucceeds(t *testing.T) {
+	rep := &collectingRepublisher{}
+	tr := newTaskRetrier(retryTestTasks(2), true, rep.republish, slog.Default(), "s")
+	if tr.Observe(failResult("a", "worker died")) {
+		t.Fatal("failure with retries left must not be terminal")
+	}
+	got := waitRepublished(t, rep, 1)
+	if got[0].ID != "a" || got[0].Attempt != 2 {
+		t.Fatalf("republished %+v, want task a attempt 2", got[0])
+	}
+	if tr.Observe(okResult("b", "f-b")) {
+		t.Fatal("done with task a still outstanding")
+	}
+	// Retry succeeds.
+	if !tr.Observe(okResult("a", "f-a2")) {
+		t.Fatal("not done after retry success")
+	}
+	if _, _, failed := tr.FirstError(); failed {
+		t.Fatal("unexpected terminal failure")
+	}
+	if files := tr.Files(); files[0][0] != "f-a2" {
+		t.Fatalf("files[0] = %v, want retry attempt's files", files[0])
+	}
+}
+
+func TestTaskRetrier_ExhaustsAttempts(t *testing.T) {
+	rep := &collectingRepublisher{}
+	tr := newTaskRetrier(retryTestTasks(1), true, rep.republish, slog.Default(), "s")
+	// Attempt 1 fails → retry (attempt 2). Attempt 2 fails → retry (attempt 3).
+	// Attempt 3 fails → terminal.
+	if tr.Observe(failResult("a", "boom-1")) {
+		t.Fatal("terminal after first failure")
+	}
+	waitRepublished(t, rep, 1)
+	if tr.Observe(failResult("a", "boom-2")) {
+		t.Fatal("terminal after second failure")
+	}
+	got := waitRepublished(t, rep, 2)
+	if got[1].Attempt != 3 {
+		t.Fatalf("second republish attempt = %d, want 3", got[1].Attempt)
+	}
+	if !tr.Observe(failResult("a", "boom-3")) {
+		t.Fatal("not terminal after attempts exhausted")
+	}
+	taskID, errMsg, failed := tr.FirstError()
+	if !failed || taskID != "a" || errMsg != "boom-3" {
+		t.Fatalf("FirstError = (%s,%s,%v), want (a,boom-3,true)", taskID, errMsg, failed)
+	}
+	if len(rep.snapshot()) != 2 {
+		t.Fatalf("republished %d times, want exactly 2", len(rep.snapshot()))
+	}
+}
+
+func TestTaskRetrier_RetryDisabled(t *testing.T) {
+	rep := &collectingRepublisher{}
+	tr := newTaskRetrier(retryTestTasks(1), false, rep.republish, slog.Default(), "s")
+	if !tr.Observe(failResult("a", "boom")) {
+		t.Fatal("with retry disabled, first failure must be terminal")
+	}
+	if _, _, failed := tr.FirstError(); !failed {
+		t.Fatal("expected terminal failure")
+	}
+	if len(rep.snapshot()) != 0 {
+		t.Fatal("must not republish with retry disabled")
+	}
+}
+
+// TestTaskRetrier_DuplicateDeliveryIgnored locks the dedup fix: the worker's
+// result publish retries up to 3x, so duplicate notifications happen. The old
+// append-only slice double-counted them and could complete a stage early with
+// a task still outstanding.
+func TestTaskRetrier_DuplicateDeliveryIgnored(t *testing.T) {
+	rep := &collectingRepublisher{}
+	tr := newTaskRetrier(retryTestTasks(2), true, rep.republish, slog.Default(), "s")
+	if tr.Observe(okResult("a", "f-a")) {
+		t.Fatal("done after 1/2")
+	}
+	// Duplicate delivery of a's result must NOT complete the stage.
+	if tr.Observe(okResult("a", "f-a")) {
+		t.Fatal("duplicate delivery completed the stage with b outstanding")
+	}
+	if tr.Terminal() != 1 {
+		t.Fatalf("terminal = %d after dup, want 1", tr.Terminal())
+	}
+	if !tr.Observe(okResult("b", "f-b")) {
+		t.Fatal("not done after both tasks")
+	}
+}
+
+func TestTaskRetrier_UnknownTaskIgnored(t *testing.T) {
+	tr := newTaskRetrier(retryTestTasks(1), true, nil, slog.Default(), "s")
+	if tr.Observe(okResult("zzz", "f")) {
+		t.Fatal("unknown task must not complete the stage")
+	}
+	if tr.Terminal() != 0 {
+		t.Fatal("unknown task must not count")
+	}
+}
+
+// TestTaskRetrier_LateDuplicateAfterRetry: attempt 1's failure notification
+// arrives, retry is dispatched, then a DUPLICATE of attempt 1's failure
+// arrives before the retry completes. The duplicate burns one more attempt
+// (acceptable: bounded by the cap) but must never doubly-complete or panic;
+// the eventual success must still win.
+func TestTaskRetrier_LateDuplicateAfterRetry(t *testing.T) {
+	rep := &collectingRepublisher{}
+	tr := newTaskRetrier(retryTestTasks(1), true, rep.republish, slog.Default(), "s")
+	if tr.Observe(failResult("a", "boom")) {
+		t.Fatal("terminal too early")
+	}
+	if tr.Observe(failResult("a", "boom")) { // duplicate of the same failure
+		t.Fatal("terminal too early on dup")
+	}
+	if !tr.Observe(okResult("a", "f-final")) {
+		t.Fatal("success must complete the stage")
+	}
+	if _, _, failed := tr.FirstError(); failed {
+		t.Fatal("success must clear failure state")
+	}
+	if files := tr.Files(); files[0][0] != "f-final" {
+		t.Fatalf("files = %v, want f-final", files[0])
+	}
+}

--- a/internal/distributed/messages.go
+++ b/internal/distributed/messages.go
@@ -25,6 +25,12 @@ type Task struct {
 	Type      TaskType `json:"type"`
 	ClusterID string   `json:"cluster_id,omitempty"` // target cluster for routing
 	TableName string   `json:"table_name,omitempty"`
+	// Attempt is the 1-based execution attempt for this task ID. Stage
+	// inputs are durable S3 files and outputs are overwrite-safe (same
+	// TaskID → same key), so the coordinator re-dispatches failed tasks
+	// with the same ID and a bumped Attempt (coordinator.taskRetrier).
+	// 0 means unset (pre-retry senders); treat as attempt 1.
+	Attempt int `json:"attempt,omitempty"`
 
 	// Pipeline-specific (full query on one worker)
 	SQLText    string `json:"sql_text,omitempty"`    // SQL query to execute as standalone pipeline

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -449,12 +449,51 @@ func (w *Worker) dispatchLoop(ctx context.Context, in <-chan dataplane.TaskDispa
 				return
 			case sem <- struct{}{}:
 			}
+			// Memory-aware admission: hold task START while the shared pool
+			// is above the pull threshold, mirroring taskLoop's pre-fetch
+			// gate (the gRPC path previously had NO pressure gate — tasks
+			// started immediately regardless of pool state). Bounded wait:
+			// pressure relaxes as in-flight tasks finish and release; if it
+			// doesn't within the cap, proceed anyway — running tasks may be
+			// waiting on cooperative spill that the new task's relief
+			// participation can unblock, and the spill machinery remains the
+			// backstop.
+			w.waitForPoolHeadroom(ctx)
 			w.wg.Add(1)
 			go func(t distributed.Task) {
 				defer w.wg.Done()
 				defer func() { <-sem }()
 				w.executeIncomingTask(ctx, t, noopAcker{})
 			}(task)
+		}
+	}
+}
+
+// poolHeadroomMaxWait caps how long dispatchLoop delays a task start while
+// waiting for shared-pool pressure to drop below poolPressurePullThreshold.
+// A cap (rather than wait-forever) avoids a stall where in-flight tasks are
+// themselves blocked on cooperative spill that needs forward progress.
+const poolHeadroomMaxWait = 30 * time.Second
+
+// waitForPoolHeadroom blocks until shared-pool pressure falls below the pull
+// threshold, ctx is done, or poolHeadroomMaxWait elapses. Mirrors taskLoop's
+// pre-fetch pressure gate for the gRPC dispatch path.
+func (w *Worker) waitForPoolHeadroom(ctx context.Context) {
+	deadline := time.Now().Add(poolHeadroomMaxWait)
+	for {
+		used, budget := w.executor.SharedPoolStats()
+		if budget <= 0 || float64(used)/float64(budget) <= poolPressurePullThreshold {
+			return
+		}
+		if time.Now().After(deadline) {
+			w.logger.Warn("pool pressure gate timed out; starting task anyway",
+				"pool_used_mb", used>>20, "pool_budget_mb", budget>>20)
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(poolPressurePullBackoff):
 		}
 	}
 }


### PR DESCRIPTION
## Why

Item 3 of the memory-stability roadmap (after #108 and the SF100 flag validation): the engine materializes every stage's output to durable, deterministic S3 files — structurally Trino-FTE — but had **no task retry** (any task failure → whole query fails) and **no memory admission on the gRPC dispatch path** (tasks started instantly regardless of pool pressure; only the legacy NATS path gated). Trino's published FTE result (2/22 → 22/22 TPC-H under full concurrency) comes precisely from bounded retryable tasks + admission, not from spill alone.

## What

**Task retry** — new `taskRetrier` (per-task terminal state keyed by TaskID; failed tasks re-dispatched up to 3 attempts, round-robin lands them elsewhere), wired into `dispatchComputeStage` and `runShuffleSide`. Soundness: task structs are fully self-contained, inputs are durable S3 files, outputs are overwrite-safe (same TaskID → same key, identical deterministic content), and collection uses only the successful attempt's reported files. **Disabled for gather-fused stages** — those stream rows to the client mid-task, so a retry would duplicate streamed output. `Task.Attempt` added to the wire.

**Latent bug fixed en route**: the old append-only result collection double-counted duplicate deliveries (the worker's result publish retries up to 3×) — a stage could complete early with a task still outstanding. Results are now keyed by TaskID and dispatch-ordered (deterministic assembly; previously arrival-ordered).

**Memory-aware admission** — `waitForPoolHeadroom`: the gRPC `dispatchLoop` now holds task starts while shared-pool pressure exceeds the 70% threshold (parity with the NATS `taskLoop` gate), capped at 30s so task starts can't deadlock behind in-flight work waiting on cooperative spill.

## Follow-ups (recorded in session memory)

retry for `dispatchScanFilterStage`/`dispatchPipelineStage` collections; worker-death reaping via the existing-but-unwired `TaskLiveness.StuckTasks`; carrying planner `EstimatedBytes` on the Task for estimate-based bin-packing (heartbeats already report `PoolUsed`/`PoolBudget`/`RSS`).

## Testing

- `taskRetrier` unit tests: first-try success, fail→retry→success, attempt exhaustion, retry-disabled, duplicate-delivery ignored (the dedup fix's teeth), unknown-task ignored, late-duplicate-after-retry.
- Gates: full `./internal/...` green; worker + distributed `-race` green; TPC-H SF0.01 22/22; `tpch-harness --mode=local` PASS (exercises the retrier-wired collection end-to-end).
- Note: coordinator package `-race` times out inside `TestTPCHNativeDAG_SF01` on **unchanged main** too (clean-worktree A/B; ~150s/query × 22 under race ≈ 55 min) — pre-existing race-mode slowness, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)