### PR TITLE
fix(coordinator): reap a failed query's in-flight tasks and local disk artifacts

### DIFF
--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -693,6 +693,26 @@ func (c *Coordinator) cleanupQuery(queryID string) {
 	}
 	c.mu.Unlock()
 
+	// Broadcast cancellation FIRST: by the time cleanupQuery runs the query
+	// is terminal (completed, failed, or timed out) and this function is
+	// about to purge queries/<id>/* from the object store — so any task
+	// still executing for it is pure waste whose uploads would recreate the
+	// scratch leak. Workers mark the query cancelled (queued tasks Term at
+	// pickup, running tasks abort within the ~500ms cancelTicker) and free
+	// their local/broadcast caches. Without this, a query that FAILED
+	// terminally left its in-flight tasks running to completion — at SF100
+	// run 20260610-203304, Q21's tasks kept downloading multi-GB cache
+	// files and writing partition outputs for minutes after the query
+	// failed on ENOSPC, so the disk never recovered and Q22 died on Q21's
+	// garbage. CancelSubject was previously only published by the
+	// user-facing CancelQuery API, never on internal failure.
+	if c.nc != nil {
+		if err := c.nc.Publish(distributed.CancelSubject(queryID), []byte(queryID)); err != nil {
+			c.logger.Debug("failed to publish query cancellation",
+				"query_id", queryID, "error", err)
+		}
+	}
+
 	// Notify workers that the query is finished so they can release per-
 	// query state (LocalStageCache spill files). Best-effort: workers that
 	// miss the message will eventually leak entries until process exit, but

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -854,7 +854,14 @@ func (e *Executor) executeShuffle(ctx context.Context, task distributed.Task, re
 	if err := os.MkdirAll(spillDir, 0o755); err != nil {
 		return fmt.Errorf("shuffle task %s: creating spill dir: %w", task.ID, err)
 	}
-	defer os.RemoveAll(spillDir)
+	// Cleanup failure must be visible: a leaked partition dir eats spill
+	// volume silently until a later query dies on ENOSPC.
+	defer func() {
+		if rmErr := os.RemoveAll(spillDir); rmErr != nil {
+			e.logger.Warn("shuffle spill dir cleanup failed; disk space may leak",
+				"task_id", task.ID, "dir", spillDir, "error", rmErr)
+		}
+	}()
 
 	// Per-task progress reporter — each AddRows call updates the worker's
 	// TaskProgress counter, which the worker's per-task progress goroutine

--- a/internal/worker/local_stage_cache.go
+++ b/internal/worker/local_stage_cache.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 )
 
 // LocalStageCache maps (queryID, key) → localPath for stage outputs the
@@ -30,7 +31,19 @@ type LocalStageCache struct {
 	rootDir string
 	mu      sync.RWMutex
 	entries map[localStageKey]string
+	// cleaned tombstones queries whose CleanupQuery already ran. A task
+	// that was mid-upload when its query terminated can reach Adopt AFTER
+	// the cleanup signal was processed; without the tombstone the adopted
+	// file is registered into a query directory nothing will ever clean
+	// again (the cleanup message fires once per query). Entries are pruned
+	// on insert after tombstoneTTL.
+	cleaned map[string]time.Time
 }
