### PR TITLE
feat(tpch): catalog snapshot/restore on bench boot — skip per-deploy discovery+ANALYZE

### DIFF
--- a/cmd/tpch-bench/catalog_snapshot_test.go
+++ b/cmd/tpch-bench/catalog_snapshot_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/storage/catalog"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+const (
+	snapTestBucket = "bench-bucket"
+	snapTestPrefix = "catalog/"
+)
+
+func newBenchCatalog(t *testing.T, store objstore.Store) *catalog.Catalog {
+	t.Helper()
+	cat := catalog.NewWithCluster(catalog.NewMemKV(), store, snapTestBucket, "local")
+	if err := cat.Init(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	return cat
+}
+
+// TestRestoreOrDiscoverSequence exercises the boot glue: first boot finds no
+// snapshot (falls back to discovery, then snapshots); second boot against a
+// fresh KV restores and reports true; a non-empty KV refuses to restore.
+func TestRestoreOrDiscoverSequence(t *testing.T) {
+	ctx := context.Background()
+	store := objstore.NewMemStore() // shared "S3" across boots
+
+	// Boot 1: nothing to restore yet.
+	cat1 := newBenchCatalog(t, store)
+	if restoreCatalogSnapshot(ctx, cat1, store, snapTestBucket, snapTestPrefix) {
+		t.Fatal("restore must report false when no snapshot exists")
+	}
+	// "Discovery" populates the catalog…
+	schema := parquet.Schema{Columns: []parquet.Column{{Name: "id", Type: parquet.TypeInt64}}}
+	if err := cat1.CreateTable(ctx, "orders", schema, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := cat1.AddFiles(ctx, "orders", nil, "", []catalog.FileEntry{
+		{Path: "orders/1.parquet", SizeBytes: 123, NumRows: 42},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// …and the boot path snapshots it.
+	snapshotCatalog(ctx, cat1, store, snapTestBucket, snapTestPrefix)
+
+	// Boot 2: fresh KV (new deploy), same bucket — restore must succeed and
+	// reproduce the discovered state.
+	cat2 := newBenchCatalog(t, store)
+	if !restoreCatalogSnapshot(ctx, cat2, store, snapTestBucket, snapTestPrefix) {
+		t.Fatal("restore must report true when a snapshot exists and KV is fresh")
+	}
+	tm, err := cat2.GetTable(ctx, "orders")
+	if err != nil {
+		t.Fatalf("restored catalog missing table: %v", err)
+	}
+	if len(tm.Schema.Columns) != 1 || tm.Schema.Columns[0].Name != "id" {
+		t.Fatalf("restored schema mismatch: %+v", tm.Schema)
+	}
+	mf, err := cat2.GetManifest(ctx, "orders")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mf.Partitions) != 1 || len(mf.Partitions[0].Files) != 1 || mf.Partitions[0].Files[0].NumRows != 42 {
+		t.Fatalf("restored manifest mismatch: %+v", mf)
+	}
+
+	// Boot 3: catalog already populated (e.g. restore raced something) —
+	// refuse to overwrite.
+	if restoreCatalogSnapshot(ctx, cat2, store, snapTestBucket, snapTestPrefix) {
+		t.Fatal("restore must report false when the KV is not empty")
+	}
+
+	// nil store (S3 client construction failed) degrades to disabled.
+	if restoreCatalogSnapshot(ctx, cat2, nil, snapTestBucket, snapTestPrefix) {
+		t.Fatal("restore with nil store must report false")
+	}
+	snapshotCatalog(ctx, cat2, nil, snapTestBucket, snapTestPrefix) // must not panic
+}

--- a/cmd/tpch-bench/config.go
+++ b/cmd/tpch-bench/config.go
@@ -35,6 +35,15 @@ type BenchProfile struct {
 		QueryTimeout string `yaml:"query_timeout"`
 		SkipLoad     bool   `yaml:"skip_load"`
 		SkipQueries  []int  `yaml:"skip_queries"`
+		// CatalogSnapshotPrefix enables catalog snapshot/restore under
+		// s3://<bucket>/<prefix> (e.g. "catalog/"). When set with
+		// skip_load, boot first tries to restore the latest snapshot —
+		// skipping the ~5 min discovery + ~10 min ANALYZE entirely — and
+		// after a fresh discovery+ANALYZE it writes a new snapshot for the
+		// next deploy. Only safe while the bucket's table data is immutable
+		// across deploys (true for all pre-staged bench buckets); delete
+		// s3://<bucket>/<prefix> after changing the data.
+		CatalogSnapshotPrefix string `yaml:"catalog_snapshot_prefix"`
 	} `yaml:"benchmark"`
 }
 

--- a/cmd/tpch-bench/main.go
+++ b/cmd/tpch-bench/main.go
@@ -61,6 +61,7 @@ func main() {
 		memProf     = flag.String("memprofile", "", "Write memory profile to file")
 		profDir     = flag.String("profdir", "", "Directory for per-query profiles")
 		dataPrefix  = flag.String("data-prefix", "tables/", "S3 prefix for table data (e.g. 'tables/' or '' for root)")
+		catalogSnapshotPrefix = flag.String("catalog-snapshot-prefix", "", "S3 prefix for catalog snapshots (e.g. 'catalog/'). With --skip-load: restore the latest snapshot instead of running discovery+ANALYZE; after a fresh discovery, write one. Empty = disabled.")
 	)
 	flag.Parse()
 
@@ -105,6 +106,9 @@ func main() {
 		// "tables/" is wrong for buckets with data at root level.
 		if !setFlags["data-prefix"] {
 			*dataPrefix = profile.Storage.DataPrefix
+		}
+		if !setFlags["catalog-snapshot-prefix"] && profile.Benchmark.CatalogSnapshotPrefix != "" {
+			*catalogSnapshotPrefix = profile.Benchmark.CatalogSnapshotPrefix
 		}
 		if !setFlags["query-timeout"] && profile.Benchmark.QueryTimeout != "" {
 			d, err := time.ParseDuration(profile.Benchmark.QueryTimeout)
@@ -170,7 +174,20 @@ func main() {
 
 	sf := tpch.ScaleFactor(float64(*scale))
 	if *skipLoad {
-		discoverData(ctx, db, *s3Endpoint, *s3Region, *s3Bucket, *ssl, *dataPrefix)
+		// Pre-staged bucket data is immutable across deploys, so the
+		// post-discovery catalog (schemas, file manifests with row counts,
+		// SketchesKey references into stats/) is too. Restoring it from a
+		// snapshot replaces ~5 min of discovery + ~10 min of ANALYZE per
+		// deploy with a few S3 GETs.
+		if *catalogSnapshotPrefix != "" {
+			snapStore := newCatalogSnapshotStore(*s3Endpoint, *s3Region, *ssl)
+			if !restoreCatalogSnapshot(ctx, db.Catalog(), snapStore, *s3Bucket, *catalogSnapshotPrefix) {
+				discoverData(ctx, db, *s3Endpoint, *s3Region, *s3Bucket, *ssl, *dataPrefix)
+				snapshotCatalog(ctx, db.Catalog(), snapStore, *s3Bucket, *catalogSnapshotPrefix)
+			}
+		} else {
+			discoverData(ctx, db, *s3Endpoint, *s3Region, *s3Bucket, *ssl, *dataPrefix)
+		}
 	} else {
 		loadData(ctx, db, sf)
 	}
@@ -365,6 +382,72 @@ func setupDistributed(ctx context.Context, logger *slog.Logger, endpoint, region
 	}
 
 	return db, coord, nc
+}
+
+// newCatalogSnapshotStore builds the S3 client for snapshot/restore, or nil
+// (with a warning) on failure — callers treat nil as "mechanism disabled".
+func newCatalogSnapshotStore(endpoint, region string, ssl bool) objstore.Store {
+	store, err := objstore.NewMinIOStore(objstore.MinIOConfig{
+		Endpoint: endpoint,
+		UseSSL:   ssl,
+		Region:   region,
+	})
+	if err != nil {
+		log.Printf("WARNING: creating S3 store for catalog snapshot/restore: %v", err)
+		return nil
+	}
+	return store
+}
+
+// restoreCatalogSnapshot imports the latest catalog snapshot from
+// s3://<bucket>/<prefix>, replacing discovery + ANALYZE. Returns true only
+// when a snapshot was actually restored; every failure mode logs and returns
+// false so the caller falls back to full discovery — the mechanism is an
+// accelerator, never a gate.
+func restoreCatalogSnapshot(ctx context.Context, cat *catalog.Catalog, store objstore.Store, bucket, prefix string) bool {
+	if store == nil {
+		return false
+	}
+	// Restore Puts blindly into the KV; only proceed on a fresh catalog.
+	// "Fresh" means no tables registered — setupDistributed already ran
+	// Init(), which writes the meta key, so IsKVEmpty is always false by
+	// the time this runs. Restore overwrites meta with the snapshot's own
+	// copy, so the Init-written stub is fine to clobber.
+	tables, err := cat.ListTables(ctx)
+	if err != nil || len(tables) > 0 {
+		log.Printf("catalog already has %d tables (err=%v); skipping snapshot restore", len(tables), err)
+		return false
+	}
+	ts, err := cat.Restore(ctx, catalog.RestoreOptions{
+		SnapshotOptions: catalog.SnapshotOptions{Store: store, Bucket: bucket, Prefix: prefix},
+	})
+	if err != nil {
+		log.Printf("WARNING: catalog snapshot restore failed (%v); falling back to discovery", err)
+		return false
+	}
+	if ts == "" {
+		log.Printf("No catalog snapshot at s3://%s/%s yet — running discovery", bucket, prefix)
+		return false
+	}
+	log.Printf("Catalog restored from snapshot %s (discovery + ANALYZE skipped)", ts)
+	return true
+}
+
+// snapshotCatalog persists the post-discovery+ANALYZE catalog state so the
+// next boot against this immutable bucket can restore it in seconds.
+// Best-effort: a failed snapshot only costs the next deploy a re-discovery.
+func snapshotCatalog(ctx context.Context, cat *catalog.Catalog, store objstore.Store, bucket, prefix string) {
+	if store == nil {
+		return
+	}
+	ts, err := cat.Snapshot(ctx, catalog.SnapshotOptions{
+		Store: store, Bucket: bucket, Prefix: prefix,
+	})
+	if err != nil {
+		log.Printf("WARNING: catalog snapshot failed: %v", err)
+		return
+	}
+	log.Printf("Catalog snapshotted to s3://%s/%ssnapshots/%s (next boot restores it in seconds)", bucket, prefix, ts)
 }
 
 func discoverData(ctx context.Context, db *wadjet.DB, endpoint, region, bucket string, ssl bool, dataPrefix string) {

--- a/deploy/benchmark/profiles/sf10-distributed.yaml
+++ b/deploy/benchmark/profiles/sf10-distributed.yaml
@@ -32,3 +32,9 @@ benchmark:
   runs: 1
   query_timeout: 30m
   skip_load: true
+  # Restore the post-discovery catalog from s3://<bucket>/catalog/ instead
+  # of re-running discovery + ANALYZE every deploy. First deploy with this
+  # set pays the full cost once and writes the snapshot; later deploys
+  # restore in seconds. Safe while the bucket's table data is immutable;
+  # delete s3://<bucket>/catalog/ after changing it.
+  catalog_snapshot_prefix: "catalog/"

--- a/deploy/benchmark/profiles/sf100-distributed.yaml
+++ b/deploy/benchmark/profiles/sf100-distributed.yaml
@@ -31,3 +31,9 @@ benchmark:
   runs: 1
   query_timeout: 30m
   skip_load: true
+  # Restore the post-discovery catalog from s3://<bucket>/catalog/ instead
+  # of re-running discovery + ANALYZE every deploy. First deploy with this
+  # set pays the full cost once and writes the snapshot; later deploys
+  # restore in seconds. Safe while the bucket's table data is immutable;
+  # delete s3://<bucket>/catalog/ after changing it.
+  catalog_snapshot_prefix: "catalog/"


### PR DESCRIPTION
## What

Kills the ~15 min discovery+ANALYZE tax on every benchmark deploy against the immutable pre-staged buckets, using the already-existing (and already-tested) `Catalog.Snapshot()/Restore()` machinery — this PR is just the tpch-bench boot wiring.

- New profile field `benchmark.catalog_snapshot_prefix` (+ `--catalog-snapshot-prefix` flag). With `skip_load`:
  - boot tries to restore the latest snapshot from `s3://<bucket>/<prefix>` → skips discovery **and** ANALYZE (sketches live in `stats/` and load lazily via restored `SketchesKey` references)
  - on a fresh discovery+ANALYZE, writes a snapshot for the next deploy
- Every failure mode (no snapshot yet, store error, integrity mismatch, populated catalog) logs and falls back to full discovery — accelerator, never a gate.
- Enabled in the sf100/sf10 distributed profiles (`"catalog/"`). First deploy pays full cost once; subsequent deploys restore in seconds. Delete `s3://<bucket>/catalog/` if table data ever changes.

## Notable

The freshness check is "zero tables registered", **not** `IsKVEmpty` — `setupDistributed` runs `catalog.Init()` (which writes the meta key) before this code, so `IsKVEmpty` is always false at boot. The unit test caught this; with the naive check, restore would never have fired in production.

## Tests

`TestRestoreOrDiscoverSequence` — no-snapshot fallback → discovery → snapshot → fresh-boot restore (schema + manifest row counts verified) → populated-catalog refusal → nil-store degradation. Plus existing catalog snapshot round-trip suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)