### PR TITLE
fix: never-OOM sweep quick batch — 6 unbounded-materialization and scratch-leak fixes

### DIFF
--- a/internal/coordinator/alerts.go
+++ b/internal/coordinator/alerts.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/citc-tech/wadjet/internal/alerts"
 	"github.com/citc-tech/wadjet/internal/auth"
+	"github.com/citc-tech/wadjet/internal/engine/batch"
 	sql "github.com/citc-tech/wadjet/internal/planner/sql"
 	"github.com/citc-tech/wadjet/internal/storage/catalog"
 )
@@ -160,26 +161,46 @@ func (e *coordinatorExecutor) Execute(ctx context.Context, sqlText string) error
 }
 
 // Query runs a SELECT and returns rows as []map[string]any.
-// SQLResult.Rows() materializes RecordBatch slices into row maps; we cap at
-// limit here but count all rows for the total. This is adequate for the
-// threshold-style queries alerts use (low cardinality).
+// Rows are boxed batch-by-batch and only until limit is reached — alerts
+// run unattended on every scheduled tick on a GOMEMLIMIT'd coordinator, so
+// boxing the full result via rs.Rows() before truncating (the previous
+// shape) charged every tick for the query's whole cardinality, firing or
+// not. Truncation is detected from row counts, never by boxing the excess.
 func (e *coordinatorExecutor) Query(ctx context.Context, sqlText string, limit int) ([]map[string]any, []alerts.ColumnMeta, int64, bool, error) {
 	rs, err := e.c.ExecuteSQL(ctx, sqlText)
 	if err != nil {
 		return nil, nil, 0, false, err
 	}
-	all := rs.Rows()
-	total := rs.TotalRows
+	boxed, truncated := boxRowsUpTo(rs.Batches, limit)
 	// Build column schema from the Columns list. Type information is not
 	// carried through SQLResult at this time, so Type is left empty.
 	schema := make([]alerts.ColumnMeta, 0, len(rs.Columns))
 	for _, name := range rs.Columns {
 		schema = append(schema, alerts.ColumnMeta{Name: name})
 	}
-	truncated := false
-	if limit > 0 && len(all) > limit {
-		all = all[:limit]
-		truncated = true
+	return boxed, schema, rs.TotalRows, truncated, nil
+}
+
+// boxRowsUpTo materializes batch rows into maps, stopping once limit rows
+// are boxed (limit <= 0 means no limit). The excess is never boxed; the
+// truncated flag reports whether any active rows were left behind.
+func boxRowsUpTo(batches []*batch.RecordBatch, limit int) ([]map[string]any, bool) {
+	var boxed []map[string]any
+	for _, b := range batches {
+		if limit > 0 && len(boxed) >= limit {
+			if b.ActiveLen() > 0 {
+				return boxed, true
+			}
+			continue
+		}
+		rows := b.ToRows()
+		if limit > 0 && len(boxed)+len(rows) > limit {
+			boxed = append(boxed, rows[:limit-len(boxed)]...)
+			// More active rows exist past the cap — truncated, and any
+			// remaining batches need not be examined.
+			return boxed, true
+		}
+		boxed = append(boxed, rows...)
 	}
-	return all, schema, total, truncated, nil
+	return boxed, false
 }

--- a/internal/coordinator/alerts_test.go
+++ b/internal/coordinator/alerts_test.go
@@ -5,8 +5,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/citc-tech/wadjet/internal/engine/batch"
 	"github.com/citc-tech/wadjet/internal/storage/catalog"
 	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
 )
 
 func newTestCoordinator(t *testing.T) *Coordinator {
@@ -76,5 +78,47 @@ func TestCreateAlertRejectedWhenDisabled(t *testing.T) {
 	err := c.handleCreateAlertSQL(context.Background(), `CREATE ALERT a AS SELECT 1 FROM t EVERY 10 SECONDS WEBHOOK 'http://x'`)
 	if err == nil || !strings.Contains(err.Error(), "disabled") {
 		t.Errorf("want disabled error, got %v", err)
+	}
+}
+
+// Regression test for sweep finding #22: the alert executor boxed the full
+// result via rs.Rows() and only then truncated to limit — every scheduled
+// tick paid for the query's whole cardinality. boxRowsUpTo must stop boxing
+// at the limit and report truncation without materializing the excess.
+func TestBoxRowsUpTo(t *testing.T) {
+	schema := []parquet.Column{{Name: "n", Type: parquet.TypeInt64}}
+	mk := func(vals ...int64) *batch.RecordBatch {
+		rows := make([]map[string]any, len(vals))
+		for i, v := range vals {
+			rows[i] = map[string]any{"n": v}
+		}
+		return batch.FromRows(schema, rows)
+	}
+
+	tests := []struct {
+		name      string
+		batches   []*batch.RecordBatch
+		limit     int
+		wantRows  int
+		wantTrunc bool
+	}{
+		{"under limit", []*batch.RecordBatch{mk(1, 2)}, 5, 2, false},
+		{"exact limit", []*batch.RecordBatch{mk(1, 2, 3)}, 3, 3, false},
+		{"split mid-batch", []*batch.RecordBatch{mk(1, 2, 3, 4)}, 2, 2, true},
+		{"stops at later batch", []*batch.RecordBatch{mk(1, 2), mk(3, 4)}, 2, 2, true},
+		{"trailing empty batch is not truncation", []*batch.RecordBatch{mk(1, 2), mk()}, 2, 2, false},
+		{"no limit", []*batch.RecordBatch{mk(1), mk(2)}, 0, 2, false},
+		{"empty result", nil, 5, 0, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rows, trunc := boxRowsUpTo(tc.batches, tc.limit)
+			if len(rows) != tc.wantRows {
+				t.Errorf("got %d rows, want %d", len(rows), tc.wantRows)
+			}
+			if trunc != tc.wantTrunc {
+				t.Errorf("truncated = %v, want %v", trunc, tc.wantTrunc)
+			}
+		})
 	}
 }

--- a/internal/engine/exec/collect_sink_test.go
+++ b/internal/engine/exec/collect_sink_test.go
@@ -1,0 +1,88 @@
+package exec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// Regression test for sweep finding #26: CollectSink.ToRows kept the
+// columnar batches alive after boxing, so the full result lived twice
+// (columnar + boxed) for the sink's lifetime. ToRows must release the
+// batches as it converts, while Schema() keeps the schema available for
+// callers that previously recovered it via Batches()[0].Schema.
+func TestCollectSink_ToRowsReleasesBatches(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "n", Type: parquet.TypeInt64},
+		{Name: "s", Type: parquet.TypeString},
+	}
+	mk := func(rows ...map[string]any) *batch.RecordBatch {
+		return batch.FromRows(schema, rows)
+	}
+
+	sink := &CollectSink{}
+	ctx := context.Background()
+	if err := sink.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.Consume(ctx, mk(
+		map[string]any{"n": int64(1), "s": "alpha"},
+		map[string]any{"n": int64(2), "s": "beta"},
+	)); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.Consume(ctx, mk(
+		map[string]any{"n": int64(3), "s": "gamma"},
+	)); err != nil {
+		t.Fatal(err)
+	}
+
+	rows := sink.ToRows()
+	if len(rows) != 3 {
+		t.Fatalf("got %d rows, want 3", len(rows))
+	}
+	// Boxed values must remain valid after the batches are released.
+	if rows[0]["s"] != "alpha" || rows[2]["s"] != "gamma" {
+		t.Errorf("boxed string values corrupted: %v / %v", rows[0]["s"], rows[2]["s"])
+	}
+	if rows[1]["n"] != int64(2) {
+		t.Errorf("rows[1][n] = %v, want 2", rows[1]["n"])
+	}
+
+	if got := sink.Batches(); got != nil {
+		t.Errorf("Batches() = %d batches after ToRows, want nil (released)", len(got))
+	}
+	if got := sink.Schema(); len(got) != 2 || got[0].Name != "n" {
+		t.Errorf("Schema() = %v after ToRows, want the consumed schema", got)
+	}
+
+	// Second call must be idempotent, not re-convert or lose rows.
+	if again := sink.ToRows(); len(again) != 3 {
+		t.Fatalf("second ToRows returned %d rows, want 3", len(again))
+	}
+}
+
+// SkipFinalizeToRows is the worker-stage contract: Finalize must not box,
+// and Batches must stay available.
+func TestCollectSink_SkipFinalizeToRows(t *testing.T) {
+	schema := []parquet.Column{{Name: "n", Type: parquet.TypeInt64}}
+	sink := &CollectSink{SkipFinalizeToRows: true}
+	ctx := context.Background()
+	if err := sink.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.Consume(ctx, batch.FromRows(schema, []map[string]any{{"n": int64(7)}})); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.Finalize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if sink.Rows != nil {
+		t.Error("Finalize boxed rows despite SkipFinalizeToRows")
+	}
+	if got := sink.Batches(); len(got) != 1 {
+		t.Fatalf("Batches() = %d, want 1", len(got))
+	}
+}

--- a/internal/engine/exec/coverage_test.go
+++ b/internal/engine/exec/coverage_test.go
@@ -991,11 +991,21 @@ func TestCollectSinkBatches(t *testing.T) {
 		{"val": int64(1)},
 	})
 	sink.Consume(context.Background(), b)
