### PR TITLE
build(deploy): select NVMe instance store by model, fail loudly on mount failure

### DIFF
--- a/deploy/benchmark/terraform/main.tf
+++ b/deploy/benchmark/terraform/main.tf
@@ -521,12 +521,30 @@ resource "aws_instance" "worker" {
     # loops until 30m timeout. /var/spill on the EBS root volume is
     # slower than NVMe but unbounded by RAM and grows with the configured
     # volume_size (200 GB).
-    NVME_DEV=$(lsblk -dno NAME,TYPE | awk '$2=="disk" && $1~/nvme[0-9]+n1/ && $1!~/nvme0n1/{print "/dev/"$1; exit}')
+    # Select the instance store by device MODEL, never by name: NVMe
+    # enumeration order is racy, and the old name-based exclusion of
+    # nvme0n1 picked the EBS ROOT disk on a worker where the instance
+    # store enumerated first (2026-06-12 SF100 run 105815: mkfs/mount
+    # failed, spill fell through to the 200G root, Q21/Q22 ENOSPC).
+    NVME_DEV=""
+    for d in $(lsblk -dno NAME,TYPE | awk '$2=="disk"{print $1}'); do
+      model=$(cat /sys/block/$d/device/model 2>/dev/null || true)
+      case "$model" in
+        *"Instance Storage"*) NVME_DEV="/dev/$d"; break ;;
+      esac
+    done
     if [ -n "$NVME_DEV" ]; then
+      if lsblk -no MOUNTPOINTS "$NVME_DEV" 2>/dev/null | grep -q . ; then
+        echo "FATAL: instance store $NVME_DEV already mounted/partitioned — refusing to format" >&2
+        exit 1
+      fi
       echo "Formatting NVMe instance store: $NVME_DEV"
       mkfs.xfs -f "$NVME_DEV"
       mkdir -p /mnt/nvme
-      mount "$NVME_DEV" /mnt/nvme
+      if ! mount "$NVME_DEV" /mnt/nvme; then
+        echo "FATAL: failed to mount $NVME_DEV at /mnt/nvme — refusing to run with spill on the root volume" >&2
+        exit 1
+      fi
       mkdir -p /mnt/nvme/spill
       SPILL_DIR="/mnt/nvme/spill"
       echo "NVMe spill directory ready at $SPILL_DIR"


### PR DESCRIPTION
SF100 run `20260612-105815` post-mortem: one worker's NVMe instance store enumerated as `nvme0n1`, so the name-based device selection (which excludes `nvme0n1` assuming it's the EBS root) targeted the EBS root disk instead. mkfs/mount failed silently, `/mnt/nvme` fell through to a plain directory on the 200GB root volume, which filled to 100% over the suite and ENOSPC'd Q21+Q22.

Notably the engine side behaved exactly as designed: 3 clean retry attempts per task, clean query failure, no crash, and all 20 completed queries byte-identical rows vs baseline. The infra just shouldn't have let a degraded worker run at all.

- Select instance store by `/sys/block/*/device/model` (`*Instance Storage*`), never enumeration-order names
- Refuse to format anything mounted/partitioned
- `exit 1` on mount failure: failing cloud-init loudly beats running a worker with EBS-root spill (poisons wall comparability, dies late)

`tofu validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)