### PR TITLE
feat(exec): close the Sort/Window spill residuals — nested-type columnar runs + streaming global windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ SQL text
 - **Selection vectors**: Filtering marks indices instead of copying rows
 - **Push-based pipelines**: Source → UnaryOperator chain → Sink
 - **Pipeline breakers**: Aggregate, Sort, Window act as SinkSource (consume all, then produce)
-- **Spill-to-disk**: All pipeline breakers degrade gracefully past memory — HashJoin (grace partition-on-arrival), HashAggregate (partial-state k-way merge), Sort and Window (sorted-run external merge, streaming k-way). Residuals that still materialize fully: window specs with empty PARTITION BY, nested-type (Array/Map/Row) schemas in Sort/Window (legacy row spill).
+- **Spill-to-disk**: All pipeline breakers degrade gracefully past memory — HashJoin (grace partition-on-arrival), HashAggregate (partial-state k-way merge), Sort and Window (sorted-run external merge, streaming k-way; empty-PARTITION-BY windows stream via a two-pass evaluator over the runs; nested Array/Map/Row schemas ride the columnar run format). Remaining bound: cume_dist holds back the open ORDER-BY peer group; window-partition peak memory is the largest single partition.
 - **Batch pooling**: `BatchPool` for zero-alloc batch reuse
 
 ### Core Interfaces

--- a/internal/engine/batch/batch.go
+++ b/internal/engine/batch/batch.go
@@ -156,72 +156,26 @@ func FromRows(schema []parquet.Column, rows []map[string]any) *RecordBatch {
 	return b
 }
 