-	sink.Finalize(context.Background())
 
 	batches := sink.Batches()
 	if len(batches) != 1 {
 		t.Fatalf("expected 1 batch, got %d", len(batches))
+	}
+
+	// Default Finalize boxes via ToRows, which releases the columnar
+	// batches — callers that need Batches() after Finalize must set
+	// SkipFinalizeToRows (see TestCollectSink_SkipFinalizeToRows).
+	sink.Finalize(context.Background())
+	if got := sink.Batches(); got != nil {
+		t.Fatalf("expected batches released after Finalize, got %d", len(got))
+	}
+	if len(sink.Rows) != 1 {
+		t.Fatalf("expected 1 boxed row after Finalize, got %d", len(sink.Rows))
 	}
 }
 
@@ -1037,15 +1047,15 @@ func TestSinkDetachPooledBatch(t *testing.T) {
 	b2.ColumnByName("id").Int64Data[1] = 0
 	b2.Len = 2
 
-	// Verify CollectSink still has original data
+	// Verify CollectSink still has original data (boxed at Finalize; the
+	// columnar batches are released by ToRows, so assert on Rows).
 	collect.Finalize(context.Background())
-	batches := collect.Batches()
-	if len(batches) != 1 {
-		t.Fatalf("expected 1 batch, got %d", len(batches))
+	if len(collect.Rows) != 2 {
+		t.Fatalf("expected 2 boxed rows, got %d", len(collect.Rows))
 	}
-	got := batches[0].ColumnByName("id").Int64Data
-	if got[0] != 42 || got[1] != 99 {
-		t.Errorf("CollectSink data corrupted: got [%d, %d], want [42, 99]", got[0], got[1])
+	if collect.Rows[0]["id"] != int64(42) || collect.Rows[1]["id"] != int64(99) {
+		t.Errorf("CollectSink data corrupted: got [%v, %v], want [42, 99]",
+			collect.Rows[0]["id"], collect.Rows[1]["id"])
 	}
 
 	// --- Test Sort ---

--- a/internal/engine/exec/join_spill.go
+++ b/internal/engine/exec/join_spill.go
@@ -263,27 +263,46 @@ func (sw *spillBatchWriter) writeBatch(b *batch.RecordBatch) error {
 	return nil
 }
 
+// abort closes the writer and unconditionally removes the partial file.
+// Error paths must use this instead of close(): a half-written run is
+// unusable, and in the worker-lifetime shared spill dir it would outlive
+// the failed query — compounding exactly the ENOSPC condition that most
+// often causes the failure in the first place. Skips the page-cache
+// writeback (the data is about to be unlinked). Idempotent.
+func (sw *spillBatchWriter) abort() {
+	if sw.f == nil {
+		return
+	}
+	sw.f.Close()
+	sw.f = nil
+	os.Remove(sw.path)
+}
+
 func (sw *spillBatchWriter) close() (string, error) {
 	if sw.f == nil {
 		return "", nil
 	}
+	// On any failure the file is unusable — remove it rather than strand
+	// a partial run in the shared spill dir (see abort).
 	if err := sw.w.Flush(); err != nil {
-		sw.f.Close()
+		sw.abort()
 		return "", fmt.Errorf("flushing spill: %w", err)
 	}
 	// Seek back and write batch count
 	if _, err := sw.f.Seek(0, 0); err != nil {
-		sw.f.Close()
+		sw.abort()
 		return "", err
 	}
 	var buf [4]byte
 	binary.LittleEndian.PutUint32(buf[:], uint32(sw.count))
 	if _, err := sw.f.Write(buf[:]); err != nil {
-		sw.f.Close()
+		sw.abort()
 		return "", err
 	}
 	sw.fl.Finish()
 	if err := sw.f.Close(); err != nil {
+		sw.f = nil
+		os.Remove(sw.path)
 		return "", err
 	}
 	sw.f = nil

--- a/internal/engine/exec/pipeline.go
+++ b/internal/engine/exec/pipeline.go
@@ -550,8 +550,9 @@ func (s *BatchSink) Batches() []*batch.RecordBatch {
 }
 
 type CollectSink struct {
-	Rows    []map[string]any     // populated lazily on first access
-	batches []*batch.RecordBatch // columnar storage
+	Rows     []map[string]any     // populated lazily on first access
+	batches  []*batch.RecordBatch // columnar storage; released by ToRows
+	schema   []parquet.Column     // captured from the first batch; survives ToRows
 	rowsDone bool
 	mu       sync.Mutex
 	// SkipFinalizeToRows, when true, makes Finalize a no-op instead of
@@ -567,12 +568,16 @@ type CollectSink struct {
 func (s *CollectSink) Init(_ context.Context) error {
 	s.Rows = nil
 	s.batches = nil
+	s.schema = nil
 	s.rowsDone = false
 	return nil
 }
 
 func (s *CollectSink) Consume(_ context.Context, b *batch.RecordBatch) error {
 	s.mu.Lock()
+	if s.schema == nil {
+		s.schema = b.Schema
+	}
 	b.Detach() // prevent pool recycle — pipeline calls Release() after Consume()
 	// Snapshot the selection vector — see BatchSink.Consume for the full
 	// rationale. Filter operators reuse outSel across calls; sinks that
@@ -596,19 +601,35 @@ func (s *CollectSink) Finalize(_ context.Context) error {
 }
 
 // ToRows returns all results as rows, converting from batches on first call.
+// Each batch reference is dropped as it is boxed: holding both forms alive
+// for the sink's lifetime doubled the result's residency (columnar + boxed)
+// on every row-consuming path. Dropping is safe — Consume Detach()ed the
+// batches from their pools, so the arenas that boxed TypeBytes values alias
+// are never recycled out from under them. Batches() returns nil after this;
+// use Schema() for post-conversion schema access.
 func (s *CollectSink) ToRows() []map[string]any {
 	if !s.rowsDone {
 		s.rowsDone = true
-		for _, b := range s.batches {
+		for i, b := range s.batches {
 			s.Rows = append(s.Rows, b.ToRows()...)
+			s.batches[i] = nil
 		}
+		s.batches = nil
 	}
 	return s.Rows
 }
 
 // Batches returns the raw columnar batches (zero-copy, no conversion).
+// Returns nil once ToRows has converted the result.
 func (s *CollectSink) Batches() []*batch.RecordBatch {
 	return s.batches
+}
+
+// Schema returns the schema of the first consumed batch (nil if no batch
+// was consumed). Unlike Batches()[0].Schema, it remains available after
+// ToRows releases the batches.
+func (s *CollectSink) Schema() []parquet.Column {
+	return s.schema
 }
 
 func (s *CollectSink) Close() error { return nil }

--- a/internal/engine/exec/sort.go
+++ b/internal/engine/exec/sort.go
@@ -176,6 +176,10 @@ func (s *Sort) finalizeExternalMerge() error {
 		return err
 	}
 
+	// Error contract below: s.runFiles was already nil'd, so any failure
+	// before s.mergeRuns is assigned must delete the run files here —
+	// Close's backstops would see nothing and the runs would outlive the
+	// query in the worker-lifetime spill dir.
 	cursors := make([]*runCursor, 0, len(runs)+1)
 	for ord, p := range runs {
 		c, err := newFileRunCursor(p)
@@ -183,6 +187,7 @@ func (s *Sort) finalizeExternalMerge() error {
 			for _, prev := range cursors {
 				prev.close()
 			}
+			removeRunFiles(runs)
 			return err
 		}
 		c.ord = ord
@@ -201,6 +206,7 @@ func (s *Sort) finalizeExternalMerge() error {
 			for _, prev := range cursors {
 				prev.close()
 			}
+			removeRunFiles(runs)
 			return err
 		}
 		c.ord = len(runs)

--- a/internal/engine/exec/sort_external.go
+++ b/internal/engine/exec/sort_external.go
@@ -195,7 +195,7 @@ func writeSortedRun(dir string, schema []parquet.Column, batches []*batch.Record
 			end = len(entries)
 		}
 		if err := sw.writeBatch(gatherEntriesBatch(schema, batches, entries[pos:end])); err != nil {
-			sw.close()
+			sw.abort()
 			return "", err
 		}
 		pos = end
@@ -430,6 +430,12 @@ func (m *runMerger) close() {
 // maxMergeFanIn runs into longer runs (multi-level external merge). Consumed
 // run files are deleted. limit > 0 truncates intermediate runs (sorted, so
 // rows past limit cannot reach the global top-K).
+//
+// Ownership contract: on error, every run file involved — accumulated
+// intermediates and not-yet-consumed inputs alike — has been deleted. The
+// query is failing; stranding scratch in the worker-lifetime spill dir
+// (which has no per-task RemoveAll) would self-compound the ENOSPC
+// conditions these merges die under.
 func preMergeRuns(dir string, schema []parquet.Column, keys []SortKey, runs []string, maxRuns, limit int) ([]string, error) {
 	for len(runs) > maxRuns {
 		next := make([]string, 0, (len(runs)+maxMergeFanIn-1)/maxMergeFanIn)
@@ -445,6 +451,10 @@ func preMergeRuns(dir string, schema []parquet.Column, keys []SortKey, runs []st
 			}
 			path, err := mergeRunsToFile(dir, schema, keys, group, limit)
 			if err != nil {
+				// mergeRunsToFile removed its partial output; runs[:i]
+				// were consumed and deleted by earlier groups.
+				removeRunFiles(next)
+				removeRunFiles(runs[i:])
 				return nil, err
 			}
 			for _, p := range group {
@@ -487,7 +497,7 @@ func mergeRunsToFile(dir string, schema []parquet.Column, keys []SortKey, runs [
 	for {
 		b, err := m.Next()
 		if err != nil {
-			sw.close()
+			sw.abort()
 			return "", err
 		}
 		if b == nil {
@@ -497,7 +507,7 @@ func mergeRunsToFile(dir string, schema []parquet.Column, keys []SortKey, runs [
 			b.Len = limit - written // safe: columnar format writes b.Len rows
 		}
 		if err := sw.writeBatch(b); err != nil {
-			sw.close()
+			sw.abort()
 			return "", err
 		}
 		written += b.Len

--- a/internal/engine/exec/spill_scratch_cleanup_test.go
+++ b/internal/engine/exec/spill_scratch_cleanup_test.go
@@ -1,0 +1,194 @@
+package exec
+
+import (
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// Regression tests for sweep finding #24: external sort/window error paths
+// orphaned run files and partial merge outputs in the worker-lifetime spill
+// dir (no per-task RemoveAll there), self-compounding the ENOSPC conditions
+// that trigger those very errors. The contract under test: every helper
+// deletes its consumed inputs and partial outputs on its own error paths.
+
+func binFiles(tb testing.TB, dir string) []string {
+	tb.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "*.bin"))
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return matches
+}
+
+var scratchKeys = []SortKey{{Column: "val", Order: Ascending}}
+
+func makeRun(tb testing.TB, dir string, vals ...int64) string {
+	tb.Helper()
+	schema := []parquet.Column{{Name: "val", Type: parquet.TypeInt64}}
+	rows := make([]map[string]any, len(vals))
+	for i, v := range vals {
+		rows[i] = map[string]any{"val": v}
+	}
+	b := batch.FromRows(schema, rows)
+	path, err := sortBatchesToRun(dir, schema, []*batch.RecordBatch{b}, len(vals), scratchKeys, 0)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return path
+}
+
+// corruptRunTail bumps the run's batch count and appends a truncated tail,
+// so the cursor opens cleanly (first batch valid) but errors mid-merge on
+// the second batch — exercising the post-writer-creation error paths.
+func corruptRunTail(tb testing.TB, path string) {
+	tb.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	binary.LittleEndian.PutUint32(data[:4], binary.LittleEndian.Uint32(data[:4])+1)
+	data = append(data, 0xDE, 0xAD)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		tb.Fatal(err)
+	}
+}
+
+func TestSpillBatchWriter_AbortRemovesFile(t *testing.T) {
+	dir := t.TempDir()
+	sw, err := newSpillBatchWriter(dir, "sort-merge")
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema := []parquet.Column{{Name: "val", Type: parquet.TypeInt64}}
+	if err := sw.writeBatch(batch.FromRows(schema, []map[string]any{{"val": int64(1)}})); err != nil {
+		t.Fatal(err)
+	}
+	sw.abort()
+	if got := binFiles(t, dir); len(got) != 0 {
+		t.Fatalf("abort left files behind: %v", got)
+	}
+	sw.abort() // idempotent
+	if path, err := sw.close(); err != nil || path != "" {
+		t.Fatalf("close after abort = (%q, %v), want no-op", path, err)
+	}
+}
+
+func TestMergeRunsToFile_MidMergeErrorRemovesPartial(t *testing.T) {
+	dir := t.TempDir()
+	good := makeRun(t, dir, 1, 2, 3)
+	evil := makeRun(t, dir, 4, 5, 6)
+	corruptRunTail(t, evil)
+
+	schema := []parquet.Column{{Name: "val", Type: parquet.TypeInt64}}
+	if _, err := mergeRunsToFile(dir, schema, scratchKeys, []string{good, evil}, 0); err == nil {
+		t.Fatal("expected merge error from corrupt run")
+	}
+	// Inputs are the caller's to clean; the partial sort-merge output must
+	// be gone.
+	for _, f := range binFiles(t, dir) {
+		if filepath.Base(f) != filepath.Base(good) && filepath.Base(f) != filepath.Base(evil) {
+			t.Errorf("partial merge output left behind: %s", f)
+		}
+	}
+}
+
+func TestPreMergeRuns_ErrorCleansEverything(t *testing.T) {
+	dir := t.TempDir()
+	oldFan := maxMergeFanIn
+	maxMergeFanIn = 2
+	t.Cleanup(func() { maxMergeFanIn = oldFan })
+
+	runs := []string{
+		makeRun(t, dir, 1, 2),
+		makeRun(t, dir, 3, 4),
+		makeRun(t, dir, 5, 6),
+	}
+	corruptRunTail(t, runs[1])
+
+	schema := []parquet.Column{{Name: "val", Type: parquet.TypeInt64}}
+	if _, err := preMergeRuns(dir, schema, scratchKeys, runs, 2, 0); err == nil {
+		t.Fatal("expected error from corrupt run")
+	}
+	if got := binFiles(t, dir); len(got) != 0 {
+		t.Fatalf("preMergeRuns error left scratch behind: %v", got)
+	}
+}
+
+func TestResortRunsByKeys_ErrorCleansEverything(t *testing.T) {
+	dir := t.TempDir()
+	runs := []string{
+		makeRun(t, dir, 1, 2),
+		makeRun(t, dir, 3, 4),
+	}
+	corruptRunTail(t, runs[1])
+
+	schema := []parquet.Column{{Name: "val", Type: parquet.TypeInt64}}
+	if _, err := resortRunsByKeys(dir, schema, runs, scratchKeys); err == nil {
+		t.Fatal("expected error from corrupt run")
+	}
+	if got := binFiles(t, dir); len(got) != 0 {
+		t.Fatalf("resortRunsByKeys error left scratch behind: %v", got)
+	}
+}
+
+func TestOpenRunMerger_CursorErrorCleansRuns(t *testing.T) {
+	dir := t.TempDir()
+	good := makeRun(t, dir, 1, 2)
+	// 2-byte file: openSpillBatchReader fails reading the count header.
+	evil := filepath.Join(dir, "sort-run-evil.bin")
+	if err := os.WriteFile(evil, []byte{0x01, 0x02}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	schema := []parquet.Column{{Name: "val", Type: parquet.TypeInt64}}
+	m, _, err := openRunMerger(dir, schema, scratchKeys, []string{good, evil})
+	if err == nil {
+		m.close()
+		t.Fatal("expected cursor error from corrupt run")
+	}
+	if got := binFiles(t, dir); len(got) != 0 {
+		t.Fatalf("openRunMerger error left runs behind: %v", got)
+	}
+}
+
+// Sort.Finalize with a run file corrupted on disk (the ENOSPC-adjacent
+// shape: a run that can't be read back) must not strand the other runs —
+// finalizeExternalMerge nils s.runFiles up front, so Close's backstops
+// never see them.
+func TestSortFinalize_CursorErrorCleansRuns(t *testing.T) {
+	forceTinyRuns(t)
+	schema := []parquet.Column{{Name: "val", Type: parquet.TypeInt64}}
+	s := newSortSpillHarness(t, scratchKeys, 256)
+
+	ctx := context.Background()
+	for i := 0; i < 200; i += 5 {
+		rows := make([]map[string]any, 0, 5)
+		for j := i; j < i+5; j++ {
+			rows = append(rows, map[string]any{"val": int64(j)})
+		}
+		if err := s.Consume(ctx, batch.FromRows(schema, rows)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(s.runFiles) < 2 {
+		t.Fatalf("need ≥2 runs, got %d", len(s.runFiles))
+	}
+	dir := filepath.Dir(s.runFiles[0])
+	// Truncate one run so its cursor fails to open.
+	if err := os.WriteFile(s.runFiles[0], []byte{0x01}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.Finalize(ctx); err == nil {
+		t.Fatal("expected Finalize error from corrupt run")
+	}
+	if got := binFiles(t, dir); len(got) != 0 {
+		t.Fatalf("Finalize error left runs behind: %v", got)
+	}
+}

--- a/internal/engine/exec/window.go
+++ b/internal/engine/exec/window.go
@@ -232,6 +232,9 @@ func (w *Window) finalizeExternal() error {
 	w.runFiles = nil
 	w.mu.Unlock()
 	if ferr != nil {
+		// runFiles was already taken; Close's backstop sees nil. Delete
+		// here or the runs outlive the query in the shared spill dir.
+		removeRunFiles(runs)
 		return ferr
 	}
 	dir := w.Spill.SpillDir()
@@ -247,6 +250,12 @@ func (w *Window) finalizeExternal() error {
 		}
 	}
 
+	// Cleanup contract: resortRunsByKeys, windowDiskPass, and openRunMerger
+	// each delete every run file they were given (inputs and partial
+	// outputs) on their own error paths — callers below just propagate.
+	// The previous caller-side removeRunFiles calls here were no-ops: the
+	// multi-assignment had already overwritten runs with the helper's nil
+	// error return before the cleanup ran.
 	var err error
 	for gi := 0; gi < len(w.groups)-1; gi++ {
 		if gi > 0 {
@@ -257,7 +266,6 @@ func (w *Window) finalizeExternal() error {
 		}
 		runs, passSchema, err = windowDiskPass(dir, passSchema, runs, w.groups[gi], charge)
 		if err != nil {
-			removeRunFiles(runs)
 			return err
 		}
 	}
@@ -274,7 +282,6 @@ func (w *Window) finalizeExternal() error {
 		// accumulating the whole input as one partition (window_global.go).
 		merger, runs, err := openRunMerger(dir, passSchema, last.sortKeys, runs)
 		if err != nil {
-			removeRunFiles(runs)
 			return err
 		}
 		stats, err := collectGlobalWindowStats(merger, passSchema, last)
@@ -285,7 +292,6 @@ func (w *Window) finalizeExternal() error {
 		}
 		merger2, runs2, err := openRunMerger(dir, passSchema, last.sortKeys, runs)
 		if err != nil {
-			removeRunFiles(runs)
 			return err
 		}
 		w.ext = &windowExtState{
@@ -301,7 +307,6 @@ func (w *Window) finalizeExternal() error {
 	}
 	merger, runs, err := openRunMerger(dir, passSchema, last.sortKeys, runs)
 	if err != nil {
-		removeRunFiles(runs)
 		return err
 	}
 	w.ext = &windowExtState{

--- a/internal/engine/exec/window_external.go
+++ b/internal/engine/exec/window_external.go
@@ -296,10 +296,14 @@ func resortRunsByKeys(dir string, schema []parquet.Column, runs []string, keys [
 		buf, bufRows, bufBytes = nil, 0, 0
 		return nil
 	}
+	// Error contract: delete the rewritten outputs AND the input runs —
+	// the operation is unrecoverable, and inputs are otherwise deleted
+	// only on the success path below.
 	for _, rp := range runs {
 		r, err := openSpillBatchReader(rp)
 		if err != nil {
 			removeRunFiles(out)
+			removeRunFiles(runs)
 			return nil, err
 		}
 		for {
@@ -307,6 +311,7 @@ func resortRunsByKeys(dir string, schema []parquet.Column, runs []string, keys [
 			if err != nil {
 				r.Close()
 				removeRunFiles(out)
+				removeRunFiles(runs)
 				return nil, err
 			}
 			if b == nil {
@@ -319,6 +324,7 @@ func resortRunsByKeys(dir string, schema []parquet.Column, runs []string, keys [
 				if err := flush(); err != nil {
 					r.Close()
 					removeRunFiles(out)
+					removeRunFiles(runs)
 					return nil, err
 				}
 			}
@@ -327,6 +333,7 @@ func resortRunsByKeys(dir string, schema []parquet.Column, runs []string, keys [
 	}
 	if err := flush(); err != nil {
 		removeRunFiles(out)
+		removeRunFiles(runs)
 		return nil, err
 	}
 	removeRunFiles(runs)
@@ -335,6 +342,9 @@ func resortRunsByKeys(dir string, schema []parquet.Column, runs []string, keys [
 
 // openRunMerger pre-merges runs down to the fan-in cap and returns a merger
 // over file cursors, plus the (possibly rewritten) run list for cleanup.
+// On error every run file has been deleted (preMergeRuns cleans its own
+// failures; cursor failures clean the post-merge list here) — callers just
+// propagate.
 func openRunMerger(dir string, schema []parquet.Column, keys []SortKey, runs []string) (*runMerger, []string, error) {
 	runs, err := preMergeRuns(dir, schema, keys, runs, maxMergeFanIn, 0)
 	if err != nil {
@@ -347,6 +357,7 @@ func openRunMerger(dir string, schema []parquet.Column, keys []SortKey, runs []s
 			for _, prev := range cursors {
 				prev.close()
 			}
+			removeRunFiles(runs)
 			return nil, nil, err
 		}
 		c.ord = ord
@@ -445,13 +456,15 @@ func windowDiskPass(dir string, schema []parquet.Column, runs []string, g window
 
 	sw, err := newSpillBatchWriter(dir, "window-pass")
 	if err != nil {
+		removeRunFiles(runs)
 		return nil, nil, err
 	}
 	for {
 		parts, bytes, err := walker.nextPartition()
 		if err != nil {
 			walker.releaseCurrent()
-			sw.close()
+			sw.abort()
+			removeRunFiles(runs)
 			return nil, nil, err
 		}
 		if parts == nil {
@@ -464,13 +477,15 @@ func windowDiskPass(dir string, schema []parquet.Column, runs []string, g window
 		}
 		for _, chunk := range chunkBatch(combined, batch.DefaultBatchSize) {
 			if err := sw.writeBatch(chunk); err != nil {
-				sw.close()
+				sw.abort()
+				removeRunFiles(runs)
 				return nil, nil, err
 			}
 		}
 	}
 	path, err := sw.close()
 	if err != nil {
+		removeRunFiles(runs)
 		return nil, nil, err
 	}
 	removeRunFiles(runs)

--- a/internal/engine/exec/window_global.go
+++ b/internal/engine/exec/window_global.go
@@ -690,7 +690,7 @@ func globalWindowDiskPass(dir string, schema []parquet.Column, runs []string, g 
 
 	merger2, runs2, err := openRunMerger(dir, schema, g.sortKeys, runs)
 	if err != nil {
-		removeRunFiles(runs)
+		// openRunMerger deleted the run files on its own error paths.
 		return nil, nil, err
 	}
 	defer merger2.close()
@@ -705,7 +705,7 @@ func globalWindowDiskPass(dir string, schema []parquet.Column, runs []string, g 
 		b, err := streamer.Next()
 		if err != nil {
 			streamer.release()
-			sw.close()
+			sw.abort()
 			removeRunFiles(runs2)
 			return nil, nil, err
 		}
@@ -715,7 +715,7 @@ func globalWindowDiskPass(dir string, schema []parquet.Column, runs []string, g 
 		for _, chunk := range chunkBatch(b, batch.DefaultBatchSize) {
 			if err := sw.writeBatch(chunk); err != nil {
 				streamer.release()
-				sw.close()
+				sw.abort()
 				removeRunFiles(runs2)
 				return nil, nil, err
 			}

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -3696,7 +3696,10 @@ type deferredJoinBridge struct {
 func (d *deferredJoinBridge) Init(ctx context.Context) error {
 	// Run child pipeline (scan → early probes) to collect filtered batches.
 	// This overlaps with the deferred build goroutine(s) running in background.
-	sink := &exec.CollectSink{}
+	// BatchSink, not CollectSink: the bridge replays raw batches and never
+	// touches the row representation — CollectSink.Finalize would box the
+	// entire collected set just to discard it (see reverseBloomBridge).
+	sink := &exec.BatchSink{}
 	pipe := &exec.Pipeline{
 		Source:  d.childSource,
 		Ops:     d.childOps,
@@ -5428,11 +5431,11 @@ func (u *setOpSourceAdapter) Next(ctx context.Context) (*batch.RecordBatch, erro
 		}
 
 		if len(resultRows) > 0 {
-			var schema []parquet.Column
-			if leftBatches := leftSink.Batches(); len(leftBatches) > 0 {
-				schema = leftBatches[0].Schema
-			} else if rightBatches := rightSink.Batches(); len(rightBatches) > 0 {
-				schema = rightBatches[0].Schema
+			// Schema() instead of Batches()[0].Schema — ToRows above
+			// released the sinks' batches as it boxed them.
+			schema := leftSink.Schema()
+			if schema == nil {
+				schema = rightSink.Schema()
 			}
 			if schema != nil {
 				u.batches = []*batch.RecordBatch{batch.FromRows(schema, resultRows)}

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -163,72 +163,116 @@ func (g *GRPCServer) QueryStream(req *wadjetv1.QueryRequest, stream wadjetv1.Wad
 		return status.Error(codes.InvalidArgument, "sql is required")
 	}
 
-	var rows []map[string]any
-	var columns []string
-	var stats *wadjetv1.QueryStats
-
 	if g.coord != nil {
 		result, err := g.coord.ExecuteSQL(stream.Context(), req.Sql)
 		if err != nil {
 			return status.Errorf(codes.Internal, "query error: %v", err)
 		}
-		rows = result.Rows()
-		columns = result.Columns
-		stats = &wadjetv1.QueryStats{
-			TotalRows: result.TotalRows,
-			Elapsed:   durationpb.New(result.Elapsed),
-			Plan:      result.Plan,
+		cs := &chunkStreamer{
+			stream:  stream,
+			columns: result.Columns,
+			stats: &wadjetv1.QueryStats{
+				TotalRows: result.TotalRows,
+				Elapsed:   durationpb.New(result.Elapsed),
+				Plan:      result.Plan,
+			},
 		}
-	} else if g.db != nil {
+		return streamResultBatches(cs, result)
+	}
+
+	if g.db != nil {
 		result, err := g.db.Query(stream.Context(), req.Sql)
 		if err != nil {
 			return status.Errorf(codes.Internal, "query error: %v", err)
 		}
-		rows = result.Rows
-		columns = result.Columns
-		stats = &wadjetv1.QueryStats{
-			TotalRows: int64(len(result.Rows)),
-			Plan:      result.Plan,
+		// Legacy embedded path: db.Query returns pre-boxed rows, so the
+		// full materialization already happened inside it — chunk as-is.
+		cs := &chunkStreamer{
+			stream:  stream,
+			columns: result.Columns,
+			stats: &wadjetv1.QueryStats{
+				TotalRows: int64(len(result.Rows)),
+				Plan:      result.Plan,
+			},
 		}
-	} else {
-		return status.Error(codes.Unavailable, "no query engine available")
+		if err := cs.pushRows(result.Rows); err != nil {
+			return err
+		}
+		return cs.finish()
 	}
 
-	// Stream rows in batches
+	return status.Error(codes.Unavailable, "no query engine available")
+}
+
+// streamResultBatches boxes and sends the coord result one RecordBatch at a
+// time. The previous implementation called result.Rows(), materializing the
+// entire result as map[string]any rows up front — a concurrent ~3-10x boxed
+// copy held alive alongside result.Batches for the whole stream, violating
+// SQLResult's own "prefer iterating Batches" contract on the default-on
+// :9090 server. Peak boxed residency is now one batch (~2K rows) plus the
+// one held-back chunk, and each batch reference is dropped after boxing so
+// the columnar copy can be reclaimed while the stream proceeds.
+func streamResultBatches(cs *chunkStreamer, result *coordinator.SQLResult) error {
+	batches := result.Batches
+	result.Batches = nil
+	for i := range batches {
+		rows := batches[i].ToRows()
+		batches[i] = nil
+		if err := cs.pushRows(rows); err != nil {
+			return err
+		}
+	}
+	return cs.finish()
+}
+
+// chunkStreamer sends row chunks of at most streamBatchSize, holding back
+// one chunk so the final send carries IsLast + stats. Columns ride only the
+// first response; an empty result still produces a single columns+stats
+// response — both exactly the legacy wire behavior.
+type chunkStreamer struct {
+	stream      wadjetv1.WadjetService_QueryStreamServer
+	columns     []string
+	stats       *wadjetv1.QueryStats
+	pending     []*wadjetv1.Row
+	havePending bool
+	sentColumns bool
+}
+
+func (cs *chunkStreamer) pushRows(rows []map[string]any) error {
 	for i := 0; i < len(rows); i += streamBatchSize {
 		end := i + streamBatchSize
 		if end > len(rows) {
 			end = len(rows)
 		}
-		isLast := end >= len(rows)
-
-		resp := &wadjetv1.QueryStreamResponse{
-			Rows:   rowsToProto(rows[i:end]),
-			IsLast: isLast,
+		if cs.havePending {
+			if err := cs.send(cs.pending, false); err != nil {
+				return err
+			}
 		}
-		// Send columns and stats only on first batch
-		if i == 0 {
-			resp.Columns = columns
-		}
-		if isLast {
-			resp.Stats = stats
-		}
-
-		if err := stream.Send(resp); err != nil {
-			return err
-		}
+		cs.pending = rowsToProto(rows[i:end])
+		cs.havePending = true
 	}
-
-	// Empty result set
-	if len(rows) == 0 {
-		return stream.Send(&wadjetv1.QueryStreamResponse{
-			Columns: columns,
-			Stats:   stats,
-			IsLast:  true,
-		})
-	}
-
 	return nil
+}
+
+func (cs *chunkStreamer) finish() error {
+	return cs.send(cs.pending, true)
+}
+
+func (cs *chunkStreamer) send(rows []*wadjetv1.Row, isLast bool) error {
+	resp := &wadjetv1.QueryStreamResponse{
+		Rows:   rows,
+		IsLast: isLast,
+	}
+	if !cs.sentColumns {
+		resp.Columns = cs.columns
+		cs.sentColumns = true
+	}
+	if isLast {
+		resp.Stats = cs.stats
+	}
+	cs.pending = nil
+	return cs.stream.Send(resp)
 }
 
 // SubmitQuery submits an async query (distributed mode only).

--- a/internal/server/grpc_stream_test.go
+++ b/internal/server/grpc_stream_test.go
@@ -1,0 +1,135 @@
+package server
+
+import (
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	wadjetv1 "github.com/citc-tech/wadjet/gen/wadjet/v1"
+	"github.com/citc-tech/wadjet/internal/coordinator"
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// fakeQueryStream records every response Send'd by the streaming path.
+// Only Send is exercised; the embedded ServerStream is never touched.
+type fakeQueryStream struct {
+	grpc.ServerStream
+	sent []*wadjetv1.QueryStreamResponse
+}
+
+func (f *fakeQueryStream) Send(resp *wadjetv1.QueryStreamResponse) error {
+	f.sent = append(f.sent, resp)
+	return nil
+}
+
+func makeIntBatch(tb testing.TB, vals ...int64) *batch.RecordBatch {
+	tb.Helper()
+	schema := []parquet.Column{{Name: "n", Type: parquet.TypeInt64}}
+	rows := make([]map[string]any, len(vals))
+	for i, v := range vals {
+		rows[i] = map[string]any{"n": v}
+	}
+	return batch.FromRows(schema, rows)
+}
+
+// Regression test for sweep finding #20: QueryStream materialized the full
+// result via Rows() before chunking. The streaming path must consume
+// result.Batches incrementally — dropping each batch reference as it goes —
+// and preserve the wire contract: columns only on the first response, stats
+// and IsLast only on the last.
+func TestStreamResultBatches_PerBatch(t *testing.T) {
+	result := &coordinator.SQLResult{
+		Columns: []string{"n"},
+		Batches: []*batch.RecordBatch{
+			makeIntBatch(t, 1, 2, 3),
+			makeIntBatch(t, 4, 5),
+			makeIntBatch(t), // trailing empty batch must not produce a stray chunk
+		},
+		TotalRows: 5,
+	}
+	stats := &wadjetv1.QueryStats{TotalRows: 5, Elapsed: durationpb.New(0)}
+
+	fs := &fakeQueryStream{}
+	cs := &chunkStreamer{stream: fs, columns: result.Columns, stats: stats}
+	if err := streamResultBatches(cs, result); err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Batches != nil {
+		t.Error("result.Batches not released after streaming")
+	}
+	if len(fs.sent) != 2 {
+		t.Fatalf("got %d responses, want 2 (one per non-empty batch)", len(fs.sent))
+	}
+
+	var gotRows []*wadjetv1.Row
+	for i, resp := range fs.sent {
+		isFirst, isLast := i == 0, i == len(fs.sent)-1
+		if (resp.Columns != nil) != isFirst {
+			t.Errorf("response %d: columns presence = %v, want first-only", i, resp.Columns != nil)
+		}
+		if resp.IsLast != isLast {
+			t.Errorf("response %d: IsLast = %v, want %v", i, resp.IsLast, isLast)
+		}
+		if (resp.Stats != nil) != isLast {
+			t.Errorf("response %d: stats presence = %v, want last-only", i, resp.Stats != nil)
+		}
+		gotRows = append(gotRows, resp.Rows...)
+	}
+	if len(gotRows) != 5 {
+		t.Fatalf("got %d total rows, want 5", len(gotRows))
+	}
+}
+
+func TestStreamResultBatches_Empty(t *testing.T) {
+	result := &coordinator.SQLResult{Columns: []string{"n"}}
+	stats := &wadjetv1.QueryStats{TotalRows: 0}
+
+	fs := &fakeQueryStream{}
+	cs := &chunkStreamer{stream: fs, columns: result.Columns, stats: stats}
+	if err := streamResultBatches(cs, result); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(fs.sent) != 1 {
+		t.Fatalf("got %d responses, want 1", len(fs.sent))
+	}
+	resp := fs.sent[0]
+	if len(resp.Rows) != 0 || !resp.IsLast || resp.Stats == nil || resp.Columns == nil {
+		t.Fatalf("empty result response = %+v; want no rows, IsLast, stats, columns", resp)
+	}
+}
+
+// A batch larger than streamBatchSize must be split into multiple chunks.
+func TestChunkStreamer_SplitsLargeBatch(t *testing.T) {
+	vals := make([]int64, streamBatchSize+10)
+	for i := range vals {
+		vals[i] = int64(i)
+	}
+	result := &coordinator.SQLResult{
+		Columns:   []string{"n"},
+		Batches:   []*batch.RecordBatch{makeIntBatch(t, vals...)},
+		TotalRows: int64(len(vals)),
+	}
+
+	fs := &fakeQueryStream{}
+	cs := &chunkStreamer{stream: fs, columns: result.Columns, stats: &wadjetv1.QueryStats{}}
+	if err := streamResultBatches(cs, result); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(fs.sent) != 2 {
+		t.Fatalf("got %d responses, want 2", len(fs.sent))
+	}
+	if n := len(fs.sent[0].Rows); n != streamBatchSize {
+		t.Errorf("first chunk = %d rows, want %d", n, streamBatchSize)
+	}
+	if n := len(fs.sent[1].Rows); n != 10 {
+		t.Errorf("last chunk = %d rows, want 10", n)
+	}
+	if !fs.sent[1].IsLast || fs.sent[0].IsLast {
+		t.Error("IsLast must be set on the final chunk only")
+	}
+}

--- a/internal/server/pgwire/coord_query.go
+++ b/internal/server/pgwire/coord_query.go
@@ -46,43 +46,51 @@ func (c *pgConn) canBypassDB() bool {
 	return c.authProvider == nil && c.identity == nil
 }
 
-// queryViaCoord executes sql through coord.ExecuteSQL and adapts the result
-// into a *wadjet.QueryResult shape that the existing pgwire send-row path
-// can consume. Rows are materialized batch-by-batch via batch.RecordBatch.ToRows
-// — which is bounded by the batch size (~2K rows) per call but the returned
-// slice is the full row set. The OOM win is that we no longer flow through
-// the legacy CollectSink.Finalize path that allocates the same rows once at
-// the planner pipeline and once at db.Query.
+// queryViaCoord executes sql through coord.ExecuteSQL. The columnar batches
+// are returned as-is, NOT boxed into QueryResult.Rows — the send path boxes
+// one batch (~2K rows) at a time via sendResultRows. The previous shape
+// (batchesToRows up front) materialized the full row set (~10x the columnar
+// footprint) on top of the already-held Batches before writing a single
+// DataRow, on the no-auth standalone/edge production profile — exactly what
+// SQLResult's doc forbids.
 //
-// For Q18 SF10 (60M intermediate rows reduced to 100 by LIMIT), the ToRows
-// allocation in this adapter only sees the 100 final rows because coord's
-// native-DAG executor produces the post-LIMIT batches at Gather. Legacy
-// db.Query materialized the full pre-LIMIT pipeline output.
-func (c *pgConn) queryViaCoord(ctx context.Context, sql string) (*wadjet.QueryResult, error) {
+// For Q18 SF10 (60M intermediate rows reduced to 100 by LIMIT), boxing here
+// only ever sees the 100 final rows because coord's native-DAG executor
+// produces the post-LIMIT batches at Gather. Legacy db.Query materialized
+// the full pre-LIMIT pipeline output.
+func (c *pgConn) queryViaCoord(ctx context.Context, sql string) (*wadjet.QueryResult, []*batch.RecordBatch, error) {
 	res, err := c.coord.ExecuteSQL(ctx, sql)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	rows := batchesToRows(res.Batches)
-	return &wadjet.QueryResult{
-		Columns: res.Columns,
-		Rows:    rows,
-	}, nil
+	batches := res.Batches
+	res.Batches = nil
+	return &wadjet.QueryResult{Columns: res.Columns}, batches, nil
 }
 
-// batchesToRows materializes columnar batches into row form. Bounded
-// allocation per batch (one slice grow per batch instead of per row).
-func batchesToRows(batches []*batch.RecordBatch) []map[string]any {
-	if len(batches) == 0 {
-		return nil
+// sendResultRows emits a DataRow per result row and returns the count sent.
+// Columnar batches (coord path) are boxed one batch at a time, dropping each
+// batch reference once sent so peak boxed residency stays one batch; boxed
+// rows (legacy db path) are sent as-is. fmtCodes selects the formatted
+// variant used by the extended protocol; nil sends text-format rows.
+func (c *pgConn) sendResultRows(columns []string, batches []*batch.RecordBatch, rows []map[string]any, fmtCodes []int16) int {
+	sent := 0
+	send := func(row map[string]any) {
+		if len(fmtCodes) > 0 {
+			c.sendDataRowFormatted(columns, row, fmtCodes)
+		} else {
+			c.sendDataRow(columns, row)
+		}
+		sent++
 	}
-	total := 0
-	for _, b := range batches {
-		total += b.ActiveLen()
+	for i := range batches {
+		for _, row := range batches[i].ToRows() {
+			send(row)
+		}
+		batches[i] = nil
 	}
-	out := make([]map[string]any, 0, total)
-	for _, b := range batches {
-		out = append(out, b.ToRows()...)
+	for _, row := range rows {
+		send(row)
 	}
-	return out
+	return sent
 }

--- a/internal/server/pgwire/coord_query_test.go
+++ b/internal/server/pgwire/coord_query_test.go
@@ -1,0 +1,83 @@
+package pgwire
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// recordConn is a net.Conn that captures everything written to it.
+type recordConn struct {
+	net.Conn
+	buf bytes.Buffer
+}
+
+func (r *recordConn) Write(p []byte) (int, error)      { return r.buf.Write(p) }
+func (r *recordConn) SetWriteDeadline(time.Time) error { return nil }
+
+// countMsgs walks the captured wire bytes and counts messages of the given type.
+func countMsgs(data []byte, typ byte) int {
+	n := 0
+	for len(data) >= 5 {
+		msgLen := int(binary.BigEndian.Uint32(data[1:5]))
+		if data[0] == typ {
+			n++
+		}
+		data = data[1+msgLen:]
+	}
+	return n
+}
+
+// Regression test for sweep finding #21: the coord-routed pgwire path boxed
+// the full row set (batchesToRows) before writing any DataRow — ~10x the
+// columnar footprint held on top of the already-held Batches. sendResultRows
+// must emit DataRows batch-by-batch, dropping each batch reference as it
+// goes, and report the exact row count for CommandComplete.
+func TestSendResultRows_PerBatch(t *testing.T) {
+	schema := []parquet.Column{{Name: "n", Type: parquet.TypeInt64}}
+	mk := func(vals ...int64) *batch.RecordBatch {
+		rows := make([]map[string]any, len(vals))
+		for i, v := range vals {
+			rows[i] = map[string]any{"n": v}
+		}
+		return batch.FromRows(schema, rows)
+	}
+
+	rc := &recordConn{}
+	c := &pgConn{conn: rc}
+
+	batches := []*batch.RecordBatch{mk(1, 2, 3), mk(4, 5)}
+	sent := c.sendResultRows([]string{"n"}, batches, nil, nil)
+
+	if sent != 5 {
+		t.Errorf("sent = %d, want 5", sent)
+	}
+	if got := countMsgs(rc.buf.Bytes(), 'D'); got != 5 {
+		t.Errorf("DataRow messages = %d, want 5", got)
+	}
+	for i, b := range batches {
+		if b != nil {
+			t.Errorf("batch %d reference not dropped after send", i)
+		}
+	}
+}
+
+func TestSendResultRows_LegacyRows(t *testing.T) {
+	rc := &recordConn{}
+	c := &pgConn{conn: rc}
+
+	rows := []map[string]any{{"n": int64(1)}, {"n": int64(2)}}
+	sent := c.sendResultRows([]string{"n"}, nil, rows, nil)
+
+	if sent != 2 {
+		t.Errorf("sent = %d, want 2", sent)
+	}
+	if got := countMsgs(rc.buf.Bytes(), 'D'); got != 2 {
+		t.Errorf("DataRow messages = %d, want 2", got)
+	}
+}

--- a/internal/server/pgwire/server.go
+++ b/internal/server/pgwire/server.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/citc-tech/wadjet/internal/auth"
 	"github.com/citc-tech/wadjet/internal/coordinator"
+	"github.com/citc-tech/wadjet/internal/engine/batch"
 	"github.com/citc-tech/wadjet/internal/storage/ingest"
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
 	"github.com/citc-tech/wadjet/wadjet"
@@ -40,7 +41,7 @@ type Server struct {
 	queryTimeout time.Duration
 	authProvider *auth.Provider // nil = no auth enforcement
 	querySem     chan struct{}  // nil = unlimited concurrent queries
-	queryQueue   int64         // atomic: number of queries waiting for admission
+	queryQueue   int64          // atomic: number of queries waiting for admission
 }
 
 // SetCoordinator attaches a coordinator so SELECT statements stream through
@@ -57,12 +58,12 @@ func (s *Server) SetCoordinator(coord *coordinator.Coordinator) {
 
 // Config holds configuration for the pgwire server.
 type Config struct {
-	Addr              string         // listen address, e.g. ":5433"
-	TLSConfig         *tls.Config    // nil = plain TCP
-	MaxConnections    int            // 0 = unlimited
-	MaxConcurrentQry  int            // 0 = unlimited concurrent queries
-	QueryTimeout      time.Duration  // 0 = no timeout
-	AuthProvider      *auth.Provider // nil = no auth enforcement
+	Addr             string         // listen address, e.g. ":5433"
+	TLSConfig        *tls.Config    // nil = plain TCP
+	MaxConnections   int            // 0 = unlimited
+	MaxConcurrentQry int            // 0 = unlimited concurrent queries
+	QueryTimeout     time.Duration  // 0 = no timeout
+	AuthProvider     *auth.Provider // nil = no auth enforcement
 }
 
 // NewServer creates a new PostgreSQL wire protocol server.
@@ -204,26 +205,27 @@ type pgConn struct {
 	conn         net.Conn
 	db           *wadjet.DB
 	coord        *coordinator.Coordinator // optional: routes SELECT through native-DAG when non-nil
-	server       *Server        // back-pointer for query admission
+	server       *Server                  // back-pointer for query admission
 	logger       *slog.Logger
 	buf          []byte
-	tlsConfig    *tls.Config    // non-nil = offer TLS upgrade on SSLRequest
-	queryTimeout time.Duration  // server-level default; overridden by statement_timeout
+	tlsConfig    *tls.Config   // non-nil = offer TLS upgrade on SSLRequest
+	queryTimeout time.Duration // server-level default; overridden by statement_timeout
 
 	// Authentication
-	authProvider *auth.Provider  // nil = no auth
-	identity     *auth.Identity  // set after successful auth
+	authProvider *auth.Provider // nil = no auth
+	identity     *auth.Identity // set after successful auth
 
 	// Session variables (SET key = value)
 	sessionVars map[string]string
 
 	// Extended Query protocol state
-	preparedSQL     string            // last parsed statement SQL
-	portalSQL       string            // last bound portal SQL
-	stmts           map[string]string // named prepared statements
-	described       bool              // true if Describe was sent for current portal
-	resultFmtCodes  []int16           // result format codes from Bind (0=text, 1=binary)
-	describeResult  *wadjet.QueryResult // cached Describe result for Execute reuse
+	preparedSQL     string               // last parsed statement SQL
+	portalSQL       string               // last bound portal SQL
+	stmts           map[string]string    // named prepared statements
+	described       bool                 // true if Describe was sent for current portal
+	resultFmtCodes  []int16              // result format codes from Bind (0=text, 1=binary)
+	describeResult  *wadjet.QueryResult  // cached Describe result for Execute reuse
+	describeBatches []*batch.RecordBatch // columnar half of describeResult (coord path)
 
 	// Transaction state: 'I' = idle, 'T' = in transaction, 'E' = failed
 	txState byte
@@ -778,9 +780,10 @@ func (c *pgConn) handleQuery(sql string) {
 		return
 	}
 	var result *wadjet.QueryResult
+	var batches []*batch.RecordBatch
 	var err error
 	if c.coord != nil && c.canBypassDB() && shouldRouteThroughCoord(sql) {
-		result, err = c.queryViaCoord(ctx, sql)
+		result, batches, err = c.queryViaCoord(ctx, sql)
 	} else {
 		result, err = c.db.Query(ctx, sql)
 	}
@@ -798,7 +801,7 @@ func (c *pgConn) handleQuery(sql string) {
 			columns = append(columns, k)
 		}
 	}
-	if len(columns) == 0 && len(result.Rows) == 0 {
+	if len(columns) == 0 && len(result.Rows) == 0 && len(batches) == 0 {
 		c.sendEmptyQuery()
 		c.sendReadyForQuery()
 		return
@@ -809,13 +812,12 @@ func (c *pgConn) handleQuery(sql string) {
 		c.sendRowDescription(columns)
 	}
 
-	// Send DataRow for each row
-	for _, row := range result.Rows {
-		c.sendDataRow(columns, row)
-	}
+	// Send DataRow for each row — coord-path batches are boxed and sent
+	// one batch at a time, never materialized as a whole.
+	sent := c.sendResultRows(columns, batches, result.Rows, nil)
 
 	// Send CommandComplete
-	c.sendCommandComplete(fmt.Sprintf("SELECT %d", len(result.Rows)))
+	c.sendCommandComplete(fmt.Sprintf("SELECT %d", sent))
 	c.sendReadyForQuery()
 }
 
@@ -834,6 +836,7 @@ func (c *pgConn) handleParse(payload []byte) {
 	}
 	c.described = false
 	c.describeResult = nil // invalidate cached result for new statement
+	c.describeBatches = nil
 
 	// Send ParseComplete ('1')
 	c.sendMsg('1', nil)
@@ -972,9 +975,10 @@ func (c *pgConn) describeSQL(sql string) {
 	ctx, cancel := c.queryContext()
 	defer cancel()
 	var result *wadjet.QueryResult
+	var batches []*batch.RecordBatch
 	var err error
 	if c.coord != nil && c.canBypassDB() && shouldRouteThroughCoord(sql) {
-		result, err = c.queryViaCoord(ctx, sql)
+		result, batches, err = c.queryViaCoord(ctx, sql)
 	} else {
 		result, err = c.db.Query(ctx, sql)
 	}
@@ -985,6 +989,7 @@ func (c *pgConn) describeSQL(sql string) {
 		return
 	}
 	c.describeResult = result
+	c.describeBatches = batches
 
 	if len(result.ColumnMetas) > 0 {
 		c.sendTypedRowDescription(result.ColumnMetas)
@@ -1052,15 +1057,18 @@ func (c *pgConn) handleExecute(payload []byte) {
 	// RowDescription (critical for SELECT * where Go map iteration order
 	// is non-deterministic).
 	var result *wadjet.QueryResult
+	var batches []*batch.RecordBatch
 	if c.describeResult != nil {
 		result = c.describeResult
+		batches = c.describeBatches
 		c.describeResult = nil
+		c.describeBatches = nil
 	} else {
 		ctx, cancel := c.queryContext()
 		defer cancel()
 		var err error
 		if c.coord != nil && c.canBypassDB() && shouldRouteThroughCoord(sql) {
-			result, err = c.queryViaCoord(ctx, sql)
+			result, batches, err = c.queryViaCoord(ctx, sql)
 		} else {
 			result, err = c.db.Query(ctx, sql)
 		}
@@ -1083,14 +1091,9 @@ func (c *pgConn) handleExecute(payload []byte) {
 
 	// Extended query protocol: Execute sends only DataRow + CommandComplete.
 	// RowDescription was already sent by Describe. Do NOT send it again.
-	for _, row := range result.Rows {
-		if len(c.resultFmtCodes) > 0 {
-			c.sendDataRowFormatted(columns, row, c.resultFmtCodes)
-		} else {
-			c.sendDataRow(columns, row)
-		}
-	}
-	c.sendCommandComplete(fmt.Sprintf("SELECT %d", len(result.Rows)))
+	// Coord-path batches are boxed and sent one batch at a time.
+	sent := c.sendResultRows(columns, batches, result.Rows, c.resultFmtCodes)
+	c.sendCommandComplete(fmt.Sprintf("SELECT %d", sent))
 }
 
 func (c *pgConn) handleClose(payload []byte) {
@@ -1503,10 +1506,10 @@ func (c *pgConn) handleAttributeQuery(ctx context.Context, normalized string) bo
 // Drivers like pgjdbc query pg_type to map OIDs to Java types.
 func (c *pgConn) handlePgType(normalized string) bool {
 	type pgType struct {
-		oid      string
-		typname  string
-		typlen   string
-		typtype  string
+		oid          string
+		typname      string
+		typlen       string
+		typtype      string
 		typnamespace string
 	}
 

--- a/internal/storage/objstore/filestore.go
+++ b/internal/storage/objstore/filestore.go
@@ -1,7 +1,6 @@
 package objstore
 
 import (
-	"bytes"
 	"context"
 	"crypto/md5"
 	"fmt"
@@ -147,21 +146,32 @@ func (f *FileStore) Get(_ context.Context, bucket, key string) (io.ReadCloser, O
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
-	data, err := os.ReadFile(path)
+	// Return the open file directly instead of os.ReadFile — the previous
+	// whole-object read meant every "streaming" consumer (stream_source
+	// staging, coordinator result readers, scan) actually held the full
+	// object in heap, uncharged, multiplied by read concurrency. Same
+	// envelope bug as the Put side fixed 2026-06-11. The ETag is derived
+	// from mtime+size like Head(); no production caller consumes a
+	// content-MD5 ETag from Get. Reads after the rename-based Put see a
+	// consistent file (Put never writes in place).
+	file, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, ObjectInfo{}, ErrNotFound
 		}
-		return nil, ObjectInfo{}, fmt.Errorf("reading file: %w", err)
+		return nil, ObjectInfo{}, fmt.Errorf("opening file: %w", err)
 	}
 
-	info, _ := os.Stat(path)
-	etag := fmt.Sprintf("%x", md5.Sum(data))
+	info, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, ObjectInfo{}, fmt.Errorf("stat file: %w", err)
+	}
 
-	return io.NopCloser(bytes.NewReader(data)), ObjectInfo{
+	return file, ObjectInfo{
 		Key:          key,
-		Size:         int64(len(data)),
-		ETag:         etag,
+		Size:         info.Size(),
+		ETag:         fmt.Sprintf("%x-%x", info.ModTime().UnixNano(), info.Size()),
 		LastModified: info.ModTime(),
 	}, nil
 }

--- a/internal/storage/objstore/filestore_test.go
+++ b/internal/storage/objstore/filestore_test.go
@@ -79,8 +79,53 @@ func TestFileStore_PutAndGet(t *testing.T) {
 	if info.Size != int64(len(content)) {
 		t.Fatalf("size = %d, want %d", info.Size, len(content))
 	}
-	if info.ETag != etag {
-		t.Fatalf("etag mismatch: get=%q put=%q", info.ETag, etag)
+	// Get derives its ETag from file metadata (mtime+size) like Head, not
+	// content MD5 — hashing would require reading the whole object, which
+	// defeats streaming. It must agree with Head for the same object.
+	if info.ETag == "" {
+		t.Fatal("expected non-empty etag from Get")
+	}
+	headInfo, err := fs.Head(ctx, "b", "dir/file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.ETag != headInfo.ETag {
+		t.Fatalf("etag mismatch: get=%q head=%q", info.ETag, headInfo.ETag)
+	}
+}
+
+// TestFileStore_GetStreams is the regression test for the whole-object Get:
+// the reader handed back must be the file itself (an *os.File / io.ReaderAt),
+// not a fully-materialized heap copy. The Put-side twin of this bug
+// OOM-killed 512 MiB edge nodes on ~280 MB stage outputs (2026-06-11).
+func TestFileStore_GetStreams(t *testing.T) {
+	fs := setupFileStore(t)
+	ctx := context.Background()
+	_ = fs.MakeBucket(ctx, "b")
+
+	content := []byte("streaming content")
+	if _, err := fs.Put(ctx, "b", "file.bin", bytes.NewReader(content), int64(len(content)), ""); err != nil {
+		t.Fatal(err)
+	}
+
+	rc, info, err := fs.Get(ctx, "b", "file.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+
+	if _, ok := rc.(*os.File); !ok {
+		t.Fatalf("Get returned %T; want *os.File (streaming, not a heap copy)", rc)
+	}
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatalf("got %q, want %q", got, content)
+	}
+	if info.Size != int64(len(content)) {
+		t.Fatalf("size = %d, want %d", info.Size, len(content))
 	}
 }
 

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -664,16 +664,21 @@ func (e *Executor) executePipeline(ctx context.Context, task distributed.Task, r
 		return nil
 	}
 
+	// Worker stage outputs are consumed columnar via Batches(); without
+	// SkipFinalizeToRows, Finalize boxed every collected batch into
+	// map[string]any rows that were thrown away — a full extra boxed copy
+	// of the stage output, per task.
+	collectSink, ok := pipeline.Sink.(*exec.CollectSink)
+	if !ok {
+		return fmt.Errorf("pipeline sink is not CollectSink")
+	}
+	collectSink.SkipFinalizeToRows = true
+
 	// Execute the pipeline — same path as standalone mode
 	if err := pipeline.Run(ctx); err != nil {
 		return fmt.Errorf("pipeline execution: %w", err)
 	}
 
-	// Collect results from the pipeline's sink
-	collectSink, ok := pipeline.Sink.(*exec.CollectSink)
-	if !ok {
-		return fmt.Errorf("pipeline sink is not CollectSink")
-	}
 	batches := collectSink.Batches()
 	var totalRows int64
 	for _, b := range batches {

--- a/internal/worker/spill_sweep_test.go
+++ b/internal/worker/spill_sweep_test.go
@@ -28,19 +28,29 @@ func TestSweepStaleSpillArtifacts(t *testing.T) {
 		return full
 	}
 
-	// Orphans the sweep must remove.
+	// Orphans the sweep must remove. The wadjet-spill/ entries are the
+	// finding-#24 backstop: SpillManager operator scratch (sort runs, merge
+	// intermediates, window passes) orphaned by error paths in a prior
+	// process previously survived restarts — the sweep didn't look inside
+	// the directory.
 	swept := []string{
 		mustWrite("build-cache-123.wshf"),
 		mustWrite("build-cache-load-456.wshf"),
 		mustWrite("parquet-stream-789.parquet"),
 		mustWrite("shuffle-deadbeef/part-0000.wshf"),
+		mustWrite("wadjet-spill/sort-run-1234.1.bin"),
+		mustWrite("wadjet-spill/sort-merge-1234.2.bin"),
+		mustWrite("wadjet-spill/window-pass-1234.3.bin"),
+		mustWrite("wadjet-spill/window-global-pass-1234.4.bin"),
+		mustWrite("wadjet-spill/agg-spill-1234.5.bin"),
 	}
 	sweptDir := filepath.Join(dir, "shuffle-deadbeef")
+	spillScratchDir := filepath.Join(dir, "wadjet-spill")
 
 	// Files the sweep must NOT touch.
 	kept := []string{
 		mustWrite("stage-task1.wshf"),               // stage sink output naming differs
-		mustWrite("sort-run-1.1.bin"),               // operator spill (task-scoped lifecycle)
+		mustWrite("sort-run-1.1.bin"),               // outside wadjet-spill/ — not SpillManager scratch
 		mustWrite("stage-cache/q1/abc_part.wshf"),   // LocalStageCache tree (wiped by its own constructor)
 		mustWrite("parquet-stream-789.parquet.tmp"), // wrong suffix
 	}
@@ -58,6 +68,11 @@ func TestSweepStaleSpillArtifacts(t *testing.T) {
 	}
 	if _, err := os.Stat(sweptDir); !os.IsNotExist(err) {
 		t.Errorf("sweep should have removed dir %s (stat err=%v)", sweptDir, err)
+	}
+	// The scratch dir itself survives (a constructed SpillManager holds the
+	// path); only its contents are swept.
+	if _, err := os.Stat(spillScratchDir); err != nil {
+		t.Errorf("sweep must keep the wadjet-spill dir itself: %v", err)
 	}
 	for _, p := range kept {
 		if _, err := os.Stat(p); err != nil {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -600,7 +600,19 @@ func (w *Worker) sweepStaleBuildCacheFiles() {
 		//   build-cache-load-*.wshf  — read-side mmap source download
 		//   parquet-stream-*.parquet — read-side parquet mmap download
 		//   shuffle-<taskID>/        — partitioned shuffle sink output dirs
+		//   wadjet-spill/            — SpillManager operator scratch (sort
+		//     runs, merge intermediates, window passes, join/agg spills);
+		//     normally deleted by the owning operator, but error paths can
+		//     orphan them and the dir has no per-task RemoveAll. Contents
+		//     are swept, the dir itself kept (an already-constructed
+		//     SpillManager holds the path).
 		isDir := e.IsDir()
+		if isDir && name == "wadjet-spill" {
+			r, b := sweepDirContents(filepath.Join(dir, name), w.logger)
+			removed += r
+			bytesFreed += b
+			continue
+		}
 		switch {
 		case !isDir && strings.HasPrefix(name, "build-cache-") && strings.HasSuffix(name, ".wshf"):
 		case !isDir && strings.HasPrefix(name, "parquet-stream-") && strings.HasSuffix(name, ".parquet"):
@@ -623,6 +635,30 @@ func (w *Worker) sweepStaleBuildCacheFiles() {
 		w.logger.Info("swept stale spill artifacts",
 			"dir", dir, "items", removed, "bytes_freed", bytesFreed)
 	}
+}
+
+// sweepDirContents removes every entry inside dir (keeping dir itself) and
+// returns the count and bytes freed. Used for scratch directories whose
+// entire contents are prior-process orphans.
+func sweepDirContents(dir string, logger *slog.Logger) (int, int64) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0, 0
+	}
+	var removed int
+	var bytesFreed int64
+	for _, e := range entries {
+		full := filepath.Join(dir, e.Name())
+		if info, statErr := e.Info(); statErr == nil && !e.IsDir() {
+			bytesFreed += info.Size()
+		}
+		if rmErr := os.RemoveAll(full); rmErr != nil {
+			logger.Warn("removing stale spill artifact", "path", full, "error", rmErr)
+			continue
+		}
+		removed++
+	}
+	return removed, bytesFreed
 }
 
 func (w *Worker) taskLoop(ctx context.Context, consumer jetstream.Consumer, sem chan struct{}) {


### PR DESCRIPTION
## Summary

Quick batch from the 2026-06-12 never-OOM sweep (follow-up to #123/#124). Six adversarially-verified findings, one commit each, all with regression tests:

| Finding | Fix |
|---|---|
| **#15** `FileStore.Get` whole-object ReadFile | Return the open `*os.File` (the shape `GetReaderAt` proves); ETag from mtime+size like `Head()`. Symmetric to the Put-side fix that was OOM-killing 512 MiB edge nodes. |
| **#20** gRPC `QueryStream` boxed full result before chunking | Box one `RecordBatch` at a time, drop each reference after send; wire contract unchanged (columns first, stats+IsLast last, single response for empty results). |
| **#21** pgwire coord path boxed full row set before any DataRow | `queryViaCoord` hands batches through; `sendResultRows` boxes/sends per ~2K-row batch across simple-query, Describe, and Execute (Describe→Execute cache carries the columnar half). |
| **#22** alert executor boxed full result, then truncated | Box batch-by-batch, stop at limit; truncation detected from row counts, never by boxing the excess. Ticks no longer pay full cardinality. |
| **#24** external sort/window error paths orphaned spill scratch | Ownership contract: every helper (`preMergeRuns`, `mergeRunsToFile` via new `spillBatchWriter.abort()`, `resortRunsByKeys`, `openRunMerger`, `windowDiskPass`, `globalWindowDiskPass`, `Sort.finalizeExternalMerge`, `Window.finalizeExternal`) deletes consumed inputs + partial outputs on its own error paths. Boot sweep now also clears `wadjet-spill/` contents (backstop). These leaks fire exactly under ENOSPC — the Q21 SF100 kill mode — and self-compounded it. |
| **#26** `CollectSink.ToRows` held columnar + boxed copies | Convert-and-release per batch; `Schema()` accessor replaces post-ToRows `Batches()[0].Schema`. Bonus: the dead `SkipFinalizeToRows` flag is now set on the worker stage path (Finalize was boxing every stage output and discarding it), and `deferredJoinBridge` moved to `BatchSink` mirroring `reverseBloomBridge`. |

## Gates

- `go test ./internal/...` — green
- `-race` on objstore/server/pgwire/coordinator/exec/worker — green. (`TestTPCHNativeDAG_SF01` times out under `-race` **identically on main** — pre-existing, not from this branch.)
- TPC-H SF0.01 — 22/22 pass
- Local distributed harness (`tpch-harness -mode=local`) — 25/25 pass
- Finding-#24 regression tests verified to **fail against pre-fix code** (corrupt-run injection through four helpers + Sort.Finalize)

Remaining sweep backlog (architectural batch, not in this PR): #11 Distinct→hash-agg, #12 bloom/deferred bridge collection, #13 CTE materialization, #14 gatherReceiver, #16 read_json streaming, #17 probe-split merge, #18 deduplicatePartials, #19 UPDATE DML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #129, fixes #134, fixes #135, fixes #136, fixes #137, fixes #138.