+
+// tombstoneTTL bounds how long a cleaned query refuses late Adopts. It only
+// needs to outlive the slowest straggler task of a terminated query; 30
+// minutes matches the worker's cancelled-map retention.
+const tombstoneTTL = 30 * time.Minute
 
 type localStageKey struct {
 	queryID string
@@ -52,6 +65,7 @@ func NewLocalStageCache(rootDir string) *LocalStageCache {
 	return &LocalStageCache{
 		rootDir: rootDir,
 		entries: make(map[localStageKey]string),
+		cleaned: make(map[string]time.Time),
 	}
 }
 
@@ -67,6 +81,15 @@ func (c *LocalStageCache) Adopt(queryID, key, srcPath string) string {
 		return ""
 	}
 	if _, err := os.Stat(srcPath); err != nil {
+		return ""
+	}
+	c.mu.RLock()
+	_, tombstoned := c.cleaned[queryID]
+	c.mu.RUnlock()
+	if tombstoned {
+		// The query already terminated and its cleanup ran; adopting now
+		// would leak the file forever. Decline — the caller keeps srcPath
+		// ownership and deletes it via its normal no-adopt path.
 		return ""
 	}
 	queryDir := filepath.Join(c.rootDir, queryID)
@@ -109,6 +132,15 @@ func (c *LocalStageCache) CleanupQuery(queryID string) int {
 		if k.queryID == queryID {
 			paths = append(paths, p)
 			delete(c.entries, k)
+		}
+	}
+	if c.cleaned != nil {
+		c.cleaned[queryID] = time.Now()
+		cutoff := time.Now().Add(-tombstoneTTL)
+		for q, at := range c.cleaned {
+			if at.Before(cutoff) {
+				delete(c.cleaned, q)
+			}
 		}
 	}
 	c.mu.Unlock()

--- a/internal/worker/local_stage_cache_test.go
+++ b/internal/worker/local_stage_cache_test.go
@@ -58,6 +58,49 @@ func TestLocalStageCache_AdoptGetCleanup(t *testing.T) {
 	}
 }
 
