### PR TITLE
feat(coordinator): feed worker-reported output sizes into downstream task estimates

### DIFF
--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -731,12 +731,15 @@ func (c *Coordinator) dispatchShuffleStage(
 			Files:         make([][]string, numParts),
 		}, nil
 	}
-	// Synthesize a source stage for runShuffleSide.
+	// Synthesize a source stage for runShuffleSide. EstimatedBytes carries
+	// the upstream's worker-reported output size so the shuffle tasks get
+	// per-task admission estimates (runShuffleSide splits it per task).
 	synthetic := physical.Stage{
-		ID:        stage.ID + "-src",
-		Type:      physical.StageScan,
-		ScanFiles: sourceFiles,
-		TableName: stage.TableName, // may be empty for chained shuffles; worker falls back to generic scan
+		ID:             stage.ID + "-src",
+		Type:           physical.StageScan,
+		ScanFiles:      sourceFiles,
+		TableName:      stage.TableName, // may be empty for chained shuffles; worker falls back to generic scan
+		EstimatedBytes: upstream.Bytes,
 	}
 	numParts := stage.Exchange.Count
 	if numParts == 0 {
@@ -745,7 +748,7 @@ func (c *Coordinator) dispatchShuffleStage(
 	// Forward any dynamic-filter specs the upstream (probe-side) leaf scan
 	// resolved through pass-through. Each shuffle task gets a copy so its
 	// parquet scan applies the bloom at row-group level.
-	shards, err := c.runShuffleSide(ctx, queryID, "stage-"+stage.ID, synthetic, stage.Exchange.Keys, numParts, workerCount, upstream.DynamicFilters)
+	shards, shardBytes, err := c.runShuffleSide(ctx, queryID, "stage-"+stage.ID, synthetic, stage.Exchange.Keys, numParts, workerCount, upstream.DynamicFilters)
 	if err != nil {
 		return StageOutput{}, err
 	}
@@ -753,6 +756,7 @@ func (c *Coordinator) dispatchShuffleStage(
 		Kind:          OutputPartitioned,
 		NumPartitions: numParts,
 		Files:         shards,
+		Bytes:         shardBytes,
 	}, nil
 }
 
@@ -825,10 +829,11 @@ func (c *Coordinator) dispatchReplicateStage(
 		return StageOutput{
 			Kind:  OutputReplicated,
 			Files: [][]string{upstreamFiles},
+			Bytes: upstream.Bytes,
 		}, nil
 	}
 
-	cacheFiles, err := c.materializeReplicate(ctx, queryID, stage, stage.Dependencies[0], upstreamFiles)
+	cacheFiles, cacheBytes, err := c.materializeReplicate(ctx, queryID, stage, stage.Dependencies[0], upstreamFiles, upstream.Bytes)
 	if err != nil {
 		// Materialization failure must not break the query — fall back to
 		// pass-through. Workers can still read the raw upstream files; we
@@ -839,12 +844,14 @@ func (c *Coordinator) dispatchReplicateStage(
 		return StageOutput{
 			Kind:  OutputReplicated,
 			Files: [][]string{upstreamFiles},
+			Bytes: upstream.Bytes,
 		}, nil
 	}
 
 	return StageOutput{
 		Kind:  OutputReplicated,
 		Files: [][]string{cacheFiles},
+		Bytes: cacheBytes,
 	}, nil
 }
 
@@ -862,17 +869,19 @@ func (c *Coordinator) materializeReplicate(
 	stage physical.Stage,
 	upstreamID string,
 	files []string,
-) ([]string, error) {
+	estBytes int64, // upstream output size; the task reads all of it
+) ([]string, int64, error) {
 	resultPrefix := fmt.Sprintf("queries/%s/%s/", queryID, stage.ID)
 	task := distributed.Task{
-		ID:           uuid.New().String()[:8],
-		QueryID:      queryID,
-		StageID:      stage.ID,
-		Type:         distributed.TaskTypeStage,
-		DataBucket:   c.config.ResultBucket,
-		ResultBucket: c.config.ResultBucket,
-		ResultPrefix: resultPrefix,
-		CreatedAt:    time.Now(),
+		ID:             uuid.New().String()[:8],
+		QueryID:        queryID,
+		StageID:        stage.ID,
+		Type:           distributed.TaskTypeStage,
+		DataBucket:     c.config.ResultBucket,
+		ResultBucket:   c.config.ResultBucket,
+		ResultPrefix:   resultPrefix,
+		EstimatedBytes: estBytes,
+		CreatedAt:      time.Now(),
 		// Fragment dispatch: stream upstream files through OpScan into an
 		// unpartitioned WSHF sink. cachedFileStreamSource auto-detects
 		// parquet vs WSHF, so the consolidation pattern (this caller's job)
@@ -941,28 +950,28 @@ func (c *Coordinator) materializeReplicate(
 		}
 	})
 	if err != nil {
-		return nil, fmt.Errorf("subscribe materialize: %w", err)
+		return nil, 0, fmt.Errorf("subscribe materialize: %w", err)
 	}
 	defer sub.Unsubscribe()
 
 	c.logger.Info("dispatchReplicateStage: materializing",
 		"stage_id", stage.ID, "upstream_files", len(files), "task_id", task.ID)
 	if err := c.scheduler.PublishTasks(ctx, []distributed.Task{task}); err != nil {
-		return nil, fmt.Errorf("publish materialize: %w", err)
+		return nil, 0, fmt.Errorf("publish materialize: %w", err)
 	}
 	if err := awaitStageProgress(ctx, done, progress, "replicate "+stage.ID); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	if _, errMsg, failed := retrier.FirstError(); failed {
-		return nil, fmt.Errorf("materialize task failed after %d attempts: %s", maxTaskAttempts, errMsg)
+		return nil, 0, fmt.Errorf("materialize task failed after %d attempts: %s", maxTaskAttempts, errMsg)
 	}
 	resultFiles := retrier.Files()[0]
 	if len(resultFiles) == 0 {
-		return nil, fmt.Errorf("materialize task returned no files")
+		return nil, 0, fmt.Errorf("materialize task returned no files")
 	}
 	c.logger.Info("dispatchReplicateStage: materialized",
 		"stage_id", stage.ID, "input_files", len(files), "cache_files", len(resultFiles))
-	return resultFiles, nil
+	return resultFiles, retrier.TotalBytes(), nil
 }
 
 // dispatchPipelineStage executes a compute stage (scan/join/aggregate/etc.)
