### PR TITLE
fix(worker): self-relieving WSHF walkers — consumed-prefix MADV instead of LRU thrash

### DIFF
--- a/internal/worker/mmap_relief.go
+++ b/internal/worker/mmap_relief.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"os"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -49,12 +50,26 @@ func SetMmapRelief(enabled bool, thresholdBytes int64) {
 // MmapReliefThreshold returns the current relief threshold in bytes (0 if unset).
 func MmapReliefThreshold() int64 { return mmapReliefThresholdBytes.Load() }
 
+// mmapSelfReliefChunkBytes is the hysteresis for consumed-prefix self-relief:
+// a streaming WSHF walker advises away its consumed prefix only after another
+// chunk of this size has been fully decoded, so the cost is one madvise per
+// 64 MiB walked instead of one per batch. Declared as var so tests can lower it.
+var mmapSelfReliefChunkBytes = int64(64 << 20) // 64 MiB
+
+// mmapPageSize is the kernel page size; madvise offsets must be page-aligned.
+var mmapPageSize = int64(os.Getpagesize())
+
 // mmapRegion is one tracked file mapping. lastTouch is updated atomically and
 // lock-free on every Next() that reads the region; the relief path sorts by it
 // lazily (only at eviction time), so there is no per-Next lock or list reorder.
 type mmapRegion struct {
 	data      []byte // the mmap'd slice (PROT_READ MAP_SHARED file mapping)
 	lastTouch atomic.Int64
+	// relieved is the page-aligned prefix length [0, relieved) the OWNING
+	// walker has already MADV_DONTNEED'd via relieveConsumedPrefix. Written
+	// only by the owner goroutine; read by the global relief path for live-
+	// byte accounting.
+	relieved atomic.Int64
 }
 
 // touch records the current time as this region's last access. Cheap: one
@@ -63,6 +78,50 @@ func (r *mmapRegion) touch() {
 	if r != nil {
 		r.lastTouch.Store(time.Now().UnixNano())
 	}
+}
+
+// relieveConsumedPrefix MADV_DONTNEEDs the dead prefix behind a strictly-
+// forward walker's read cursor. The WSHF chunk walk never re-reads consumed
+// bytes and decode copies out of the mapping, so pages behind the cursor
+// re-fault never — advising them away is pure RSS relief with zero re-fault
+// cost, unlike the global LRU relief which (under a working set larger than
+// the RSS ceiling) evicts exactly the pages a cyclic walker is about to
+// read again (the SF100 Q18 2× wall, threshold-insensitive 16000↔19000,
+// runs 20260610-004232 / 20260610-132630).
+//
+// consumed is the walker's byte offset into the region. Relief happens in
+// page-aligned mmapSelfReliefChunkBytes steps (one madvise per 64 MiB
+// walked); calls between steps are one atomic load + compare. Owner-
+// goroutine only — no lock; a concurrent whole-region MADV from the global
+// relief path is idempotent and harmless. nil-safe (relief disabled).
+// Returns the bytes advised away (0 between steps).
+func (r *mmapRegion) relieveConsumedPrefix(consumed int64) int64 {
+	if r == nil {
+		return 0
+	}
+	target := consumed &^ (mmapPageSize - 1)
+	if max := int64(len(r.data)) &^ (mmapPageSize - 1); target > max {
+		target = max
+	}
+	prev := r.relieved.Load()
+	if target-prev < mmapSelfReliefChunkBytes {
+		return 0
+	}
+	if err := unix.Madvise(r.data[prev:target], unix.MADV_DONTNEED); err != nil {
+		return 0
+	}
+	r.relieved.Store(target)
+	return target - prev
+}
+
+// liveBytes is the region length minus the self-relieved prefix — the bytes
+// a global relief pass can still meaningfully advise away.
+func (r *mmapRegion) liveBytes() int64 {
+	n := int64(len(r.data)) - r.relieved.Load()
+	if n < 0 {
+		n = 0
+	}
+	return n
 }
 
 // mmapRegistry holds every live file mapping across cachedFileStreamSources on
@@ -121,11 +180,15 @@ func relieveMmap(target int64) int64 {
 		if freed >= target {
 			break
 		}
-		if len(r.data) == 0 {
+		// Count (and skip by) live bytes only: a walker may have already
+		// self-relieved its consumed prefix, and crediting the full region
+		// here would stop the pass before enough real RSS was released.
+		live := r.liveBytes()
+		if live < mmapPageSize {
 			continue
 		}
 		if err := unix.Madvise(r.data, unix.MADV_DONTNEED); err == nil {
-			freed += int64(len(r.data))
+			freed += live
 		}
 	}
 	return freed

--- a/internal/worker/mmap_relief_test.go
+++ b/internal/worker/mmap_relief_test.go
@@ -1,12 +1,18 @@
 package worker
 
 import (
+	"bytes"
+	"encoding/binary"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
 )
 
 // withReliefEnabled flips the relief flag on for a test and restores it + clears
@@ -162,5 +168,218 @@ func TestMmapRelief_ConcurrentRegisterTouch(t *testing.T) {
 	wg.Wait()
 	if got := liveMmapCount(); got != 0 {
 		t.Fatalf("all regions should be unregistered, got %d", got)
+	}
+}
+
+// TestMmapRelief_ConsumedPrefixSelfRelief: a forward walker's consumed prefix
+// is advised away in page-aligned hysteresis steps, the data still reads back
+// correctly (file-backed re-fault), and the global relief pass credits only
+// the remaining live bytes.
+func TestMmapRelief_ConsumedPrefixSelfRelief(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("MADV_DONTNEED path is Linux-only")
+	}
+	withReliefEnabled(t)
+
+	// Lower the hysteresis to 4 pages so the test file stays small.
+	oldChunk := mmapSelfReliefChunkBytes
+	mmapSelfReliefChunkBytes = 4 * mmapPageSize
+	defer func() { mmapSelfReliefChunkBytes = oldChunk }()
+
+	size := int(16 * mmapPageSize)
+	path := filepath.Join(t.TempDir(), "mmap-prefix-test")
+	payload := make([]byte, size)
+	for i := range payload {
+		payload[i] = byte(i % 251)
+	}
+	if err := os.WriteFile(path, payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	data, err := syscall.Mmap(int(f.Fd()), 0, size, syscall.PROT_READ, syscall.MAP_SHARED)
+	if err != nil {
+		t.Fatalf("mmap: %v", err)
+	}
+	defer syscall.Munmap(data)
+	r := registerMmap(data)
+	defer unregisterMmap(r)
+
+	// nil receiver (relief disabled path) is a no-op.
+	var nilRegion *mmapRegion
+	if got := nilRegion.relieveConsumedPrefix(1 << 30); got != 0 {
+		t.Fatalf("nil region relieved %d bytes", got)
+	}
+
+	// Below the hysteresis step: nothing advised.
+	if got := r.relieveConsumedPrefix(3 * mmapPageSize); got != 0 {
+		t.Fatalf("sub-chunk consumed relieved %d bytes, want 0", got)
+	}
+	if r.relieved.Load() != 0 {
+		t.Fatalf("relieved offset moved to %d without a full step", r.relieved.Load())
+	}
+
+	// Cursor mid-page past one full step: relief floors to the page boundary.
+	consumed := 5*mmapPageSize + 123
+	if got := r.relieveConsumedPrefix(consumed); got != 5*mmapPageSize {
+		t.Fatalf("first step relieved %d, want %d", got, 5*mmapPageSize)
+	}
+	if r.relieved.Load() != 5*mmapPageSize {
+		t.Fatalf("relieved offset = %d, want %d", r.relieved.Load(), 5*mmapPageSize)
+	}
+
+	// Re-advising the same cursor: no second step (monotonic + hysteresis).
+	if got := r.relieveConsumedPrefix(consumed); got != 0 {
+		t.Fatalf("repeat call relieved %d bytes, want 0", got)
+	}
+
+	// Cursor past EOF clamps to the page-aligned region end.
+	if got := r.relieveConsumedPrefix(int64(size) + 999); got != 11*mmapPageSize {
+		t.Fatalf("EOF clamp relieved %d, want %d", got, 11*mmapPageSize)
+	}
+
+	// Every byte must still read back correctly (re-fault from file).
+	for i := 0; i < size; i++ {
+		if data[i] != byte(i%251) {
+			t.Fatalf("data corrupted after prefix relief at %d", i)
+		}
+	}
+
+	// Global relief accounting: the region is fully self-relieved
+	// (liveBytes < page), so the pass must skip it and credit nothing.
+	if r.liveBytes() >= mmapPageSize {
+		t.Fatalf("liveBytes = %d, want < page", r.liveBytes())
+	}
+	if freed := relieveMmap(1 << 30); freed != 0 {
+		t.Fatalf("global relief freed %d from a drained region, want 0", freed)
+	}
+}
+
+// TestMmapRelief_GlobalReliefCreditsLiveBytesOnly: a half-self-relieved
+// region credits only its remaining live bytes toward the global target.
+func TestMmapRelief_GlobalReliefCreditsLiveBytesOnly(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("MADV_DONTNEED path is Linux-only")
+	}
+	withReliefEnabled(t)
+	oldChunk := mmapSelfReliefChunkBytes
+	mmapSelfReliefChunkBytes = 4 * mmapPageSize
+	defer func() { mmapSelfReliefChunkBytes = oldChunk }()
+
+	size := int(8 * mmapPageSize)
+	path := filepath.Join(t.TempDir(), "mmap-live-test")
+	if err := os.WriteFile(path, make([]byte, size), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	data, err := syscall.Mmap(int(f.Fd()), 0, size, syscall.PROT_READ, syscall.MAP_SHARED)
+	if err != nil {
+		t.Fatalf("mmap: %v", err)
+	}
+	defer syscall.Munmap(data)
+	r := registerMmap(data)
+	defer unregisterMmap(r)
+
+	if got := r.relieveConsumedPrefix(4 * mmapPageSize); got != 4*mmapPageSize {
+		t.Fatalf("prefix relief = %d, want %d", got, 4*mmapPageSize)
+	}
+	if freed := relieveMmap(1 << 30); freed != 4*mmapPageSize {
+		t.Fatalf("global relief credited %d, want live %d", freed, 4*mmapPageSize)
+	}
+}
+
+// TestMmapRelief_WSHFWalkWithSelfRelief: walking a real mmap'd WSHF file with
+// per-batch consumed-prefix relief decodes the identical rows as a plain walk
+// — locks the "consumed prefix is dead" invariant the self-relief depends on.
+func TestMmapRelief_WSHFWalkWithSelfRelief(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("MADV_DONTNEED path is Linux-only")
+	}
+	withReliefEnabled(t)
+	oldChunk := mmapSelfReliefChunkBytes
+	mmapSelfReliefChunkBytes = mmapPageSize // relieve as aggressively as possible
+	defer func() { mmapSelfReliefChunkBytes = oldChunk }()
+
+	schema := []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64, Nullable: true},
+		{Name: "name", Type: parquet.TypeString, Nullable: true},
+	}
+	const rowsPerChunk = 512
+	const numChunks = 64 // ~ enough bytes to cross several relief steps
+	src := batch.NewRecordBatch(schema, rowsPerChunk)
+	for i := 0; i < rowsPerChunk; i++ {
+		src.Columns[0].Int64Data[i] = int64(i)
+		src.Columns[1].BytesData.Set(i, []byte(strings.Repeat("x", 32)))
+	}
+	var buf bytes.Buffer
+	sw := newShuffleWriter(&buf, schema)
+	if err := sw.writeHeader(); err != nil {
+		t.Fatal(err)
+	}
+	for c := 0; c < numChunks; c++ {
+		if err := sw.writeChunk(src.Columns, nil, rowsPerChunk); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Patch the chunk count into the header (same pattern as
+	// TestShuffleFormatRoundTrip — the streaming writer's header is
+	// finalized by its sink wrapper in production).
+	fileBytes := buf.Bytes()
+	binary.LittleEndian.PutUint32(fileBytes[4:], uint32(sw.numChunks))
+
+	path := filepath.Join(t.TempDir(), "walk.wshf")
+	if err := os.WriteFile(path, fileBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	data, err := syscall.Mmap(int(f.Fd()), 0, buf.Len(), syscall.PROT_READ, syscall.MAP_SHARED)
+	if err != nil {
+		t.Fatalf("mmap: %v", err)
+	}
+	defer syscall.Munmap(data)
+	region := registerMmap(data)
+	defer unregisterMmap(region)
+
+	r, err := newShuffleChunkReader(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var rows, relieved int64
+	for {
+		b, err := r.Next()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if b == nil {
+			break
+		}
+		// Mirror cachedFileStreamSource.Next: relieve behind the cursor
+		// after every decoded batch.
+		relieved += region.relieveConsumedPrefix(int64(r.pos))
+		for i := 0; i < b.ActiveLen(); i++ {
+			want := int64(i % rowsPerChunk)
+			if b.Columns[0].Int64Data[i] != want {
+				t.Fatalf("row %d decoded %d, want %d (after %d bytes relieved)",
+					rows+int64(i), b.Columns[0].Int64Data[i], want, relieved)
+			}
+		}
+		rows += int64(b.ActiveLen())
+	}
+	if rows != rowsPerChunk*numChunks {
+		t.Fatalf("decoded %d rows, want %d", rows, rowsPerChunk*numChunks)
+	}
+	if relieved == 0 {
+		t.Fatal("walk never self-relieved — test exercised nothing")
 	}
 }

--- a/internal/worker/stream_source.go
+++ b/internal/worker/stream_source.go
@@ -167,6 +167,16 @@ func (s *cachedFileStreamSource) Next(ctx context.Context) (*batch.RecordBatch, 
 				return nil, err
 			}
 			if b != nil {
+				// Self-relief: the WSHF walk is strictly forward and decode
+				// copies out of the mapping, so everything behind the cursor
+				// is dead — advise it away in 64 MiB steps. Keeps each active
+				// region's RSS at a bounded window instead of the whole file,
+				// which keeps total RSS under the relief ceiling so the
+				// global LRU pass (which under working-set > ceiling evicts
+				// exactly what a walker reads next — Q18's 2× wall) rarely
+				// needs to fire at all. nil region (relief disabled, or the
+				// in-memory test path) makes this one predictable branch.
+				s.mmapRegion.relieveConsumedPrefix(int64(s.chunkReader.pos))
 				return b, nil
 			}
 			// Current file exhausted — release its mmap and remove the local


### PR DESCRIPTION
Fixes the `--mmap-relief` Q18 2× wall, which two SF100 runs (20260610-004232 @ threshold 16000, 20260610-132630 @ 19000) proved **threshold-insensitive**: Q18's mmap working set (concurrent tasks walking large shuffle/broadcast caches) exceeds any usable RSS ceiling, and LRU eviction is pessimal for cyclic sequential walks — the least-recently-touched region is exactly the next one re-read.

## The fix

The walkers know what the LRU can't. The WSHF chunk walk is strictly forward and decode copies out of the mapping (the whole-file munmap-on-advance architecture already requires that no batch aliases the mmap), so **every page behind the read cursor is provably dead**. Each `cachedFileStreamSource` now `MADV_DONTNEED`s its own consumed prefix in page-aligned 64 MiB steps as it walks:

- Active regions hold a bounded RSS window instead of the whole file → total RSS stays under the ceiling → the global LRU pass (kept as the emergency backstop, now crediting only live bytes) rarely fires at all.
- Zero re-fault cost — nothing ever re-reads a consumed prefix.
- Parquet mmaps deliberately excluded (random access: footer, per-row-group column chunks — no provably-dead prefix).
- Same `--mmap-relief` flag gate; default-off behavior unchanged. Armed cost: one atomic load+compare per batch, one madvise per 64 MiB.

## Gates

- worker `-race` clean, full internal tree green, TPC-H SF0.01 22/22, local harness 25/25
- New tests: WSHF-walk decode equivalence under aggressive self-relief (locks the dead-prefix invariant), real-MADV page-aligned hysteresis / EOF clamp / re-fault correctness, global-relief live-byte accounting
- **SF100 validation in flight** (flags on, threshold 19000, same config as run 132630): expect Q18 back near the 7m16 flags-off baseline; will post results here

🤖 Generated with [Claude Code](https://claude.com/claude-code)