### PR TITLE
fix(storage): compaction output path normalization + --background-compaction toggle

### DIFF
--- a/cmd/wadjet/main.go
+++ b/cmd/wadjet/main.go
@@ -89,6 +89,7 @@ var (
 	otelInsecure          bool
 	metricsAddr           string
 	enableAlerts          bool
+	backgroundCompaction  bool
 	dataPlane             string
 	dataPlaneAddr         string
 	coordDataPlane        string
@@ -147,6 +148,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&geoipASNDB, "geoip-asn", "", "Path to MaxMind GeoIP ASN database (GeoLite2-ASN.mmdb)")
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Log level: debug, info, warn, error")
 	rootCmd.PersistentFlags().BoolVar(&enableAlerts, "enable-alerts", false, "enable CREATE ALERT DDL and scheduler (default: disabled)")
+	rootCmd.PersistentFlags().BoolVar(&backgroundCompaction, "background-compaction", true, "Run the periodic small-file compaction sweep (5m interval). --background-compaction=false disables it — useful for benchmark comparability (compaction mid-suite shifts timings and doubles data-dir disk during the delete grace) and for read-only/pre-compacted datasets.")
 
 	rootCmd.AddCommand(serveCmd())
 	rootCmd.AddCommand(queryCmd())
@@ -926,7 +928,7 @@ func runStandalone(ctx context.Context, store objstore.Store, logger *slog.Logge
 
 	// Start background compaction
 	compactor := compaction.NewBackgroundCompactor(cat, compaction.BackgroundConfig{
-		Enabled:    true,
+		Enabled:    backgroundCompaction,
 		Compaction: compaction.DefaultConfig(),
 	}, logger)
 	compactor.Start(ctx)
@@ -1211,7 +1213,7 @@ func runCoordinator(ctx context.Context, store objstore.Store, logger *slog.Logg
 
 	// Start background compaction
 	coordCompactor := compaction.NewBackgroundCompactor(cat, compaction.BackgroundConfig{
-		Enabled:    true,
+		Enabled:    backgroundCompaction,
 		Compaction: compaction.DefaultConfig(),
 	}, logger)
 	coordCompactor.Start(ctx)

--- a/internal/storage/compaction/compactor.go
+++ b/internal/storage/compaction/compactor.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -27,11 +28,26 @@ import (
 // tables — yielding a leading-slash key at the bucket root and silently
 // orphaning data after the old files were deleted from the manifest.
 func compactedFilePath(tableName, partPath string) string {
+	return partitionedOutputPath(tableName, partPath, "compacted")
+}
+
+// partitionedOutputPath builds "<base>_<nanos>.parquet" under the partition's
+// directory. Some writers store the partition path already table-prefixed
+// (the harness datagen primes "tables/<name>/"); blindly joining
+// prefix+partPath then yields "tables/orders/tables/orders//compacted_*" —
+// consistent (write, manifest, and read all use it) but wrong. A prefixed
+// partPath is treated as the full base.
+func partitionedOutputPath(tableName, partPath, base string) string {
 	prefix := partition.TablePrefix(tableName)
-	if partPath == "" {
-		return fmt.Sprintf("%s/compacted_%d.parquet", prefix, time.Now().UnixNano())
+	dir := prefix
+	if partPath != "" {
+		if strings.HasPrefix(partPath, prefix+"/") || partPath == prefix {
+			dir = strings.TrimSuffix(partPath, "/")
+		} else {
+			dir = prefix + "/" + strings.TrimSuffix(partPath, "/")
+		}
 	}
-	return fmt.Sprintf("%s/%s/compacted_%d.parquet", prefix, partPath, time.Now().UnixNano())
+	return fmt.Sprintf("%s/%s_%d.parquet", dir, base, time.Now().UnixNano())
 }
 
 // Config controls compaction trigger thresholds and limits.
@@ -580,14 +596,9 @@ func (c *Compactor) ForceCompactFile(ctx context.Context, tableName string, file
 
 	// Write-before-delete: the streaming merge uploads the new file FIRST
 	// (inside mergeAndWriteFiles), so on failure nothing in the manifest has
-	// changed — no data loss. Mirror compactedFilePath: use the table prefix
-	// so unpartitioned tables (empty partPath) don't land at the bucket root.
-	newPath := ""
-	if partPath == "" {
-		newPath = fmt.Sprintf("%s/rewrite_%d.parquet", partition.TablePrefix(tableName), time.Now().UnixNano())
-	} else {
-		newPath = fmt.Sprintf("%s/%s/rewrite_%d.parquet", partition.TablePrefix(tableName), partPath, time.Now().UnixNano())
-	}
+	// changed — no data loss. partitionedOutputPath handles both empty and
+	// already-table-prefixed partition paths.
+	newPath := partitionedOutputPath(tableName, partPath, "rewrite")
 
 	// Merge the single file (applies delete markers internally; uploads to
 	// newPath unless every row was deleted).

--- a/internal/storage/compaction/compactor_test.go
+++ b/internal/storage/compaction/compactor_test.go
@@ -434,3 +434,26 @@ func TestBackgroundCompactor_SweepsAllTables(t *testing.T) {
 		}
 	}
 }
+
+// TestPartitionedOutputPath covers the three partition-path shapes the
+// manifest can carry: empty (unpartitioned), hive-relative, and already
+// table-prefixed (harness datagen) — the last used to double-join into
+// "tables/orders/tables/orders//compacted_*".
+func TestPartitionedOutputPath(t *testing.T) {
+	cases := []struct {
+		table, partPath, wantPrefix string
+	}{
+		{"orders", "", "tables/orders/compacted_"},
+		{"orders", "date=2026-01-01", "tables/orders/date=2026-01-01/compacted_"},
+		{"orders", "tables/orders/", "tables/orders/compacted_"},
+		{"orders", "tables/orders", "tables/orders/compacted_"},
+		{"orders", "tables/orders/date=2026-01-01/", "tables/orders/date=2026-01-01/compacted_"},
+	}
+	for _, tc := range cases {
+		got := partitionedOutputPath(tc.table, tc.partPath, "compacted")
+		if !strings.HasPrefix(got, tc.wantPrefix) || strings.Contains(got, "//") {
+			t.Errorf("partitionedOutputPath(%q,%q) = %q, want prefix %q with no //",
+				tc.table, tc.partPath, got, tc.wantPrefix)
+		}
+	}
+}


### PR DESCRIPTION
Two small follow-ups from the SF10 edge validation:

1. **Path normalization**: `partitionedOutputPath` unifies the `compacted_`/`rewrite_` key construction and fixes the `tables/orders/tables/orders//compacted_*` double-join when the manifest's partition path is already table-prefixed. Table-driven test over all three partition-path shapes.
2. **`--background-compaction` toggle** (default true): `=false` for benchmark comparability (mid-suite compaction shifts timings and doubles data-dir disk during the delete grace) and read-only datasets.

Gates: 22/22 compaction tests, full build, SF0.01 22/22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)