@@ -1059,6 +1068,7 @@ func (c *Coordinator) dispatchPipelineStage(
 		out := StageOutput{
 			Kind:  OutputSinglePart,
 			Files: [][]string{files},
+			Bytes: stage.EstimatedBytes, // catalog-true file sizes
 		}
 		// Materialize Consume specs into wire form so downstream shuffle/
 		// stage dispatchers can ship them in their task descriptors
@@ -1382,12 +1392,14 @@ func (c *Coordinator) dispatchScanAggregateStage(
 			Kind:          OutputPartitioned,
 			NumPartitions: numParts,
 			Files:         shardFiles,
+			Bytes:         retrier.TotalBytes(),
 		}, nil
 	}
 	return StageOutput{
 		Kind:          OutputPartitioned,
 		NumPartitions: len(tasks),
 		Files:         resultFiles,
+		Bytes:         retrier.TotalBytes(),
 	}, nil
 }
 
@@ -1668,6 +1680,7 @@ func (c *Coordinator) dispatchScanFilterStage(
 			NumPartitions: numParts,
 			Files:         shardFiles,
 			BuildStats:    buildStats,
+			Bytes:         retrier.TotalBytes(),
 		}, nil
 	}
 	return StageOutput{
@@ -1675,6 +1688,7 @@ func (c *Coordinator) dispatchScanFilterStage(
 		NumPartitions: len(tasks),
 		Files:         resultFiles,
 		BuildStats:    buildStats,
+		Bytes:         retrier.TotalBytes(),
 	}, nil
 }
 
