### PR TITLE
fix(engine): sweep OOM/leak quick fixes — slot charges, top-K spill, fallback mmap, walker charge

### DIFF
--- a/internal/engine/exec/window_external.go
+++ b/internal/engine/exec/window_external.go
@@ -182,6 +182,21 @@ func (w *partitionWalker) takeCurrent() ([]*batch.RecordBatch, int64) {
 	return parts, bytes
 }
 
+// releaseCurrent drops the charge for a partition still being accumulated —
+// the teardown path for an error mid-accumulation. Without it the charge
+// (ForceReserve on the worker-lifetime shared tracker) was stranded
+// permanently: up to largest-partition-sized phantom reservation per failed
+// window query, poisoning admission and spill decisions for later tasks.
+func (w *partitionWalker) releaseCurrent() {
+	if w.curBytes > 0 && w.charge != nil {
+		w.charge(-w.curBytes)
+	}
+	w.cur = nil
+	w.curBytes = 0
+	w.lastB = nil
+	w.pending = nil
+}
+
 // releasePartition returns a finished partition's charge to the tracker.
 func (w *partitionWalker) releasePartition(bytes int64) {
 	if w.charge != nil && bytes > 0 {
@@ -435,6 +450,7 @@ func windowDiskPass(dir string, schema []parquet.Column, runs []string, g window
 	for {
 		parts, bytes, err := walker.nextPartition()
 		if err != nil {
+			walker.releaseCurrent()
 			sw.close()
 			return nil, nil, err
 		}
@@ -512,6 +528,10 @@ func (e *windowExtState) cleanup() {
 	if e.global != nil {
 		e.global.release()
 		e.global = nil
+	}
+	if e.walker != nil {
+		e.walker.releaseCurrent()
+		e.walker = nil
 	}
 	if e.merger != nil {
 		e.merger.close()

--- a/internal/engine/exec/window_external_test.go
+++ b/internal/engine/exec/window_external_test.go
@@ -523,3 +523,25 @@ func TestWindowGlobal_StreamingBoundsMemory(t *testing.T) {
 		t.Fatalf("peak pending charge %d exceeds 4x max batch (%d) — not streaming (total input %d)", peak, maxBatchBytes, totalBytes)
 	}
 }
+
+// TestPartitionWalker_ReleaseCurrent: an error mid-accumulation must not
+// strand the walker's in-flight partition charge on the shared tracker.
+func TestPartitionWalker_ReleaseCurrent(t *testing.T) {
+	var outstanding int64
+	charge := func(d int64) { outstanding += d }
+	w := &partitionWalker{charge: charge}
+
+	schema := []parquet.Column{{Name: "k", Type: parquet.TypeInt64}}
+	b := batch.FromRows(schema, []map[string]any{{"k": int64(1)}, {"k": int64(1)}})
+	w.appendSegment(b, 0, b.Len)
+	if outstanding <= 0 {
+		t.Fatal("appendSegment did not charge")
+	}
+	w.releaseCurrent()
+	if outstanding != 0 {
+		t.Fatalf("outstanding charge after releaseCurrent: %d, want 0", outstanding)
+	}
+	if len(w.cur) != 0 || w.curBytes != 0 {
+		t.Fatal("walker state not cleared")
+	}
+}

--- a/internal/engine/exec/window_global.go
+++ b/internal/engine/exec/window_global.go
@@ -704,6 +704,7 @@ func globalWindowDiskPass(dir string, schema []parquet.Column, runs []string, g 
 	for {
 		b, err := streamer.Next()
 		if err != nil {
+			streamer.release()
 			sw.close()
 			removeRunFiles(runs2)
 			return nil, nil, err
@@ -713,6 +714,7 @@ func globalWindowDiskPass(dir string, schema []parquet.Column, runs []string, g 
 		}
 		for _, chunk := range chunkBatch(b, batch.DefaultBatchSize) {
 			if err := sw.writeBatch(chunk); err != nil {
+				streamer.release()
 				sw.close()
 				removeRunFiles(runs2)
 				return nil, nil, err

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -5223,6 +5223,13 @@ func (p *Planner) buildTopN(ctx context.Context, sortNode *logical.Node, n int) 
 
 	sortOp := exec.NewSort(keys)
 	sortOp.Limit = n // Top-K: only materialize top N rows
+	// Parity with buildSort: without the spill manager, the pre-sort input
+	// of every ORDER BY ... LIMIT query buffered fully untracked — the
+	// top-K heap only runs at finalize, so this was an unbounded,
+	// pressure-invisible accumulation on the most common query shape.
+	if sm := p.getSpillManager(); sm != nil {
+		sortOp.Spill = sm
+	}
 
 	return &sortSourceAdapter{
 		childSource: childSource,
@@ -7035,6 +7042,24 @@ func (inner *scanSourceInner) releaseScanBatch(b *batch.RecordBatch) {
 	}
 }
 
+// drainSlotCharges releases the lazy fileSlot state of every slot whose row
+// groups were not fully consumed — buffers, loadSem slots and shared-tracker
+// charges abandoned by an early Close (LIMIT, cancel, error). Must run after
+// wg.Wait (no rg worker may still be loading) and BEFORE releasePooledBufs,
+// which nils rgUnits (the only reference to the slots).
+func (inner *scanSourceInner) drainSlotCharges() {
+	seen := make(map[*fileSlot]bool)
+	for _, u := range inner.rgUnits {
+		if u.slot == nil || seen[u.slot] {
+			continue
+		}
+		seen[u.slot] = true
+		if u.slot.rgRemaining.Load() > 0 {
+			u.slot.drainAbandoned(inner)
+		}
+	}
+}
+
 // drainBatchCharges releases every outstanding decoded-batch charge —
 // batches stranded in batchCh by cancellation or never sent by an exiting
 // worker. Callers must ensure the rg/scan workers have exited first (the
@@ -7275,6 +7300,7 @@ func (s *scannerExecSource) Close() error {
 		// select, so this wait is bounded by one in-flight row-group decode.
 		s.scanner.wg.Wait()
 		s.scanner.drainBatchCharges()
+		s.scanner.drainSlotCharges()
 		s.scanner.releasePooledBufs()
 	}
 	return nil

--- a/internal/planner/physical/plan_test.go
+++ b/internal/planner/physical/plan_test.go
@@ -1369,3 +1369,30 @@ func TestDeferredJoinBridgeBuildError(t *testing.T) {
 	}
 }
 
+
+// TestBuildTopN_WiresSpillManager: ORDER BY ... LIMIT plans must attach the
+// spill manager like plain ORDER BY does — without it the pre-sort input
+// buffered fully untracked (the top-K heap only runs at finalize).
+func TestBuildTopN_WiresSpillManager(t *testing.T) {
+	cat, ctx := setupCatalog(t)
+	p := NewPlanner(cat)
+	p.MemoryBudget = 1 << 30
+
+	node := logical.NewScan("events", "e")
+	sortNode := logical.NewSort(node, []logical.OrderExpr{{Column: "event_id"}})
+
+	src, _, _, err := p.buildTopN(ctx, sortNode, 10)
+	if err != nil {
+		t.Fatalf("buildTopN: %v", err)
+	}
+	adapter, ok := src.(*sortSourceAdapter)
+	if !ok {
+		t.Fatalf("expected sortSourceAdapter, got %T", src)
+	}
+	if adapter.sort.Spill == nil {
+		t.Fatal("buildTopN left Sort.Spill nil — pre-sort input is untracked and unspillable")
+	}
+	if adapter.sort.Limit != 10 {
+		t.Fatalf("Limit = %d, want 10", adapter.sort.Limit)
+	}
+}

--- a/internal/planner/physical/scan_accounting_test.go
+++ b/internal/planner/physical/scan_accounting_test.go
@@ -230,3 +230,38 @@ func TestScanAccounting_DrainOnClose(t *testing.T) {
 		t.Fatalf("used = %d after drain, want 0", used)
 	}
 }
+
+// TestScanAccounting_DrainSlotChargesOnAbandonedScan: a scan torn down
+// before consuming every row group (LIMIT, cancel, error) must release the
+// fileSlot's buffer, semaphore slot and tracker charge — the charge lives
+// on the worker-lifetime SHARED tracker, so a leak here was a permanent
+// phantom reservation poisoning admission for every later task.
+func TestScanAccounting_DrainSlotChargesOnAbandonedScan(t *testing.T) {
+	cat, entry := scanAccountingFixture(t, testRows(10, 0), testRows(10, 10))
+
+	tracker := memory.NewTracker("scan-test", 1<<30)
+	inner := &scanSourceInner{cat: cat, memTracker: tracker}
+	inner.loadSem = make(chan struct{}, 1)
+
+	slot := &fileSlot{entry: entry}
+	slot.rgRemaining.Store(2)
+	inner.rgUnits = []rgUnit{{slot: slot, rgIndex: 0}, {slot: slot, rgIndex: 1}}
+
+	if _, err := slot.ensureLoaded(inner, context.Background()); err != nil {
+		t.Fatalf("ensureLoaded: %v", err)
+	}
+	slot.releaseRG(inner) // 1 of 2 consumed, then the scan is abandoned
+
+	if used := tracker.Used(); used < entry.SizeBytes {
+		t.Fatalf("used = %d before drain, want >= %d", used, entry.SizeBytes)
+	}
+	inner.drainSlotCharges()
+	if used := tracker.Used(); used != 0 {
+		t.Fatalf("used = %d after drainSlotCharges, want 0 (phantom reservation)", used)
+	}
+	select {
+	case inner.loadSem <- struct{}{}: // sem slot must have been released
+	default:
+		t.Fatal("loadSem slot still held after drain")
+	}
+}

--- a/internal/planner/physical/util.go
+++ b/internal/planner/physical/util.go
@@ -461,6 +461,32 @@ func (s *fileSlot) releaseRG(inner *scanSourceInner) {
 	}
 }
 
+// drainAbandoned releases everything a slot still holds when its scan is
+// torn down before all row groups were consumed (ctx cancel, LIMIT
+// satisfied, downstream error): the pooled buffer, the loadSem slot, and —
+// critically — the memTracker charge, which lives on the worker-lifetime
+// SHARED tracker and would otherwise remain a permanent phantom reservation
+// (up to loadConcurrency x file_size per cancelled scan), starving later
+// tasks' admission and forcing chronic over-spilling. Callers must ensure
+// the rg workers have exited (Close does wg.Wait first).
+func (s *fileSlot) drainAbandoned(inner *scanSourceInner) {
+	s.mu.Lock()
+	wasLoaded := s.loaded && s.loadErr == nil && s.reader != nil
+	s.reader = nil
+	s.nativeReader = nil
+	s.metaReader = nil
+	buf := s.dataBuf
+	s.dataBuf = nil
+	s.releaseCharge(inner)
+	s.mu.Unlock()
+	if buf != nil {
+		putReadBuf(buf)
+	}
+	if wasLoaded && inner.loadSem != nil {
+		<-inner.loadSem
+	}
+}
+
 // prefetchResult holds a speculatively read row group batch and its unit index.
 type prefetchResult struct {
 	idx   int

--- a/internal/worker/stream_source.go
+++ b/internal/worker/stream_source.go
@@ -207,6 +207,18 @@ func (s *cachedFileStreamSource) Next(ctx context.Context) (*batch.RecordBatch, 
 			s.fallbackBatchIdx++
 			return b, nil
 		}
+		if s.fallbackBatches != nil {
+			// Fallback exhausted — release the mmap/local temp backing it
+			// before advancing, mirroring the parquetIter branch above.
+			// Without this, openNextFile overwrote mmapData/localPath and a
+			// multi-file Array/Map source leaked N-1 mmaps + temp files (in
+			// the worker-lifetime spill dir, outside the per-task sweeps)
+			// plus permanent mmapRegistry entries.
+			s.fallbackBatches = nil
+			s.fallbackBatchIdx = 0
+			s.releaseParquetIter()
+			s.releaseCurrentFile()
+		}
 
 		// All files exhausted.
 		if s.fileIdx >= len(s.files) {
@@ -661,7 +673,10 @@ func (s *cachedFileStreamSource) openShuffleFromLocalFile(localPath string) erro
 	s.chunkReader = r
 	s.mmapData = mmapData
 	s.mmapRegion = registerMmap(mmapData) // nil when relief disabled
-	// Intentionally leave s.localPath empty — LocalStageCache owns this file.
+	// LocalStageCache owns this file — clear localPath EXPLICITLY rather
+	// than assuming it is empty: a stale path from a previous file would
+	// make releaseCurrentFile delete the wrong file later.
+	s.localPath = ""
 	return nil
 }
 

--- a/internal/worker/stream_source_fallback_release_test.go
+++ b/internal/worker/stream_source_fallback_release_test.go
@@ -1,0 +1,107 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// TestFallbackPath_ReleasesMmapAndTempPerFile: the Array/Map eager-decode
+// fallback used to leak the file's mmap + spill temp on every multi-file
+// advance (openNextFile overwrote mmapData/localPath without release) —
+// N fallback files leaked N-1 mmaps and temp files in the worker-lifetime
+// spill dir for the process lifetime.
+func TestFallbackPath_ReleasesMmapAndTempPerFile(t *testing.T) {
+	elem := parquet.Column{Name: "element", Type: parquet.TypeInt64}
+	schema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "tags", Type: parquet.TypeArray, ElementType: &elem},
+	}}
+
+	store := objstore.NewMemStore()
+	ctx := context.Background()
+	if err := store.MakeBucket(ctx, "b"); err != nil {
+		t.Fatal(err)
+	}
+	var files []string
+	for f := 0; f < 3; f++ {
+		var buf bytes.Buffer
+		w, err := parquet.NewWriter(&buf, schema, parquet.DefaultWriterConfig())
+		if err != nil {
+			t.Fatal(err)
+		}
+		rows := make([]map[string]any, 5)
+		for i := range rows {
+			rows[i] = map[string]any{"id": int64(f*10 + i), "tags": []any{int64(i)}}
+		}
+		if err := w.WriteRows(rows); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		path := fmt.Sprintf("q/file%d.parquet", f)
+		if _, err := store.Put(ctx, "b", path, bytes.NewReader(buf.Bytes()), int64(buf.Len()), ""); err != nil {
+			t.Fatal(err)
+		}
+		files = append(files, path)
+	}
+
+	spillDir := t.TempDir()
+	ex := &Executor{store: store, spillDir: spillDir}
+	src := newCachedFileStreamSource(ex, "", "b", files)
+	if err := src.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	rows := 0
+	for {
+		b, err := src.Next(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if b == nil {
+			break
+		}
+		rows += b.Len
+		// The fallback path must never hold more than ONE file's temp at a
+		// time — the leak left every prior file's temp behind.
+		if n := countFiles(t, spillDir); n > 1 {
+			t.Fatalf("%d temp files held mid-stream, want <=1 (per-file release missing)", n)
+		}
+	}
+	if rows != 15 {
+		t.Fatalf("rows = %d, want 15", rows)
+	}
+	if err := src.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if src.mmapData != nil || src.localPath != "" {
+		t.Fatal("mmap/localPath still held after Close")
+	}
+	if n := countFiles(t, spillDir); n != 0 {
+		t.Fatalf("%d temp files leaked after Close, want 0", n)
+	}
+}
+
+func countFiles(t *testing.T, dir string) int {
+	t.Helper()
+	n := 0
+	if err := filepath.Walk(dir, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			n++
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return n
+}


### PR DESCRIPTION
## What

The four highest-leverage quick fixes from the never-OOM code sweep:

1. **Cancelled scans leaked permanent phantom reservations** — `scannerExecSource.Close` now drains abandoned `fileSlot` state (buffer, loadSem slot, shared-tracker charge). Early Close (LIMIT, cancel, downstream error) leaked up to `loadConcurrency × file_size` per cancelled scan on the **worker-lifetime** shared tracker, accumulating into chronic over-spilling and admission starvation. (Follow-up to #121.)
2. **`buildTopN` never wired the SpillManager** — every `ORDER BY … LIMIT` query buffered its full pre-sort input untracked and unspillable (the top-K heap only runs at finalize). One-line parity with `buildSort`.
3. **Array/Map fallback leaked mmaps + spill temp files** — `cachedFileStreamSource`'s eager-decode path now releases per file at exhaustion; multi-file sources leaked N−1 mmaps/temps in the worker-lifetime spill dir (the known ENOSPC kill mode) plus permanent mmapRegistry entries. Also fixes a stale `localPath` that could delete the wrong file.
4. **`partitionWalker` stranded its in-flight partition charge on error** — new `releaseCurrent()` wired into cleanup and both disk-pass error paths (plus `globalWindowStreamer.release()` on global-pass errors).

## Validation

Regression test per fix (behavioral ones teeth-verified against pre-fix code). Full `./internal/...` green, `-race` green (exec/worker/physical), TPC-H SF0.01 22/22.

Companion PR: `fix/nested-null-primitive-family` (the sweep's wrong-results findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)