### PR TITLE
feat(coordinator): task-retry phase 2 — full dispatcher coverage, worker-death reaping, memory-aware admission + bin-packing

### DIFF
--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -124,6 +124,9 @@ func New(cfg Config, cat *catalog.Catalog, nc *nats.Conn, js jetstream.JetStream
 		queryMetas: make(map[string]*queryMeta),
 		querySem:   make(chan struct{}, maxInflight),
 	}
+	// Memory-aware gRPC placement: the scheduler bin-packs estimated task
+	// footprints against heartbeat pool stats. No-op on the NATS path.
+	c.scheduler.SetWorkerRegistry(c.workers)
 
 	// NATS KV result cache: coordinator writes inline results here instead of S3.
 	// Workers already read from this bucket (tier 2 in getFileData), so this
@@ -176,6 +179,19 @@ func (c *Coordinator) SetDataPlaneServer(srv *dataplane.Server) {
 // Workers returns the worker registry for inspecting active workers.
 func (c *Coordinator) Workers() *WorkerRegistry {
 	return c.workers
+}
+
+// noteTaskResult records the cross-cutting bookkeeping every stage result
+// subscription performs on a ResultNotification: the publishing worker is
+// alive (multi-signal liveness), the task's per-task liveness entry is
+// done (it must stop scanning as stuck), and the scheduler's in-flight
+// admission estimate for it is released.
+func (c *Coordinator) noteTaskResult(r distributed.ResultNotification) {
+	c.workers.MarkWorkerSeen(r.WorkerID)
+	if c.workers.Liveness != nil {
+		c.workers.Liveness.Remove(r.TaskID)
+	}
+	c.scheduler.TaskDone(r.TaskID)
 }
 
 // SetTelemetry enables OpenTelemetry tracing on the coordinator.
@@ -1769,6 +1785,7 @@ func (c *Coordinator) subscribeResults(ctx context.Context, queryID string, done
 		if c.workers.Liveness != nil {
 			c.workers.Liveness.Remove(result.TaskID)
 		}
+		c.scheduler.TaskDone(result.TaskID)
 		// Multi-signal liveness: a result publish proves the worker is
 		// alive even if its heartbeat goroutine starves or the heartbeat
 		// NATS conn lags. Updates LastSeen for the worker, no-op if not

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -905,37 +905,42 @@ func (c *Coordinator) materializeReplicate(
 	c.tracker.Start(stageQueryID)
 	defer c.tracker.Delete(stageQueryID)
 	task.QueryID = stageQueryID
+	task.Attempt = 1
 
 	subject := distributed.QueryResultSubject(stageQueryID)
-	type result struct {
-		files []string
-		err   string
-	}
-	var collected result
-	var mu sync.Mutex
 	done := make(chan struct{}, 1)
 	progress := make(chan struct{}, 1)
 	defer stageProgressBridgeFromContext(ctx).Register(stage.ID, progress)()
+	// Materialize sinks to S3 (OpUnpartitionedSink) — retry-safe.
+	retrier := newTaskRetrier([]distributed.Task{task}, true, func(t distributed.Task) {
+		if ctx.Err() != nil {
+			return
+		}
+		if pubErr := c.scheduler.PublishTasks(ctx, []distributed.Task{t}); pubErr != nil {
+			c.logger.Error("materialize task retry publish failed",
+				"stage_id", stage.ID, "task_id", t.ID, "error", pubErr)
+		}
+	}, c.logger, stage.ID)
+	defer c.watchStuckTasks(ctx, retrier)()
 	sub, err := c.nc.Subscribe(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
 		if uerr := distributed.Unmarshal(msg.Data, &r); uerr != nil {
 			return
 		}
 		c.workers.MarkWorkerSeen(r.WorkerID)
-		mu.Lock()
-		if r.Success {
-			collected = result{files: r.ResultFiles}
-		} else {
-			collected = result{err: r.Error}
+		if c.workers.Liveness != nil {
+			c.workers.Liveness.Remove(r.TaskID)
 		}
-		mu.Unlock()
+		allDone := retrier.Observe(r)
 		select {
 		case progress <- struct{}{}:
 		default:
 		}
-		select {
-		case done <- struct{}{}:
-		default:
+		if allDone {
+			select {
+			case done <- struct{}{}:
+			default:
+			}
 		}
 	})
 	if err != nil {
@@ -951,17 +956,16 @@ func (c *Coordinator) materializeReplicate(
 	if err := awaitStageProgress(ctx, done, progress, "replicate "+stage.ID); err != nil {
 		return nil, err
 	}
-	mu.Lock()
-	defer mu.Unlock()
-	if collected.err != "" {
-		return nil, fmt.Errorf("materialize task failed: %s", collected.err)
+	if _, errMsg, failed := retrier.FirstError(); failed {
+		return nil, fmt.Errorf("materialize task failed after %d attempts: %s", maxTaskAttempts, errMsg)
 	}
-	if len(collected.files) == 0 {
+	resultFiles := retrier.Files()[0]
+	if len(resultFiles) == 0 {
 		return nil, fmt.Errorf("materialize task returned no files")
 	}
 	c.logger.Info("dispatchReplicateStage: materialized",
-		"stage_id", stage.ID, "input_files", len(files), "cache_files", len(collected.files))
-	return collected.files, nil
+		"stage_id", stage.ID, "input_files", len(files), "cache_files", len(resultFiles))
+	return resultFiles, nil
 }
 
 // dispatchPipelineStage executes a compute stage (scan/join/aggregate/etc.)
@@ -1294,39 +1298,42 @@ func (c *Coordinator) dispatchScanAggregateStage(
 
 	for i := range tasks {
 		tasks[i].QueryID = stageQueryID
+		tasks[i].Attempt = 1
 	}
 	subject := distributed.QueryResultSubject(stageQueryID)
-	type taskResult struct {
-		files []string
-		err   string
-	}
-	collected := make([]taskResult, 0, len(tasks))
-	var mu sync.Mutex
 	done := make(chan struct{}, 1)
 	progress := make(chan struct{}, len(tasks))
 	// Register with the per-query progress bridge so worker-emitted
 	// TaskProgress messages also count as forward progress for this
 	// stage's idle detection.
 	defer stageProgressBridgeFromContext(ctx).Register(stage.ID, progress)()
+	// Scan-aggregate tasks sink to S3 (unpartitioned or exchange-sender),
+	// never gather-fused — retry is always safe.
+	retrier := newTaskRetrier(tasks, true, func(t distributed.Task) {
+		if ctx.Err() != nil {
+			return
+		}
+		if pubErr := c.scheduler.PublishTasks(ctx, []distributed.Task{t}); pubErr != nil {
+			c.logger.Error("scan-agg task retry publish failed",
+				"stage_id", stage.ID, "task_id", t.ID, "error", pubErr)
+		}
+	}, c.logger, stage.ID)
+	defer c.watchStuckTasks(ctx, retrier)()
 	sub, err := c.nc.Subscribe(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
 		if uerr := distributed.Unmarshal(msg.Data, &r); uerr != nil {
 			return
 		}
 		c.workers.MarkWorkerSeen(r.WorkerID)
-		mu.Lock()
-		if r.Success {
-			collected = append(collected, taskResult{files: r.ResultFiles})
-		} else {
-			collected = append(collected, taskResult{err: r.Error})
+		if c.workers.Liveness != nil {
+			c.workers.Liveness.Remove(r.TaskID)
 		}
-		got := len(collected)
-		mu.Unlock()
+		allDone := retrier.Observe(r)
 		select {
 		case progress <- struct{}{}:
 		default:
 		}
-		if got >= len(tasks) {
+		if allDone {
 			select {
 			case done <- struct{}{}:
 			default:
@@ -1345,15 +1352,10 @@ func (c *Coordinator) dispatchScanAggregateStage(
 		return StageOutput{}, err
 	}
 
-	mu.Lock()
-	results := make([]taskResult, len(collected))
-	copy(results, collected)
-	mu.Unlock()
-	for _, r := range results {
-		if r.err != "" {
-			return StageOutput{}, fmt.Errorf("scan-agg stage %s: task failed: %s", stage.ID, r.err)
-		}
+	if taskID, errMsg, failed := retrier.FirstError(); failed {
+		return StageOutput{}, fmt.Errorf("scan-agg stage %s: task %s failed after %d attempts: %s", stage.ID, taskID, maxTaskAttempts, errMsg)
 	}
+	resultFiles := retrier.Files()
 	if stage.Exchange != nil && len(stage.Exchange.Keys) > 0 && stage.Exchange.Count > 0 {
 		// Fused scan-aggregate + shuffle: each task produced N partition
 		// files at "<prefix>partition=NNNN/<task>.wshf". Bucket all files
@@ -1362,8 +1364,8 @@ func (c *Coordinator) dispatchScanAggregateStage(
 		// dispatchScanFilterStage's fuseShuffle path.
 		numParts := stage.Exchange.Count
 		shardFiles := make([][]string, numParts)
-		for _, r := range results {
-			for _, f := range r.files {
+		for _, taskFiles := range resultFiles {
+			for _, f := range taskFiles {
 				p, parseErr := parsePartitionFromPath(f)
 				if parseErr != nil {
 					return StageOutput{}, fmt.Errorf("scan-agg stage %s: parsing partition from %q: %w", stage.ID, f, parseErr)
@@ -1380,14 +1382,10 @@ func (c *Coordinator) dispatchScanAggregateStage(
 			Files:         shardFiles,
 		}, nil
 	}
-	files := make([][]string, len(tasks))
-	for i, r := range results {
-		files[i] = r.files
-	}
 	return StageOutput{
 		Kind:          OutputPartitioned,
 		NumPartitions: len(tasks),
-		Files:         files,
+		Files:         resultFiles,
 	}, nil
 }
 
@@ -1552,43 +1550,44 @@ func (c *Coordinator) dispatchScanFilterStage(
 
 	for i := range tasks {
 		tasks[i].QueryID = stageQueryID
+		tasks[i].Attempt = 1
 	}
 	subject := distributed.QueryResultSubject(stageQueryID)
-	type taskResult struct {
-		files    []string
-		partials []distributed.DynamicFilterPartialRef
-		err      string
-	}
-	collected := make([]taskResult, 0, len(tasks))
-	var mu sync.Mutex
 	done := make(chan struct{}, 1)
 	progress := make(chan struct{}, len(tasks))
 	// Register with the per-query progress bridge so worker-emitted
 	// TaskProgress messages also count as forward progress for this
 	// stage's idle detection.
 	defer stageProgressBridgeFromContext(ctx).Register(stage.ID, progress)()
+	// Scan-filter tasks sink to S3 (unpartitioned or fused-shuffle
+	// partition files), never gather-fused — retry is always safe.
+	// Dynamic-filter partials are collected from the successful attempt's
+	// notification, same as result files.
+	retrier := newTaskRetrier(tasks, true, func(t distributed.Task) {
+		if ctx.Err() != nil {
+			return
+		}
+		if pubErr := c.scheduler.PublishTasks(ctx, []distributed.Task{t}); pubErr != nil {
+			c.logger.Error("scan-filter task retry publish failed",
+				"stage_id", stage.ID, "task_id", t.ID, "error", pubErr)
+		}
+	}, c.logger, stage.ID)
+	defer c.watchStuckTasks(ctx, retrier)()
 	sub, err := c.nc.Subscribe(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
 		if uerr := distributed.Unmarshal(msg.Data, &r); uerr != nil {
 			return
 		}
 		c.workers.MarkWorkerSeen(r.WorkerID)
-		mu.Lock()
-		if r.Success {
-			collected = append(collected, taskResult{
-				files:    r.ResultFiles,
-				partials: r.DynamicFilterPartials,
-			})
-		} else {
-			collected = append(collected, taskResult{err: r.Error})
+		if c.workers.Liveness != nil {
+			c.workers.Liveness.Remove(r.TaskID)
 		}
-		got := len(collected)
-		mu.Unlock()
+		allDone := retrier.Observe(r)
 		select {
 		case progress <- struct{}{}:
 		default:
 		}
-		if got >= len(tasks) {
+		if allDone {
 			select {
 			case done <- struct{}{}:
 			default:
@@ -1607,25 +1606,17 @@ func (c *Coordinator) dispatchScanFilterStage(
 		return StageOutput{}, err
 	}
 
-	mu.Lock()
-	results := make([]taskResult, len(collected))
-	copy(results, collected)
-	mu.Unlock()
-	for _, r := range results {
-		if r.err != "" {
-			return StageOutput{}, fmt.Errorf("scan-filter stage %s: task failed: %s", stage.ID, r.err)
-		}
+	if taskID, errMsg, failed := retrier.FirstError(); failed {
+		return StageOutput{}, fmt.Errorf("scan-filter stage %s: task %s failed after %d attempts: %s", stage.ID, taskID, maxTaskAttempts, errMsg)
 	}
+	resultFiles := retrier.Files()
 
 	// Union per-task dynamic-filter partials into stage-level BuildStats.
 	// Skipped if the stage didn't emit (no partials expected) — saves the
 	// S3 round-trip for the common non-emit case.
 	var buildStats map[string]*BuildStats
 	if len(stage.EmitDynamicFilters) > 0 {
-		var allRefs []distributed.DynamicFilterPartialRef
-		for _, r := range results {
-			allRefs = append(allRefs, r.partials...)
-		}
+		allRefs := retrier.DynamicFilterPartials()
 		merged, mergeErr := mergeBuildStatsFromPartials(ctx, c.catalog.Store(), allRefs)
 		if mergeErr != nil {
 			c.logger.Warn("dynamic_filter: partial merge failed; downstream consumes will see no filter",
@@ -1653,8 +1644,8 @@ func (c *Coordinator) dispatchScanFilterStage(
 		// each partition's full set. Same shape as runShuffleSide.
 		numParts := stage.Exchange.Count
 		shardFiles := make([][]string, numParts)
-		for _, r := range results {
-			for _, f := range r.files {
+		for _, taskFiles := range resultFiles {
+			for _, f := range taskFiles {
 				p, parseErr := parsePartitionFromPath(f)
 				if parseErr != nil {
 					return StageOutput{}, fmt.Errorf("scan-filter stage %s: parsing partition from %q: %w", stage.ID, f, parseErr)
@@ -1672,14 +1663,10 @@ func (c *Coordinator) dispatchScanFilterStage(
 			BuildStats:    buildStats,
 		}, nil
 	}
-	files := make([][]string, len(tasks))
-	for i, r := range results {
-		files[i] = r.files
-	}
 	return StageOutput{
 		Kind:          OutputPartitioned,
 		NumPartitions: len(tasks),
-		Files:         files,
+		Files:         resultFiles,
 		BuildStats:    buildStats,
 	}, nil
 }
@@ -2045,12 +2032,16 @@ func (c *Coordinator) dispatchComputeStage(
 				"stage_id", stage.ID, "task_id", t.ID, "error", pubErr)
 		}
 	}, c.logger, stage.ID)
+	defer c.watchStuckTasks(ctx, retrier)()
 	sub, err := c.nc.Subscribe(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
 		if err := distributed.Unmarshal(msg.Data, &r); err != nil {
 			return
 		}
 		c.workers.MarkWorkerSeen(r.WorkerID)
+		if c.workers.Liveness != nil {
+			c.workers.Liveness.Remove(r.TaskID)
+		}
 		allDone := retrier.Observe(r)
 		select {
 		case progress <- struct{}{}:
@@ -2618,10 +2609,12 @@ func (c *Coordinator) dispatchFinalAggregateFanout(
 		c.enrichTaskWithQueryContext(qm, &t)
 		intermTasks = append(intermTasks, t)
 	}
+	// Intermediates always sink to S3 (no fused subject) — retry-safe.
 	intermFiles, err := c.runStageTasks(ctx,
 		fmt.Sprintf("st-%s-interm-%s", stage.ID, queryID),
 		stage.ID+"-interm",
-		intermTasks)
+		intermTasks,
+		true)
 	if err != nil {
 		return StageOutput{}, fmt.Errorf("final_aggregate fanout %s: intermediate phase: %w", stage.ID, err)
 	}
@@ -2678,10 +2671,13 @@ func (c *Coordinator) dispatchFinalAggregateFanout(
 	c.mu.Unlock()
 	c.enrichTaskWithQueryContext(qm, &finalTask)
 
+	// The final task streams to the client when gather-fused — retry only
+	// when it sinks to S3 instead.
 	finalFiles, err := c.runStageTasks(ctx,
 		fmt.Sprintf("st-%s-%s", stage.ID, queryID),
 		stage.ID,
-		[]distributed.Task{finalTask})
+		[]distributed.Task{finalTask},
+		fusion == nil)
 	if err != nil {
 		return StageOutput{}, fmt.Errorf("final_aggregate fanout %s: final phase: %w", stage.ID, err)
 	}
@@ -2694,13 +2690,18 @@ func (c *Coordinator) dispatchFinalAggregateFanout(
 
 // runStageTasks publishes the given tasks under stageQueryID, subscribes to
 // the per-stage result subject, and waits for all completions. Returns one
-// []string of result files per task, in completion order. Used by
+// []string of result files per task, in dispatch order. Used by
 // dispatchFinalAggregateFanout for both phases; mirrors the inline
 // dispatch+collect in dispatchScanAggregateStage / dispatchComputeStage.
+//
+// retryEnabled must be false when any task streams output mid-task
+// (gather-fused terminal sinks) — a retried task would duplicate the
+// streamed rows.
 func (c *Coordinator) runStageTasks(
 	ctx context.Context,
 	stageQueryID, stageLabel string,
 	tasks []distributed.Task,
+	retryEnabled bool,
 ) ([][]string, error) {
 	if len(tasks) == 0 {
 		return nil, nil
@@ -2714,39 +2715,40 @@ func (c *Coordinator) runStageTasks(
 
 	for i := range tasks {
 		tasks[i].QueryID = stageQueryID
+		tasks[i].Attempt = 1
 	}
 	subject := distributed.QueryResultSubject(stageQueryID)
-	type taskResult struct {
-		files []string
-		err   string
-	}
-	collected := make([]taskResult, 0, len(tasks))
-	var mu sync.Mutex
 	done := make(chan struct{}, 1)
 	progress := make(chan struct{}, len(tasks))
 	// Register with the per-query progress bridge so worker-emitted
 	// TaskProgress messages also count as forward progress for this
 	// stage's idle detection.
 	defer stageProgressBridgeFromContext(ctx).Register(stageLabel, progress)()
+	retrier := newTaskRetrier(tasks, retryEnabled, func(t distributed.Task) {
+		if ctx.Err() != nil {
+			return
+		}
+		if pubErr := c.scheduler.PublishTasks(ctx, []distributed.Task{t}); pubErr != nil {
+			c.logger.Error("task retry publish failed",
+				"stage_id", stageLabel, "task_id", t.ID, "error", pubErr)
+		}
+	}, c.logger, stageLabel)
+	defer c.watchStuckTasks(ctx, retrier)()
 	sub, err := c.nc.Subscribe(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
 		if uerr := distributed.Unmarshal(msg.Data, &r); uerr != nil {
 			return
 		}
 		c.workers.MarkWorkerSeen(r.WorkerID)
-		mu.Lock()
-		if r.Success {
-			collected = append(collected, taskResult{files: r.ResultFiles})
-		} else {
-			collected = append(collected, taskResult{err: r.Error})
+		if c.workers.Liveness != nil {
+			c.workers.Liveness.Remove(r.TaskID)
 		}
-		got := len(collected)
-		mu.Unlock()
+		allDone := retrier.Observe(r)
 		select {
 		case progress <- struct{}{}:
 		default:
 		}
-		if got >= len(tasks) {
+		if allDone {
 			select {
 			case done <- struct{}{}:
 			default:
@@ -2765,18 +2767,10 @@ func (c *Coordinator) runStageTasks(
 		return nil, err
 	}
 
-	mu.Lock()
-	results := make([]taskResult, len(collected))
-	copy(results, collected)
-	mu.Unlock()
-	files := make([][]string, len(tasks))
-	for i, r := range results {
-		if r.err != "" {
-			return nil, fmt.Errorf("stage %s: task failed: %s", stageLabel, r.err)
-		}
-		files[i] = r.files
+	if taskID, errMsg, failed := retrier.FirstError(); failed {
+		return nil, fmt.Errorf("stage %s: task %s failed after %d attempts: %s", stageLabel, taskID, maxTaskAttempts, errMsg)
 	}
-	return files, nil
+	return retrier.Files(), nil
 }
 
 // buildTaskInputsForStage maps a stage's Dependencies (upstream stage IDs)

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -927,10 +927,7 @@ func (c *Coordinator) materializeReplicate(
 		if uerr := distributed.Unmarshal(msg.Data, &r); uerr != nil {
 			return
 		}
-		c.workers.MarkWorkerSeen(r.WorkerID)
-		if c.workers.Liveness != nil {
-			c.workers.Liveness.Remove(r.TaskID)
-		}
+		c.noteTaskResult(r)
 		allDone := retrier.Observe(r)
 		select {
 		case progress <- struct{}{}:
@@ -1296,9 +1293,17 @@ func (c *Coordinator) dispatchScanAggregateStage(
 	c.tracker.Start(stageQueryID)
 	defer c.tracker.Delete(stageQueryID)
 
+	// Per-task admission estimate: the catalog-true scan bytes split
+	// across tasks (files are split evenly; row-group shards each read
+	// ~1/N of the file).
+	perTaskEst := int64(0)
+	if stage.EstimatedBytes > 0 {
+		perTaskEst = stage.EstimatedBytes / int64(len(tasks))
+	}
 	for i := range tasks {
 		tasks[i].QueryID = stageQueryID
 		tasks[i].Attempt = 1
+		tasks[i].EstimatedBytes = perTaskEst
 	}
 	subject := distributed.QueryResultSubject(stageQueryID)
 	done := make(chan struct{}, 1)
@@ -1324,10 +1329,7 @@ func (c *Coordinator) dispatchScanAggregateStage(
 		if uerr := distributed.Unmarshal(msg.Data, &r); uerr != nil {
 			return
 		}
-		c.workers.MarkWorkerSeen(r.WorkerID)
-		if c.workers.Liveness != nil {
-			c.workers.Liveness.Remove(r.TaskID)
-		}
+		c.noteTaskResult(r)
 		allDone := retrier.Observe(r)
 		select {
 		case progress <- struct{}{}:
@@ -1548,9 +1550,17 @@ func (c *Coordinator) dispatchScanFilterStage(
 	c.tracker.Start(stageQueryID)
 	defer c.tracker.Delete(stageQueryID)
 
+	// Per-task admission estimate: the catalog-true scan bytes split
+	// across tasks (files are split evenly; row-group shards each read
+	// ~1/N of the file).
+	perTaskEst := int64(0)
+	if stage.EstimatedBytes > 0 {
+		perTaskEst = stage.EstimatedBytes / int64(len(tasks))
+	}
 	for i := range tasks {
 		tasks[i].QueryID = stageQueryID
 		tasks[i].Attempt = 1
+		tasks[i].EstimatedBytes = perTaskEst
 	}
 	subject := distributed.QueryResultSubject(stageQueryID)
 	done := make(chan struct{}, 1)
@@ -1578,10 +1588,7 @@ func (c *Coordinator) dispatchScanFilterStage(
 		if uerr := distributed.Unmarshal(msg.Data, &r); uerr != nil {
 			return
 		}
-		c.workers.MarkWorkerSeen(r.WorkerID)
-		if c.workers.Liveness != nil {
-			c.workers.Liveness.Remove(r.TaskID)
-		}
+		c.noteTaskResult(r)
 		allDone := retrier.Observe(r)
 		select {
 		case progress <- struct{}{}:
@@ -2038,10 +2045,7 @@ func (c *Coordinator) dispatchComputeStage(
 		if err := distributed.Unmarshal(msg.Data, &r); err != nil {
 			return
 		}
-		c.workers.MarkWorkerSeen(r.WorkerID)
-		if c.workers.Liveness != nil {
-			c.workers.Liveness.Remove(r.TaskID)
-		}
+		c.noteTaskResult(r)
 		allDone := retrier.Observe(r)
 		select {
 		case progress <- struct{}{}:
@@ -2739,10 +2743,7 @@ func (c *Coordinator) runStageTasks(
 		if uerr := distributed.Unmarshal(msg.Data, &r); uerr != nil {
 			return
 		}
-		c.workers.MarkWorkerSeen(r.WorkerID)
-		if c.workers.Liveness != nil {
-			c.workers.Liveness.Remove(r.TaskID)
-		}
+		c.noteTaskResult(r)
 		allDone := retrier.Observe(r)
 		select {
 		case progress <- struct{}{}:

--- a/internal/coordinator/orchestrate_repartition.go
+++ b/internal/coordinator/orchestrate_repartition.go
@@ -236,6 +236,7 @@ func (c *Coordinator) runShuffleSide(
 				"side", sideName, "task_id", t.ID, "error", pubErr)
 		}
 	}, c.logger, stageID)
+	defer c.watchStuckTasks(ctx, retrier)()
 
 	sub, err := c.nc.Subscribe(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
@@ -243,6 +244,9 @@ func (c *Coordinator) runShuffleSide(
 			return
 		}
 		c.workers.MarkWorkerSeen(r.WorkerID)
+		if c.workers.Liveness != nil {
+			c.workers.Liveness.Remove(r.TaskID)
+		}
 		if retrier.Observe(r) {
 			select {
 			case done <- struct{}{}:

--- a/internal/coordinator/orchestrate_repartition.go
+++ b/internal/coordinator/orchestrate_repartition.go
@@ -198,6 +198,12 @@ func (c *Coordinator) runShuffleSide(
 	subject := distributed.QueryResultSubject(shuffleQueryID)
 	done := make(chan struct{}, 1)
 
+	// Per-task admission estimate from the source scan's catalog-true
+	// bytes (0 = unknown when the source isn't a planner-estimated scan).
+	perTaskEst := int64(0)
+	if sourceStage.EstimatedBytes > 0 && actualTasks > 0 {
+		perTaskEst = sourceStage.EstimatedBytes / int64(actualTasks)
+	}
 	tasks := make([]distributed.Task, actualTasks)
 	for i, files := range fileSets {
 		t := distributed.Task{
@@ -220,6 +226,7 @@ func (c *Coordinator) runShuffleSide(
 			t.ClusterID = clusterID
 		}
 		t.Attempt = 1
+		t.EstimatedBytes = perTaskEst
 		tasks[i] = t
 	}
 
@@ -243,10 +250,7 @@ func (c *Coordinator) runShuffleSide(
 		if unmarshalErr := distributed.Unmarshal(msg.Data, &r); unmarshalErr != nil {
 			return
 		}
-		c.workers.MarkWorkerSeen(r.WorkerID)
-		if c.workers.Liveness != nil {
-			c.workers.Liveness.Remove(r.TaskID)
-		}
+		c.noteTaskResult(r)
 		if retrier.Observe(r) {
 			select {
 			case done <- struct{}{}:

--- a/internal/coordinator/scheduler.go
+++ b/internal/coordinator/scheduler.go
@@ -5,11 +5,30 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
+	"time"
 
 	"github.com/citc-tech/wadjet/internal/dataplane"
 	"github.com/citc-tech/wadjet/internal/distributed"
 	"github.com/nats-io/nats.go"
 )
+
+// schedulerInflightTTL bounds how long a dispatched task's EstimatedBytes
+// counts against its worker in pickLeastLoaded. The estimate covers the
+// dispatch→pool-visible blind window: once the task is admitted its real
+// allocations show up in the worker's heartbeat PoolUsed (10s cadence), so
+// holding the estimate past that double-counts (conservative, never
+// unsafe). Result arrival clears the entry early via TaskDone; the TTL is
+// the backstop for lost results.
+const schedulerInflightTTL = 60 * time.Second
+
+// inflightTask is one dispatched-not-yet-done task's admission estimate,
+// charged against a worker in pickLeastLoaded.
+type inflightTask struct {
+	workerID string
+	bytes    int64
+	expires  time.Time
+}
 
 // Scheduler publishes tasks to NATS and tracks stage DAGs.
 type Scheduler struct {
@@ -17,11 +36,20 @@ type Scheduler struct {
 	logger *slog.Logger
 
 	// dpSrv is the optional data-plane gRPC server. When set, PublishTasks
-	// pushes each task over a per-worker gRPC stream instead of NATS,
-	// using round-robin worker selection (see Server.PickWorker). NATS is
-	// not used as a fallback in this mode — gRPC dispatch is either all
-	// or nothing per the Phase C design.
+	// pushes each task over a per-worker gRPC stream instead of NATS.
+	// Placement: bin-packed by estimated memory fit when the task carries
+	// an EstimatedBytes and heartbeat pool stats exist (see pickWorkerFor),
+	// round-robin otherwise (Server.PickWorker). NATS is not used as a
+	// fallback in this mode — gRPC dispatch is either all or nothing per
+	// the Phase C design.
 	dpSrv *dataplane.Server
+
+	// registry provides heartbeat pool stats (PoolUsed/PoolBudget) for
+	// bin-packed placement. nil = always round-robin.
+	registry *WorkerRegistry
+
+	inflightMu sync.Mutex
+	inflight   map[string]inflightTask // task ID → estimate charged to a worker
 }
 
 // NewScheduler creates a new task scheduler.
@@ -29,13 +57,30 @@ func NewScheduler(nc *nats.Conn, logger *slog.Logger) *Scheduler {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Scheduler{nc: nc, logger: logger}
+	return &Scheduler{nc: nc, logger: logger, inflight: make(map[string]inflightTask)}
 }
 
 // SetDataPlaneServer enables gRPC task dispatch. When set, PublishTasks
 // pushes through the data-plane server instead of NATS publish.
 func (s *Scheduler) SetDataPlaneServer(srv *dataplane.Server) {
 	s.dpSrv = srv
+}
+
+// SetWorkerRegistry enables memory-aware placement for gRPC dispatch:
+// tasks carrying an EstimatedBytes go to the worker with the most free
+// pool (heartbeat budget − heartbeat used − in-flight estimates) instead
+// of round-robin.
+func (s *Scheduler) SetWorkerRegistry(wr *WorkerRegistry) {
+	s.registry = wr
+}
+
+// TaskDone clears the task's in-flight admission estimate. Called by the
+// stage result subscriptions on every ResultNotification; the TTL covers
+// lost results.
+func (s *Scheduler) TaskDone(taskID string) {
+	s.inflightMu.Lock()
+	delete(s.inflight, taskID)
+	s.inflightMu.Unlock()
 }
 
 // preparedTask is the per-task scratch built by PublishTasks before
@@ -95,14 +140,15 @@ func (s *Scheduler) PublishTasks(_ context.Context, tasks []distributed.Task) er
 	return nil
 }
 
-// publishViaDataPlane pushes each task to a worker selected by
-// round-robin over the data-plane server's connected set. Send blocks
-// on HTTP/2 flow control when a worker is saturated, applying
+// publishViaDataPlane pushes each task to a selected worker. Tasks
+// carrying an EstimatedBytes are bin-packed onto the worker with the most
+// free pool; tasks without an estimate round-robin (see pickWorkerFor).
+// Send blocks on HTTP/2 flow control when a worker is saturated, applying
 // backpressure to the scheduler. The full set is rejected if no worker
 // is connected — there is no NATS fallback in gRPC mode.
 func (s *Scheduler) publishViaDataPlane(batch []preparedTask) error {
 	for _, p := range batch {
-		workerID, ok := s.dpSrv.PickWorker()
+		workerID, ok := s.pickWorkerFor(p.task)
 		if !ok {
 			return fmt.Errorf("dispatching task %s: %w", p.task.ID, dataplane.ErrNoWorkers)
 		}
@@ -114,13 +160,98 @@ func (s *Scheduler) publishViaDataPlane(batch []preparedTask) error {
 				workerID2, ok2 := s.dpSrv.PickWorker()
 				if ok2 && workerID2 != workerID {
 					if err2 := s.dpSrv.SendTaskDispatch(workerID2, p.task.ID, p.task.QueryID, p.task.StageID, p.data, 0); err2 == nil {
+						s.noteInflight(p.task, workerID2)
 						continue
 					}
 				}
 			}
 			return fmt.Errorf("dispatching task %s to %s: %w", p.task.ID, workerID, err)
 		}
+		s.noteInflight(p.task, workerID)
 	}
 	s.logger.Info("published tasks", "count", len(batch), "transport", "grpc")
 	return nil
+}
+
+// pickWorkerFor selects a worker for one task. Memory-aware bin-packing
+// applies only when the task carries an estimate AND heartbeat pool stats
+// exist — otherwise placement is the pre-existing round-robin. Estimates
+// of 0 deliberately round-robin: with no per-task charge, "most free"
+// would be static between heartbeats and pile every task of a fan-out
+// onto one worker.
+func (s *Scheduler) pickWorkerFor(t distributed.Task) (string, bool) {
+	if t.EstimatedBytes > 0 && s.registry != nil {
+		if id, ok := s.pickLeastLoaded(); ok {
+			return id, true
+		}
+	}
+	return s.dpSrv.PickWorker()
+}
+
+// pickLeastLoaded returns the connected worker with the most free shared
+// pool: heartbeat budget − heartbeat used − in-flight dispatch estimates.
+// Workers without pool stats (legacy builds, pre-first-heartbeat) are
+// skipped; returns ok=false when none qualify so the caller round-robins.
+func (s *Scheduler) pickLeastLoaded() (string, bool) {
+	return pickLeastLoadedWorker(s.dpSrv.ConnectedWorkers(), s.registry.ActiveWorkers(), s.inflightByWorker())
+}
+
+// pickLeastLoadedWorker is pickLeastLoaded's pure scoring core: max over
+// connected workers of (PoolBudget − PoolUsed − in-flight estimate),
+// skipping workers with no pool stats. Free space may legitimately go
+// negative under burst dispatch — the least-overcommitted worker still
+// wins (every placement choice exists; refusing here would just push the
+// decision to round-robin, which picks blind).
+func pickLeastLoadedWorker(connected []string, active []*WorkerInfo, inflight map[string]int64) (string, bool) {
+	infos := make(map[string]*WorkerInfo, len(active))
+	for _, w := range active {
+		infos[w.WorkerID] = w
+	}
+	var bestID string
+	var bestFree int64
+	found := false
+	for _, id := range connected {
+		info, ok := infos[id]
+		if !ok || info.PoolBudget <= 0 {
+			continue
+		}
+		free := info.PoolBudget - info.PoolUsed - inflight[id]
+		if !found || free > bestFree {
+			bestID, bestFree, found = id, free, true
+		}
+	}
+	return bestID, found
+}
+
+// inflightByWorker sums live in-flight estimates per worker, lazily
+// expiring stale entries (no background goroutine).
+func (s *Scheduler) inflightByWorker() map[string]int64 {
+	s.inflightMu.Lock()
+	defer s.inflightMu.Unlock()
+	now := time.Now()
+	perWorker := make(map[string]int64)
+	for id, e := range s.inflight {
+		if now.After(e.expires) {
+			delete(s.inflight, id)
+			continue
+		}
+		perWorker[e.workerID] += e.bytes
+	}
+	return perWorker
+}
+
+// noteInflight charges a dispatched task's estimate to its worker until
+// the result arrives (TaskDone) or the TTL hands accounting off to the
+// worker's heartbeat PoolUsed.
+func (s *Scheduler) noteInflight(t distributed.Task, workerID string) {
+	if t.EstimatedBytes <= 0 {
+		return
+	}
+	s.inflightMu.Lock()
+	s.inflight[t.ID] = inflightTask{
+		workerID: workerID,
+		bytes:    t.EstimatedBytes,
+		expires:  time.Now().Add(schedulerInflightTTL),
+	}
+	s.inflightMu.Unlock()
 }

--- a/internal/coordinator/scheduler_binpack_test.go
+++ b/internal/coordinator/scheduler_binpack_test.go
@@ -1,0 +1,105 @@
+package coordinator
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+)
+
+func TestPickLeastLoadedWorker(t *testing.T) {
+	active := []*WorkerInfo{
+		{WorkerID: "w1", PoolBudget: 1000, PoolUsed: 800}, // free 200
+		{WorkerID: "w2", PoolBudget: 1000, PoolUsed: 100}, // free 900
+		{WorkerID: "w3", PoolBudget: 2000, PoolUsed: 500}, // free 1500
+		{WorkerID: "legacy"},                              // no pool stats
+	}
+	tests := []struct {
+		name      string
+		connected []string
+		inflight  map[string]int64
+		wantID    string
+		wantOK    bool
+	}{
+		{"most free wins", []string{"w1", "w2", "w3"}, nil, "w3", true},
+		{"inflight charges count", []string{"w1", "w2", "w3"},
+			map[string]int64{"w3": 1400}, "w2", true}, // w3 free drops to 100
+		{"disconnected workers excluded", []string{"w1", "w2"}, nil, "w2", true},
+		{"unregistered and legacy skipped", []string{"legacy", "ghost"}, nil, "", false},
+		{"no connected workers", nil, nil, "", false},
+		{"all overcommitted picks least bad", []string{"w1", "w2"},
+			map[string]int64{"w1": 500, "w2": 2000}, "w1", true}, // -300 vs -1100
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			id, ok := pickLeastLoadedWorker(tc.connected, active, tc.inflight)
+			if id != tc.wantID || ok != tc.wantOK {
+				t.Fatalf("pickLeastLoadedWorker = (%q,%v), want (%q,%v)", id, ok, tc.wantID, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestSchedulerInflightLifecycle(t *testing.T) {
+	s := NewScheduler(nil, nil)
+	s.noteInflight(distributed.Task{ID: "t1", EstimatedBytes: 100}, "w1")
+	s.noteInflight(distributed.Task{ID: "t2", EstimatedBytes: 50}, "w1")
+	s.noteInflight(distributed.Task{ID: "t3", EstimatedBytes: 0}, "w1") // no estimate → not tracked
+	s.noteInflight(distributed.Task{ID: "t4", EstimatedBytes: 70}, "w2")
+
+	per := s.inflightByWorker()
+	if per["w1"] != 150 || per["w2"] != 70 {
+		t.Fatalf("inflight = %v, want w1:150 w2:70", per)
+	}
+
+	// Result arrival releases the charge.
+	s.TaskDone("t1")
+	if per := s.inflightByWorker(); per["w1"] != 50 {
+		t.Fatalf("after TaskDone, w1 = %d, want 50", per["w1"])
+	}
+
+	// TTL expiry hands accounting off to heartbeat PoolUsed.
+	s.inflightMu.Lock()
+	e := s.inflight["t2"]
+	e.expires = time.Now().Add(-time.Second)
+	s.inflight["t2"] = e
+	s.inflightMu.Unlock()
+	if per := s.inflightByWorker(); per["w1"] != 0 {
+		t.Fatalf("after TTL expiry, w1 = %d, want 0", per["w1"])
+	}
+}
+
+// TestTaskRetrier_GrowEstimateOnRetry: every re-dispatch (failure or stuck)
+// doubles the admission estimate, bounded by the attempt cap; tasks with no
+// estimate stay at 0 (unknown).
+func TestTaskRetrier_GrowEstimateOnRetry(t *testing.T) {
+	rep := &collectingRepublisher{}
+	tasks := retryTestTasks(2)
+	tasks[0].EstimatedBytes = 100
+	// tasks[1] stays 0.
+	tr := newTaskRetrier(tasks, true, rep.republish, slog.Default(), "s")
+
+	if tr.Observe(failResult("a", "boom")) {
+		t.Fatal("terminal too early")
+	}
+	got := waitRepublished(t, rep, 1)
+	if got[0].EstimatedBytes != 200 {
+		t.Fatalf("retry 1 estimate = %d, want 200", got[0].EstimatedBytes)
+	}
+	if re, _ := tr.RetryStuck([]string{"a"}); len(re) != 1 {
+		t.Fatalf("stuck retry = %v, want [a]", re)
+	}
+	got = waitRepublished(t, rep, 2)
+	if got[1].EstimatedBytes != 400 {
+		t.Fatalf("retry 2 estimate = %d, want 400", got[1].EstimatedBytes)
+	}
+
+	if tr.Observe(failResult("b", "boom")) {
+		t.Fatal("terminal too early for b")
+	}
+	got = waitRepublished(t, rep, 3)
+	if got[2].ID != "b" || got[2].EstimatedBytes != 0 {
+		t.Fatalf("no-estimate retry = %+v, want b with 0", got[2])
+	}
+}

--- a/internal/coordinator/task_retry.go
+++ b/internal/coordinator/task_retry.go
@@ -96,7 +96,7 @@ func (tr *taskRetrier) Observe(r distributed.ResultNotification) (allDone bool) 
 	// Failure: retry if attempts remain, else terminal failure.
 	if tr.retryEnabled && st.attempts < maxTaskAttempts {
 		st.attempts++
-		task := tr.tasks[r.TaskID]
+		task := tr.growEstimateLocked(r.TaskID)
 		task.Attempt = st.attempts
 		tr.mu.Unlock()
 		if tr.logger != nil {
@@ -121,6 +121,21 @@ func (tr *taskRetrier) Observe(r distributed.ResultNotification) (allDone bool) 
 			"attempts", st.attempts, "error", r.Error)
 	}
 	return done
+}
+
+// growEstimateLocked doubles the task's admission size estimate and returns
+// the updated task (grow-on-retry, the Trino FTE pattern). A failure or a
+// presumed-dead worker can't tell us whether memory was the cause, so the
+// retry asks for strictly more headroom before being admitted — cheap
+// insurance, bounded to 4x by maxTaskAttempts. No-op when the dispatcher
+// had no estimate (0 stays 0 = unknown). Caller must hold tr.mu.
+func (tr *taskRetrier) growEstimateLocked(taskID string) distributed.Task {
+	task := tr.tasks[taskID]
+	if task.EstimatedBytes > 0 {
+		task.EstimatedBytes *= 2
+		tr.tasks[taskID] = task
+	}
+	return task
 }
 
 // Terminal returns how many tasks have reached a terminal state.
@@ -196,7 +211,7 @@ func (tr *taskRetrier) RetryStuck(stuck []string) (redispatched, terminal []stri
 			continue
 		}
 		st.attempts++
-		task := tr.tasks[id]
+		task := tr.growEstimateLocked(id)
 		task.Attempt = st.attempts
 		tr.mu.Unlock()
 		if tr.logger != nil {

--- a/internal/coordinator/task_retry.go
+++ b/internal/coordinator/task_retry.go
@@ -1,8 +1,10 @@
 package coordinator
 
 import (
+	"context"
 	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/citc-tech/wadjet/internal/distributed"
 )
@@ -43,6 +45,7 @@ type taskRetrier struct {
 
 type taskAttemptState struct {
 	files    []string
+	partials []distributed.DynamicFilterPartialRef
 	errMsg   string
 	attempts int
 	terminal bool
@@ -82,6 +85,7 @@ func (tr *taskRetrier) Observe(r distributed.ResultNotification) (allDone bool) 
 	}
 	if r.Success {
 		st.files = r.ResultFiles
+		st.partials = r.DynamicFilterPartials
 		st.errMsg = ""
 		st.terminal = true
 		tr.terminal++
@@ -148,4 +152,126 @@ func (tr *taskRetrier) Files() [][]string {
 		out[i] = tr.states[id].files
 	}
 	return out
+}
+
+// DynamicFilterPartials returns every successful task's dynamic-filter
+// partial refs, flattened in dispatch order.
+func (tr *taskRetrier) DynamicFilterPartials() []distributed.DynamicFilterPartialRef {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	var out []distributed.DynamicFilterPartialRef
+	for _, id := range tr.order {
+		out = append(out, tr.states[id].partials...)
+	}
+	return out
+}
+
+// RetryStuck re-dispatches every non-terminal task in stuck — task IDs whose
+// worker has gone silent (no heartbeat ActiveTaskIDs mention and no
+// TaskProgress) past the liveness threshold. Burns an attempt like a failure
+// retry. Unlike Observe, exhausting the attempt cap does NOT mark the task
+// terminally failed: "stuck" is a liveness inference, not a reported failure
+// — the original attempt may still be alive (e.g. a long GC stall) and its
+// result, arriving first, is accepted as usual. The stage idle timeout
+// remains the backstop for a task stuck past its cap.
+//
+// Returns the re-dispatched task IDs and, separately, the stuck IDs that
+// belong to this retrier but are already terminal (their liveness entries
+// outlived the task; the caller should drop them from tracking).
+func (tr *taskRetrier) RetryStuck(stuck []string) (redispatched, terminal []string) {
+	for _, id := range stuck {
+		tr.mu.Lock()
+		st, ok := tr.states[id]
+		if !ok {
+			tr.mu.Unlock()
+			continue
+		}
+		if st.terminal {
+			tr.mu.Unlock()
+			terminal = append(terminal, id)
+			continue
+		}
+		if !tr.retryEnabled || st.attempts >= maxTaskAttempts {
+			tr.mu.Unlock()
+			continue
+		}
+		st.attempts++
+		task := tr.tasks[id]
+		task.Attempt = st.attempts
+		tr.mu.Unlock()
+		if tr.logger != nil {
+			tr.logger.Warn("re-dispatching stuck task (worker presumed dead)",
+				"stage_id", tr.stageID, "task_id", id,
+				"attempt", task.Attempt, "max_attempts", maxTaskAttempts)
+		}
+		go tr.republish(task)
+		redispatched = append(redispatched, id)
+	}
+	return redispatched, terminal
+}
+
+// stuckTaskThreshold is how long a started task may go without any liveness
+// signal (heartbeat ActiveTaskIDs mention, or a TaskProgress message) before
+// the coordinator presumes its worker dead and re-dispatches it. Workers
+// heartbeat every 10s and emit per-task progress every 2s, and the worker
+// registry reaps workers at 90s of silence — so 2 minutes of per-task
+// silence means the owning worker has already been reaped (drained), OOM-
+// killed, or lost its result publish. Deliberately above the registry's
+// staleTTL so worker-level reaping fires first.
+//
+// Only tasks a worker has REPORTED (via heartbeat or progress) are tracked:
+// a task queued behind busy workers never enters liveness and is never
+// falsely re-dispatched, no matter how long it queues.
+const stuckTaskThreshold = 2 * time.Minute
+
+// stuckTaskPollEvery is the watcher's poll cadence. StuckTasks is a cheap
+// read-locked map scan; stages that finish faster than one tick pay nothing.
+const stuckTaskPollEvery = 15 * time.Second
+
+// watchStuckTasks starts a goroutine that polls per-task liveness and
+// re-dispatches tasks whose worker has gone silent (the FTE answer to
+// worker death mid-stage: stage inputs are durable S3 files, so a dead
+// worker's tasks just run again elsewhere instead of the stage idling out
+// after stageIdleTimeout). Returns a stop func the dispatcher must defer.
+func (c *Coordinator) watchStuckTasks(ctx context.Context, retrier *taskRetrier) (stop func()) {
+	if c.workers == nil || c.workers.Liveness == nil {
+		return func() {}
+	}
+	liveness := c.workers.Liveness
+	watchCtx, cancel := context.WithCancel(ctx)
+	go func() {
+		ticker := time.NewTicker(stuckTaskPollEvery)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-watchCtx.Done():
+				return
+			case <-ticker.C:
+				reapStuckOnce(liveness, retrier, stuckTaskThreshold)
+			}
+		}
+	}()
+	return cancel
+}
+
+// reapStuckOnce runs one stuck-task sweep for watchStuckTasks (split out
+// for testing). Re-dispatches this retrier's stuck non-terminal tasks and
+// drops liveness entries that are either re-dispatched (resets the clock —
+// the new attempt's heartbeats re-register them; without this the next tick
+// would burn another attempt immediately) or terminal (the entry outlived
+// the result, e.g. an in-flight heartbeat re-added it after the result
+// handler's Remove). Other stages' task IDs are left untouched.
+func reapStuckOnce(liveness *TaskLiveness, retrier *taskRetrier, threshold time.Duration) (redispatched int) {
+	stuck := liveness.StuckTasks(threshold)
+	if len(stuck) == 0 {
+		return 0
+	}
+	re, term := retrier.RetryStuck(stuck)
+	for _, id := range re {
+		liveness.Remove(id)
+	}
+	for _, id := range term {
+		liveness.Remove(id)
+	}
+	return len(re)
 }

--- a/internal/coordinator/task_retry_test.go
+++ b/internal/coordinator/task_retry_test.go
@@ -212,3 +212,131 @@ func TestTaskRetrier_LateDuplicateAfterRetry(t *testing.T) {
 		t.Fatalf("files = %v, want f-final", files[0])
 	}
 }
+
+// TestTaskRetrier_DynamicFilterPartials: partial refs from the successful
+// attempt's notification are captured per task and flattened in dispatch
+// order; duplicates must not double-collect.
+func TestTaskRetrier_DynamicFilterPartials(t *testing.T) {
+	tr := newTaskRetrier(retryTestTasks(2), true, nil, slog.Default(), "s")
+	rA := okResult("a", "f-a")
+	rA.DynamicFilterPartials = []distributed.DynamicFilterPartialRef{
+		{FilterID: "df1", Bucket: "b", Key: "a-df1"},
+	}
+	rB := okResult("b", "f-b")
+	rB.DynamicFilterPartials = []distributed.DynamicFilterPartialRef{
+		{FilterID: "df1", Bucket: "b", Key: "b-df1"},
+		{FilterID: "df2", Bucket: "b", Key: "b-df2"},
+	}
+	tr.Observe(rB) // arrival order reversed vs dispatch order
+	tr.Observe(rA)
+	tr.Observe(rB) // duplicate must not double-collect
+	got := tr.DynamicFilterPartials()
+	if len(got) != 3 {
+		t.Fatalf("partials = %d, want 3", len(got))
+	}
+	if got[0].Key != "a-df1" || got[1].Key != "b-df1" || got[2].Key != "b-df2" {
+		t.Fatalf("partials out of dispatch order: %+v", got)
+	}
+}
+
+// TestTaskRetrier_RetryStuck_Redispatches: a stuck non-terminal task burns an
+// attempt and is republished; unknown IDs are ignored; terminal IDs are
+// reported back for liveness cleanup.
+func TestTaskRetrier_RetryStuck_Redispatches(t *testing.T) {
+	rep := &collectingRepublisher{}
+	tr := newTaskRetrier(retryTestTasks(2), true, rep.republish, slog.Default(), "s")
+	tr.Observe(okResult("b", "f-b")) // b terminal
+
+	re, term := tr.RetryStuck([]string{"a", "b", "zzz"})
+	if len(re) != 1 || re[0] != "a" {
+		t.Fatalf("redispatched = %v, want [a]", re)
+	}
+	if len(term) != 1 || term[0] != "b" {
+		t.Fatalf("terminal = %v, want [b]", term)
+	}
+	got := waitRepublished(t, rep, 1)
+	if got[0].ID != "a" || got[0].Attempt != 2 {
+		t.Fatalf("republished %+v, want task a attempt 2", got[0])
+	}
+	// The original (presumed-dead) attempt's late success still wins.
+	if !tr.Observe(okResult("a", "f-a1")) {
+		t.Fatal("stage must complete on the surviving attempt's result")
+	}
+	if _, _, failed := tr.FirstError(); failed {
+		t.Fatal("unexpected terminal failure")
+	}
+}
+
+// TestTaskRetrier_RetryStuck_CapDoesNotFail: a task stuck past the attempt
+// cap is NOT marked terminally failed — stuck is an inference, not a
+// reported failure; the stage idle timeout is the backstop.
+func TestTaskRetrier_RetryStuck_CapDoesNotFail(t *testing.T) {
+	rep := &collectingRepublisher{}
+	tr := newTaskRetrier(retryTestTasks(1), true, rep.republish, slog.Default(), "s")
+	re, _ := tr.RetryStuck([]string{"a"}) // attempt 2
+	if len(re) != 1 {
+		t.Fatalf("first stuck sweep redispatched %v, want [a]", re)
+	}
+	re, _ = tr.RetryStuck([]string{"a"}) // attempt 3 (cap)
+	if len(re) != 1 {
+		t.Fatalf("second stuck sweep redispatched %v, want [a]", re)
+	}
+	re, term := tr.RetryStuck([]string{"a"}) // capped: no-op
+	if len(re) != 0 || len(term) != 0 {
+		t.Fatalf("capped sweep = (%v,%v), want empty", re, term)
+	}
+	if tr.Terminal() != 0 {
+		t.Fatal("stuck-past-cap must not mark the task terminal")
+	}
+	if _, _, failed := tr.FirstError(); failed {
+		t.Fatal("stuck-past-cap must not record a terminal failure")
+	}
+	// A surviving attempt's success still completes the stage.
+	if !tr.Observe(okResult("a", "f-a")) {
+		t.Fatal("success must complete the stage")
+	}
+}
+
+// TestTaskRetrier_RetryStuck_RetryDisabled: gather-fused stages must never
+// re-dispatch, even for stuck tasks (a retry would duplicate streamed rows).
+func TestTaskRetrier_RetryStuck_RetryDisabled(t *testing.T) {
+	rep := &collectingRepublisher{}
+	tr := newTaskRetrier(retryTestTasks(1), false, rep.republish, slog.Default(), "s")
+	re, _ := tr.RetryStuck([]string{"a"})
+	if len(re) != 0 {
+		t.Fatalf("redispatched %v with retry disabled", re)
+	}
+	if len(rep.snapshot()) != 0 {
+		t.Fatal("must not republish with retry disabled")
+	}
+}
+
+// TestReapStuckOnce: one watcher sweep re-dispatches this retrier's stuck
+// tasks and clears their liveness clocks, drops terminal strays, and leaves
+// other stages' entries alone.
+func TestReapStuckOnce(t *testing.T) {
+	rep := &collectingRepublisher{}
+	tr := newTaskRetrier(retryTestTasks(2), true, rep.republish, slog.Default(), "s")
+	tr.Observe(okResult("b", "f-b")) // b terminal
+
+	liveness := NewTaskLiveness()
+	stale := time.Now().Add(-5 * time.Minute)
+	liveness.Update([]string{"a", "b", "other-stage-task"}, stale)
+
+	if n := reapStuckOnce(liveness, tr, 2*time.Minute); n != 1 {
+		t.Fatalf("redispatched = %d, want 1", n)
+	}
+	waitRepublished(t, rep, 1)
+
+	stuck := liveness.StuckTasks(2 * time.Minute)
+	if len(stuck) != 1 || stuck[0] != "other-stage-task" {
+		t.Fatalf("post-sweep stuck = %v, want [other-stage-task] only", stuck)
+	}
+
+	// A fresh entry (the re-dispatched attempt heartbeating) must not be
+	// swept again.
+	liveness.Update([]string{"a"}, time.Now())
+	if n := reapStuckOnce(liveness, tr, 2*time.Minute); n != 0 {
+		t.Fatalf("fresh task redispatched %d times, want 0", n)
+	}
+}

--- a/internal/distributed/messages.go
+++ b/internal/distributed/messages.go
@@ -31,6 +31,15 @@ type Task struct {
 	// with the same ID and a bumped Attempt (coordinator.taskRetrier).
 	// 0 means unset (pre-retry senders); treat as attempt 1.
 	Attempt int `json:"attempt,omitempty"`
+	// EstimatedBytes is the coordinator's estimate of this task's input
+	// footprint, used for memory-aware admission (worker holds the task
+	// start until the shared pool has room for it) and coordinator-side
+	// bin-packing. 0 = unknown — admission and placement fall back to
+	// pressure-threshold / round-robin behavior. Doubled on every
+	// re-dispatch (grow-on-retry, the Trino FTE pattern): a task whose
+	// worker died possibly-of-memory is only admitted where strictly more
+	// headroom exists.
+	EstimatedBytes int64 `json:"estimated_bytes,omitempty"`
 
 	// Pipeline-specific (full query on one worker)
 	SQLText    string `json:"sql_text,omitempty"`    // SQL query to execute as standalone pipeline

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -458,7 +458,7 @@ func (w *Worker) dispatchLoop(ctx context.Context, in <-chan dataplane.TaskDispa
 			// waiting on cooperative spill that the new task's relief
 			// participation can unblock, and the spill machinery remains the
 			// backstop.
-			w.waitForPoolHeadroom(ctx)
+			w.waitForPoolHeadroom(ctx, task.EstimatedBytes)
 			w.wg.Add(1)
 			go func(t distributed.Task) {
 				defer w.wg.Done()
@@ -476,18 +476,32 @@ func (w *Worker) dispatchLoop(ctx context.Context, in <-chan dataplane.TaskDispa
 const poolHeadroomMaxWait = 30 * time.Second
 
 // waitForPoolHeadroom blocks until shared-pool pressure falls below the pull
-// threshold, ctx is done, or poolHeadroomMaxWait elapses. Mirrors taskLoop's
-// pre-fetch pressure gate for the gRPC dispatch path.
-func (w *Worker) waitForPoolHeadroom(ctx context.Context) {
+// threshold AND, when the task carries a size estimate, the pool has room
+// for its estimated input footprint. Returns on ctx done or after
+// poolHeadroomMaxWait. Mirrors taskLoop's pre-fetch pressure gate for the
+// gRPC dispatch path; the size requirement only exists here because the
+// gRPC path has the task in hand before start (the NATS pull gate is
+// task-blind by construction, and blocking a fetched JetStream message
+// risks AckWait redelivery = duplicate execution = more memory, not less).
+//
+// estBytes <= 0 means unknown — only the pressure threshold applies,
+// identical to the pre-estimate behavior.
+func (w *Worker) waitForPoolHeadroom(ctx context.Context, estBytes int64) {
 	deadline := time.Now().Add(poolHeadroomMaxWait)
 	for {
 		used, budget := w.executor.SharedPoolStats()
-		if budget <= 0 || float64(used)/float64(budget) <= poolPressurePullThreshold {
+		if budget <= 0 {
+			return
+		}
+		pressureOK := float64(used)/float64(budget) <= poolPressurePullThreshold
+		fitsOK := estBytes <= 0 || used+estBytes <= budget
+		if pressureOK && fitsOK {
 			return
 		}
 		if time.Now().After(deadline) {
 			w.logger.Warn("pool pressure gate timed out; starting task anyway",
-				"pool_used_mb", used>>20, "pool_budget_mb", budget>>20)
+				"pool_used_mb", used>>20, "pool_budget_mb", budget>>20,
+				"task_estimated_mb", estBytes>>20)
 			return
 		}
 		select {


### PR DESCRIPTION
Phase 2 of the FTE-style reliability work (follows #109). Two commits:

## Commit 1 — retry coverage everywhere + worker-death task reaping

- **All stage dispatchers now use `taskRetrier`**: scan-aggregate, scan-filter, `runStageTasks` (final-aggregate fanout, with retry disabled for the gather-fused final task), and the replicate-stage materialize task join compute + shuffle from #109. This kills the append-only duplicate-delivery hazard (worker result publish retries 3×; a dup could complete a stage early with a task outstanding) at every site and makes result assembly dispatch-ordered.
- **Worker-death task reaping**: a per-stage watcher polls `TaskLiveness.StuckTasks` (2 min of per-task silence across heartbeat + TaskProgress signals) and re-dispatches the dead worker's tasks, bounded by the same attempt cap. Previously a worker crash mid-stage meant the 30-minute idle timeout and a failed query. Stuck-past-cap never marks a task failed (stuck is an inference; the surviving attempt's result still wins, the idle timeout remains the backstop). Only heartbeat-reported tasks are tracked, so tasks queued behind busy workers are never falsely re-dispatched.

## Commit 2 — EstimatedBytes admission + bin-packed placement

- `Task.EstimatedBytes` on the wire; scan-family dispatchers stamp tasks with their share of catalog-true scan bytes (0 = unknown → exactly today's behavior).
- **Grow-on-retry** (Trino FTE pattern): every re-dispatch doubles the estimate — a possibly-OOM-killed task is only admitted where strictly more headroom exists (≤4× via attempt cap).
- **Worker admission (gRPC)**: dispatchLoop's pool gate additionally holds task start until the pool fits the task's estimated footprint (30s cap unchanged). NATS path deliberately unchanged — blocking a fetched JetStream message risks AckWait redelivery = duplicate execution.
- **Placement (gRPC)**: estimated tasks bin-pack onto the worker with the most free pool (heartbeat budget − used − in-flight estimates, TTL 60s, released on result arrival); unestimated tasks keep round-robin.

## Gates

- `./internal/...` full tree green; coordinator/worker/distributed `-race` clean
- TPC-H SF0.01 22/22
- Local distributed harness 25/25 PASS on **both** transports (`--data-plane=nats` and `grpc`)
- 16 unit tests on the retrier/watcher/picker (incl. dup-delivery, stuck-cap, partials ordering, TTL lifecycle)

Follow-up (next session): feed worker-reported `ResultNotification.SizeBytes` back into `StageOutput` so non-scan stages (joins/aggregates reading upstream outputs) get honest estimates too — replicated inputs charged full, partitioned inputs split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)