@@ -2016,9 +2030,16 @@ func (c *Coordinator) dispatchComputeStage(
 	defer c.tracker.Delete(stageQueryID)
 
 	subject := distributed.QueryResultSubject(stageQueryID)
+	// Per-task admission estimate from upstream output sizes: partitioned
+	// inputs (and the manually-sliced probe of a probe-split) divide across
+	// tasks; replicated and single-part inputs are read in full by EVERY
+	// task (partitionFilesForWorker hands non-partitioned deps to each task
+	// whole), so they charge their full bytes.
+	perTaskEst := estimateComputeTaskBytes(stage, inputs, numTasks, probeSplit)
 	for i := range tasks {
 		tasks[i].QueryID = stageQueryID
 		tasks[i].Attempt = 1
+		tasks[i].EstimatedBytes = perTaskEst
 	}
 	done := make(chan struct{}, 1)
 	progress := make(chan struct{}, len(tasks))
@@ -2113,6 +2134,7 @@ func (c *Coordinator) dispatchComputeStage(
 			Kind:          OutputPartitioned,
 			NumPartitions: numParts,
 			Files:         shardFiles,
+			Bytes:         retrier.TotalBytes(),
 		}, nil
 	}
 	// resultFiles is in dispatch order (taskRetrier keys results by task ID),
@@ -2146,12 +2168,14 @@ func (c *Coordinator) dispatchComputeStage(
 			Kind:          OutputSinglePart,
 			NumPartitions: 1,
 			Files:         [][]string{flat},
+			Bytes:         retrier.TotalBytes(),
 		}, nil
 	}
 	return StageOutput{
 		Kind:          kind,
 		NumPartitions: len(tasks),
 		Files:         files,
+		Bytes:         retrier.TotalBytes(),
 	}, nil
 }
 
@@ -2588,16 +2612,23 @@ func (c *Coordinator) dispatchFinalAggregateFanout(
 		Type:        "merge_aggregate",
 		GroupByCols: stage.GroupByCols,
 	}