+// TestLocalStageCache_AdoptAfterCleanupDeclined is the regression test for
+// the SF100 run-20260610-203304 leak: a straggler task of a terminated query
+// reached Adopt AFTER the query's CleanupQuery had already run, registering a
+// file into a per-query directory that no future cleanup message would ever
+// visit. Adopt must decline for tombstoned queries so the caller keeps
+// ownership and deletes the file via its normal no-adopt path.
+func TestLocalStageCache_AdoptAfterCleanupDeclined(t *testing.T) {
+	root := t.TempDir()
+	c := NewLocalStageCache(root)
+
+	// Query terminates (cleanup runs first, e.g. via the failure path)…
+	c.CleanupQuery("dead-query")
+
+	// …then a straggler producer tries to adopt its output.
+	src := filepath.Join(t.TempDir(), "late.wshf")
+	if err := os.WriteFile(src, []byte("payload"), 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	if dst := c.Adopt("dead-query", "out/s/late.wshf", src); dst != "" {
+		t.Fatalf("Adopt after CleanupQuery must decline, got %q", dst)
+	}
+	// Caller retains ownership: the source file is untouched.
+	if _, err := os.Stat(src); err != nil {
+		t.Fatalf("declined Adopt must leave srcPath in place: %v", err)
+	}
+	// Nothing registered, no orphan directory recreated.
+	if got := c.Get("dead-query", "out/s/late.wshf"); got != "" {
+		t.Fatalf("Get returned %q for declined adopt, want empty", got)
+	}
+	if c.Count() != 0 {
+		t.Fatalf("cache should be empty, has %d entries", c.Count())
+	}
+
+	// Other queries are unaffected.
+	src2 := filepath.Join(t.TempDir(), "live.wshf")
+	if err := os.WriteFile(src2, []byte("payload"), 0o600); err != nil {
+		t.Fatalf("write src2: %v", err)
+	}
+	if dst := c.Adopt("live-query", "out/s/live.wshf", src2); dst == "" {
+		t.Fatal("Adopt for a live query must still succeed")
+	}
+}
+
 func TestLocalStageCache_AdoptMissingFile(t *testing.T) {
 	c := NewLocalStageCache(t.TempDir())
 	if got := c.Adopt("q", "k", "/no/such/file"); got != "" {

--- a/internal/worker/spill_sweep_test.go
+++ b/internal/worker/spill_sweep_test.go
@@ -1,0 +1,67 @@
+package worker
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestSweepStaleSpillArtifacts covers the startup sweep of orphaned spill-dir
+// artifacts from a prior worker process. Regression for SF100 run
+// 20260610-203304: the sweep previously only matched build-cache-*.wshf, so
+// shuffle-<taskID>/ partition dirs and parquet-stream-*.parquet downloads
+// left by a crashed or killed worker survived restarts and silently ate the
+// spill volume.
+func TestSweepStaleSpillArtifacts(t *testing.T) {
+	dir := t.TempDir()
+
+	mustWrite := func(rel string) string {
+		t.Helper()
+		full := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return full
+	}
+
+	// Orphans the sweep must remove.
+	swept := []string{
+		mustWrite("build-cache-123.wshf"),
+		mustWrite("build-cache-load-456.wshf"),
+		mustWrite("parquet-stream-789.parquet"),
+		mustWrite("shuffle-deadbeef/part-0000.wshf"),
+	}
+	sweptDir := filepath.Join(dir, "shuffle-deadbeef")
+
+	// Files the sweep must NOT touch.
+	kept := []string{
+		mustWrite("stage-task1.wshf"),               // stage sink output naming differs
+		mustWrite("sort-run-1.1.bin"),               // operator spill (task-scoped lifecycle)
+		mustWrite("stage-cache/q1/abc_part.wshf"),   // LocalStageCache tree (wiped by its own constructor)
+		mustWrite("parquet-stream-789.parquet.tmp"), // wrong suffix
+	}
+
+	w := &Worker{
+		config: Config{SpillDir: dir},
+		logger: slog.Default(),
+	}
+	w.sweepStaleBuildCacheFiles()
+
+	for _, p := range swept {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("sweep should have removed %s (stat err=%v)", p, err)
+		}
+	}
+	if _, err := os.Stat(sweptDir); !os.IsNotExist(err) {
+		t.Errorf("sweep should have removed dir %s (stat err=%v)", sweptDir, err)
+	}
+	for _, p := range kept {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("sweep must not touch %s: %v", p, err)
+		}
+	}
+}

--- a/internal/worker/stream_source.go
+++ b/internal/worker/stream_source.go
@@ -259,7 +259,13 @@ func (s *cachedFileStreamSource) releaseCurrentFile() {
 		s.mmapData = nil
 	}
 	if s.localPath != "" {
-		_ = os.Remove(s.localPath)
+		if rmErr := os.Remove(s.localPath); rmErr != nil && !os.IsNotExist(rmErr) && s.executor.logger != nil {
+			// Visibility only — clearing localPath below means nothing will
+			// retry this delete, and a leaked multi-GB cache file eats spill
+			// volume until the next process start sweeps it.
+			s.executor.logger.Warn("local cache file cleanup failed",
+				"path", s.localPath, "error", rmErr)
+		}
 		s.localPath = ""
 	}
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -290,6 +290,16 @@ func (w *Worker) Start(ctx context.Context) error {
 		queryID := string(msg.Data)
 		w.cancelledMu.Lock()
 		w.cancelled[queryID] = time.Now()
+		// Prune on insert: the coordinator broadcasts a cancel for EVERY
+		// terminal query (cleanupQuery), so this map gains one entry per
+		// query for the process lifetime. 30 minutes comfortably outlives
+		// any straggler task the entry exists to suppress.
+		cutoff := time.Now().Add(-30 * time.Minute)
+		for q, at := range w.cancelled {
+			if at.Before(cutoff) {
+				delete(w.cancelled, q)
+			}
+		}
 		w.cancelledMu.Unlock()
 		// Free per-query state. Cancelled queries won't read any further
 		// stage outputs, so their spill files are pure leak otherwise.
@@ -573,26 +583,34 @@ func (w *Worker) sweepStaleBuildCacheFiles() {
 	var bytesFreed int64
 	for _, e := range entries {
 		name := e.Name()
-		// Two prefixes are used by the build-cache pipeline:
+		// Spill-dir artifacts from a prior worker process, all orphaned by
+		// definition (nothing in this process references them):
 		//   build-cache-*.wshf       — write-side spill from shuffleStreamSink
 		//   build-cache-load-*.wshf  — read-side mmap source download
-		if !strings.HasPrefix(name, "build-cache-") || !strings.HasSuffix(name, ".wshf") {
+		//   parquet-stream-*.parquet — read-side parquet mmap download
+		//   shuffle-<taskID>/        — partitioned shuffle sink output dirs
+		isDir := e.IsDir()
+		switch {
+		case !isDir && strings.HasPrefix(name, "build-cache-") && strings.HasSuffix(name, ".wshf"):
+		case !isDir && strings.HasPrefix(name, "parquet-stream-") && strings.HasSuffix(name, ".parquet"):
+		case isDir && strings.HasPrefix(name, "shuffle-"):
+		default:
 			continue
 		}
 		full := filepath.Join(dir, name)
-		if info, statErr := e.Info(); statErr == nil {
+		if info, statErr := e.Info(); statErr == nil && !isDir {
 			bytesFreed += info.Size()
 		}
-		if rmErr := os.Remove(full); rmErr != nil {
-			w.logger.Warn("removing stale build-cache file",
+		if rmErr := os.RemoveAll(full); rmErr != nil {
+			w.logger.Warn("removing stale spill artifact",
 				"path", full, "error", rmErr)
 			continue
 		}
 		removed++
 	}
 	if removed > 0 {
-		w.logger.Info("swept stale build-cache spill files",
-			"dir", dir, "files", removed, "bytes_freed", bytesFreed)
+		w.logger.Info("swept stale spill artifacts",
+			"dir", dir, "items", removed, "bytes_freed", bytesFreed)
 	}
 }
 


### PR DESCRIPTION
## What

Closes the ENOSPC cascade from SF100 run `20260610-203304`: Q21 failed terminally on a full spill volume, its in-flight tasks **kept running** (one uploaded a 4.5GB partition output 30s after the query died), the disk never recovered, and Q22 then failed on Q21's garbage.

Root cause: `CancelSubject` was only published by the user-facing `CancelQuery` API. Internal terminal failure — stage failed after max retry attempts, or query timeout — never told workers to abandon the query's tasks. The worker-side machinery (cancelled-map, queued-task `Term`, ~500ms in-flight abort ticker, cache cleanup) has existed all along; the failure path just never triggered it.

## Changes

1. **`cleanupQuery` broadcasts `CancelSubject` before `CompleteSubject`** — it runs on every terminal path, and by then result subs are closed and the S3 scratch is about to be purged, so any still-running task is pure waste (whose uploads also recreate the `queries/` scratch leak). Also reaps straggler duplicate attempts left by the task retrier on success paths.
2. **Cancelled-map pruning** (30m TTL on insert) — it now gains an entry per query.
3. **LocalStageCache tombstones** — a straggler reaching `Adopt` after `CleanupQuery` ran would register a file nothing will ever clean. Adopt now declines for 30m-tombstoned queries; caller deletes via its normal no-adopt path.
4. **Startup sweep extended** to `parquet-stream-*.parquet` and `shuffle-<taskID>/` dirs (was: only `build-cache-*.wshf`).
5. **Cleanup failures now logged** (executeShuffle spill-dir RemoveAll, releaseCurrentFile Remove) — a silent leak is how this incident stayed invisible.

## Tests

- `TestLocalStageCache_AdoptAfterCleanupDeclined` — fails before the tombstone, passes after
- `TestSweepStaleSpillArtifacts` — fails before the sweep extension, passes after
- Gates: worker `-race`, coordinator, full `./internal/...`, TPC-H SF0.01 22/22, `tpch-harness --mode=local` PASS on **both** nats and grpc data planes

Incident evidence (worker logs pulled pre-teardown): `s3://wadjet-bench-sf100-use2/results/20260610-203304/worker-logs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)