### PR TITLE
build(deploy): wire catalog_snapshot_prefix through tfvars deploys

### DIFF
--- a/deploy/benchmark/run-benchmark.sh
+++ b/deploy/benchmark/run-benchmark.sh
@@ -103,6 +103,13 @@ fi
 PROFILE_FLAG=()
 [ -n "$PROFILE" ] && PROFILE_FLAG=(--config="${PROFILE}")
 
+# Catalog snapshot/restore (PR #115): non-empty prefix makes tpch-bench
+# restore the post-discovery catalog from s3://<bucket>/<prefix> (or write
+# the first snapshot after a fresh discovery+ANALYZE). Profile-file fields
+# don't reach tfvars-driven deploys (no --config), so this flows via env.
+CATALOG_SNAP_FLAGS=()
+[ -n "${TPCH_CATALOG_SNAPSHOT_PREFIX:-}" ] && CATALOG_SNAP_FLAGS=(--catalog-snapshot-prefix="${TPCH_CATALOG_SNAPSHOT_PREFIX}")
+
 # Decide whether to pass --data-prefix on the CLI:
 #   - If DATA_PREFIX is explicitly set in the environment, honor it (overrides profile).
 #   - Else if no profile is set, fall back to the legacy default "tables/".
@@ -129,6 +136,7 @@ if [ "$MODE" = "standalone" ]; then
     "${DATA_PREFIX_FLAG[@]}" \
     "${S3_FLAGS[@]}" \
     "${LOAD_FLAGS[@]}" \
+    "${CATALOG_SNAP_FLAGS[@]}" \
     "${SKIP_FLAGS[@]}" \
     --cpuprofile="${PROF_DIR}/cpu-standalone.prof" \
     --memprofile="${PROF_DIR}/mem-standalone.prof" \
@@ -165,6 +173,7 @@ elif [ "$MODE" = "distributed" ]; then
     "${DATA_PREFIX_FLAG[@]}" \
     "${S3_FLAGS[@]}" \
     "${LOAD_FLAGS[@]}" \
+    "${CATALOG_SNAP_FLAGS[@]}" \
     "${SKIP_FLAGS[@]}" \
     "${NATIVE_DAG_FLAGS[@]}" \
     "${DATA_PLANE_FLAGS[@]}" \

--- a/deploy/benchmark/terraform/main.tf
+++ b/deploy/benchmark/terraform/main.tf
@@ -368,6 +368,10 @@ locals {
     # ${var.data_plane_port}.
     export TPCH_DATA_PLANE="${var.data_plane}"
     export TPCH_DATA_PLANE_ADDR=":${var.data_plane_port}"
+    # Catalog snapshot/restore prefix (PR #115). Non-empty = restore the
+    # post-discovery catalog from s3://<bucket>/<prefix> instead of paying
+    # ~15 min of discovery+ANALYZE per deploy; first boot writes it.
+    export TPCH_CATALOG_SNAPSHOT_PREFIX="${var.catalog_snapshot_prefix}"
     # Force GOGC=100 so heap is bounded by 2x live data instead of growing to
     # GOMEMLIMIT before triggering mark-assist. Without this, scan-3 SF10
     # tasks accumulated parquet-decode garbage to ~10 GB peak heap before

--- a/deploy/benchmark/terraform/sf10-distributed.tfvars
+++ b/deploy/benchmark/terraform/sf10-distributed.tfvars
@@ -15,3 +15,4 @@ data_bucket              = "wadjet-bench-sf10-use2"
 skip_queries             = ""
 query_timeout            = "30m"  # SF10 heavy queries (Q03/Q05/Q21 lineitem joins) need >10m; the 26 April AWS run hit the 10m cap on Q03 even though stages were progressing
 data_plane               = "grpc" # Phase C+D+E gRPC data-plane (task dispatch + results + gather + TaskProgress). NATS retained for heartbeats + cancellation + KV only.
+catalog_snapshot_prefix   = "catalog/" # restore post-discovery catalog; first boot writes it (PR #115)

--- a/deploy/benchmark/terraform/sf100-distributed.tfvars
+++ b/deploy/benchmark/terraform/sf100-distributed.tfvars
@@ -33,3 +33,4 @@ query_timeout             = "30m"           # SF100 heavy queries need >10m defa
 #   Raised to 4 — the concurrency payoff the engine was always targeting.
 max_concurrent            = 4
 data_plane                = "grpc" # Phase C+D+E gRPC data-plane (task dispatch + results + gather + TaskProgress). NATS retained for heartbeats + cancellation + KV only. SF100 is where the design was actually targeted — Q17 dispatch-stall + NATS lock-contention pathologies.
+catalog_snapshot_prefix   = "catalog/" # restore post-discovery catalog; first boot writes it (PR #115)

--- a/deploy/benchmark/terraform/variables.tf
+++ b/deploy/benchmark/terraform/variables.tf
@@ -140,6 +140,12 @@ variable "bounded_dirty_writes" {
   default     = false
 }
 
+variable "catalog_snapshot_prefix" {
+  description = "S3 prefix (within the data bucket) for catalog snapshots, e.g. 'catalog/'. Non-empty: tpch-bench restores the post-discovery catalog instead of running discovery+ANALYZE (~15 min/deploy), writing a snapshot on the first boot. Empty = disabled. Delete s3://<bucket>/<prefix> after changing table data."
+  type        = string
+  default     = ""
+}
+
 variable "workers_per_node" {
   description = "Number of independent wadjet worker processes to launch per node. >1 gives crash isolation: when one process OOMs, sibling workers on the same node keep running. Each process gets a per-process memory envelope (auto-derived from /N of total) and registers separately with the coord."
   type        = number


### PR DESCRIPTION
PR #115's profile field never reaches real deploys: tfvars-driven runs don't pass `--config` to tpch-bench (`BENCHMARK_PROFILE` is only exported when `-var=profile` is set). Verified live on run `20260611-112836` — profile on disk had the field, tpch-bench cmdline had no `--config`, no snapshot written.

Fix mirrors the `data_plane` plumbing: terraform var → `TPCH_CATALOG_SNAPSHOT_PREFIX` env → `--catalog-snapshot-prefix` flag in both run-benchmark.sh invocations. Enabled in sf100/sf10 distributed tfvars. `tofu validate` + `bash -n` clean; deploy-tooling only, no engine code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)