+	// Per-task admission estimate: each intermediate reads ~1/N of the
+	// upstream output (worker-reported bytes; 0 = unknown).
+	intermEst := int64(0)
+	if b := inputs[depID].Bytes; b > 0 && N > 0 {
+		intermEst = b / int64(N)
+	}
 	for i, group := range groups {
 		t := distributed.Task{
-			ID:           uuid.New().String()[:8],
-			QueryID:      queryID,
-			StageID:      fmt.Sprintf("%s-merge-%d", stage.ID, i),
-			Type:         distributed.TaskTypeStage,
-			DataBucket:   c.config.ResultBucket,
-			ResultBucket: c.config.ResultBucket,
-			ResultPrefix: resultPrefix,
-			CreatedAt:    time.Now(),
+			ID:             uuid.New().String()[:8],
+			QueryID:        queryID,
+			StageID:        fmt.Sprintf("%s-merge-%d", stage.ID, i),
+			Type:           distributed.TaskTypeStage,
+			DataBucket:     c.config.ResultBucket,
+			ResultBucket:   c.config.ResultBucket,
+			ResultPrefix:   resultPrefix,
+			EstimatedBytes: intermEst,
+			CreatedAt:      time.Now(),
 		}
 		ops, ferr := buildAggregateFragment(intermStage, &t, map[string][]string{depID: group}, aggs, nil, "")
 		if ferr != nil {
@@ -2614,7 +2645,7 @@ func (c *Coordinator) dispatchFinalAggregateFanout(
 		intermTasks = append(intermTasks, t)
 	}
 	// Intermediates always sink to S3 (no fused subject) — retry-safe.
-	intermFiles, err := c.runStageTasks(ctx,
+	intermFiles, intermBytes, err := c.runStageTasks(ctx,
 		fmt.Sprintf("st-%s-interm-%s", stage.ID, queryID),
 		stage.ID+"-interm",
 		intermTasks,
@@ -2651,6 +2682,7 @@ func (c *Coordinator) dispatchFinalAggregateFanout(
 		DataBucket:      c.config.ResultBucket,
 		ResultBucket:    c.config.ResultBucket,
 		ResultPrefix:    resultPrefix,
+		EstimatedBytes:  intermBytes, // final merge reads every intermediate output
 		CreatedAt:       time.Now(),
 		PostFilterExprs: append([]string(nil), stage.FilterExprs...),
 	}
@@ -2677,7 +2709,7 @@ func (c *Coordinator) dispatchFinalAggregateFanout(
 
 	// The final task streams to the client when gather-fused — retry only
 	// when it sinks to S3 instead.
-	finalFiles, err := c.runStageTasks(ctx,
+	finalFiles, finalBytes, err := c.runStageTasks(ctx,
 		fmt.Sprintf("st-%s-%s", stage.ID, queryID),
 		stage.ID,
 		[]distributed.Task{finalTask},
@@ -2689,14 +2721,16 @@ func (c *Coordinator) dispatchFinalAggregateFanout(
 		Kind:          OutputSinglePart,
 		NumPartitions: 1,
 		Files:         finalFiles,
+		Bytes:         finalBytes,
 	}, nil
 }
 
 // runStageTasks publishes the given tasks under stageQueryID, subscribes to
 // the per-stage result subject, and waits for all completions. Returns one
-// []string of result files per task, in dispatch order. Used by
-// dispatchFinalAggregateFanout for both phases; mirrors the inline
-// dispatch+collect in dispatchScanAggregateStage / dispatchComputeStage.
+// []string of result files per task in dispatch order, plus the worker-
+// reported total output bytes. Used by dispatchFinalAggregateFanout for
+// both phases; mirrors the inline dispatch+collect in
+// dispatchScanAggregateStage / dispatchComputeStage.
 //
 // retryEnabled must be false when any task streams output mid-task
 // (gather-fused terminal sinks) — a retried task would duplicate the
@@ -2706,9 +2740,9 @@ func (c *Coordinator) runStageTasks(
 	stageQueryID, stageLabel string,
 	tasks []distributed.Task,
 	retryEnabled bool,
-) ([][]string, error) {
+) ([][]string, int64, error) {
 	if len(tasks) == 0 {
-		return nil, nil
+		return nil, 0, nil
 	}
 	trackerStages := map[string]*StageInfo{
 		stageLabel: {StageID: stageLabel, Type: distributed.TaskTypeStage, TotalTasks: len(tasks)},
@@ -2757,21 +2791,54 @@ func (c *Coordinator) runStageTasks(
 		}
 	})
 	if err != nil {
-		return nil, fmt.Errorf("stage %s: subscribe: %w", stageLabel, err)
+		return nil, 0, fmt.Errorf("stage %s: subscribe: %w", stageLabel, err)
 	}
 	defer sub.Unsubscribe()
 
 	if err := c.scheduler.PublishTasks(ctx, tasks); err != nil {
-		return nil, fmt.Errorf("stage %s: publish: %w", stageLabel, err)
+		return nil, 0, fmt.Errorf("stage %s: publish: %w", stageLabel, err)
 	}
 	if err := awaitStageProgress(ctx, done, progress, stageLabel); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	if taskID, errMsg, failed := retrier.FirstError(); failed {
-		return nil, fmt.Errorf("stage %s: task %s failed after %d attempts: %s", stageLabel, taskID, maxTaskAttempts, errMsg)
+		return nil, 0, fmt.Errorf("stage %s: task %s failed after %d attempts: %s", stageLabel, taskID, maxTaskAttempts, errMsg)
 	}
-	return retrier.Files(), nil
+	return retrier.Files(), retrier.TotalBytes(), nil
+}
+
+// estimateComputeTaskBytes estimates one compute task's input footprint
+// from upstream output sizes, mirroring the slicing semantics of
+// buildTaskInputsForStage / buildTaskInputsForBroadcastJoinSplitProbe:
+// OutputPartitioned deps split across tasks; Replicated and SinglePart
+// deps are read in full by every task; a probe-split's probe dep is
+// manually sliced, so it splits too. Deps with unknown size (Bytes == 0,
+// e.g. legacy workers) contribute nothing — the estimate degrades toward
+// 0 = unknown rather than inventing numbers.
+func estimateComputeTaskBytes(stage physical.Stage, inputs map[string]StageOutput, numTasks int, probeSplit bool) int64 {
+	if numTasks <= 0 {
+		numTasks = 1
+	}
+	probeDep := ""
+	if probeSplit {
+		probeDep = stage.LeftDepStage
+		if probeDep == "" && len(stage.Dependencies) > 0 {
+			probeDep = stage.Dependencies[0]
+		}
+	}
+	var est int64
+	for depID, out := range inputs {
+		if out.Bytes <= 0 {
+			continue
+		}
+		if depID == probeDep || out.Kind == OutputPartitioned {
+			est += out.Bytes / int64(numTasks)
+		} else {
+			est += out.Bytes
+		}
+	}
+	return est
 }
 
 // buildTaskInputsForStage maps a stage's Dependencies (upstream stage IDs)

--- a/internal/coordinator/orchestrate_repartition.go
+++ b/internal/coordinator/orchestrate_repartition.go
@@ -96,7 +96,7 @@ func (c *Coordinator) orchestrateRepartition(
 	g, gctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		shards, err := c.runShuffleSide(gctx, queryID, "build", buildStage, cand.BuildKeys, numParts, workerCount, nil)
+		shards, _, err := c.runShuffleSide(gctx, queryID, "build", buildStage, cand.BuildKeys, numParts, workerCount, nil)
 		if err != nil {
 			return fmt.Errorf("build-side shuffle for %s: %w", cand.BuildAlias, err)
 		}
@@ -105,7 +105,7 @@ func (c *Coordinator) orchestrateRepartition(
 	})
 
 	g.Go(func() error {
-		shards, err := c.runShuffleSide(gctx, queryID, "probe", probeStage, cand.ProbeKeys, numParts, workerCount, nil)
+		shards, _, err := c.runShuffleSide(gctx, queryID, "probe", probeStage, cand.ProbeKeys, numParts, workerCount, nil)
 		if err != nil {
 			return fmt.Errorf("probe-side shuffle for %s: %w", cand.ProbeAlias, err)
 		}
@@ -134,7 +134,9 @@ func (c *Coordinator) orchestrateRepartition(
 // runShuffleSide dispatches workerCount TaskTypeShuffle tasks for one side
 // (build or probe), each reading its file slice and hash-partitioning into
 // numParts outputs. Waits for all tasks. Returns shardFiles[p] = slice of
-// S3 keys for partition p (concatenated from each task's per-partition output).
+// S3 keys for partition p (concatenated from each task's per-partition
+// output) plus the worker-reported total bytes written across all tasks
+// (0 if workers didn't report).
 func (c *Coordinator) runShuffleSide(
 	ctx context.Context,
 	parentQueryID string,
@@ -144,7 +146,7 @@ func (c *Coordinator) runShuffleSide(
 	numParts int,
 	workerCount int,
 	dynamicFilters []distributed.DynamicFilterSpec, // resolved bloom/range pushdowns from upstream build stat
-) ([][]string, error) {
+) ([][]string, int64, error) {
 	ctx, cancel := context.WithTimeout(ctx, shuffleStageTimeout)
 	defer cancel()
 
@@ -178,7 +180,7 @@ func (c *Coordinator) runShuffleSide(
 	actualTasks := len(fileSets)
 	if actualTasks == 0 {
 		// No files — nothing to shuffle. Return empty partition layout.
-		return make([][]string, numParts), nil
+		return make([][]string, numParts), 0, nil
 	}
 
 	// Register an ephemeral tracker entry for this shuffle stage.
@@ -259,24 +261,24 @@ func (c *Coordinator) runShuffleSide(
 		}
 	})
 	if err != nil {
-		return nil, fmt.Errorf("subscribing for shuffle-%s results: %w", sideName, err)
+		return nil, 0, fmt.Errorf("subscribing for shuffle-%s results: %w", sideName, err)
 	}
 	defer sub.Unsubscribe()
 
 	if err := c.scheduler.PublishTasks(ctx, tasks); err != nil {
-		return nil, fmt.Errorf("publishing shuffle-%s tasks: %w", sideName, err)
+		return nil, 0, fmt.Errorf("publishing shuffle-%s tasks: %w", sideName, err)
 	}
 
 	// Wait for all tasks to complete.
 	select {
 	case <-done:
 	case <-ctx.Done():
-		return nil, fmt.Errorf("shuffle-%s timed out after %s: %w", sideName, shuffleStageTimeout, ctx.Err())
+		return nil, 0, fmt.Errorf("shuffle-%s timed out after %s: %w", sideName, shuffleStageTimeout, ctx.Err())
 	}
 
 	// Check for any task failures (terminal: retries exhausted).
 	if taskID, errMsg, failed := retrier.FirstError(); failed {
-		return nil, fmt.Errorf("shuffle-%s task %s failed after %d attempts: %s", sideName, taskID, maxTaskAttempts, errMsg)
+		return nil, 0, fmt.Errorf("shuffle-%s task %s failed after %d attempts: %s", sideName, taskID, maxTaskAttempts, errMsg)
 	}
 
 	// Bucket result files by partition. Each file has a path like:
@@ -288,10 +290,10 @@ func (c *Coordinator) runShuffleSide(
 		for _, f := range taskFiles {
 			p, parseErr := parsePartitionFromPath(f)
 			if parseErr != nil {
-				return nil, fmt.Errorf("shuffle-%s: parsing partition from %q: %w", sideName, f, parseErr)
+				return nil, 0, fmt.Errorf("shuffle-%s: parsing partition from %q: %w", sideName, f, parseErr)
 			}
 			if p < 0 || p >= numParts {
-				return nil, fmt.Errorf("shuffle-%s: partition %d out of range [0,%d) in path %q", sideName, p, numParts, f)
+				return nil, 0, fmt.Errorf("shuffle-%s: partition %d out of range [0,%d) in path %q", sideName, p, numParts, f)
 			}
 			shardFiles[p] = append(shardFiles[p], f)
 		}
@@ -312,7 +314,7 @@ func (c *Coordinator) runShuffleSide(
 		"num_partitions", numParts,
 	)
 
-	return shardFiles, nil
+	return shardFiles, retrier.TotalBytes(), nil
 }
 
 // parsePartitionFromPath extracts the partition index from an S3 key that

--- a/internal/coordinator/scheduler_binpack_test.go
+++ b/internal/coordinator/scheduler_binpack_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/planner/physical"
 )
 
 func TestPickLeastLoadedWorker(t *testing.T) {
@@ -101,5 +102,67 @@ func TestTaskRetrier_GrowEstimateOnRetry(t *testing.T) {
 	got = waitRepublished(t, rep, 3)
 	if got[2].ID != "b" || got[2].EstimatedBytes != 0 {
 		t.Fatalf("no-estimate retry = %+v, want b with 0", got[2])
+	}
+}
+
+// TestTaskRetrier_TotalBytes: worker-reported SizeBytes sums across
+// successful tasks; duplicates don't double-count; failures contribute 0.
+func TestTaskRetrier_TotalBytes(t *testing.T) {
+	tr := newTaskRetrier(retryTestTasks(3), false, nil, slog.Default(), "s")
+	rA := okResult("a", "f-a")
+	rA.SizeBytes = 100
+	rB := okResult("b", "f-b")
+	rB.SizeBytes = 250
+	tr.Observe(rA)
+	tr.Observe(rB)
+	tr.Observe(rA) // duplicate
+	tr.Observe(failResult("c", "boom"))
+	if got := tr.TotalBytes(); got != 350 {
+		t.Fatalf("TotalBytes = %d, want 350", got)
+	}
+}
+
+func TestEstimateComputeTaskBytes(t *testing.T) {
+	join := physical.Stage{
+		Type:         physical.StageBroadcastJoin,
+		Dependencies: []string{"probe-dep", "build-dep"},
+		LeftDepStage: "probe-dep",
+	}
+	tests := []struct {
+		name       string
+		stage      physical.Stage
+		inputs     map[string]StageOutput
+		numTasks   int
+		probeSplit bool
+		want       int64
+	}{
+		{"partitioned splits", physical.Stage{}, map[string]StageOutput{
+			"d": {Kind: OutputPartitioned, Bytes: 900},
+		}, 3, false, 300},
+		{"replicated charges full", physical.Stage{}, map[string]StageOutput{
+			"d": {Kind: OutputReplicated, Bytes: 900},
+		}, 3, false, 900},
+		{"singlepart charges full", physical.Stage{}, map[string]StageOutput{
+			"d": {Kind: OutputSinglePart, Bytes: 900},
+		}, 3, false, 900},
+		{"probe-split slices the probe", join, map[string]StageOutput{
+			"probe-dep": {Kind: OutputSinglePart, Bytes: 600},
+			"build-dep": {Kind: OutputReplicated, Bytes: 90},
+		}, 3, true, 290}, // 600/3 + 90
+		{"unknown sizes contribute nothing", physical.Stage{}, map[string]StageOutput{
+			"d1": {Kind: OutputPartitioned, Bytes: 0},
+			"d2": {Kind: OutputReplicated, Bytes: 100},
+		}, 2, false, 100},
+		{"zero tasks clamps to 1", physical.Stage{}, map[string]StageOutput{
+			"d": {Kind: OutputPartitioned, Bytes: 500},
+		}, 0, false, 500},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := estimateComputeTaskBytes(tc.stage, tc.inputs, tc.numTasks, tc.probeSplit)
+			if got != tc.want {
+				t.Fatalf("estimateComputeTaskBytes = %d, want %d", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/coordinator/stage_output.go
+++ b/internal/coordinator/stage_output.go
@@ -32,6 +32,15 @@ type StageOutput struct {
 	NumPartitions int        // valid when Kind == OutputPartitioned
 	Files         [][]string // Partitioned: Files[p]; Replicated/SinglePart: Files[0]
 
+	// Bytes is the total on-disk size of Files as reported by the workers
+	// that wrote them (ResultNotification.SizeBytes), or the catalog size
+	// for pass-through leaf scans. Feeds downstream tasks' EstimatedBytes
+	// for memory-aware admission. 0 = unknown (legacy worker, empty
+	// output) — downstream estimates degrade to unknown, never to wrong.
+	// Note these are file bytes (compressed), the same unit the scan-stage
+	// estimates use; in-memory footprint is larger by the codec ratio.
+	Bytes int64
+
 	// BuildStats, populated when this stage's Stage.EmitDynamicFilters was
 	// non-empty. One entry per emit, keyed by FilterID. Downstream consumer
 	// stages reach in via the stat-dep edge to pull the materialized stats.

--- a/internal/coordinator/task_retry.go
+++ b/internal/coordinator/task_retry.go
@@ -46,6 +46,7 @@ type taskRetrier struct {
 type taskAttemptState struct {
 	files    []string
 	partials []distributed.DynamicFilterPartialRef
+	bytes    int64
 	errMsg   string
 	attempts int
 	terminal bool
@@ -86,6 +87,7 @@ func (tr *taskRetrier) Observe(r distributed.ResultNotification) (allDone bool) 
 	if r.Success {
 		st.files = r.ResultFiles
 		st.partials = r.DynamicFilterPartials
+		st.bytes = r.SizeBytes
 		st.errMsg = ""
 		st.terminal = true
 		tr.terminal++
@@ -167,6 +169,20 @@ func (tr *taskRetrier) Files() [][]string {
 		out[i] = tr.states[id].files
 	}
 	return out
+}
+
+// TotalBytes sums the worker-reported output size (ResultNotification.
+// SizeBytes) across all successful tasks. Feeds StageOutput.Bytes so
+// downstream dispatchers can estimate their tasks' input footprints.
+// 0 when workers didn't report sizes (legacy builds).
+func (tr *taskRetrier) TotalBytes() int64 {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	var total int64
+	for _, st := range tr.states {
+		total += st.bytes
+	}
+	return total
 }
 
 // DynamicFilterPartials returns every successful task's dynamic-filter


### PR DESCRIPTION
Phase 3 of the memory-aware scheduling work (follows #110) — closes the `EstimatedBytes` feedback loop so **non-scan stages get honest admission estimates** instead of 0/unknown.

## What

- **`StageOutput.Bytes`**: total on-disk output size of each stage, summed by the `taskRetrier` from `ResultNotification.SizeBytes` (workers already report it on every write path). Pass-through leaf scans carry their catalog-true size. `0 = unknown` degrades to prior behavior everywhere — never invented numbers.
- **All dispatchers populate it**: scan-filter / scan-aggregate, compute (all three return shapes), exchange-repartition (`runShuffleSide` now returns bytes), replicate (pass-through inherits upstream's; the materialize task reports its own), final-aggregate fanout.
- **Consumers mirror input-slicing semantics exactly** (`estimateComputeTaskBytes`): `OutputPartitioned` deps charge 1/numTasks; `Replicated`/`SinglePart` deps charge full bytes (every task reads them whole via `partitionFilesForWorker`); a probe-split's manually-sliced probe dep charges 1/numTasks. Exchange-repartition tasks split upstream bytes via the synthetic source stage; fanout intermediates take 1/N; the final merge charges all intermediate output.

With #110's worker-side gate and bin-packing, this means a Q18-style join task whose build input is 2 GB now waits for 2 GB of pool headroom before starting, and lands on the worker with the most free pool — instead of starting blind on a worker at 85% pressure.

Estimates are file bytes (compressed), the same unit scan estimates use; grow-on-retry (×2 per re-dispatch) compensates where decode expansion matters.

## Gates

- `./internal/...` full tree green; coordinator/worker/distributed `-race` clean
- TPC-H SF0.01 22/22
- Local distributed harness 25/25 PASS on **both** transports (`nats` and `grpc`)
- Unit tests: `TotalBytes` dedup/failure semantics, `estimateComputeTaskBytes` across all five slicing shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)