-// Compact creates a new RecordBatch containing only the active rows.
-// If there is no selection vector, it returns the batch as-is.
+// Compact materializes the selection vector into a contiguous batch using
+// the typed nested-aware value copier. Returns the batch unchanged when no
+// selection vector is set.
+//
+// Was previously a hand-rolled per-type switch whose ROW case wrote null
+// child rows via SetNull alone — never advancing a string child's offset
+// slot — so every later row in that child read back as concatenated
+// garbage (same bug class as the windowCopyVectorRange nullable-BYTES fix;
+// regression test TestCompact_RowChildNullableString).
 func (b *RecordBatch) Compact() *RecordBatch {
 	if b.Sel == nil {
 		return b
 	}
 	n := len(b.Sel)
 	out := NewRecordBatch(b.Schema, n)
-	for di, si := range b.Sel {
-		for j := range b.Schema {
-			src := b.Columns[j]
-			dst := out.Columns[j]
-			if src.Nulls.IsNullFast(int(si)) {
-				dst.Nulls.SetNull(di)
-				switch dst.Type {
-				case TypeString, TypeBytes, TypeIPv6, TypeCIDR, TypeUUID:
-					dst.BytesData.Set(di, nil)
-				}
-				continue
-			}
-			dst.Nulls.SetValid(di)
-			switch dst.Type {
-			case TypeBool:
-				dst.BoolData[di] = src.BoolData[si]
-			case TypeInt32, TypePort, TypeProtocol, TypeDate:
-				dst.Int32Data[di] = src.Int32Data[si]
-			case TypeInt64, TypeTimestamp, TypeIPv4, TypeMAC, TypeDuration:
-				dst.Int64Data[di] = src.Int64Data[si]
-			case TypeFloat32:
-				dst.Float32Data[di] = src.Float32Data[si]
-			case TypeFloat64:
-				dst.Float64Data[di] = src.Float64Data[si]
-			case TypeString, TypeBytes, TypeIPv6, TypeCIDR, TypeUUID:
-				dst.BytesData.SetFrom(di, &src.BytesData, int(si))
-			case TypeDecimal:
-				dst.DecimalData.Data[di] = src.DecimalData.Data[si]
-			case TypeVector:
-				dim := src.VectorDim
-				if dim > 0 {
-					srcOff := int(si) * dim
-					dstOff := di * dim
-					copy(dst.Float32Data[dstOff:dstOff+dim], src.Float32Data[srcOff:srcOff+dim])
-				}
-			case TypeArray, TypeMap:
-				if src.Child != nil && dst.Child != nil {
-					start := int(src.Offsets[si])
-					end := int(src.Offsets[si+1])
-					dstStart := int32(dst.Child.Len)
-					for k := start; k < end; k++ {
-						appendToVector(dst.Child, src.Child.GetValue(k))
-					}
-					dst.Offsets[di] = dstStart
-					dst.Offsets[di+1] = int32(dst.Child.Len)
-				}
-			case TypeRow:
-				for ci, child := range src.Children {
-					if ci < len(dst.Children) {
-						dstChild := dst.Children[ci]
-						if child.Nulls.IsNullFast(int(si)) {
-							dstChild.Nulls.SetNull(di)
-						} else {
-							dstChild.SetValue(di, child.GetValue(int(si)))
-						}
-					}
-				}
-			}
+	for j := range b.Schema {
+		src := b.Columns[j]
+		dst := out.Columns[j]
+		for di, si := range b.Sel {
+			dst.CopyValueFrom(di, src, int(si))
 		}
 	}
 	return out

--- a/internal/engine/batch/nested_copy_test.go
+++ b/internal/engine/batch/nested_copy_test.go
@@ -1,0 +1,118 @@
+package batch
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+func nestedSchemaForTest() []parquet.Column {
+	elem := parquet.Column{Name: "element", Type: parquet.TypeString}
+	return []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "tags", Type: parquet.TypeArray, ElementType: &elem, Nullable: true},
+		{Name: "rec", Type: parquet.TypeRow, Fields: []parquet.Column{
+			{Name: "a", Type: parquet.TypeInt64},
+			{Name: "b", Type: parquet.TypeString, Nullable: true},
+		}},
+	}
+}
+
+func nestedRowsForTest() []map[string]any {
+	return []map[string]any{
+		{"id": int64(0), "tags": []any{"t0", "u0"}, "rec": map[string]any{"a": int64(0), "b": "b0"}},
+		{"id": int64(1), "tags": nil, "rec": map[string]any{"a": int64(2), "b": nil}}, // null array + NULL row field
+		{"id": int64(2), "tags": []any{}, "rec": map[string]any{"a": int64(4), "b": "b2"}},
+		{"id": int64(3), "tags": []any{"t3"}, "rec": map[string]any{"a": int64(6), "b": "b3"}},
+		{"id": int64(4), "tags": []any{"t4", nil, "u4"}, "rec": map[string]any{"a": int64(8), "b": "b4"}},
+	}
+}
+
+// TestCompact_RowChildNullableString is the regression test for the Compact
+// ROW-child offsets bug: a NULL value in a nullable string field inside a
+// ROW column must still advance the child's offset slot, or every later
+// row in the compacted batch reads back as concatenated garbage.
+func TestCompact_RowChildNullableString(t *testing.T) {
+	rows := nestedRowsForTest()
+	b := FromRows(nestedSchemaForTest(), rows)
+	b.Sel = []uint32{0, 1, 3, 4} // drop row 2, keep the null-b row in the middle
+
+	got := b.Compact().ToRows()
+	want := []map[string]any{rows[0], rows[1], rows[3], rows[4]}
+	if len(got) != len(want) {
+		t.Fatalf("rows: got %d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if !reflect.DeepEqual(got[i], want[i]) {
+			t.Fatalf("row %d differs:\n got  %#v\n want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+// TestCopyValueFrom_SequentialNested writes nested rows one by one into a
+// pre-allocated destination (NewRecordBatch shape) and checks value-identity,
+// including null arrays, empty arrays, null elements and null row fields.
+func TestCopyValueFrom_SequentialNested(t *testing.T) {
+	rows := nestedRowsForTest()
+	src := FromRows(nestedSchemaForTest(), rows)
+
+	dst := NewRecordBatch(nestedSchemaForTest(), src.Len)
+	for j := range src.Columns {
+		for i := 0; i < src.Len; i++ {
+			dst.Columns[j].CopyValueFrom(i, src.Columns[j], i)
+		}
+	}
+	got := dst.ToRows()
+	for i := range rows {
+		if !reflect.DeepEqual(got[i], rows[i]) {
+			t.Fatalf("row %d differs:\n got  %#v\n want %#v", i, got[i], rows[i])
+		}
+	}
+}
+
+// TestAppendFrom_NestedLazyStructure builds the destination with
+// NewVectorLike (no pre-allocation at all) and appends every row, covering
+// the append-built shape of ROW children and ARRAY child growth — plus an
+// array-of-row column (the MAP storage shape) for nested-of-nested.
+func TestAppendFrom_NestedLazyStructure(t *testing.T) {
+	rows := nestedRowsForTest()
+	src := FromRows(nestedSchemaForTest(), rows)
+
+	for j := range src.Columns {
+		dst := NewVectorLike(src.Columns[j])
+		for i := 0; i < src.Len; i++ {
+			dst.AppendFrom(src.Columns[j], i)
+		}
+		if dst.Len != src.Len {
+			t.Fatalf("col %d: len got %d want %d", j, dst.Len, src.Len)
+		}
+		for i := 0; i < src.Len; i++ {
+			if !reflect.DeepEqual(dst.GetValue(i), src.Columns[j].GetValue(i)) {
+				t.Fatalf("col %d row %d: got %#v want %#v", j, i, dst.GetValue(i), src.Columns[j].GetValue(i))
+			}
+		}
+	}
+
+	// MAP column: offsets over a ROW(key,value) child.
+	mapSchema := []parquet.Column{{Name: "m", Type: parquet.TypeMap,
+		ElementType: &parquet.Column{Name: "kv", Type: parquet.TypeRow, Fields: []parquet.Column{
+			{Name: "key", Type: parquet.TypeString},
+			{Name: "value", Type: parquet.TypeInt64},
+		}}}}
+	mapRows := []map[string]any{
+		{"m": []any{map[string]any{"key": "k1", "value": int64(1)}, map[string]any{"key": "k2", "value": int64(2)}}},
+		{"m": []any{}},
+		{"m": []any{map[string]any{"key": "k3", "value": int64(3)}}},
+	}
+	msrc := FromRows(mapSchema, mapRows)
+	mdst := NewVectorLike(msrc.Columns[0])
+	for i := 0; i < msrc.Len; i++ {
+		mdst.AppendFrom(msrc.Columns[0], i)
+	}
+	for i := 0; i < msrc.Len; i++ {
+		if !reflect.DeepEqual(mdst.GetValue(i), msrc.Columns[0].GetValue(i)) {
+			t.Fatalf("map row %d: got %#v want %#v", i, mdst.GetValue(i), msrc.Columns[0].GetValue(i))
+		}
+	}
+}

--- a/internal/engine/batch/vector.go
+++ b/internal/engine/batch/vector.go
@@ -1085,3 +1085,275 @@ func parseDateString(s string) int32 {
 	}
 	return int32(t.Sub(epochDate).Hours() / 24)
 }
+
+// --- Nested-aware typed copy primitives ---
+//
+// These three primitives are the kernel surface that lets Sort/Window
+// columnar runs and the run merger carry ARRAY/MAP/ROW columns without
+// boxing. They share one contract with BytesColumn: destinations are
+// written SEQUENTIALLY (row 0, 1, 2, ...), and null rows still advance
+// variable-length bookkeeping (array offsets, row children) — skipping a
+// null would shift every later row's elements.
+
+// NewVectorLike returns an empty (zero-row) vector with src's type and
+// nested structure: child element types, ROW field names, VECTOR dim and
+// DECIMAL scale. Element storage is appended by AppendFrom.
+func NewVectorLike(src *Vector) *Vector {
+	if src == nil {
+		return nil
+	}
+	v := &Vector{Type: src.Type}
+	switch src.Type {
+	case TypeString, TypeBytes, TypeIPv6, TypeCIDR, TypeUUID:
+		v.BytesData = NewBytesColumn(0)
+	case TypeDecimal:
+		v.DecimalData = NewDecimalColumn(0, src.DecimalData.Scale)
+	case TypeVector:
+		v.VectorDim = src.VectorDim
+	case TypeArray, TypeMap:
+		v.Offsets = []int32{0}
+		v.Child = NewVectorLike(src.Child)
+	case TypeRow:
+		v.Children = make([]*Vector, len(src.Children))
+		for j, ch := range src.Children {
+			v.Children[j] = NewVectorLike(ch)
+		}
+		v.FieldNames = append([]string(nil), src.FieldNames...)
+	}
+	return v
+}
+
+// AppendFrom appends src[si] to dst, growing dst by one row. Typed copy —
+// no boxing, no string round-trips — recursive for nested types. dst's
+// nested structure must match src's (build it with NewVectorLike).
+func (v *Vector) AppendFrom(src *Vector, si int) {
+	idx := v.Len
+	v.Len++
+	v.Nulls = v.Nulls.Grow(v.Len)
+	isNull := src.Nulls.IsNull(si)
+	if isNull {
+		v.Nulls.SetNull(idx)
+	}
+	switch v.Type {
+	case TypeBool:
+		var x bool
+		if !isNull {
+			x = src.BoolData[si]
+		}
+		v.BoolData = append(v.BoolData, x)
+	case TypeInt32, TypePort, TypeProtocol, TypeDate:
+		var x int32
+		if !isNull {
+			x = src.Int32Data[si]
+		}
+		v.Int32Data = append(v.Int32Data, x)
+	case TypeInt64, TypeTimestamp, TypeIPv4, TypeMAC, TypeDuration:
+		var x int64
+		if !isNull {
+			x = src.Int64Data[si]
+		}
+		v.Int64Data = append(v.Int64Data, x)
+	case TypeFloat32:
+		var x float32
+		if !isNull {
+			x = src.Float32Data[si]
+		}
+		v.Float32Data = append(v.Float32Data, x)
+	case TypeFloat64:
+		var x float64
+		if !isNull {
+			x = src.Float64Data[si]
+		}
+		v.Float64Data = append(v.Float64Data, x)
+	case TypeString, TypeBytes, TypeIPv6, TypeCIDR, TypeUUID:
+		if isNull {
+			v.BytesData.Offsets = append(v.BytesData.Offsets, uint32(len(v.BytesData.Data)))
+		} else {
+			start, end := src.BytesData.Offsets[si], src.BytesData.Offsets[si+1]
+			v.BytesData.Data = append(v.BytesData.Data, src.BytesData.Data[start:end]...)
+			v.BytesData.Offsets = append(v.BytesData.Offsets, uint32(len(v.BytesData.Data)))
+		}
+	case TypeDecimal:
+		var x Int128
+		if !isNull {
+			x = src.DecimalData.Data[si]
+		}
+		v.DecimalData.Data = append(v.DecimalData.Data, x)
+	case TypeVector:
+		dim := v.VectorDim
+		if dim > 0 {
+			off := len(v.Float32Data)
+			v.Float32Data = append(v.Float32Data, make([]float32, dim)...)
+			if !isNull {
+				copy(v.Float32Data[off:off+dim], src.Float32Data[si*dim:(si+1)*dim])
+			}
+		}
+	case TypeArray, TypeMap:
+		if v.Child == nil && src.Child != nil {
+			v.Child = NewVectorLike(src.Child)
+		}
+		last := v.Offsets[len(v.Offsets)-1]
+		if isNull || src.Child == nil {
+			v.Offsets = append(v.Offsets, last)
+		} else {
+			start, end := src.Offsets[si], src.Offsets[si+1]
+			for j := start; j < end; j++ {
+				v.Child.AppendFrom(src.Child, int(j))
+			}
+			v.Offsets = append(v.Offsets, last+(end-start))
+		}
+	case TypeRow:
+		if v.Children == nil && src.Children != nil {
+			v.Children = make([]*Vector, len(src.Children))
+			for j, ch := range src.Children {
+				v.Children[j] = NewVectorLike(ch)
+			}
+			v.FieldNames = append([]string(nil), src.FieldNames...)
+		}
+		for j, child := range v.Children {
+			if isNull || j >= len(src.Children) {
+				appendToVector(child, nil)
+			} else {
+				child.AppendFrom(src.Children[j], si)
+			}
+		}
+	}
+}
+
+// CopyValueFrom writes src[si] into position di of dst using typed access —
+// no boxing, no string round-trips — for every column type including nested
+// ARRAY/MAP/ROW. Fixed-width slots are indexed; variable-length storage
+// (bytes data, array child elements, lazily-created row children) is
+// appended, so writes must be SEQUENTIAL per column (di = 0, 1, 2, ...) —
+// the same contract BytesColumn.Set has always had. Null source rows still
+// advance offsets and children; skipping them would shift every later row.
+//
+// Destination shape is flexible per level: parent slots may be
+// pre-allocated (NewRecordBatch with full nested schema) or append-built
+// (NewVectorLike); ROW children handle both — indexed writes when
+// pre-allocated, appends when built lazily.
+func (v *Vector) CopyValueFrom(di int, src *Vector, si int) {
+	isNull := src.Nulls.IsNull(si)
+	if isNull {
+		v.Nulls.SetNull(di)
+	} else {
+		v.Nulls.SetValid(di)
+	}
+	switch v.Type {
+	case TypeBool:
+		if !isNull {
+			v.BoolData[di] = src.BoolData[si]
+		}
+	case TypeInt32, TypePort, TypeProtocol, TypeDate:
+		if !isNull {
+			v.Int32Data[di] = src.Int32Data[si]
+		}
+	case TypeInt64, TypeTimestamp, TypeIPv4, TypeMAC, TypeDuration:
+		if !isNull {
+			v.Int64Data[di] = src.Int64Data[si]
+		}
+	case TypeFloat32:
+		if !isNull {
+			v.Float32Data[di] = src.Float32Data[si]
+		}
+	case TypeFloat64:
+		if !isNull {
+			v.Float64Data[di] = src.Float64Data[si]
+		}
+	case TypeString, TypeBytes, TypeIPv6, TypeCIDR, TypeUUID:
+		if isNull {
+			v.BytesData.Set(di, nil)
+		} else {
+			v.BytesData.SetFrom(di, &src.BytesData, si)
+		}
+	case TypeDecimal:
+		if !isNull {
+			v.DecimalData.Data[di] = src.DecimalData.Data[si]
+		}
+	case TypeVector:
+		dim := src.VectorDim
+		if v.VectorDim == 0 {
+			v.VectorDim = dim
+		}
+		if dim > 0 {
+			need := (di + 1) * dim
+			if len(v.Float32Data) < need {
+				v.Float32Data = append(v.Float32Data, make([]float32, need-len(v.Float32Data))...)
+			}
+			if !isNull {
+				copy(v.Float32Data[di*dim:(di+1)*dim], src.Float32Data[si*dim:(si+1)*dim])
+			}
+		}
+	case TypeArray, TypeMap:
+		if v.Child == nil && src.Child != nil {
+			v.Child = NewVectorLike(src.Child)
+		}
+		var base int32
+		if v.Child != nil {
+			base = int32(v.Child.Len)
+		}
+		v.Offsets[di] = base
+		if isNull || src.Child == nil {
+			v.Offsets[di+1] = base
+			return
+		}
+		start, end := src.Offsets[si], src.Offsets[si+1]
+		for j := start; j < end; j++ {
+			v.Child.AppendFrom(src.Child, int(j))
+		}
+		v.Offsets[di+1] = base + (end - start)
+	case TypeRow:
+		if v.Children == nil && src.Children != nil {
+			v.Children = make([]*Vector, len(src.Children))
+			for j, ch := range src.Children {
+				v.Children[j] = NewVectorLike(ch)
+			}
+			v.FieldNames = append([]string(nil), src.FieldNames...)
+		}
+		for j, child := range v.Children {
+			srcOK := !isNull && j < len(src.Children)
+			if child.Len > di {
+				// Pre-allocated parallel child (NewRecordBatch with nested
+				// schema): indexed write.
+				if srcOK {
+					child.CopyValueFrom(di, src.Children[j], si)
+				} else {
+					writeNullAt(child, di)
+				}
+			} else {
+				// Append-built child (NewVectorLike): grow by one.
+				if srcOK {
+					child.AppendFrom(src.Children[j], si)
+				} else {
+					appendToVector(child, nil)
+				}
+			}
+		}
+	}
+}
+
+// writeNullAt writes a null into position di of a pre-allocated vector,
+// advancing variable-length bookkeeping (bytes offsets, array offsets, row
+// children) so later sequential writes stay aligned.
+func writeNullAt(v *Vector, di int) {
+	v.Nulls.SetNull(di)
+	switch v.Type {
+	case TypeString, TypeBytes, TypeIPv6, TypeCIDR, TypeUUID:
+		v.BytesData.Set(di, nil)
+	case TypeArray, TypeMap:
+		var base int32
+		if v.Child != nil {
+			base = int32(v.Child.Len)
+		}
+		v.Offsets[di] = base
+		v.Offsets[di+1] = base
+	case TypeRow:
+		for _, child := range v.Children {
+			if child.Len > di {
+				writeNullAt(child, di)
+			} else {
+				appendToVector(child, nil)
+			}
+		}
+	}
+}

--- a/internal/engine/exec/join_spill.go
+++ b/internal/engine/exec/join_spill.go
@@ -523,13 +523,114 @@ func writeColumnData(w *bufio.Writer, v *batch.Vector, n int, buf []byte) error 
 			w.Write(buf[:4])
 		}
 
+	case batch.TypeArray, batch.TypeMap:
+		// [offsets:(n+1)*u32] [child vector]. MAP shares ARRAY's layout (its
+		// child is a ROW(key,value) vector), so the recursion covers it.
+		if len(v.Offsets) < n+1 {
+			return fmt.Errorf("columnar spill: %v column has %d offsets, need %d", v.Type, len(v.Offsets), n+1)
+		}
+		for i := 0; i <= n; i++ {
+			binary.LittleEndian.PutUint32(buf[:4], uint32(v.Offsets[i]))
+			w.Write(buf[:4])
+		}
+		childLen := int(v.Offsets[n])
+		if v.Child == nil && childLen > 0 {
+			return fmt.Errorf("columnar spill: %v column has %d child elements but nil child vector", v.Type, childLen)
+		}
+		if err := writeNestedVector(w, v.Child, childLen, buf); err != nil {
+			return err
+		}
+
+	case batch.TypeRow:
+		// [numChildren:u32] then per child: [fieldNameLen:u16][fieldName]
+		// [child vector]. Children are parallel arrays of the parent's length.
+		binary.LittleEndian.PutUint32(buf[:4], uint32(len(v.Children)))
+		w.Write(buf[:4])
+		for j, ch := range v.Children {
+			var name string
+			if j < len(v.FieldNames) {
+				name = v.FieldNames[j]
+			}
+			binary.LittleEndian.PutUint16(buf[:2], uint16(len(name)))
+			w.Write(buf[:2])
+			w.WriteString(name)
+			if err := writeNestedVector(w, ch, n, buf); err != nil {
+				return err
+			}
+		}
+
 	default:
-		// Nested types (Array/Map/Row) have no columnar spill encoding.
-		// Writing nothing here would silently corrupt data on read-back, so
-		// fail loudly — callers gate on columnarSpillableSchema.
 		return fmt.Errorf("columnar spill: unsupported column type %v", v.Type)
 	}
 	return nil
+}
+
+// nestedNilChildMarker is the type byte written for a nil child vector (only
+// legal when the child has zero elements). 0xFF is outside the TypeID space.
+const nestedNilChildMarker = 0xFF
+
+// writeNestedVector serializes a child vector of a nested column:
+// [typeID:u8] [hasNulls:u8] [nullBitmap?] [typed data via writeColumnData].
+// Mirrors the per-column framing of writeColumnarBatch minus name/nullable,
+// which only exist at the schema level.
+func writeNestedVector(w *bufio.Writer, v *batch.Vector, n int, buf []byte) error {
+	if v == nil {
+		if n > 0 {
+			return fmt.Errorf("columnar spill: nil nested vector with %d elements", n)
+		}
+		w.WriteByte(nestedNilChildMarker)
+		return nil
+	}
+	w.WriteByte(byte(v.Type))
+	if v.Nulls.HasNulls() {
+		w.WriteByte(1)
+		bitmapLen := (n + 7) / 8
+		bitmapData := make([]byte, bitmapLen)
+		for j := 0; j < n; j++ {
+			if v.Nulls.IsNullFast(j) {
+				bitmapData[j/8] |= 1 << (uint(j) % 8)
+			}
+		}
+		w.Write(bitmapData)
+	} else {
+		w.WriteByte(0)
+	}
+	return writeColumnData(w, v, n, buf)
+}
+
+// readNestedVector mirrors writeNestedVector.
+func readNestedVector(r *bufio.Reader, n int, buf []byte) (*batch.Vector, error) {
+	typeByte, err := r.ReadByte()
+	if err != nil {
+		return nil, fmt.Errorf("reading nested vector type: %w", err)
+	}
+	if typeByte == nestedNilChildMarker {
+		if n > 0 {
+			return nil, fmt.Errorf("columnar spill: nil nested vector marker with %d elements", n)
+		}
+		return nil, nil
+	}
+	v := batch.NewVector(parquet.TypeID(typeByte), n)
+	hasNulls, err := r.ReadByte()
+	if err != nil {
+		return nil, fmt.Errorf("reading nested hasNulls: %w", err)
+	}
+	if hasNulls == 1 {
+		bitmapLen := (n + 7) / 8
+		bitmapData := make([]byte, bitmapLen)
+		if _, err := io.ReadFull(r, bitmapData); err != nil {
+			return nil, fmt.Errorf("reading nested null bitmap: %w", err)
+		}
+		for j := 0; j < n; j++ {
+			if bitmapData[j/8]&(1<<(uint(j)%8)) != 0 {
+				v.Nulls.SetNull(j)
+			}
+		}
+	}
+	if err := readColumnData(r, v, n, buf); err != nil {
+		return nil, fmt.Errorf("reading nested vector data: %w", err)
+	}
+	return v, nil
 }
 
 // readColumnarBatch reads a single RecordBatch from the columnar binary format.
@@ -707,6 +808,45 @@ func readColumnData(r *bufio.Reader, v *batch.Vector, n int, buf []byte) error {
 				return err
 			}
 			v.Float32Data[i] = math.Float32frombits(binary.LittleEndian.Uint32(buf[:4]))
+		}
+
+	case batch.TypeArray, batch.TypeMap:
+		// NewVector pre-allocated Offsets to n+1.
+		for i := 0; i <= n; i++ {
+			if _, err := io.ReadFull(r, buf[:4]); err != nil {
+				return err
+			}
+			v.Offsets[i] = int32(binary.LittleEndian.Uint32(buf[:4]))
+		}
+		childLen := int(v.Offsets[n])
+		child, err := readNestedVector(r, childLen, buf)
+		if err != nil {
+			return err
+		}
+		v.Child = child
+
+	case batch.TypeRow:
+		if _, err := io.ReadFull(r, buf[:4]); err != nil {
+			return err
+		}
+		numChildren := int(binary.LittleEndian.Uint32(buf[:4]))
+		v.Children = make([]*batch.Vector, numChildren)
+		v.FieldNames = make([]string, numChildren)
+		for j := 0; j < numChildren; j++ {
+			if _, err := io.ReadFull(r, buf[:2]); err != nil {
+				return err
+			}
+			nameLen := int(binary.LittleEndian.Uint16(buf[:2]))
+			nameBuf := make([]byte, nameLen)
+			if _, err := io.ReadFull(r, nameBuf); err != nil {
+				return err
+			}
+			v.FieldNames[j] = string(nameBuf)
+			ch, err := readNestedVector(r, n, buf)
+			if err != nil {
+				return err
+			}
+			v.Children[j] = ch
 		}
 
 	default:

--- a/internal/engine/exec/join_spill_test.go
+++ b/internal/engine/exec/join_spill_test.go
@@ -665,3 +665,172 @@ func TestConcurrentSpillFileNaming(t *testing.T) {
 func fromRowsForTest(schema []parquet.Column, rows []map[string]any) *batch.RecordBatch {
 	return batch.FromRows(schema, rows)
 }
+
+// nestedTestStringVec builds a STRING vector from values; nil = NULL.
+func nestedTestStringVec(vals []*string) *batch.Vector {
+	v := batch.NewVector(parquet.TypeString, len(vals))
+	var data []byte
+	offsets := make([]uint32, len(vals)+1)
+	for i, s := range vals {
+		if s == nil {
+			v.Nulls.SetNull(i)
+		} else {
+			data = append(data, *s...)
+		}
+		offsets[i+1] = uint32(len(data))
+	}
+	v.BytesData.Data = data
+	v.BytesData.Offsets = offsets
+	return v
+}
+
+func nestedTestCompareVectors(t *testing.T, label string, got, want *batch.Vector, n int) {
+	t.Helper()
+	if (got == nil) != (want == nil) {
+		t.Fatalf("%s: nil mismatch got=%v want=%v", label, got == nil, want == nil)
+	}
+	if got == nil {
+		return
+	}
+	if got.Type != want.Type {
+		t.Fatalf("%s: type got %v want %v", label, got.Type, want.Type)
+	}
+	for i := 0; i < n; i++ {
+		if got.Nulls.IsNullFast(i) != want.Nulls.IsNullFast(i) {
+			t.Fatalf("%s: null bit row %d got %v want %v", label, i, got.Nulls.IsNullFast(i), want.Nulls.IsNullFast(i))
+		}
+	}
+	switch want.Type {
+	case batch.TypeInt64:
+		for i := 0; i < n; i++ {
+			if got.Int64Data[i] != want.Int64Data[i] {
+				t.Fatalf("%s: row %d got %d want %d", label, i, got.Int64Data[i], want.Int64Data[i])
+			}
+		}
+	case batch.TypeString:
+		for i := 0; i < n; i++ {
+			if want.Nulls.IsNullFast(i) {
+				continue
+			}
+			gs, _ := got.GetString(i)
+			ws, _ := want.GetString(i)
+			if gs != ws {
+				t.Fatalf("%s: row %d got %q want %q", label, i, gs, ws)
+			}
+		}
+	case batch.TypeArray, batch.TypeMap:
+		for i := 0; i <= n; i++ {
+			if got.Offsets[i] != want.Offsets[i] {
+				t.Fatalf("%s: offset %d got %d want %d", label, i, got.Offsets[i], want.Offsets[i])
+			}
+		}
+		nestedTestCompareVectors(t, label+".child", got.Child, want.Child, int(want.Offsets[n]))
+	case batch.TypeRow:
+		if len(got.Children) != len(want.Children) {
+			t.Fatalf("%s: children got %d want %d", label, len(got.Children), len(want.Children))
+		}
+		for j := range want.Children {
+			if got.FieldNames[j] != want.FieldNames[j] {
+				t.Fatalf("%s: field %d name got %q want %q", label, j, got.FieldNames[j], want.FieldNames[j])
+			}
+			nestedTestCompareVectors(t, label+"."+want.FieldNames[j], got.Children[j], want.Children[j], n)
+		}
+	default:
+		t.Fatalf("%s: comparator missing for type %v", label, want.Type)
+	}
+}
+
+// TestColumnarSpillRoundtrip_NestedTypes round-trips ARRAY, MAP, ROW and
+// ARRAY(ROW(...)) columns through the columnar spill format, including
+// top-level nulls, null child elements, empty arrays, and a nil child.
+func TestColumnarSpillRoundtrip_NestedTypes(t *testing.T) {
+	const n = 3
+	sp := func(s string) *string { return &s }
+
+	// ARRAY(INT64): [1, NULL-elem], NULL(empty), [3]
+	arr := batch.NewVector(parquet.TypeArray, n)
+	arr.Offsets = []int32{0, 2, 2, 3}
+	arrChild := batch.NewVector(parquet.TypeInt64, 3)
+	copy(arrChild.Int64Data, []int64{1, 2, 3})
+	arrChild.Nulls.SetNull(1)
+	arr.Child = arrChild
+	arr.Nulls.SetNull(1)
+
+	// ROW(a INT64, b STRING) with a null string field
+	rec := batch.NewVector(parquet.TypeRow, n)
+	recA := batch.NewVector(parquet.TypeInt64, n)
+	copy(recA.Int64Data, []int64{10, 20, 30})
+	rec.Children = []*batch.Vector{recA, nestedTestStringVec([]*string{sp("x"), sp("y"), nil})}
+	rec.FieldNames = []string{"a", "b"}
+
+	// MAP(STRING->INT64) stored as offsets + ROW(key,value) child:
+	// {"k1":1,"k2":2}, {}, {"k3":3}
+	m := batch.NewVector(parquet.TypeMap, n)
+	m.Offsets = []int32{0, 2, 2, 3}
+	kv := batch.NewVector(parquet.TypeRow, 3)
+	vals := batch.NewVector(parquet.TypeInt64, 3)
+	copy(vals.Int64Data, []int64{1, 2, 3})
+	kv.Children = []*batch.Vector{nestedTestStringVec([]*string{sp("k1"), sp("k2"), sp("k3")}), vals}
+	kv.FieldNames = []string{"key", "value"}
+	m.Child = kv
+
+	// ARRAY with all-empty rows and a nil child vector
+	empty := batch.NewVector(parquet.TypeArray, n)
+	empty.Offsets = []int32{0, 0, 0, 0}
+	empty.Child = nil
+
+	schema := []parquet.Column{
+		{Name: "arr", Type: parquet.TypeArray, Nullable: true},
+		{Name: "rec", Type: parquet.TypeRow},
+		{Name: "m", Type: parquet.TypeMap},
+		{Name: "empty", Type: parquet.TypeArray},
+	}
+	original := &batch.RecordBatch{
+		Schema:  schema,
+		Columns: []*batch.Vector{arr, rec, m, empty},
+		Len:     n,
+	}
+
+	tmpDir := t.TempDir()
+	path, err := writeSpillBatches(tmpDir, []*batch.RecordBatch{original})
+	if err != nil {
+		t.Fatalf("writeSpillBatches: %v", err)
+	}
+	batches, err := readSpillBatches(path)
+	if err != nil {
+		t.Fatalf("readSpillBatches: %v", err)
+	}
+	if len(batches) != 1 || batches[0].Len != n {
+		t.Fatalf("expected 1 batch of %d rows, got %+v", n, batches)
+	}
+	got := batches[0]
+	for i, name := range []string{"arr", "rec", "m", "empty"} {
+		if got.Schema[i].Name != name {
+			t.Fatalf("schema col %d: got %q want %q", i, got.Schema[i].Name, name)
+		}
+		nestedTestCompareVectors(t, name, got.Columns[i], original.Columns[i], n)
+	}
+}
+
+// TestColumnarSpillRoundtrip_NestedZeroRows ensures a zero-row batch with
+// nested columns round-trips (offsets arrays still have their single 0).
+func TestColumnarSpillRoundtrip_NestedZeroRows(t *testing.T) {
+	arr := batch.NewVector(parquet.TypeArray, 0)
+	arr.Child = batch.NewVector(parquet.TypeInt64, 0)
+	original := &batch.RecordBatch{
+		Schema:  []parquet.Column{{Name: "arr", Type: parquet.TypeArray}},
+		Columns: []*batch.Vector{arr},
+		Len:     0,
+	}
+	path, err := writeSpillBatches(t.TempDir(), []*batch.RecordBatch{original})
+	if err != nil {
+		t.Fatalf("writeSpillBatches: %v", err)
+	}
+	batches, err := readSpillBatches(path)
+	if err != nil {
+		t.Fatalf("readSpillBatches: %v", err)
+	}
+	if len(batches) != 1 || batches[0].Len != 0 {
+		t.Fatalf("expected 1 empty batch, got %+v", batches)
+	}
+}

--- a/internal/engine/exec/sort.go
+++ b/internal/engine/exec/sort.go
@@ -2,7 +2,6 @@ package exec
 
 import (
 	"context"
-	"sort"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -41,7 +40,6 @@ type Sort struct {
 	batches    []*batch.RecordBatch // columnar storage
 	totalRows  int
 	trackedMem int64                // memory reserved from shared tracker by this operator
-	spillFiles []string             // legacy row-oriented spill (schemas the columnar run format can't carry)
 	runFiles   []string             // sorted columnar runs (external-merge path)
 	sorted     []*batch.RecordBatch // materialized sorted results
 	pos        int
@@ -54,7 +52,7 @@ type Sort struct {
 	accInstanceID       uint64
 	accState            atomic.Int32
 	unregisterAccounted func()
-	// finalized is set once finalizeColumnar/finalizeWithSpill begins; after
+	// finalized is set once finalize begins; after
 	// that the input batches are gone and there is nothing left to spill.
 	finalized bool
 }
@@ -106,11 +104,9 @@ func (s *Sort) Consume(_ context.Context, b *batch.RecordBatch) error {
 
 	// Spill to disk if memory pressure is high. The columnar run path
 	// accumulates at least minSortRunBytes before flushing so runs stay
-	// merge-friendly; the legacy row path (nested-type schemas) keeps the
-	// old flush-on-pressure behavior. Peer relief (SpillSome) bypasses the
-	// floor.
+	// merge-friendly. Peer relief (SpillSome) bypasses the floor.
 	if s.Spill != nil && s.Spill.ShouldSpillFor(memory.SpillCheap) && len(s.batches) > 0 {
-		if !columnarSpillableSchema(s.schema) || s.trackedMem >= minSortRunBytes {
+		if s.trackedMem >= minSortRunBytes {
 			if _, err := s.flushSpillLocked(); err != nil {
 				return err
 			}
@@ -120,31 +116,20 @@ func (s *Sort) Consume(_ context.Context, b *batch.RecordBatch) error {
 }
 
 // flushSpillLocked drains all buffered batches to disk and releases their
-// tracking, returning the bytes freed. Columnar-spillable schemas write a
-// SORTED run (the external-merge unit); nested-type schemas fall back to the
-// legacy row-oriented spill file. Caller holds s.mu.
+// tracking, returning the bytes freed. Every schema writes a SORTED columnar
+// run (the external-merge unit) — nested ARRAY/MAP/ROW columns round-trip
+// the run format since the typed nested copy primitives landed. Caller
+// holds s.mu.
 func (s *Sort) flushSpillLocked() (int64, error) {
 	if len(s.batches) == 0 || s.trackedMem == 0 {
 		return 0, nil
 	}
-	if columnarSpillableSchema(s.schema) {
-		path, err := sortBatchesToRun(s.Spill.SpillDir(), s.schema, s.batches, s.totalRows, s.Keys, s.Limit)
-		if err != nil {
-			return 0, err
-		}
-		if path != "" {
-			s.runFiles = append(s.runFiles, path)
-		}
-	} else {
-		var rows []map[string]any
-		for _, sb := range s.batches {
-			rows = append(rows, sb.ToRows()...)
-		}
-		path, err := s.Spill.SpillRows(rows)
-		if err != nil {
-			return 0, err
-		}
-		s.spillFiles = append(s.spillFiles, path)
+	path, err := sortBatchesToRun(s.Spill.SpillDir(), s.schema, s.batches, s.totalRows, s.Keys, s.Limit)
+	if err != nil {
+		return 0, err
+	}
+	if path != "" {
+		s.runFiles = append(s.runFiles, path)
 	}
 	s.batches = s.batches[:0]
 	s.totalRows = 0
@@ -169,9 +154,6 @@ func (s *Sort) Finalize(_ context.Context) error {
 		s.accState.Store(int32(memory.OpClosed))
 		s.unregisterAccounted()
 		s.unregisterAccounted = nil
-	}
-	if len(s.spillFiles) > 0 {
-		return s.finalizeWithSpill()
 	}
 	if len(s.runFiles) > 0 {
 		return s.finalizeExternalMerge()
@@ -247,69 +229,6 @@ func (s *Sort) finishMergeLocked() {
 		s.trackedMem = 0
 	}
 	s.mergeDone = true
-}
-
-// finalizeWithSpill falls back to row-oriented sort when spill files exist.
-func (s *Sort) finalizeWithSpill() error {
-	// Convert stored batches to rows
-	var rows []map[string]any
-	for _, b := range s.batches {
-		rows = append(rows, b.ToRows()...)
-	}
-	s.batches = nil
-
-	// Merge spilled data
-	for _, spillFile := range s.spillFiles {
-		spilled, err := memory.ReadSpilledRows(spillFile)
-		if err != nil {
-			return err
-		}
-		rows = append(rows, spilled...)
-	}
-	s.spillFiles = nil
-
-	sort.SliceStable(rows, func(i, j int) bool {
-		for _, key := range s.Keys {
-			vi := rows[i][key.Column]
-			vj := rows[j][key.Column]
-			viNil := vi == nil
-			vjNil := vj == nil
-			if viNil && vjNil {
-				continue
-			}
-			if viNil || vjNil {
-				if key.NullsLast {
-					return !viNil // nil sorts last: non-nil < nil
-				}
-				return viNil // nil sorts first: nil < non-nil
-			}
-			cmp := compareAny(vi, vj)
-			if cmp == 0 {
-				continue
-			}
-			if key.Order == Descending {
-				return cmp > 0
-			}
-			return cmp < 0
-		}
-		return false
-	})
-
-	// Materialize into sorted batches.
-	// When Limit > 0, only materialize the top Limit rows (Top-K).
-	materializeN := len(rows)
-	if s.Limit > 0 && s.Limit < materializeN {
-		materializeN = s.Limit
-	}
-	for pos := 0; pos < materializeN; {
-		end := pos + batch.DefaultBatchSize
-		if end > materializeN {
-			end = materializeN
-		}
-		s.sorted = append(s.sorted, batch.FromRows(s.schema, rows[pos:end]))
-		pos = end
-	}
-	return nil
 }
 
 // sortEntry identifies a row within the accumulated batches by batch and row index.
@@ -538,6 +457,13 @@ func (s *Sort) nextMerged() (*batch.RecordBatch, error) {
 // copyVectorValue copies a single value between vectors using typed access (no boxing).
 // For bytes-based types, values must be copied in sequential order for dst (i = 0, 1, 2, ...).
 func copyVectorValue(dst *batch.Vector, di int, src *batch.Vector, si int) {
+	switch dst.Type {
+	case batch.TypeArray, batch.TypeMap, batch.TypeRow:
+		// Nested writes share the sequential-dst contract; CopyValueFrom
+		// advances offsets/children for null rows itself.
+		dst.CopyValueFrom(di, src, si)
+		return
+	}
 	if src.Nulls.IsNull(si) {
 		dst.Nulls.SetNull(di)
 		switch dst.Type {

--- a/internal/engine/exec/sort_external.go
+++ b/internal/engine/exec/sort_external.go
@@ -37,20 +37,6 @@ var minSortRunBytes int64 = 64 << 20
 // multi-level path with few runs.
 var maxMergeFanIn = 64
 
-// columnarSpillableSchema reports whether every column type round-trips
-// through the columnar spill format (writeColumnarBatch/readColumnarBatch).
-// Nested types do not — schemas containing them fall back to the legacy
-// row-oriented spill path, which boxes but is correct.
-func columnarSpillableSchema(schema []parquet.Column) bool {
-	for _, c := range schema {
-		switch c.Type {
-		case parquet.TypeArray, parquet.TypeMap, parquet.TypeRow:
-			return false
-		}
-	}
-	return true
-}
-
 // resolvedSortKey is a sort key resolved against a concrete batch set: column
 // index plus the typed comparison kernel with null ordering baked in.
 type resolvedSortKey struct {

--- a/internal/engine/exec/sort_external_test.go
+++ b/internal/engine/exec/sort_external_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"reflect"
 	"sort"
 	"testing"
 
@@ -347,34 +348,88 @@ func TestColumnarSpillVectorRoundTrip(t *testing.T) {
 	}
 }
 
-// TestColumnarSpillNestedTypeError locks the fail-loudly contract: nested
-// types have no columnar encoding and must error instead of silently
-// corrupting (the pre-change behavior wrote nothing and read garbage).
-func TestColumnarSpillNestedTypeError(t *testing.T) {
-	schema := []parquet.Column{{Name: "arr", Type: parquet.TypeArray}}
-	b := batch.NewRecordBatch(schema, 1)
-	if _, err := writeSpillBatches(t.TempDir(), []*batch.RecordBatch{b}); err == nil {
-		t.Fatal("writeSpillBatches on Array column should error, got nil")
-	}
-}
+// TestSortExternalMerge_NestedSchema pushes ARRAY/MAP/ROW columns through
+// the forced run-spill path and verifies the merged stream is value-identical
+// to the in-memory reference sort. Locks the nested round-trip through:
+// sortBatchesToRun gather -> columnar run encode/decode -> runMerger
+// copyVectorValue reassembly.
+func TestSortExternalMerge_NestedSchema(t *testing.T) {
+	forceTinyRuns(t)
 
-// TestSortExternalFallback_NestedSchema verifies nested-type schemas route to
-// the legacy row spill (correct, if memory-hungry) instead of columnar runs.
-func TestSortExternalFallback_NestedSchema(t *testing.T) {
-	if columnarSpillableSchema([]parquet.Column{{Name: "a", Type: parquet.TypeArray}}) {
-		t.Fatal("Array schema must not be columnar-spillable")
+	elem := parquet.Column{Name: "element", Type: parquet.TypeString}
+	schema := []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "tags", Type: parquet.TypeArray, ElementType: &elem, Nullable: true},
+		{Name: "rec", Type: parquet.TypeRow, Fields: []parquet.Column{
+			{Name: "a", Type: parquet.TypeInt64},
+			{Name: "b", Type: parquet.TypeString, Nullable: true},
+		}},
 	}
-	if columnarSpillableSchema([]parquet.Column{{Name: "m", Type: parquet.TypeMap}}) {
-		t.Fatal("Map schema must not be columnar-spillable")
+
+	makeRows := func() []map[string]any {
+		rng := rand.New(rand.NewSource(7))
+		perm := rng.Perm(300)
+		rows := make([]map[string]any, 0, len(perm))
+		for _, id := range perm {
+			var tags any
+			switch id % 4 {
+			case 0:
+				tags = nil // null array
+			case 1:
+				tags = []any{} // empty array
+			default:
+				tags = []any{fmt.Sprintf("t%d", id), fmt.Sprintf("u%d", id%7)}
+			}
+			var b any
+			if id%5 == 0 {
+				b = nil
+			} else {
+				b = fmt.Sprintf("b%d", id)
+			}
+			rows = append(rows, map[string]any{
+				"id":   int64(id),
+				"tags": tags,
+				"rec":  map[string]any{"a": int64(id * 2), "b": b},
+			})
+		}
+		return rows
 	}
-	if columnarSpillableSchema([]parquet.Column{{Name: "r", Type: parquet.TypeRow}}) {
-		t.Fatal("Row schema must not be columnar-spillable")
+
+	feed := func(s *Sort, rows []map[string]any) {
+		for pos := 0; pos < len(rows); pos += 32 {
+			end := pos + 32
+			if end > len(rows) {
+				end = len(rows)
+			}
+			if err := s.Consume(context.Background(), batch.FromRows(schema, rows[pos:end])); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := s.Finalize(context.Background()); err != nil {
+			t.Fatal(err)
+		}
 	}
-	if !columnarSpillableSchema([]parquet.Column{
-		{Name: "v", Type: parquet.TypeVector, Dimension: 4},
-		{Name: "s", Type: parquet.TypeString},
-	}) {
-		t.Fatal("Vector+String schema should be columnar-spillable")
+
+	keys := []SortKey{{Column: "id", Order: Ascending}}
+
+	ref := NewSort(keys) // no spill manager: pure in-memory reference
+	if err := ref.Init(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	feed(ref, makeRows())
+	want := drainSortRows(t, ref)
+
+	s := newSortSpillHarness(t, keys, 1) // 1-byte budget: every Consume is over-pressure
+	feed(s, makeRows())
+	got := drainSortRows(t, s)
+
+	if len(got) != len(want) {
+		t.Fatalf("row count: got %d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if !reflect.DeepEqual(got[i], want[i]) {
+			t.Fatalf("row %d differs:\n got  %#v\n want %#v", i, got[i], want[i])
+		}
 	}
 }
 

--- a/internal/engine/exec/window.go
+++ b/internal/engine/exec/window.go
@@ -269,6 +269,36 @@ func (w *Window) finalizeExternal() error {
 			return err
 		}
 	}
+	if len(last.partitionBy) == 0 {
+		// Final group with no PARTITION BY: two-pass streaming instead of
+		// accumulating the whole input as one partition (window_global.go).
+		merger, runs, err := openRunMerger(dir, passSchema, last.sortKeys, runs)
+		if err != nil {
+			removeRunFiles(runs)
+			return err
+		}
+		stats, err := collectGlobalWindowStats(merger, passSchema, last)
+		merger.close()
+		if err != nil {
+			removeRunFiles(runs)
+			return err
+		}
+		merger2, runs2, err := openRunMerger(dir, passSchema, last.sortKeys, runs)
+		if err != nil {
+			removeRunFiles(runs)
+			return err
+		}
+		w.ext = &windowExtState{
+			global:    newGlobalWindowStreamer(merger2, passSchema, last, stats, charge),
+			merger:    merger2,
+			schema:    passSchema,
+			group:     last,
+			reorder:   buildWindowReorder(len(w.schema), w.groups, len(w.Columns)),
+			outSchema: w.buildOutputSchema(),
+			runs:      runs2,
+		}
+		return nil
+	}
 	merger, runs, err := openRunMerger(dir, passSchema, last.sortKeys, runs)
 	if err != nil {
 		removeRunFiles(runs)
@@ -498,6 +528,20 @@ func (w *Window) nextExternal() (*batch.RecordBatch, error) {
 		}
 		if e.done {
 			return nil, nil
+		}
+		if e.global != nil {
+			b, err := e.global.Next()
+			if err != nil {
+				return nil, err
+			}
+			if b == nil {
+				e.cleanup()
+				return nil, nil
+			}
+			out := reorderBatchColumns(b, e.reorder, e.outSchema)
+			e.queue = chunkBatch(out, batch.DefaultBatchSize)
+			e.qpos = 0
+			continue
 		}
 		parts, bytes, err := e.walker.nextPartition()
 		if err != nil {

--- a/internal/engine/exec/window.go
+++ b/internal/engine/exec/window.go
@@ -155,10 +155,12 @@ func (w *Window) Consume(_ context.Context, b *batch.RecordBatch) error {
 }
 
 // useColumnarRuns reports whether spill goes through the external
-// partition-at-a-time path: every column type must round-trip the columnar
-// run format and there must be a window spec to sort runs by.
+// partition-at-a-time path. Every column type round-trips the columnar run
+// format (nested ARRAY/MAP/ROW included); the only remaining requirement is
+// a window spec to sort runs by — the degenerate no-spec case keeps the
+// legacy row spill.
 func (w *Window) useColumnarRuns() bool {
-	return len(w.groups) > 0 && columnarSpillableSchema(w.schema)
+	return len(w.groups) > 0
 }
 
 // flushSpillLocked drains all buffered batches to disk and releases their
@@ -579,10 +581,11 @@ func windowCopyVectorRange(dst, src *batch.Vector, dstOff, srcOff, count int) {
 	case batch.TypeDecimal:
 		copy(dst.DecimalData.Data[dstOff:dstOff+count], src.DecimalData.Data[srcOff:srcOff+count])
 	default:
+		// Typed per-value copy; handles VECTOR and nested ARRAY/MAP/ROW
+		// (sequential-dst contract holds at every call site — concat and
+		// chunk assembly write ranges in order).
 		for i := 0; i < count; i++ {
-			if !src.Nulls.IsNullFast(srcOff + i) {
-				dst.SetValue(dstOff+i, src.GetValue(srcOff+i))
-			}
+			copyVectorValue(dst, dstOff+i, src, srcOff+i)
 		}
 	}
 }
@@ -658,8 +661,10 @@ func windowGatherVector(dst, src *batch.Vector, perm []int) {
 			}
 		}
 	default:
+		// Typed per-value copy; handles VECTOR and nested ARRAY/MAP/ROW
+		// (perm gathers write dst sequentially).
 		for i, p := range perm {
-			dst.SetValue(i, src.GetValue(p))
+			copyVectorValue(dst, i, src, p)
 		}
 	}
 }

--- a/internal/engine/exec/window_external.go
+++ b/internal/engine/exec/window_external.go
@@ -14,8 +14,8 @@ import (
 // k-way merge, and materializes ONE partition at a time: peak memory is the
 // largest partition plus one buffered batch per run. Window columns with an
 // empty PARTITION BY form a single partition spanning the input — that case
-// (like DuckDB's holistic aggregates) still materializes fully; partitioned
-// windows degrade gracefully.
+// streams through the two-pass evaluator in window_global.go instead of
+// materializing (lead/cume_dist hold back a bounded lookahead window).
 //
 // Window columns are grouped by identical (PartitionBy, OrderBy). Each group
 // is one pass: re-sort runs by the group's keys (skipped for the first group,
@@ -410,6 +410,11 @@ func chunkBatch(b *batch.RecordBatch, size int) []*batch.RecordBatch {
 // a single new run (the pass preserves the merge's sort order). Consumed runs
 // are deleted. Returns the new run list and the augmented schema.
 func windowDiskPass(dir string, schema []parquet.Column, runs []string, g windowSpecGroup, charge func(int64)) ([]string, []parquet.Column, error) {
+	if len(g.partitionBy) == 0 {
+		// Empty PARTITION BY: the walker would accumulate the whole input
+		// as one partition. Stream it twice instead (window_global.go).
+		return globalWindowDiskPass(dir, schema, runs, g, charge)
+	}
 	merger, runs, err := openRunMerger(dir, schema, g.sortKeys, runs)
 	if err != nil {
 		return nil, nil, err
@@ -491,6 +496,7 @@ func reorderBatchColumns(b *batch.RecordBatch, reorder []int, outSchema []parque
 // windowExtState is the final group's streaming state, driven by Next().
 type windowExtState struct {
 	walker    *partitionWalker
+	global    *globalWindowStreamer // non-nil when the final group has no PARTITION BY
 	merger    *runMerger
 	schema    []parquet.Column // input schema of the final pass
 	group     windowSpecGroup
@@ -503,6 +509,10 @@ type windowExtState struct {
 }
 
 func (e *windowExtState) cleanup() {
+	if e.global != nil {
+		e.global.release()
+		e.global = nil
+	}
 	if e.merger != nil {
 		e.merger.close()
 		e.merger = nil

--- a/internal/engine/exec/window_external_test.go
+++ b/internal/engine/exec/window_external_test.go
@@ -272,3 +272,51 @@ func TestWindowConcat_NullableStringCorruption(t *testing.T) {
 		}
 	}
 }
+
+// TestWindowExternal_NestedPayload: ARRAY and ROW payload columns ride
+// through the columnar run path (write -> resort -> merge -> partition
+// walk -> concat -> output chunk) and must come back value-identical to
+// the in-memory path.
+func TestWindowExternal_NestedPayload(t *testing.T) {
+	elem := parquet.Column{Name: "element", Type: parquet.TypeInt64}
+	schema := []parquet.Column{
+		{Name: "grp", Type: parquet.TypeInt64},
+		{Name: "ts", Type: parquet.TypeInt64},
+		{Name: "tags", Type: parquet.TypeArray, ElementType: &elem, Nullable: true},
+		{Name: "rec", Type: parquet.TypeRow, Fields: []parquet.Column{
+			{Name: "a", Type: parquet.TypeInt64},
+			{Name: "b", Type: parquet.TypeString, Nullable: true},
+		}},
+	}
+	cols := []WindowColumn{
+		{Func: WinRowNumber, OutputCol: "rn", OutputType: parquet.TypeInt64,
+			PartitionBy: []string{"grp"}, OrderBy: []SortKey{{Column: "ts", Order: Ascending}}},
+	}
+	rng := rand.New(rand.NewSource(13))
+	var rows []map[string]any
+	for i := 0; i < 180; i++ {
+		var tags any
+		switch i % 4 {
+		case 0:
+			tags = nil
+		case 1:
+			tags = []any{}
+		default:
+			tags = []any{int64(i), int64(i % 9)}
+		}
+		var b any
+		if i%5 == 0 {
+			b = nil
+		} else {
+			b = fmt.Sprintf("b%d", i)
+		}
+		rows = append(rows, map[string]any{
+			"grp":  int64(rng.Intn(6)),
+			"ts":   int64(i),
+			"tags": tags,
+			"rec":  map[string]any{"a": int64(i * 3), "b": b},
+		})
+	}
+	runWindowBothPaths(t, schema, cols, rows, 16,
+		[]string{"grp", "ts", "tags", "rec", "rn"})
+}

--- a/internal/engine/exec/window_external_test.go
+++ b/internal/engine/exec/window_external_test.go
@@ -320,3 +320,206 @@ func TestWindowExternal_NestedPayload(t *testing.T) {
 	runWindowBothPaths(t, schema, cols, rows, 16,
 		[]string{"grp", "ts", "tags", "rec", "rn"})
 }
+
+// TestWindowGlobal_AllFunctions: empty PARTITION BY with ORDER BY containing
+// duplicate keys (real peer groups), covering every window function through
+// the two-pass streaming path against the in-memory reference.
+func TestWindowGlobal_AllFunctions(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "ts", Type: parquet.TypeInt64},
+		{Name: "v", Type: parquet.TypeFloat64},
+		{Name: "s", Type: parquet.TypeString, Nullable: true},
+	}
+	ob := []SortKey{{Column: "ts", Order: Ascending}}
+	cols := []WindowColumn{
+		{Func: WinRowNumber, OutputCol: "rn", OutputType: parquet.TypeInt64, OrderBy: ob},
+		{Func: WinRank, OutputCol: "rk", OutputType: parquet.TypeInt64, OrderBy: ob},
+		{Func: WinDenseRank, OutputCol: "drk", OutputType: parquet.TypeInt64, OrderBy: ob},
+		{Func: WinPercentRank, OutputCol: "prk", OutputType: parquet.TypeFloat64, OrderBy: ob},
+		{Func: WinCumeDist, OutputCol: "cd", OutputType: parquet.TypeFloat64, OrderBy: ob},
+		{Func: WinSum, InputCol: "v", OutputCol: "rsum", OutputType: parquet.TypeFloat64, OrderBy: ob},
+		{Func: WinCount, OutputCol: "rcnt", OutputType: parquet.TypeInt64, OrderBy: ob},
+		{Func: WinAvg, InputCol: "v", OutputCol: "ravg", OutputType: parquet.TypeFloat64, OrderBy: ob},
+		{Func: WinMin, InputCol: "v", OutputCol: "rmin", OutputType: parquet.TypeFloat64, OrderBy: ob},
+		{Func: WinMax, InputCol: "v", OutputCol: "rmax", OutputType: parquet.TypeFloat64, OrderBy: ob},
+		{Func: WinLag, InputCol: "s", OutputCol: "lag2", OutputType: parquet.TypeString, OrderBy: ob, LagLeadOffset: 2, LagLeadDefault: "DFLT"},
+		{Func: WinLead, InputCol: "s", OutputCol: "lead3", OutputType: parquet.TypeString, OrderBy: ob, LagLeadOffset: 3},
+		{Func: WinFirstValue, InputCol: "s", OutputCol: "fv", OutputType: parquet.TypeString, OrderBy: ob},
+		{Func: WinLastValue, InputCol: "s", OutputCol: "lv", OutputType: parquet.TypeString, OrderBy: ob},
+		{Func: WinNthValue, InputCol: "s", OutputCol: "nth5", OutputType: parquet.TypeString, OrderBy: ob, NthValueN: 5},
+		{Func: WinNtile, OutputCol: "nt", OutputType: parquet.TypeInt64, OrderBy: ob, NtileBuckets: 7},
+	}
+	rng := rand.New(rand.NewSource(21))
+	var rows []map[string]any
+	for i := 0; i < 260; i++ {
+		var sv any
+		if i%7 == 0 {
+			sv = nil
+		} else {
+			sv = fmt.Sprintf("s%d", i)
+		}
+		rows = append(rows, map[string]any{
+			"ts": int64(i / 3), // duplicates → 3-row peer groups
+			"v":  float64(rng.Intn(1000)),
+			"s":  sv,
+		})
+	}
+	runWindowBothPaths(t, schema, cols, rows, 16, []string{
+		"ts", "v", "s", "rn", "rk", "drk", "prk", "cd", "rsum", "rcnt",
+		"ravg", "rmin", "rmax", "lag2", "lead3", "fv", "lv", "nth5", "nt"})
+}
+
+// TestWindowGlobal_NoOrderBy: whole-partition aggregates with neither
+// PARTITION BY nor ORDER BY — pass-1 scalars broadcast to every row.
+func TestWindowGlobal_NoOrderBy(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "v", Type: parquet.TypeFloat64},
+	}
+	cols := []WindowColumn{
+		{Func: WinSum, InputCol: "v", OutputCol: "tsum", OutputType: parquet.TypeFloat64},
+		{Func: WinCount, OutputCol: "tcnt", OutputType: parquet.TypeInt64},
+		{Func: WinAvg, InputCol: "v", OutputCol: "tavg", OutputType: parquet.TypeFloat64},
+		{Func: WinMin, InputCol: "v", OutputCol: "tmin", OutputType: parquet.TypeFloat64},
+		{Func: WinMax, InputCol: "v", OutputCol: "tmax", OutputType: parquet.TypeFloat64},
+		{Func: WinLastValue, InputCol: "v", OutputCol: "tlast", OutputType: parquet.TypeFloat64},
+	}
+	var rows []map[string]any
+	for i := 0; i < 200; i++ {
+		rows = append(rows, map[string]any{"id": int64(i), "v": float64((i * 37) % 211)})
+	}
+	runWindowBothPaths(t, schema, cols, rows, 16,
+		[]string{"id", "v", "tsum", "tcnt", "tavg", "tmin", "tmax", "tlast"})
+}
+
+// TestWindowGlobal_MixedWithPartitioned: a partitioned group and a global
+// group in both orders, exercising the global path as a non-final disk pass
+// and as the final streaming pass (plus the re-sort between groups).
+func TestWindowGlobal_MixedWithPartitioned(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "grp", Type: parquet.TypeInt64},
+		{Name: "ts", Type: parquet.TypeInt64},
+		{Name: "v", Type: parquet.TypeFloat64},
+	}
+	rng := rand.New(rand.NewSource(31))
+	var rows []map[string]any
+	for i := 0; i < 220; i++ {
+		rows = append(rows, map[string]any{
+			"grp": int64(rng.Intn(5)),
+			"ts":  int64(i),
+			"v":   float64(rng.Intn(500)),
+		})
+	}
+	// Global group declared first → runs as a non-final disk pass.
+	colsGlobalFirst := []WindowColumn{
+		{Func: WinRank, OutputCol: "grank", OutputType: parquet.TypeInt64,
+			OrderBy: []SortKey{{Column: "v", Order: Descending}}},
+		{Func: WinSum, InputCol: "v", OutputCol: "psum", OutputType: parquet.TypeFloat64,
+			PartitionBy: []string{"grp"}, OrderBy: []SortKey{{Column: "ts", Order: Ascending}}},
+	}
+	runWindowBothPaths(t, schema, colsGlobalFirst, rows, 16,
+		[]string{"grp", "ts", "v", "grank", "psum"})
+
+	// Partitioned group first → global group is the final streaming pass.
+	colsGlobalLast := []WindowColumn{
+		{Func: WinRowNumber, OutputCol: "prn", OutputType: parquet.TypeInt64,
+			PartitionBy: []string{"grp"}, OrderBy: []SortKey{{Column: "ts", Order: Ascending}}},
+		{Func: WinCumeDist, OutputCol: "gcd", OutputType: parquet.TypeFloat64,
+			OrderBy: []SortKey{{Column: "v", Order: Ascending}}},
+	}
+	runWindowBothPaths(t, schema, colsGlobalLast, rows, 16,
+		[]string{"grp", "ts", "v", "prn", "gcd"})
+}
+
+// TestWindowGlobal_StreamingBoundsMemory drives the pass-2 streamer directly
+// over real run files and asserts pending-batch charge stays bounded by a
+// few batches while the input is far larger — the property the global path
+// exists to provide (the walker it replaces accumulated the whole input).
+func TestWindowGlobal_StreamingBoundsMemory(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "ts", Type: parquet.TypeInt64},
+		{Name: "v", Type: parquet.TypeFloat64},
+	}
+	dir := t.TempDir()
+
+	const nBatches, rowsPer = 40, 1024
+	var batches []*batch.RecordBatch
+	var totalBytes, maxBatchBytes int64
+	for bi := 0; bi < nBatches; bi++ {
+		rows := make([]map[string]any, rowsPer)
+		for i := range rows {
+			rows[i] = map[string]any{"ts": int64(bi*rowsPer + i), "v": float64(i)}
+		}
+		b := batch.FromRows(schema, rows)
+		batches = append(batches, b)
+		mb := b.MemBytes()
+		totalBytes += mb
+		if mb > maxBatchBytes {
+			maxBatchBytes = mb
+		}
+	}
+	keys := []SortKey{{Column: "ts", Order: Ascending}}
+	run, err := sortBatchesToRun(dir, schema, batches, nBatches*rowsPer, keys, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := windowSpecGroup{
+		orderBy:  keys,
+		sortKeys: keys,
+		cols: []WindowColumn{
+			{Func: WinRowNumber, OutputCol: "rn", OutputType: parquet.TypeInt64, OrderBy: keys},
+			{Func: WinSum, InputCol: "v", OutputCol: "rsum", OutputType: parquet.TypeFloat64, OrderBy: keys},
+		},
+	}
+
+	m1, runs, err := openRunMerger(dir, schema, keys, []string{run})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stats, err := collectGlobalWindowStats(m1, schema, g)
+	m1.close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.n != nBatches*rowsPer {
+		t.Fatalf("stats.n = %d, want %d", stats.n, nBatches*rowsPer)
+	}
+
+	m2, runs, err := openRunMerger(dir, schema, keys, runs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m2.close()
+	defer removeRunFiles(runs)
+
+	var cur, peak int64
+	charge := func(d int64) {
+		cur += d
+		if cur > peak {
+			peak = cur
+		}
+	}
+	st := newGlobalWindowStreamer(m2, schema, g, stats, charge)
+	var rows int64
+	for {
+		b, err := st.Next()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if b == nil {
+			break
+		}
+		rows += int64(b.Len)
+	}
+	if rows != stats.n {
+		t.Fatalf("streamed %d rows, want %d", rows, stats.n)
+	}
+	if cur != 0 {
+		t.Fatalf("outstanding charge after drain: %d, want 0", cur)
+	}
+	// Streaming bound: a handful of batches, never the whole input.
+	if peak > 4*maxBatchBytes {
+		t.Fatalf("peak pending charge %d exceeds 4x max batch (%d) — not streaming (total input %d)", peak, maxBatchBytes, totalBytes)
+	}
+}

--- a/internal/engine/exec/window_global.go
+++ b/internal/engine/exec/window_global.go
@@ -1,0 +1,746 @@
+package exec
+
+import (
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/engine/exec/kernel"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// ---- Global (empty PARTITION BY) window: two-pass streaming over runs ----
+//
+// A window spec with no PARTITION BY makes the whole input one partition, so
+// the partition-at-a-time walker degenerates to full materialization — the
+// last remaining unbounded-memory path in Window. Instead, the sorted runs
+// on disk let us stream the single partition twice:
+//
+//   pass 1  stream the merge once, collecting the partition-level scalars a
+//           row can depend on (row count n, whole-partition aggregates,
+//           first/last/nth values);
+//   pass 2  re-open the merge and stream output batch-at-a-time, computing
+//           each function incrementally with O(1) carried state.
+//
+// Per-function streaming needs (mirroring computePartitionColumnar exactly —
+// the golden A/B tests enforce value-identity with the in-memory path):
+//
+//   row_number, rank, dense_rank, percent_rank   prev-row peer compare
+//   sum/count/avg/min/max WITH order by           running state
+//   sum/count/avg/min/max WITHOUT order by        pass-1 scalar
+//   first_value, nth_value, last_value (no OB)    pass-1 scalar
+//   last_value (with OB)                          current row
+//   ntile                                         counter state + n
+//   lag(k)                                        k-slot ring buffer
+//   lead(k)                                       k-row lookahead
+//   cume_dist                                     peer-group lookahead
+//
+// Only lead and cume_dist hold rows back; everything else resolves the row
+// the moment it arrives. Memory is bounded by max lead offset plus the
+// largest ORDER-BY peer group when cume_dist is used (an all-equal-keys
+// input degenerates to the full partition for cume_dist specifically —
+// documented bound, charged to the tracker).
+
+// globalWindowStats carries the pass-1 partition-level scalars.
+type globalWindowStats struct {
+	n     int64
+	sum   []float64 // per group column; only aggregates fill these
+	first []any
+	last  []any
+	nth   []any
+	minV  []any
+	maxV  []any
+}
+
+// globalInputIdxs resolves each group column's input column index in schema
+// (-1 when the function takes no input).
+func globalInputIdxs(schema []parquet.Column, g windowSpecGroup) []int {
+	idxs := make([]int, len(g.cols))
+	for i, wc := range g.cols {
+		idxs[i] = -1
+		if wc.InputCol == "" {
+			continue
+		}
+		for j, c := range schema {
+			if c.Name == wc.InputCol {
+				idxs[i] = j
+				break
+			}
+		}
+	}
+	return idxs
+}
+
+// collectGlobalWindowStats streams the merger once (consuming it) and
+// returns the partition-level scalars for g's columns.
+func collectGlobalWindowStats(m *runMerger, schema []parquet.Column, g windowSpecGroup) (*globalWindowStats, error) {
+	nc := len(g.cols)
+	st := &globalWindowStats{
+		sum:   make([]float64, nc),
+		first: make([]any, nc),
+		last:  make([]any, nc),
+		nth:   make([]any, nc),
+		minV:  make([]any, nc),
+		maxV:  make([]any, nc),
+	}
+	inputIdxs := globalInputIdxs(schema, g)
+	for {
+		b, err := m.Next()
+		if err != nil {
+			return nil, err
+		}
+		if b == nil {
+			return st, nil
+		}
+		for r := 0; r < b.Len; r++ {
+			rowIdx := st.n
+			st.n++
+			for i, wc := range g.cols {
+				ii := inputIdxs[i]
+				if ii < 0 || ii >= len(b.Columns) {
+					continue
+				}
+				switch wc.Func {
+				case WinSum, WinAvg:
+					if len(wc.OrderBy) == 0 {
+						st.sum[i] += vecFloat64(b.Columns[ii], r)
+					}
+				case WinMin:
+					if len(wc.OrderBy) == 0 {
+						v := b.Columns[ii].GetValue(r)
+						if st.minV[i] == nil || (v != nil && compareAny(v, st.minV[i]) < 0) {
+							st.minV[i] = v
+						}
+					}
+				case WinMax:
+					if len(wc.OrderBy) == 0 {
+						v := b.Columns[ii].GetValue(r)
+						if st.maxV[i] == nil || (v != nil && compareAny(v, st.maxV[i]) > 0) {
+							st.maxV[i] = v
+						}
+					}
+				case WinFirstValue:
+					if rowIdx == 0 {
+						st.first[i] = b.Columns[ii].GetValue(r)
+					}
+				case WinLastValue:
+					if len(wc.OrderBy) == 0 {
+						st.last[i] = b.Columns[ii].GetValue(r)
+					}
+				case WinNthValue:
+					nth := wc.NthValueN
+					if nth <= 0 {
+						nth = 1
+					}
+					if rowIdx == int64(nth-1) {
+						st.nth[i] = b.Columns[ii].GetValue(r)
+					}
+				}
+			}
+		}
+	}
+}
+
+// pendingGlobalBatch is an input batch whose appended output vectors may
+// still have unresolved rows (lead lookahead, open cume_dist peer group).
+type pendingGlobalBatch struct {
+	b        *batch.RecordBatch // input columns + appended group output vectors
+	startRow int64              // global row index of row 0
+	bytes    int64              // charged to the tracker while pending
+}
+
+// globalWindowStreamer is the pass-2 engine. Next() returns augmented
+// batches (input schema + group columns) in stream order.
+type globalWindowStreamer struct {
+	m      *runMerger
+	schema []parquet.Column
+	g      windowSpecGroup
+	stats  *globalWindowStats
+	charge func(int64)
+
+	inputIdxs []int
+	orderIdxs []int
+	compare   []kernel.SortCompareKernel
+	resolved  bool
+
+	// carried state
+	rowIdx    int64 // rows consumed from the merger
+	rank      int64 // current rank (rank/percent_rank)
+	denseRank int64
+	runSum    []float64 // per col, running aggregates
+	runCount  []int64
+	runMin    []any
+	runMax    []any
+	lagRings  [][]any // per col, ring of size offset
+	// ntile state (replicates the in-memory loop exactly)
+	ntileBucket []int64
+	ntileCount  []int
+	ntileLimit  []int
+	ntileInit   []bool
+
+	// prev row for peer compare: ref into a pending or emitted batch (run
+	// merger batches are pool-free, safe to retain)
+	prevB   *batch.RecordBatch
+	prevRow int
+
+	// lookahead
+	maxLead      int   // max lead offset across cols (0 = none)
+	leadCursor   []int64 // per col, next global row still needing its lead value
+	needCumeDist bool
+	peerStart    int64 // global row index where the open peer group began
+	cdCursor     int64 // next global row still needing its cume_dist value
+
+	pending  []*pendingGlobalBatch
+	emitFrom int // pending[:emitFrom] fully resolved, ready to emit
+	eof      bool
+}
+
+func newGlobalWindowStreamer(m *runMerger, schema []parquet.Column, g windowSpecGroup, stats *globalWindowStats, charge func(int64)) *globalWindowStreamer {
+	nc := len(g.cols)
+	s := &globalWindowStreamer{
+		m: m, schema: schema, g: g, stats: stats, charge: charge,
+		inputIdxs:   globalInputIdxs(schema, g),
+		rank:        1,
+		denseRank:   1,
+		runSum:      make([]float64, nc),
+		runCount:    make([]int64, nc),
+		runMin:      make([]any, nc),
+		runMax:      make([]any, nc),
+		lagRings:    make([][]any, nc),
+		ntileBucket: make([]int64, nc),
+		ntileCount:  make([]int, nc),
+		ntileLimit:  make([]int, nc),
+		ntileInit:   make([]bool, nc),
+		leadCursor:  make([]int64, nc),
+	}
+	for i, wc := range g.cols {
+		switch wc.Func {
+		case WinLag:
+			off := wc.LagLeadOffset
+			if off <= 0 {
+				off = 1
+			}
+			s.lagRings[i] = make([]any, off)
+		case WinLead:
+			off := wc.LagLeadOffset
+			if off <= 0 {
+				off = 1
+			}
+			if off > s.maxLead {
+				s.maxLead = off
+			}
+		case WinCumeDist:
+			s.needCumeDist = true
+		}
+	}
+	// ORDER BY column indices + null-aware compare kernels (group-level:
+	// every column in a spec group shares the same ORDER BY).
+	for _, key := range g.orderBy {
+		idx := -1
+		for j, c := range schema {
+			if c.Name == key.Column {
+				idx = j
+				break
+			}
+		}
+		s.orderIdxs = append(s.orderIdxs, idx)
+	}
+	return s
+}
+
+// resolveKernels picks compare kernels from the first batch's column types.
+func (s *globalWindowStreamer) resolveKernels(b *batch.RecordBatch) {
+	s.compare = make([]kernel.SortCompareKernel, len(s.orderIdxs))
+	for i, idx := range s.orderIdxs {
+		if idx >= 0 && idx < len(b.Columns) {
+			s.compare[i] = kernel.ResolveSortCompare(b.Columns[idx].Type)
+		}
+	}
+	s.resolved = true
+}
+
+// samePeer reports whether two rows are ORDER-BY peers (null==null equal,
+// matching sameColumnar's semantics on the in-memory path).
+func (s *globalWindowStreamer) samePeer(ba *batch.RecordBatch, ra int, bb *batch.RecordBatch, rb int) bool {
+	for i, idx := range s.orderIdxs {
+		if idx < 0 || s.compare[i] == nil {
+			continue
+		}
+		if s.compare[i](ba.Columns[idx], ra, bb.Columns[idx], rb) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// outVec returns pending batch pb's output vector for group column i.
+func (pb *pendingGlobalBatch) outVec(numInputCols, i int) *batch.Vector {
+	return pb.b.Columns[numInputCols+i]
+}
+
+// locate maps a global row index to (pending batch, local row). Only rows
+// still pending are addressable.
+func (s *globalWindowStreamer) locate(row int64) (*pendingGlobalBatch, int) {
+	for _, pb := range s.pending {
+		if row >= pb.startRow && row < pb.startRow+int64(pb.b.Len) {
+			return pb, int(row - pb.startRow)
+		}
+	}
+	return nil, 0
+}
+
+// Next returns the next fully-resolved augmented batch, or nil at EOF.
+func (s *globalWindowStreamer) Next() (*batch.RecordBatch, error) {
+	for {
+		if s.emitFrom > 0 {
+			pb := s.pending[0]
+			s.pending = s.pending[1:]
+			s.emitFrom--
+			if s.charge != nil && pb.bytes > 0 {
+				s.charge(-pb.bytes)
+			}
+			return pb.b, nil
+		}
+		if s.eof {
+			return nil, nil
+		}
+		nb, err := s.m.Next()
+		if err != nil {
+			return nil, err
+		}
+		if nb == nil {
+			s.eof = true
+			s.finishEOF()
+			s.markResolved()
+			continue
+		}
+		if nb.Len == 0 {
+			continue
+		}
+		if !s.resolved {
+			s.resolveKernels(nb)
+		}
+		s.ingest(nb)
+		s.markResolved()
+	}
+}
+
+// ingest appends the group's output vectors to nb, computes every
+// immediately-resolvable value, and advances lookahead resolution.
+func (s *globalWindowStreamer) ingest(nb *batch.RecordBatch) {
+	numInput := len(s.schema)
+	// Augment: copy the schema header before appending (it aliases the pass
+	// schema slice; appending in place could clobber its backing array).
+	outSchema := make([]parquet.Column, numInput, numInput+len(s.g.cols))
+	copy(outSchema, s.schema)
+	for _, wc := range s.g.cols {
+		vec := batch.NewVector(wc.OutputType, nb.Len)
+		vec.Nulls = batch.NewBitmapAllNull(nb.Len)
+		nb.Columns = append(nb.Columns, vec)
+		outSchema = append(outSchema, parquet.Column{Name: wc.OutputCol, Type: wc.OutputType, Nullable: true})
+	}
+	nb.Schema = outSchema
+
+	pb := &pendingGlobalBatch{b: nb, startRow: s.rowIdx}
+	if s.charge != nil {
+		pb.bytes = nb.MemBytes()
+		s.charge(pb.bytes)
+	}
+	s.pending = append(s.pending, pb)
+
+	n := s.stats.n
+	for r := 0; r < nb.Len; r++ {
+		i64 := s.rowIdx // global row index of this row
+		// Peer-group boundary detection (rank family + cume_dist).
+		newPeer := false
+		if i64 > 0 {
+			newPeer = !s.samePeer(s.prevB, s.prevRow, nb, r)
+		}
+		if i64 > 0 && newPeer {
+			s.rank = i64 + 1
+			s.denseRank++
+			if s.needCumeDist {
+				// Peer group [peerStart, i64) closed: cume_dist = i64/n.
+				s.backfillCumeDist(i64)
+				s.peerStart = i64
+			}
+		}
+
+		for i, wc := range s.g.cols {
+			vec := pb.outVec(numInput, i)
+			var inVec *batch.Vector
+			if ii := s.inputIdxs[i]; ii >= 0 && ii < numInput {
+				inVec = nb.Columns[ii]
+			}
+			s.computeImmediate(wc, i, vec, r, i64, n, inVec, nb)
+		}
+
+		s.prevB, s.prevRow = nb, r
+		s.rowIdx++
+	}
+
+	// Lead resolution: rows up to rowIdx-1 are visible, so any row r with
+	// r+offset <= rowIdx-1 can resolve its lead value now.
+	s.resolveLeads()
+}
+
+// computeImmediate writes row r's value for every function that needs no
+// lookahead. Lead and cume_dist rows are left for their resolvers.
+func (s *globalWindowStreamer) computeImmediate(wc WindowColumn, i int, vec *batch.Vector, r int, rowIdx, n int64, inVec *batch.Vector, nb *batch.RecordBatch) {
+	switch wc.Func {
+	case WinRowNumber:
+		vec.Int64Data[r] = rowIdx + 1
+		vec.Nulls.SetValid(r)
+
+	case WinRank:
+		vec.Int64Data[r] = s.rank
+		vec.Nulls.SetValid(r)
+
+	case WinDenseRank:
+		vec.Int64Data[r] = s.denseRank
+		vec.Nulls.SetValid(r)
+
+	case WinPercentRank:
+		if n <= 1 {
+			vec.Float64Data[r] = 0
+		} else {
+			vec.Float64Data[r] = float64(s.rank-1) / float64(n-1)
+		}
+		vec.Nulls.SetValid(r)
+
+	case WinSum:
+		if len(wc.OrderBy) > 0 {
+			s.runSum[i] += vecFloat64(inVec, r)
+			vec.Float64Data[r] = s.runSum[i]
+		} else {
+			vec.Float64Data[r] = s.stats.sum[i]
+		}
+		vec.Nulls.SetValid(r)
+
+	case WinCount:
+		if len(wc.OrderBy) > 0 {
+			s.runCount[i]++
+			vec.Int64Data[r] = s.runCount[i]
+		} else {
+			vec.Int64Data[r] = n
+		}
+		vec.Nulls.SetValid(r)
+
+	case WinAvg:
+		if len(wc.OrderBy) > 0 {
+			s.runSum[i] += vecFloat64(inVec, r)
+			vec.Float64Data[r] = s.runSum[i] / float64(rowIdx+1)
+		} else {
+			vec.Float64Data[r] = s.stats.sum[i] / float64(n)
+		}
+		vec.Nulls.SetValid(r)
+
+	case WinMin:
+		if len(wc.OrderBy) > 0 {
+			var v any
+			if inVec != nil {
+				v = inVec.GetValue(r)
+			}
+			if s.runMin[i] == nil || (v != nil && compareAny(v, s.runMin[i]) < 0) {
+				s.runMin[i] = v
+			}
+			vec.SetValue(r, s.runMin[i])
+		} else {
+			vec.SetValue(r, s.stats.minV[i])
+		}
+
+	case WinMax:
+		if len(wc.OrderBy) > 0 {
+			var v any
+			if inVec != nil {
+				v = inVec.GetValue(r)
+			}
+			if s.runMax[i] == nil || (v != nil && compareAny(v, s.runMax[i]) > 0) {
+				s.runMax[i] = v
+			}
+			vec.SetValue(r, s.runMax[i])
+		} else {
+			vec.SetValue(r, s.stats.maxV[i])
+		}
+
+	case WinLag:
+		off := wc.LagLeadOffset
+		if off <= 0 {
+			off = 1
+		}
+		ring := s.lagRings[i]
+		if rowIdx >= int64(off) {
+			// SetValue is nil-safe: a nil lagged value writes NULL while
+			// still advancing bytes offsets (sequential-write contract).
+			vec.SetValue(r, ring[rowIdx%int64(off)])
+		} else if wc.LagLeadDefault != nil {
+			vec.SetValue(r, wc.LagLeadDefault)
+		} else {
+			vec.SetValue(r, nil)
+		}
+		var cur any
+		if inVec != nil {
+			cur = inVec.GetValue(r)
+		}
+		ring[rowIdx%int64(off)] = cur
+
+	case WinLead:
+		// resolved by resolveLeads / finishEOF
+
+	case WinFirstValue:
+		vec.SetValue(r, s.stats.first[i])
+
+	case WinLastValue:
+		if len(wc.OrderBy) > 0 {
+			var v any
+			if inVec != nil {
+				v = inVec.GetValue(r)
+			}
+			vec.SetValue(r, v)
+		} else {
+			vec.SetValue(r, s.stats.last[i])
+		}
+
+	case WinNtile:
+		buckets := wc.NtileBuckets
+		if buckets <= 0 {
+			buckets = 1
+		}
+		if !s.ntileInit[i] {
+			s.ntileBucket[i] = 1
+			s.ntileCount[i] = 0
+			s.ntileLimit[i] = int(n) / buckets
+			if int(n)%buckets > 0 {
+				s.ntileLimit[i]++
+			}
+			s.ntileInit[i] = true
+		}
+		vec.Int64Data[r] = s.ntileBucket[i]
+		vec.Nulls.SetValid(r)
+		s.ntileCount[i]++
+		base := int(n) / buckets
+		remainder := int(n) % buckets
+		if s.ntileCount[i] >= s.ntileLimit[i] && int(s.ntileBucket[i]) < buckets {
+			s.ntileBucket[i]++
+			s.ntileCount[i] = 0
+			if int(s.ntileBucket[i]) <= remainder {
+				s.ntileLimit[i] = base + 1
+			} else {
+				s.ntileLimit[i] = base
+			}
+		}
+
+	case WinCumeDist:
+		// resolved by backfillCumeDist / finishEOF
+
+	case WinNthValue:
+		nth := wc.NthValueN
+		if nth <= 0 {
+			nth = 1
+		}
+		if int64(nth) <= n {
+			vec.SetValue(r, s.stats.nth[i])
+		} else {
+			vec.SetValue(r, nil)
+		}
+	}
+}
+
+// resolveLeads fills lead values for rows whose lookahead target has
+// arrived. Source values are read from pending batches (a lead target is
+// always at a HIGHER row index than the row being resolved, so it is still
+// pending when the resolved row is).
+func (s *globalWindowStreamer) resolveLeads() {
+	numInput := len(s.schema)
+	for i, wc := range s.g.cols {
+		if wc.Func != WinLead {
+			continue
+		}
+		off := int64(wc.LagLeadOffset)
+		if off <= 0 {
+			off = 1
+		}
+		for s.leadCursor[i]+off < s.rowIdx {
+			row := s.leadCursor[i]
+			pb, lr := s.locate(row)
+			if pb == nil {
+				// Row already emitted — cannot happen: a batch only emits
+				// once every lead cursor has passed it (markResolved).
+				s.leadCursor[i]++
+				continue
+			}
+			srcPB, sr := s.locate(row + off)
+			var v any
+			if srcPB != nil {
+				if ii := s.inputIdxs[i]; ii >= 0 {
+					v = srcPB.b.Columns[ii].GetValue(sr)
+				}
+			}
+			// nil-safe SetValue keeps bytes offsets advancing on NULLs.
+			pb.outVec(numInput, i).SetValue(lr, v)
+			s.leadCursor[i]++
+		}
+	}
+}
+
+// backfillCumeDist writes cume_dist for the closed peer group
+// [s.peerStart, end) — cd = end/n — into the pending batches.
+func (s *globalWindowStreamer) backfillCumeDist(end int64) {
+	numInput := len(s.schema)
+	cd := float64(end) / float64(s.stats.n)
+	for i, wc := range s.g.cols {
+		if wc.Func != WinCumeDist {
+			continue
+		}
+		for row := s.cdCursor; row < end; row++ {
+			pb, lr := s.locate(row)
+			if pb == nil {
+				continue
+			}
+			vec := pb.outVec(numInput, i)
+			vec.Float64Data[lr] = cd
+			vec.Nulls.SetValid(lr)
+		}
+	}
+	s.cdCursor = end
+}
+
+// finishEOF resolves everything still outstanding once the stream ends:
+// lead rows past the end (default/NULL) and the final cume_dist group.
+func (s *globalWindowStreamer) finishEOF() {
+	numInput := len(s.schema)
+	for i, wc := range s.g.cols {
+		if wc.Func != WinLead {
+			continue
+		}
+		off := int64(wc.LagLeadOffset)
+		if off <= 0 {
+			off = 1
+		}
+		// Resolve in-range targets first, then defaults for the tail.
+		for s.leadCursor[i] < s.rowIdx {
+			row := s.leadCursor[i]
+			pb, lr := s.locate(row)
+			if pb == nil {
+				s.leadCursor[i]++
+				continue
+			}
+			vec := pb.outVec(numInput, i)
+			if row+off < s.rowIdx {
+				srcPB, sr := s.locate(row + off)
+				var v any
+				if srcPB != nil {
+					if ii := s.inputIdxs[i]; ii >= 0 {
+						v = srcPB.b.Columns[ii].GetValue(sr)
+					}
+				}
+				vec.SetValue(lr, v)
+			} else if wc.LagLeadDefault != nil {
+				vec.SetValue(lr, wc.LagLeadDefault)
+			} else {
+				vec.SetValue(lr, nil)
+			}
+			s.leadCursor[i]++
+		}
+	}
+	if s.needCumeDist && s.rowIdx > s.cdCursor {
+		s.backfillCumeDist(s.rowIdx) // final group: cd = n/n = 1
+	}
+}
+
+// markResolved advances emitFrom past every pending batch whose rows are all
+// resolved: every lead cursor and the cume_dist cursor have moved beyond it.
+func (s *globalWindowStreamer) markResolved() {
+	frontier := s.rowIdx
+	for i, wc := range s.g.cols {
+		if wc.Func == WinLead && s.leadCursor[i] < frontier {
+			frontier = s.leadCursor[i]
+		}
+	}
+	if s.needCumeDist && s.cdCursor < frontier {
+		frontier = s.cdCursor
+	}
+	for s.emitFrom < len(s.pending) {
+		pb := s.pending[s.emitFrom]
+		if pb.startRow+int64(pb.b.Len) <= frontier {
+			s.emitFrom++
+		} else {
+			break
+		}
+	}
+}
+
+// globalWindowDiskPass is windowDiskPass for an empty-PARTITION-BY group:
+// two streaming passes instead of one full materialization. Returns the new
+// run list and augmented schema.
+func globalWindowDiskPass(dir string, schema []parquet.Column, runs []string, g windowSpecGroup, charge func(int64)) ([]string, []parquet.Column, error) {
+	merger, runs, err := openRunMerger(dir, schema, g.sortKeys, runs)
+	if err != nil {
+		return nil, nil, err
+	}
+	stats, err := collectGlobalWindowStats(merger, schema, g)
+	merger.close()
+	if err != nil {
+		removeRunFiles(runs)
+		return nil, nil, err
+	}
+
+	outSchema := make([]parquet.Column, len(schema), len(schema)+len(g.cols))
+	copy(outSchema, schema)
+	for _, wc := range g.cols {
+		outSchema = append(outSchema, parquet.Column{Name: wc.OutputCol, Type: wc.OutputType, Nullable: true})
+	}
+
+	merger2, runs2, err := openRunMerger(dir, schema, g.sortKeys, runs)
+	if err != nil {
+		removeRunFiles(runs)
+		return nil, nil, err
+	}
+	defer merger2.close()
+	streamer := newGlobalWindowStreamer(merger2, schema, g, stats, charge)
+
+	sw, err := newSpillBatchWriter(dir, "window-global-pass")
+	if err != nil {
+		removeRunFiles(runs2)
+		return nil, nil, err
+	}
+	for {
+		b, err := streamer.Next()
+		if err != nil {
+			sw.close()
+			removeRunFiles(runs2)
+			return nil, nil, err
+		}
+		if b == nil {
+			break
+		}
+		for _, chunk := range chunkBatch(b, batch.DefaultBatchSize) {
+			if err := sw.writeBatch(chunk); err != nil {
+				sw.close()
+				removeRunFiles(runs2)
+				return nil, nil, err
+			}
+		}
+	}
+	path, err := sw.close()
+	if err != nil {
+		removeRunFiles(runs2)
+		return nil, nil, err
+	}
+	removeRunFiles(runs2)
+	if path == "" {
+		return nil, outSchema, nil
+	}
+	return []string{path}, outSchema, nil
+}
+
+// release drops the tracker charge for any still-pending batches (early
+// close before the stream drained).
+func (s *globalWindowStreamer) release() {
+	if s.charge == nil {
+		return
+	}
+	for _, pb := range s.pending {
+		if pb.bytes > 0 {
+			s.charge(-pb.bytes)
+		}
+	}
+	s.pending = nil
+}


### PR DESCRIPTION
## What

Closes both remaining full-materialization residuals in the external spill machinery (the gap list from the never-OOM priority), in two commits:

### 1. Nested-type columnar spill (`2d4eed2`)
Sort/Window with ARRAY/MAP/ROW columns fell back to the legacy row spill — which both materializes everything at finalize **and** serializes unknown types via `fmt.Sprintf` (nested values came back as strings: latent wrong-results on any nested spill).

- Columnar run format now round-trips nested types (recursive child vectors, null bitmaps at every level, nil-child marker). Also fixes HashJoin spill of nested build batches (was fail-loudly).
- New typed batch primitives: `NewVectorLike` / `AppendFrom` / `CopyValueFrom` — recursive, no boxing, and **null rows always advance offsets/children** (the recurring offsets bug class).
- Run-path kernels (`copyVectorValue`, window gather/copy defaults) routed through them; `columnarSpillableSchema` gate deleted; Sort's legacy row path removed entirely.
- **Fixes a pre-existing `Compact()` corruption**: a NULL nullable-string field inside a ROW column didn't advance the child's offset slot — every later row in the compacted batch read back as concatenated garbage. Teeth-verified regression test (`TestCompact_RowChildNullableString` fails on old code).

### 2. Streaming empty-PARTITION-BY windows (`5f1c91c`)
A window spec with no PARTITION BY made the whole input one partition, so the partition walker accumulated everything — the last unbounded-memory path in Window. The sorted runs on disk now feed a two-pass evaluator (`window_global.go`): pass 1 streams the merge for partition-level scalars (n, whole-partition aggregates, first/last/nth); pass 2 re-streams with O(1) carried state per function. Only `lead(k)` and `cume_dist` hold rows back (bounded lookahead, charged to the tracker). Works as both a non-final disk pass and the final streaming pass.

## Validation

- All-functions A/B vs the in-memory evaluator (duplicate ORDER-BY keys, NULL inputs — caught a null-offsets bug in development), mixed global+partitioned spec groups in both orders, no-ORDER-BY broadcast aggregates
- `TestWindowGlobal_StreamingBoundsMemory`: peak pending charge ≤ 4 batches across a 40-batch input, zero outstanding after drain — the property this PR exists to provide
- Nested E2E: external sort + window with ARRAY/MAP/ROW payloads value-identical to no-spill reference; spill-format round-trip incl. nulls/empty/nil-child/zero-rows
- Full `./internal/...` green, `-race` exec/batch green, TPC-H SF0.01 22/22
- Local harness: row checksums byte-identical to main
- Edge rig SF1 @ 512MB hard cap: 25/25 PASS in 118.6s, zero hangs, row counts identical to baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)