### PR TITLE
feat(coordinator): streaming SQLResult — gather budget degrades to lazy spill-replay

### DIFF
--- a/cmd/security-bench/main.go
+++ b/cmd/security-bench/main.go
@@ -117,6 +117,7 @@ func main() {
 				if err != nil {
 					return 0, err
 				}
+				r.Close() // row count only; release batches / spill stream
 				return r.TotalRows, nil
 			}
 		} else {

--- a/cmd/tpch-bench/main.go
+++ b/cmd/tpch-bench/main.go
@@ -215,6 +215,7 @@ func main() {
 				if err != nil {
 					return 0, err
 				}
+				r.Close() // row count only; release batches / spill stream
 				return r.TotalRows, nil
 			}
 		} else {

--- a/internal/coordinator/alerts.go
+++ b/internal/coordinator/alerts.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/citc-tech/wadjet/internal/alerts"
 	"github.com/citc-tech/wadjet/internal/auth"
-	"github.com/citc-tech/wadjet/internal/engine/batch"
 	sql "github.com/citc-tech/wadjet/internal/planner/sql"
 	"github.com/citc-tech/wadjet/internal/storage/catalog"
 )
@@ -156,7 +155,8 @@ func (c *Coordinator) asSQLExecutor() alerts.SQLExecutor {
 type coordinatorExecutor struct{ c *Coordinator }
 
 func (e *coordinatorExecutor) Execute(ctx context.Context, sqlText string) error {
-	_, err := e.c.ExecuteSQL(ctx, sqlText)
+	rs, err := e.c.ExecuteSQL(ctx, sqlText)
+	rs.Close() // result is discarded; release any spill-backed stream
 	return err
 }
 
@@ -169,9 +169,13 @@ func (e *coordinatorExecutor) Execute(ctx context.Context, sqlText string) error
 func (e *coordinatorExecutor) Query(ctx context.Context, sqlText string, limit int) ([]map[string]any, []alerts.ColumnMeta, int64, bool, error) {
 	rs, err := e.c.ExecuteSQL(ctx, sqlText)
 	if err != nil {
+		rs.Close()
 		return nil, nil, 0, false, err
 	}
-	boxed, truncated := boxRowsUpTo(rs.Batches, limit)
+	boxed, truncated, err := boxRowsUpTo(ctx, rs.Stream(), limit)
+	if err != nil {
+		return nil, nil, 0, false, err
+	}
 	// Build column schema from the Columns list. Type information is not
 	// carried through SQLResult at this time, so Type is left empty.
 	schema := make([]alerts.ColumnMeta, 0, len(rs.Columns))
@@ -181,15 +185,26 @@ func (e *coordinatorExecutor) Query(ctx context.Context, sqlText string, limit i
 	return boxed, schema, rs.TotalRows, truncated, nil
 }
 
-// boxRowsUpTo materializes batch rows into maps, stopping once limit rows
+// boxRowsUpTo materializes stream rows into maps, stopping once limit rows
 // are boxed (limit <= 0 means no limit). The excess is never boxed; the
-// truncated flag reports whether any active rows were left behind.
-func boxRowsUpTo(batches []*batch.RecordBatch, limit int) ([]map[string]any, bool) {
+// truncated flag reports whether any active rows were left behind. The
+// stream is always closed before returning — once truncation is detected
+// the remaining batches (and any spill scratch behind them) are released
+// without being read.
+func boxRowsUpTo(ctx context.Context, in BatchStream, limit int) ([]map[string]any, bool, error) {
+	defer in.Close()
 	var boxed []map[string]any
-	for _, b := range batches {
+	for {
+		b, err := in.Next(ctx)
+		if err != nil {
+			return nil, false, err
+		}
+		if b == nil {
+			return boxed, false, nil
+		}
 		if limit > 0 && len(boxed) >= limit {
 			if b.ActiveLen() > 0 {
-				return boxed, true
+				return boxed, true, nil
 			}
 			continue
 		}
@@ -198,9 +213,8 @@ func boxRowsUpTo(batches []*batch.RecordBatch, limit int) ([]map[string]any, boo
 			boxed = append(boxed, rows[:limit-len(boxed)]...)
 			// More active rows exist past the cap — truncated, and any
 			// remaining batches need not be examined.
-			return boxed, true
+			return boxed, true, nil
 		}
 		boxed = append(boxed, rows...)
 	}
-	return boxed, false
 }

--- a/internal/coordinator/alerts_test.go
+++ b/internal/coordinator/alerts_test.go
@@ -112,7 +112,10 @@ func TestBoxRowsUpTo(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			rows, trunc := boxRowsUpTo(tc.batches, tc.limit)
+			rows, trunc, err := boxRowsUpTo(context.Background(), newSliceStream(tc.batches), tc.limit)
+			if err != nil {
+				t.Fatalf("boxRowsUpTo: %v", err)
+			}
 			if len(rows) != tc.wantRows {
 				t.Errorf("got %d rows, want %d", len(rows), tc.wantRows)
 			}

--- a/internal/coordinator/batch_stream.go
+++ b/internal/coordinator/batch_stream.go
@@ -1,0 +1,51 @@
+package coordinator
+
+import (
+	"context"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+)
+
+// BatchStream is a lazy, single-consumer iterator over result batches.
+// Next returns (nil, nil) when exhausted. Implementations drop their
+// reference to each batch as it is handed out, so a consumer that sends
+// and releases batch-by-batch keeps peak residency at one batch plus
+// whatever the producer still buffers.
+//
+// Close releases everything still held — buffered batches and, for
+// spill-backed streams, replay scratch on disk. It is idempotent and must
+// be called by whoever owns the stream, including on error and early-exit
+// paths: an undrained spill-backed stream pins its scratch file until
+// Close runs.
+type BatchStream interface {
+	Next(ctx context.Context) (*batch.RecordBatch, error)
+	Close() error
+}
+
+// sliceStream adapts a materialized batch slice to BatchStream.
+type sliceStream struct {
+	batches []*batch.RecordBatch
+	idx     int
+}
+
+func newSliceStream(batches []*batch.RecordBatch) *sliceStream {
+	return &sliceStream{batches: batches}
+}
+
+func (s *sliceStream) Next(_ context.Context) (*batch.RecordBatch, error) {
+	for s.idx < len(s.batches) {
+		b := s.batches[s.idx]
+		s.batches[s.idx] = nil
+		s.idx++
+		if b != nil {
+			return b, nil
+		}
+	}
+	s.batches = nil
+	return nil, nil
+}
+
+func (s *sliceStream) Close() error {
+	s.batches = nil
+	return nil
+}

--- a/internal/coordinator/batch_stream.go
+++ b/internal/coordinator/batch_stream.go
@@ -22,6 +22,12 @@ type BatchStream interface {
 	Close() error
 }
 
+// NewSliceStream adapts a materialized batch slice to BatchStream. The
+// stream takes ownership of the slice (entries are nil'd as yielded).
+func NewSliceStream(batches []*batch.RecordBatch) BatchStream {
+	return &sliceStream{batches: batches}
+}
+
 // sliceStream adapts a materialized batch slice to BatchStream.
 type sliceStream struct {
 	batches []*batch.RecordBatch
@@ -48,4 +54,22 @@ func (s *sliceStream) Next(_ context.Context) (*batch.RecordBatch, error) {
 func (s *sliceStream) Close() error {
 	s.batches = nil
 	return nil
+}
+
+// drainStream materializes the remainder of a stream into a slice. For use
+// by consumers that genuinely need the full set at once (sort, re-aggregate
+// with source back-pointers); streaming-capable consumers should iterate.
+func drainStream(in BatchStream) ([]*batch.RecordBatch, error) {
+	ctx := context.Background()
+	var out []*batch.RecordBatch
+	for {
+		b, err := in.Next(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if b == nil {
+			return out, nil
+		}
+		out = append(out, b)
+	}
 }

--- a/internal/coordinator/batch_stream_test.go
+++ b/internal/coordinator/batch_stream_test.go
@@ -1,0 +1,104 @@
+package coordinator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// mustRows drains r.Rows() and fails the test on a stream error. Shared by
+// every coordinator test that asserts on materialized result rows.
+func mustRows(tb testing.TB, r *SQLResult) []map[string]any {
+	tb.Helper()
+	rows, err := r.Rows()
+	if err != nil {
+		tb.Fatalf("SQLResult.Rows: %v", err)
+	}
+	return rows
+}
+
+func intBatch(vals ...int64) *batch.RecordBatch {
+	schema := []parquet.Column{{Name: "x", Type: parquet.TypeInt64, Nullable: true}}
+	b := batch.NewRecordBatch(schema, len(vals))
+	for i, v := range vals {
+		b.Columns[0].Int64Data[i] = v
+		b.Columns[0].Nulls.SetValid(i)
+	}
+	b.Len = len(vals)
+	return b
+}
+
+func TestSliceStream_DrainsAndDropsRefs(t *testing.T) {
+	ctx := context.Background()
+	batches := []*batch.RecordBatch{intBatch(1, 2), nil, intBatch(3)}
+	s := newSliceStream(batches)
+
+	b1, err := s.Next(ctx)
+	if err != nil || b1 == nil || b1.Len != 2 {
+		t.Fatalf("first Next = %v, %v", b1, err)
+	}
+	if batches[0] != nil {
+		t.Fatal("stream did not drop its reference to the yielded batch")
+	}
+	b2, err := s.Next(ctx)
+	if err != nil || b2 == nil || b2.Len != 1 {
+		t.Fatalf("second Next = %v, %v (nil entries must be skipped)", b2, err)
+	}
+	for i := 0; i < 3; i++ {
+		b, err := s.Next(ctx)
+		if b != nil || err != nil {
+			t.Fatalf("exhausted Next = %v, %v, want nil, nil", b, err)
+		}
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestSQLResult_StreamSingleConsumer(t *testing.T) {
+	ctx := context.Background()
+	r := &SQLResult{Batches: []*batch.RecordBatch{intBatch(1)}}
+	s := r.Stream()
+	if r.Batches != nil {
+		t.Fatal("Stream() must detach Batches from the result")
+	}
+	b, err := s.Next(ctx)
+	if err != nil || b == nil {
+		t.Fatalf("Next = %v, %v", b, err)
+	}
+	// Second Stream() call yields an empty stream, not the same data.
+	s2 := r.Stream()
+	if b2, _ := s2.Next(ctx); b2 != nil {
+		t.Fatal("second Stream() must be empty")
+	}
+}
+
+func TestSQLResult_RowsDrainsStream(t *testing.T) {
+	r := &SQLResult{stream: newSliceStream([]*batch.RecordBatch{intBatch(7, 8), intBatch(9)})}
+	rows := mustRows(t, r)
+	if len(rows) != 3 {
+		t.Fatalf("rows = %d, want 3", len(rows))
+	}
+	if rows[2]["x"] != int64(9) {
+		t.Fatalf("rows[2] = %v", rows[2])
+	}
+}
+
+func TestSQLResult_CloseIdempotentNilSafe(t *testing.T) {
+	var nilRes *SQLResult
+	if err := nilRes.Close(); err != nil {
+		t.Fatalf("nil Close: %v", err)
+	}
+	r := &SQLResult{stream: newSliceStream([]*batch.RecordBatch{intBatch(1)}), Batches: nil}
+	if err := r.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	if b, _ := r.Stream().Next(context.Background()); b != nil {
+		t.Fatal("Stream after Close must be empty")
+	}
+}

--- a/internal/coordinator/catalog_snapshot_test.go
+++ b/internal/coordinator/catalog_snapshot_test.go
@@ -148,7 +148,7 @@ func TestHandleCreateSnapshotSQL(t *testing.T) {
 	if len(res.Columns) != 3 {
 		t.Fatalf("want 3 cols (snapshot_id, prefix, key_count), got %d", len(res.Columns))
 	}
-	rows := res.Rows()
+	rows := mustRows(t, res)
 	if len(rows) != 1 {
 		t.Fatalf("want 1 row, got %d", len(rows))
 	}

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -47,10 +47,12 @@ type Config struct {
 	WorkerStaleTTL time.Duration // time after which a silent worker is reaped, 0 = default (30s)
 	DynamicFilters bool          // Trino-style semi-join dynamic-filter pushdown (off by default in v1)
 	// GatherResultBudget caps the decoded result bytes a single query may
-	// accumulate in coordinator heap (gather receiver). 0 = derive from
+	// hold in coordinator heap (gather receiver). 0 = derive from
 	// GOMEMLIMIT (half of it) or fall back to 2 GiB; negative = uncapped.
-	// Exceeding the budget fails the query cleanly instead of OOM-killing
-	// the coordinator.
+	// Past the budget the remaining gather payload spills as raw frames to
+	// local scratch and the SQLResult replays them lazily disk→wire; only
+	// a scratch-write failure fails the query (cleanly — the coordinator
+	// process never OOMs for one query's result size).
 	GatherResultBudget int64
 }
 
@@ -403,6 +405,9 @@ func (c *Coordinator) SubmitScanQuery(ctx context.Context, tableName string, col
 	}
 
 	result, err := c.ExecuteSQL(ctx, sql)
+	// Only the result metadata is returned here; release the batches (and
+	// any spill-backed stream) before they go out of scope.
+	defer result.Close()
 	if err != nil {
 		return &QueryResult{
 			QueryID: result.QueryID,
@@ -479,11 +484,21 @@ func (r *SQLResult) Close() error {
 	return err
 }
 
-// Rows materializes the result batches into row-oriented maps, consuming
-// the result. This is expensive for large results — prefer Stream().
+// Rows materializes the result batches into row-oriented maps. This is
+// expensive for large results — prefer Stream(). On a materialized result
+// it is repeatable (Batches are left in place, matching the historical
+// behavior); on a lazy result it consumes the stream, and a second call
+// returns nothing.
 func (r *SQLResult) Rows() ([]map[string]any, error) {
 	if r == nil {
 		return nil, nil
+	}
+	if r.stream == nil {
+		var rows []map[string]any
+		for _, b := range r.Batches {
+			rows = append(rows, b.ToRows()...)
+		}
+		return rows, nil
 	}
 	s := r.Stream()
 	defer s.Close()
@@ -600,14 +615,25 @@ func (c *Coordinator) ExecuteSQL(ctx context.Context, sql string) (*SQLResult, e
 			Plan:    planStr,
 		}, fmt.Errorf("native DAG: %w", gerr)
 	}
-	return &SQLResult{
+	res := &SQLResult{
 		QueryID:   queryID,
 		Columns:   gr.columns,
-		Batches:   gr.batches,
 		TotalRows: gr.totalRows,
 		Elapsed:   time.Since(start),
 		Plan:      planStr,
-	}, nil
+	}
+	if gr.spillPath != "" {
+		// Over-budget result: the in-memory prefix plus raw frames on
+		// local scratch, replayed lazily disk→wire as the consumer
+		// iterates. PR #142's hard-fail became this graceful path.
+		c.logger.Info("gather: result exceeded budget, replaying lazily from scratch",
+			"query", queryID, "spill_path", gr.spillPath,
+			"spilled_mb", gr.spillBytes>>20, "total_rows", gr.totalRows)
+		res.stream = newGatherReplayStream(gr.batches, gr.spillPath, gr.renamer)
+	} else {
+		res.Batches = gr.batches
+	}
+	return res, nil
 }
 
 // createTasksForStage creates distributed tasks for a given stage.
@@ -1111,13 +1137,16 @@ func (c *Coordinator) fetchResultData(ctx context.Context, queryID, path string)
 // mergeProbePartials re-aggregates partial results from probe-split pipeline
 // workers and applies the original sort + limit. Each worker produced partial
 // aggregates for its file partition; this merges them into the final result.
+// Consumes (and always closes) the input stream.
 //
-// For small result sets (typical: <100K rows), this runs in-memory on the
-// coordinator with negligible overhead.
-func (c *Coordinator) mergeProbePartials(batches []*batch.RecordBatch, columns []string, mi *logical.MergeInfo) ([]*batch.RecordBatch, int64, error) {
-	if len(batches) == 0 {
-		return nil, 0, nil
-	}
+// The DISTINCT-only path dedups streaming — each input batch is fed to the
+// hash aggregate and released before the next is read. The re-aggregate path
+// drains the stream up front: reAggregatePartials' group states pin their
+// source batches anyway (mergedRow.sourceBatch back-pointers), so streaming
+// its input would not reduce peak residency. Sort/limit inherently need the
+// (already merged, small) result materialized.
+func (c *Coordinator) mergeProbePartials(in BatchStream, columns []string, mi *logical.MergeInfo) ([]*batch.RecordBatch, int64, error) {
+	defer in.Close()
 
 	// Build column name → index mapping
 	colIdx := make(map[string]int, len(columns))
@@ -1125,7 +1154,16 @@ func (c *Coordinator) mergeProbePartials(batches []*batch.RecordBatch, columns [
 		colIdx[col] = i
 	}
 
+	var batches []*batch.RecordBatch
 	if mi.HasAggregate {
+		var err error
+		batches, err = drainStream(in)
+		if err != nil {
+			return nil, 0, fmt.Errorf("reading partials: %w", err)
+		}
+		if len(batches) == 0 {
+			return nil, 0, nil
+		}
 		if len(mi.GroupBy) > 0 {
 			batches = c.reAggregatePartials(batches, columns, colIdx, mi)
 		} else {
@@ -1135,10 +1173,20 @@ func (c *Coordinator) mergeProbePartials(batches []*batch.RecordBatch, columns [
 		}
 	}
 	if mi.HasDistinct {
+		src := in
+		if mi.HasAggregate {
+			src = newSliceStream(batches)
+		}
 		var err error
-		batches, err = c.deduplicatePartials(batches, columns)
+		batches, err = c.deduplicatePartials(src, columns)
 		if err != nil {
 			return nil, 0, fmt.Errorf("deduplicating distinct partials: %w", err)
+		}
+	} else if !mi.HasAggregate {
+		var err error
+		batches, err = drainStream(in)
+		if err != nil {
+			return nil, 0, fmt.Errorf("reading partials: %w", err)
 		}
 	}
 
@@ -1162,11 +1210,12 @@ func (c *Coordinator) mergeProbePartials(batches []*batch.RecordBatch, columns [
 	return batches, totalRows, nil
 }
 
-// deduplicatePartials removes duplicate rows across probe-split partial results.
-func (c *Coordinator) deduplicatePartials(batches []*batch.RecordBatch, columns []string) ([]*batch.RecordBatch, error) {
-	if len(batches) == 0 {
-		return batches, nil
-	}
+// deduplicatePartials removes duplicate rows across probe-split partial
+// results. Consumes the input stream batch-by-batch — each batch's
+// reference is dropped once the aggregate has absorbed it, so a lazy
+// (spill-backed) input never materializes fully here.
+func (c *Coordinator) deduplicatePartials(in BatchStream, columns []string) ([]*batch.RecordBatch, error) {
+	defer in.Close()
 	_ = columns // key set = every column, resolved from the batch schema
 	// Columnar dedup via a keys-only hash aggregate (the same GroupByAll
 	// machinery SELECT DISTINCT plans to). The previous implementation
@@ -1182,7 +1231,14 @@ func (c *Coordinator) deduplicatePartials(batches []*batch.RecordBatch, columns 
 	if err := agg.Init(ctx); err != nil {
 		return nil, err
 	}
-	for _, b := range batches {
+	for {
+		b, err := in.Next(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if b == nil {
+			break
+		}
 		if err := agg.Consume(ctx, b); err != nil {
 			return nil, err
 		}
@@ -2271,7 +2327,7 @@ func (c *Coordinator) GetQueryResults(ctx context.Context, queryID string) (*SQL
 
 	// Apply probe-split merge if needed (same as ExecuteSQL path)
 	if meta.mergeInfo != nil && len(batches) > 0 {
-		merged, mergedRows, mergeErr := c.mergeProbePartials(batches, columns, meta.mergeInfo)
+		merged, mergedRows, mergeErr := c.mergeProbePartials(newSliceStream(batches), columns, meta.mergeInfo)
 		if mergeErr == nil {
 			batches = merged
 			totalRows = mergedRows

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -420,9 +420,16 @@ func (c *Coordinator) SubmitScanQuery(ctx context.Context, tableName string, col
 	}, nil
 }
 
-// SQLResult holds the full result of a distributed SQL query.
+// SQLResult holds the result of a distributed SQL query.
 // Results are kept columnar (as RecordBatches) to avoid materializing
 // per-row map[string]any which causes massive heap pressure at SF10+.
+//
+// Results arrive in one of two forms: fully materialized in Batches, or
+// as a lazy stream (gather results that exceeded the coordinator budget
+// and spilled to local scratch — see gatherReceiver). Consumers should
+// iterate via Stream(), which handles both forms; whoever receives an
+// SQLResult owns it and must either drain the stream or call Close, or
+// spill scratch leaks until process exit.
 type SQLResult struct {
 	QueryID     string
 	Columns     []string
@@ -432,19 +439,65 @@ type SQLResult struct {
 	Elapsed     time.Duration
 	Plan        string
 	Error       string
+
+	// stream is the lazy form: set (and Batches nil) when the gather
+	// result is partially on local scratch. Accessed via Stream().
+	stream BatchStream
 }
 
-// Rows materializes the result batches into row-oriented maps.
-// This is expensive for large results — prefer iterating Batches directly.
-func (r *SQLResult) Rows() []map[string]any {
+// Stream returns a consuming iterator over the result batches. The first
+// call detaches the result's batches (lazy stream or materialized slice);
+// subsequent calls return an empty stream. The caller owns the returned
+// stream and must drain it or call Close.
+func (r *SQLResult) Stream() BatchStream {
+	if r == nil {
+		return newSliceStream(nil)
+	}
+	if r.stream != nil {
+		s := r.stream
+		r.stream = nil
+		return s
+	}
+	b := r.Batches
+	r.Batches = nil
+	return newSliceStream(b)
+}
+
+// Close releases whatever the result still holds — the lazy stream's
+// buffered batches and spill scratch, or the materialized slice.
+// Idempotent and nil-safe.
+func (r *SQLResult) Close() error {
 	if r == nil {
 		return nil
 	}
+	var err error
+	if r.stream != nil {
+		err = r.stream.Close()
+		r.stream = nil
+	}
+	r.Batches = nil
+	return err
+}
+
+// Rows materializes the result batches into row-oriented maps, consuming
+// the result. This is expensive for large results — prefer Stream().
+func (r *SQLResult) Rows() ([]map[string]any, error) {
+	if r == nil {
+		return nil, nil
+	}
+	s := r.Stream()
+	defer s.Close()
 	var rows []map[string]any
-	for _, b := range r.Batches {
+	for {
+		b, err := s.Next(context.Background())
+		if err != nil {
+			return rows, err
+		}
+		if b == nil {
+			return rows, nil
+		}
 		rows = append(rows, b.ToRows()...)
 	}
-	return rows
 }
 
 // ExecuteSQL parses SQL, plans, distributes across workers, and collects results.

--- a/internal/coordinator/coordinator_coverage_test.go
+++ b/internal/coordinator/coordinator_coverage_test.go
@@ -867,7 +867,7 @@ func TestReAggregatePartialsMerge(t *testing.T) {
 		}),
 	}
 
-	merged, totalRows, err := coord.mergeProbePartials(batches, columns, mi)
+	merged, totalRows, err := coord.mergeProbePartials(newSliceStream(batches), columns, mi)
 	if err != nil {
 		t.Fatalf("mergeProbePartials error: %v", err)
 	}
@@ -940,7 +940,7 @@ func TestTopKMerge(t *testing.T) {
 		HasAggregate: true,
 	}
 
-	merged, totalRows, err := coord.mergeProbePartials([]*batch.RecordBatch{b}, columns, mi)
+	merged, totalRows, err := coord.mergeProbePartials(newSliceStream([]*batch.RecordBatch{b}), columns, mi)
 	if err != nil {
 		t.Fatalf("mergeProbePartials error: %v", err)
 	}
@@ -1004,7 +1004,7 @@ func TestDeduplicatePartials(t *testing.T) {
 		makeBatch([][]string{{"EU", "active"}}),
 	}
 
-	merged, totalRows, err := coord.mergeProbePartials(batches, columns, mi)
+	merged, totalRows, err := coord.mergeProbePartials(newSliceStream(batches), columns, mi)
 	if err != nil {
 		t.Fatalf("mergeProbePartials error: %v", err)
 	}

--- a/internal/coordinator/coordinator_coverage_test.go
+++ b/internal/coordinator/coordinator_coverage_test.go
@@ -429,8 +429,8 @@ func TestExecuteSQLSortQuery(t *testing.T) {
 	if result.Error != "" {
 		t.Fatalf("unexpected error: %s", result.Error)
 	}
-	if len(result.Rows()) != 3 {
-		t.Fatalf("expected 3 rows, got %d", len(result.Rows()))
+	if len(mustRows(t, result)) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(mustRows(t, result)))
 	}
 }
 
@@ -459,8 +459,8 @@ func TestExecuteSQLWithLimit(t *testing.T) {
 		t.Fatalf("unexpected error: %s", result.Error)
 	}
 	// LIMIT 2 should give us 2 rows
-	if len(result.Rows()) > 5 { // at minimum, should not exceed total
-		t.Errorf("expected at most 5 rows, got %d", len(result.Rows()))
+	if len(mustRows(t, result)) > 5 { // at minimum, should not exceed total
+		t.Errorf("expected at most 5 rows, got %d", len(mustRows(t, result)))
 	}
 }
 

--- a/internal/coordinator/dedup_partials_test.go
+++ b/internal/coordinator/dedup_partials_test.go
@@ -26,7 +26,7 @@ func TestDeduplicatePartials_NulByteKeysDoNotCollide(t *testing.T) {
 	})
 
 	c := &Coordinator{}
-	out, err := c.deduplicatePartials([]*batch.RecordBatch{b}, []string{"x", "y"})
+	out, err := c.deduplicatePartials(newSliceStream([]*batch.RecordBatch{b}), []string{"x", "y"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +58,7 @@ func TestDeduplicatePartials_TypedColumns(t *testing.T) {
 	}
 
 	c := &Coordinator{}
-	out, err := c.deduplicatePartials(batches, []string{"n", "f"})
+	out, err := c.deduplicatePartials(newSliceStream(batches), []string{"n", "f"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/coordinator/distributed_test.go
+++ b/internal/coordinator/distributed_test.go
@@ -176,14 +176,14 @@ func TestDistributedExecuteSQL(t *testing.T) {
 	if result.Error != "" {
 		t.Fatalf("unexpected error: %s", result.Error)
 	}
-	if len(result.Rows()) != 4 {
-		t.Fatalf("expected 4 rows, got %d", len(result.Rows()))
+	if len(mustRows(t, result)) != 4 {
+		t.Fatalf("expected 4 rows, got %d", len(mustRows(t, result)))
 	}
 	if result.Plan == "" {
 		t.Error("expected non-empty plan")
 	}
 	t.Logf("Plan:\n%s", result.Plan)
-	t.Logf("Rows: %d, Elapsed: %s", len(result.Rows()), result.Elapsed)
+	t.Logf("Rows: %d, Elapsed: %s", len(mustRows(t, result)), result.Elapsed)
 }
 
 func TestDistributedAggregateQuery(t *testing.T) {
@@ -210,17 +210,17 @@ func TestDistributedAggregateQuery(t *testing.T) {
 		t.Fatalf("unexpected error: %s", result.Error)
 	}
 	t.Logf("Result files: %v", result.ResultFiles)
-	t.Logf("Rows: %d, Columns: %v", len(result.Rows()), result.Columns)
-	for i, row := range result.Rows() {
+	t.Logf("Rows: %d, Columns: %v", len(mustRows(t, result)), result.Columns)
+	for i, row := range mustRows(t, result) {
 		t.Logf("  row[%d]: %v", i, row)
 	}
-	if len(result.Rows()) != 2 {
-		t.Fatalf("expected 2 groups, got %d", len(result.Rows()))
+	if len(mustRows(t, result)) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(mustRows(t, result)))
 	}
 
 	// Verify aggregates
 	totals := make(map[string]float64)
-	for _, row := range result.Rows() {
+	for _, row := range mustRows(t, result) {
 		uid := row["user_id"].(string)
 		total, ok := row["total"].(float64)
 		if !ok {
@@ -334,13 +334,13 @@ func TestDistributedAggregateWithSpill(t *testing.T) {
 	if result.Error != "" {
 		t.Fatalf("unexpected error: %s", result.Error)
 	}
-	if len(result.Rows()) != 3 {
-		t.Fatalf("expected 3 groups, got %d", len(result.Rows()))
+	if len(mustRows(t, result)) != 3 {
+		t.Fatalf("expected 3 groups, got %d", len(mustRows(t, result)))
 	}
 
 	// Verify aggregates are correct despite spilling
 	totals := make(map[string]float64)
-	for _, row := range result.Rows() {
+	for _, row := range mustRows(t, result) {
 		cat := row["category"].(string)
 		total, ok := row["total"].(float64)
 		if !ok {
@@ -387,13 +387,13 @@ func TestDistributedQueryWithResultStore(t *testing.T) {
 	if result.Error != "" {
 		t.Fatalf("unexpected error: %s", result.Error)
 	}
-	if len(result.Rows()) != 3 {
-		t.Fatalf("expected 3 users, got %d", len(result.Rows()))
+	if len(mustRows(t, result)) != 3 {
+		t.Fatalf("expected 3 users, got %d", len(mustRows(t, result)))
 	}
 
 	// Verify correct aggregate values
 	totals := make(map[string]float64)
-	for _, row := range result.Rows() {
+	for _, row := range mustRows(t, result) {
 		uid := row["user_id"].(string)
 		total, ok := row["total"].(float64)
 		if !ok {
@@ -441,13 +441,13 @@ func TestDistributedQueryWithBudgetAndResultStore(t *testing.T) {
 	if result.Error != "" {
 		t.Fatalf("unexpected error: %s", result.Error)
 	}
-	if len(result.Rows()) != 4 {
-		t.Fatalf("expected 4 regions, got %d", len(result.Rows()))
+	if len(mustRows(t, result)) != 4 {
+		t.Fatalf("expected 4 regions, got %d", len(mustRows(t, result)))
 	}
 
 	// Each region has 20 rows, total revenue = sum of region's entries
 	var totalRevenue float64
-	for _, row := range result.Rows() {
+	for _, row := range mustRows(t, result) {
 		total, ok := row["total"].(float64)
 		if !ok {
 			if iv, ok := row["total"].(int64); ok {
@@ -461,5 +461,5 @@ func TestDistributedQueryWithBudgetAndResultStore(t *testing.T) {
 	if totalRevenue != expected {
 		t.Errorf("total revenue: got %f, want %f", totalRevenue, expected)
 	}
-	t.Logf("Result: %d rows, total revenue: %f", len(result.Rows()), totalRevenue)
+	t.Logf("Result: %d rows, total revenue: %f", len(mustRows(t, result)), totalRevenue)
 }

--- a/internal/coordinator/distributed_tpch_test.go
+++ b/internal/coordinator/distributed_tpch_test.go
@@ -832,7 +832,7 @@ func TestDistributedTPCHBuildCacheSF100Sample(t *testing.T) {
 	if result.Error != "" {
 		t.Fatalf("Q05 error: %s", result.Error)
 	}
-	rows := result.Rows()
+	rows := mustRows(t, result)
 	t.Logf("Q05 against SF100 sample: %d rows", len(rows))
 	for i, r := range rows {
 		t.Logf("  row %d: %v", i, r)
@@ -1082,7 +1082,7 @@ func runSF100SampleQuery(t *testing.T, ctx context.Context, coord *Coordinator, 
 	if result.Error != "" {
 		t.Fatalf("Q%02d error: %s (elapsed %s)", qNum, result.Error, elapsed)
 	}
-	rows := result.Rows()
+	rows := mustRows(t, result)
 	t.Logf("Q%02d (%s): %d rows in %s", qNum, q.Name, len(rows), elapsed)
 	for i, r := range rows {
 		if i >= 10 {
@@ -1194,7 +1194,7 @@ func TestDistributedTPCHBuildCachePolarsQ05(t *testing.T) {
 	if result.Error != "" {
 		t.Fatalf("Q05 error: %s", result.Error)
 	}
-	rows := result.Rows()
+	rows := mustRows(t, result)
 	t.Logf("Q05 (Polars schema, orders-only cache, groupSize=1): %d rows", len(rows))
 	for i, r := range rows {
 		t.Logf("  row %d: %v", i, r)
@@ -1247,7 +1247,7 @@ func TestDistributedTPCHQ17AggregateShuffleCorrectness(t *testing.T) {
 	if inPlan.Error != "" {
 		t.Fatalf("Q17 in-plan error: %s", inPlan.Error)
 	}
-	inPlanRows := inPlan.Rows()
+	inPlanRows := mustRows(t, inPlan)
 	t.Logf("Q17 in-plan: %d rows: %v", len(inPlanRows), inPlanRows)
 	if len(inPlanRows) != 1 {
 		t.Fatalf("Q17 in-plan: expected 1 row, got %d", len(inPlanRows))
@@ -1263,7 +1263,7 @@ func TestDistributedTPCHQ17AggregateShuffleCorrectness(t *testing.T) {
 	if aggShuffle.Error != "" {
 		t.Fatalf("Q17 aggregate-shuffle error: %s", aggShuffle.Error)
 	}
-	aggShuffleRows := aggShuffle.Rows()
+	aggShuffleRows := mustRows(t, aggShuffle)
 	t.Logf("Q17 aggregate-shuffle: %d rows: %v", len(aggShuffleRows), aggShuffleRows)
 	if len(aggShuffleRows) != 1 {
 		t.Fatalf("Q17 aggregate-shuffle: expected 1 row, got %d", len(aggShuffleRows))
@@ -1336,7 +1336,7 @@ func TestAggregateShuffleCorrectness_NonEmptyResult(t *testing.T) {
 	if a.Error != "" {
 		t.Fatalf("in-plan error: %s", a.Error)
 	}
-	aRows := a.Rows()
+	aRows := mustRows(t, a)
 	t.Logf("in-plan: %v", aRows)
 
 	// B: aggregate-shuffle
@@ -1348,7 +1348,7 @@ func TestAggregateShuffleCorrectness_NonEmptyResult(t *testing.T) {
 	if b.Error != "" {
 		t.Fatalf("agg-shuffle error: %s", b.Error)
 	}
-	bRows := b.Rows()
+	bRows := mustRows(t, b)
 	t.Logf("agg-shuffle: %v", bRows)
 
 	if len(aRows) != len(bRows) {
@@ -1427,7 +1427,7 @@ func TestDistributedTPCHQ17AggregateShuffle(t *testing.T) {
 	if result.Error != "" {
 		t.Fatalf("Q17 error: %s", result.Error)
 	}
-	rows := result.Rows()
+	rows := mustRows(t, result)
 	t.Logf("Q17 (aggregate-shuffle path forced): %d rows", len(rows))
 	for i, r := range rows {
 		t.Logf("  row %d: %v", i, r)
@@ -1476,7 +1476,7 @@ func TestDistributedTPCHBuildCachePartialOrders(t *testing.T) {
 	if result.Error != "" {
 		t.Fatalf("Q05 error: %s", result.Error)
 	}
-	rows := result.Rows()
+	rows := mustRows(t, result)
 	t.Logf("Q05 (orders-only cache, groupSize=1): %d rows", len(rows))
 	for i, r := range rows {
 		t.Logf("  row %d: %v", i, r)
@@ -1531,7 +1531,7 @@ func TestDistributedTPCHBuildCache(t *testing.T) {
 			if result.Error != "" {
 				t.Fatalf("Q%02d error: %s", tt.qNum, result.Error)
 			}
-			rows := result.Rows()
+			rows := mustRows(t, result)
 			t.Logf("Q%02d: %d rows in %v (build cache active)", tt.qNum, len(rows), elapsed)
 			if len(rows) != tt.expected {
 				t.Errorf("Q%02d: got %d rows, want %d", tt.qNum, len(rows), tt.expected)
@@ -1599,7 +1599,7 @@ func TestDistributedTPCHForcedShuffle(t *testing.T) {
 			if result.Error != "" {
 				t.Fatalf("Q%02d shuffle path: %s", tt.qNum, result.Error)
 			}
-			rows := result.Rows()
+			rows := mustRows(t, result)
 			t.Logf("Q%02d: %d rows in %v (shuffle ON, heap_delta=%d KB, heap_sys=%d KB)",
 				tt.qNum, len(rows), elapsed, heapDelta/1024, peakHeap/1024)
 			if len(rows) != tt.expected {
@@ -1650,7 +1650,7 @@ func TestDistributedTPCHBuildCacheDuplicateAlias(t *testing.T) {
 	if result.Error != "" {
 		t.Fatalf("Q02 error: %s", result.Error)
 	}
-	rows := result.Rows()
+	rows := mustRows(t, result)
 	t.Logf("Q02 (duplicate alias + group splitting): %d rows", len(rows))
 	if len(rows) != 5 {
 		for i, r := range rows {
@@ -1714,7 +1714,7 @@ func TestDistributedTPCH(t *testing.T) {
 			if result.Error != "" {
 				t.Fatalf("Q%02d error: %s", tt.qNum, result.Error)
 			}
-			rows := result.Rows()
+			rows := mustRows(t, result)
 			t.Logf("Q%02d: %d rows in %v (plan:\n%s)", tt.qNum, len(rows), elapsed, result.Plan)
 			if len(rows) > 0 {
 				t.Logf("  first row: %v", rows[0])

--- a/internal/coordinator/dynamic_filter_e2e_test.go
+++ b/internal/coordinator/dynamic_filter_e2e_test.go
@@ -39,7 +39,7 @@ func TestDynamicFilterE2EQ17Correctness(t *testing.T) {
 	if baseline.Error != "" {
 		t.Fatalf("Q17 baseline error: %s", baseline.Error)
 	}
-	baselineRows := baseline.Rows()
+	baselineRows := mustRows(t, baseline)
 	t.Logf("Q17 baseline (flag=off): %d rows", len(baselineRows))
 
 	// Flip flag, re-run.
@@ -53,7 +53,7 @@ func TestDynamicFilterE2EQ17Correctness(t *testing.T) {
 	if withFilter.Error != "" {
 		t.Fatalf("Q17 with-filter error: %s", withFilter.Error)
 	}
-	wfRows := withFilter.Rows()
+	wfRows := mustRows(t, withFilter)
 	t.Logf("Q17 with-filter (flag=on): %d rows", len(wfRows))
 
 	if len(baselineRows) != len(wfRows) {

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -290,6 +290,10 @@ func (c *Coordinator) executeStageDAG(
 				"query", queryID, "fuse_stage_id", depID,
 				"reply_subject", replySubject)
 			defer recv.sub.Unsubscribe()
+			// Remove unclaimed spill scratch on every path that returns
+			// before wait() hands the result off (dispatch errors, ctx
+			// cancellation). No-op after a successful wait().
+			defer recv.discard()
 			defer recv.registerWithDataPlane(c.dpSrv, queryID)()
 		}
 	}
@@ -521,10 +525,48 @@ func applyOutputRenames(gr *gatherResult, renames []physical.OutputRename) {
 	if gr == nil || len(renames) == 0 {
 		return
 	}
-	// Pre-compile any expression-bearing renames (wrapped aggregates etc.)
-	// once per call. Compilation can fail (e.g., unsupported AST shape); on
-	// failure we degrade the whole pass to rename-only.
-	compiledExprs := make(map[int]expr.Expr, len(renames))
+	// Decide project-vs-rename from the column list the receiver derived
+	// from the first batch's schema (identical names). When the result is
+	// fully in memory and empty, keep the historical rename-only behavior;
+	// a spilled result always has decoded prefix batches (the budget is
+	// only exceeded after at least one decode), so columns are present.
+	br := newBatchRenamer(renames, gr.columns)
+	if len(gr.batches) == 0 && gr.spillPath == "" && len(gr.columns) > 0 {
+		// Columns but no batches (historical edge): rename-only. A fully
+		// empty result (no columns either) keeps projecting the column
+		// list to the SELECT aliases, as before.
+		br.project = false
+	}
+	gr.columns = br.renameColumns(gr.columns)
+	for bi, b := range gr.batches {
+		gr.batches[bi] = br.apply(b)
+	}
+	if gr.spillPath != "" {
+		// Replayed batches get the same transform lazily as they are
+		// decoded from scratch (gatherReplayStream).
+		gr.renamer = br
+	}
+}
+
+// batchRenamer is the per-batch form of applyOutputRenames: one decision
+// (project vs rename-only) made up front from the output column names, then
+// applied to each batch — eagerly to the in-memory prefix, lazily to batches
+// replayed from gather spill scratch. Both paths MUST use the same instance
+// so a single query's batches all share one schema shape.
+type batchRenamer struct {
+	renames  []physical.OutputRename
+	compiled map[int]expr.Expr // index → compiled expr; nil map = compilation failed
+	project  bool
+}
+
+// newBatchRenamer compiles expression-bearing renames and decides whether a
+// full projection is possible: compilation succeeded AND every non-expr
+// source column resolves in columns (case-insensitive, tolerating worker-
+// side lowercasing). Otherwise batches get a rename-only pass so the output
+// is at least non-empty rather than truncated to nothing.
+func newBatchRenamer(renames []physical.OutputRename, columns []string) *batchRenamer {
+	br := &batchRenamer{renames: renames, project: true}
+	br.compiled = make(map[int]expr.Expr, len(renames))
 	for i, r := range renames {
 		if r.Expr == nil {
 			continue
@@ -532,104 +574,102 @@ func applyOutputRenames(gr *gatherResult, renames []physical.OutputRename) {
 		e, cerr := expr.Compile(r.Expr)
 		if cerr != nil {
 			// Compilation failure → degrade to rename-only.
-			compiledExprs = nil
+			br.compiled = nil
+			br.project = false
 			break
 		}
-		compiledExprs[i] = e
+		br.compiled[i] = e
 	}
-	// Determine if every source resolves in the schema. If not, degrade
-	// to rename-only behavior to avoid hiding the entire result.
-	canProject := true
-	if compiledExprs == nil {
-		canProject = false
-	}
-	if canProject && len(gr.batches) > 0 && len(gr.batches[0].Schema) > 0 {
-		schema := gr.batches[0].Schema
+	if br.project && len(columns) > 0 {
 		for _, r := range renames {
 			if r.Expr != nil {
 				continue // existence check uses expression evaluation
 			}
 			found := false
-			for _, c := range schema {
-				if strings.EqualFold(c.Name, r.From) {
+			for _, c := range columns {
+				if strings.EqualFold(c, r.From) {
 					found = true
 					break
 				}
 			}
 			if !found {
-				canProject = false
+				br.project = false
 				break
 			}
 		}
-	} else if len(gr.columns) > 0 && len(gr.batches) == 0 {
-		// No batches but columns set — fall back to rename-only.
-		canProject = false
 	}
-	if !canProject {
-		// Rename-only fallback (matches old behavior).
-		rename := func(name string) string {
-			for _, r := range renames {
-				if strings.EqualFold(name, r.From) {
-					return r.To
-				}
-			}
-			return name
+	return br
+}
+
+// renameColumns returns the output column list: the renames' To names in
+// order (project mode), or the input names with matches renamed in place.
+func (br *batchRenamer) renameColumns(columns []string) []string {
+	if br.project {
+		out := make([]string, len(br.renames))
+		for i, r := range br.renames {
+			out[i] = r.To
 		}
-		for i, c := range gr.columns {
-			gr.columns[i] = rename(c)
-		}
-		for _, b := range gr.batches {
-			if b == nil {
-				continue
-			}
-			for i := range b.Schema {
-				b.Schema[i].Name = rename(b.Schema[i].Name)
-			}
-		}
-		return
+		return out
 	}
-	// Project: keep only the renamed/computed columns, in renames order.
-	gr.columns = make([]string, len(renames))
-	for i, r := range renames {
-		gr.columns[i] = r.To
+	for i, c := range columns {
+		columns[i] = br.renameOne(c)
 	}
-	for bi, b := range gr.batches {
-		if b == nil {
+	return columns
+}
+
+func (br *batchRenamer) renameOne(name string) string {
+	for _, r := range br.renames {
+		if strings.EqualFold(name, r.From) {
+			return r.To
+		}
+	}
+	return name
+}
+
+// apply transforms one batch: project mode keeps only the renamed/computed
+// columns in renames order; rename-only mode renames schema fields in place.
+// Nil-safe (returns nil for nil input).
+func (br *batchRenamer) apply(b *batch.RecordBatch) *batch.RecordBatch {
+	if b == nil {
+		return nil
+	}
+	if !br.project {
+		for i := range b.Schema {
+			b.Schema[i].Name = br.renameOne(b.Schema[i].Name)
+		}
+		return b
+	}
+	newCols := make([]*batch.Vector, len(br.renames))
+	newSchema := make([]parquet.Column, len(br.renames))
+	for i, r := range br.renames {
+		if e, ok := br.compiled[i]; ok {
+			// Expression-bearing rename: evaluate per row, build a new
+			// column. Used for wrapped aggregates ("SUM(x)/7.0") whose
+			// post-aggregate divisor needs to be applied at gather time.
+			newCols[i] = evalExprColumn(e, b)
+			newSchema[i] = parquet.Column{Name: r.To, Type: parquet.TypeFloat64, Nullable: true}
 			continue
 		}
-		newCols := make([]*batch.Vector, len(renames))
-		newSchema := make([]parquet.Column, len(renames))
-		for i, r := range renames {
-			if e, ok := compiledExprs[i]; ok {
-				// Expression-bearing rename: evaluate per row, build a new
-				// column. Used for wrapped aggregates ("SUM(x)/7.0") whose
-				// post-aggregate divisor needs to be applied at gather time.
-				newCols[i] = evalExprColumn(e, b)
-				newSchema[i] = parquet.Column{Name: r.To, Type: parquet.TypeFloat64, Nullable: true}
-				continue
+		srcIdx := -1
+		for j, c := range b.Schema {
+			if strings.EqualFold(c.Name, r.From) {
+				srcIdx = j
+				break
 			}
-			srcIdx := -1
-			for j, c := range b.Schema {
-				if strings.EqualFold(c.Name, r.From) {
-					srcIdx = j
-					break
-				}
-			}
-			if srcIdx < 0 {
-				// Should not happen — canProject was true. Defensive.
-				continue
-			}
-			newCols[i] = b.Columns[srcIdx]
-			newSchema[i] = b.Schema[srcIdx]
-			newSchema[i].Name = r.To
 		}
-		nb := &batch.RecordBatch{
-			Schema:  newSchema,
-			Columns: newCols,
-			Len:     b.Len,
-			Sel:     b.Sel,
+		if srcIdx < 0 {
+			// Should not happen — project was decided from these names.
+			continue
 		}
-		gr.batches[bi] = nb
+		newCols[i] = b.Columns[srcIdx]
+		newSchema[i] = b.Schema[srcIdx]
+		newSchema[i].Name = r.To
+	}
+	return &batch.RecordBatch{
+		Schema:  newSchema,
+		Columns: newCols,
+		Len:     b.Len,
+		Sel:     b.Sel,
 	}
 }
 
@@ -3068,6 +3108,9 @@ func (c *Coordinator) dispatchGatherStage(
 	if err != nil {
 		return nil, fmt.Errorf("subscribing gather reply: %w", err)
 	}
+	// Remove unclaimed spill scratch on every path that returns before
+	// wait() hands the result off. No-op after a successful wait().
+	defer recv.discard()
 	defer recv.registerWithDataPlane(c.dpSrv, queryID)()
 	c.logger.Info("gather: publishing task",
 		"query_id", queryID, "task_id", task.ID, "reply_subject", replySubject,

--- a/internal/coordinator/gather_budget_test.go
+++ b/internal/coordinator/gather_budget_test.go
@@ -1,17 +1,22 @@
 package coordinator
 
 import (
+	"bufio"
+	"context"
 	"encoding/binary"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/planner/physical"
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
 )
 
 // wshfInt64Payload hand-builds a one-chunk WSHF payload with a single int64
 // column of n rows (format documented in internal/worker/shuffle_format.go).
-func wshfInt64Payload(tb testing.TB, n int) []byte {
+// Values are base, base+1, ...
+func wshfInt64Payload(tb testing.TB, n int, base int64) []byte {
 	tb.Helper()
 	var buf []byte
 	buf = append(buf, 'W', 'S', 'H', 'F')
@@ -28,54 +33,213 @@ func wshfInt64Payload(tb testing.TB, n int) []byte {
 	}
 	buf = binary.LittleEndian.AppendUint32(buf, uint32(n*8))
 	for i := 0; i < n; i++ {
-		buf = binary.LittleEndian.AppendUint64(buf, uint64(i))
+		buf = binary.LittleEndian.AppendUint64(buf, uint64(base+int64(i)))
 	}
 	return buf
 }
 
-// Regression test for sweep finding #14: the gather receiver accumulated
-// every decoded batch with no cap or charge — a no-LIMIT distributed result
-// landed fully in coordinator heap and OOM-killed the process (all queries
-// die). Over budget, the receiver must fail THIS query cleanly: drop the
-// accumulated batches, surface a clear error from wait(), and keep counting
-// terminals so wait() returns promptly.
-func TestGatherReceiver_BudgetCap(t *testing.T) {
+// drainReplay drains a stream, returning every int64 value seen in column 0
+// and asserting per-batch sanity.
+func drainReplay(tb testing.TB, s BatchStream) []int64 {
+	tb.Helper()
+	var vals []int64
+	for {
+		b, err := s.Next(context.Background())
+		if err != nil {
+			tb.Fatalf("replay Next: %v", err)
+		}
+		if b == nil {
+			return vals
+		}
+		for i := 0; i < b.ActiveLen(); i++ {
+			row := i
+			if b.Sel != nil {
+				row = int(b.Sel[i])
+			}
+			vals = append(vals, b.Columns[0].Int64Data[row])
+		}
+	}
+}
+
+// Regression test for the streaming-SQLResult refactor: past the budget the
+// receiver must DEGRADE — keep the decoded in-memory prefix, append the
+// remaining raw frames to local scratch, and replay them lazily — instead
+// of failing the query (PR #142's interim behavior) or OOMing the process
+// (the original sweep finding #14).
+func TestGatherReceiver_BudgetSpillsAndReplays(t *testing.T) {
 	r := &gatherReceiver{
 		expectedTerminals: 1,
 		budget:            32 * 1024, // 32 KiB — a few 2048-row int64 payloads
 		done:              make(chan struct{}, 1),
 	}
 
-	payload := wshfInt64Payload(t, 2048) // ~16 KiB decoded
+	const rowsPerMsg = 2048
 	for i := 0; i < 5; i++ {
-		r.handleParsed(&distributed.GatherBatchMsg{Payload: payload, RowCount: 2048, WorkerID: "w"})
+		payload := wshfInt64Payload(t, rowsPerMsg, int64(i*rowsPerMsg))
+		r.handleParsed(&distributed.GatherBatchMsg{Payload: payload, RowCount: rowsPerMsg, WorkerID: "w"})
 	}
+	r.handleParsed(&distributed.GatherBatchMsg{Terminal: true, WorkerID: "w"})
 
 	r.mu.Lock()
-	if !r.overBudget {
+	if r.workerErr != "" {
 		r.mu.Unlock()
-		t.Fatal("receiver not over budget after 5×16KiB against a 32KiB cap")
+		t.Fatalf("over-budget receiver must not fail the query, got %q", r.workerErr)
 	}
-	if r.batches != nil {
+	if r.spillPath == "" || r.spillBytes == 0 {
 		r.mu.Unlock()
-		t.Fatal("accumulated batches not freed on over-budget")
+		t.Fatal("receiver did not spill past the 32KiB budget")
 	}
-	if r.workerErr == "" {
+	if len(r.batches) == 0 {
 		r.mu.Unlock()
-		t.Fatal("no error recorded on over-budget")
+		t.Fatal("in-memory prefix dropped — prefix under budget must be kept")
+	}
+	if r.accBytes > r.budget+rowsPerMsg*16 {
+		r.mu.Unlock()
+		t.Fatalf("in-memory bytes %d far exceed budget %d", r.accBytes, r.budget)
 	}
 	r.mu.Unlock()
 
-	// Terminal must still complete the receiver.
+	gr, err := r.wait(context.Background(), time.Second)
+	if err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	if gr.totalRows != 5*rowsPerMsg {
+		t.Fatalf("totalRows = %d, want %d", gr.totalRows, 5*rowsPerMsg)
+	}
+	if gr.columns == nil || gr.columns[0] != "x" {
+		t.Fatalf("columns = %v, want [x]", gr.columns)
+	}
+	if _, statErr := os.Stat(gr.spillPath); statErr != nil {
+		t.Fatalf("scratch file missing after claim: %v", statErr)
+	}
+
+	// Replay must yield every row exactly once, in arrival order
+	// (prefix first, then spilled frames — which IS arrival order).
+	s := newGatherReplayStream(gr.batches, gr.spillPath, gr.renamer)
+	vals := drainReplay(t, s)
+	if len(vals) != 5*rowsPerMsg {
+		t.Fatalf("replayed %d rows, want %d", len(vals), 5*rowsPerMsg)
+	}
+	for i, v := range vals {
+		if v != int64(i) {
+			t.Fatalf("row %d = %d, want %d", i, v, i)
+		}
+	}
+	// Exhaustion deletes the scratch file.
+	if _, statErr := os.Stat(gr.spillPath); !os.IsNotExist(statErr) {
+		t.Fatalf("scratch file not removed after exhausted replay: %v", statErr)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close after exhaustion: %v", err)
+	}
+}
+
+// Close before exhaustion must remove the scratch file (the alerts path
+// stops at its row limit; pgwire clients can disconnect mid-stream).
+func TestGatherReplayStream_CloseRemovesScratch(t *testing.T) {
+	r := &gatherReceiver{
+		expectedTerminals: 1,
+		budget:            1, // decode exactly one payload, spill the rest
+		done:              make(chan struct{}, 1),
+	}
+	for i := 0; i < 3; i++ {
+		r.handleParsed(&distributed.GatherBatchMsg{Payload: wshfInt64Payload(t, 64, 0), RowCount: 64, WorkerID: "w"})
+	}
+	r.handleParsed(&distributed.GatherBatchMsg{Terminal: true, WorkerID: "w"})
+	gr, err := r.wait(context.Background(), time.Second)
+	if err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	s := newGatherReplayStream(gr.batches, gr.spillPath, nil)
+	if b, err := s.Next(context.Background()); err != nil || b == nil {
+		t.Fatalf("first Next = %v, %v", b, err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, statErr := os.Stat(gr.spillPath); !os.IsNotExist(statErr) {
+		t.Fatalf("scratch not removed by Close: %v", statErr)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}
+
+// discard() without a claiming wait() must remove scratch (dispatch error
+// paths) — and a late frame after discard must not recreate it.
+func TestGatherReceiver_DiscardRemovesScratch(t *testing.T) {
+	r := &gatherReceiver{
+		expectedTerminals: 1,
+		budget:            1,
+		done:              make(chan struct{}, 1),
+	}
+	for i := 0; i < 2; i++ {
+		r.handleParsed(&distributed.GatherBatchMsg{Payload: wshfInt64Payload(t, 64, 0), RowCount: 64, WorkerID: "w"})
+	}
+	r.mu.Lock()
+	path := r.spillPath
+	r.mu.Unlock()
+	if path == "" {
+		t.Fatal("no spill before discard")
+	}
+	r.discard()
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("scratch not removed by discard: %v", statErr)
+	}
+	// Late frame after discard: must not recreate scratch.
+	r.handleParsed(&distributed.GatherBatchMsg{Payload: wshfInt64Payload(t, 64, 0), RowCount: 64, WorkerID: "w"})
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.spillPath != "" || r.spillFile != nil {
+		t.Fatal("late frame recreated scratch after discard")
+	}
+}
+
+// A scratch write failure degrades to the clean per-query fail — the
+// process must not die, and the accumulated result is dropped.
+func TestGatherReceiver_SpillWriteFailureFailsQueryCleanly(t *testing.T) {
+	scratch := t.TempDir() + "/ro-scratch"
+	if err := os.WriteFile(scratch, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(scratch) // read-only handle: writes fail
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := &gatherReceiver{
+		expectedTerminals: 1,
+		budget:            1,
+		done:              make(chan struct{}, 1),
+	}
+	// First payload decodes (fills the prefix past budget=1).
+	r.handleParsed(&distributed.GatherBatchMsg{Payload: wshfInt64Payload(t, 64, 0), RowCount: 64, WorkerID: "w"})
+	// Force the spill file to the read-only handle, with a tiny buffer so
+	// the write surfaces immediately (payload > 16 bytes forces a flush).
+	r.mu.Lock()
+	r.spillFile = f
+	r.spillPath = scratch
+	r.spillW = bufio.NewWriterSize(f, 16)
+	r.mu.Unlock()
+	r.handleParsed(&distributed.GatherBatchMsg{Payload: wshfInt64Payload(t, 64, 0), RowCount: 64, WorkerID: "w"})
 	r.handleParsed(&distributed.GatherBatchMsg{Terminal: true, WorkerID: "w"})
 
-	// wait() needs a subscription only for its deferred Unsubscribe; give
-	// it none by checking the done/err state directly through the public
-	// pieces we can reach: done fired and workerErr set.
-	select {
-	case <-r.done:
-	case <-time.After(time.Second):
-		t.Fatal("done not signaled after terminal")
+	r.mu.Lock()
+	if !r.spillFailed {
+		r.mu.Unlock()
+		t.Fatal("spill write failure not recorded")
+	}
+	if r.workerErr == "" {
+		r.mu.Unlock()
+		t.Fatal("no error recorded on spill failure")
+	}
+	if r.batches != nil {
+		r.mu.Unlock()
+		t.Fatal("accumulated batches not freed on spill failure")
+	}
+	r.mu.Unlock()
+
+	if _, err := r.wait(context.Background(), time.Second); err == nil {
+		t.Fatal("wait must surface the spill failure as a query error")
 	}
 }
 
@@ -85,19 +249,64 @@ func TestGatherReceiver_UnderBudgetUnaffected(t *testing.T) {
 		budget:            1 << 20,
 		done:              make(chan struct{}, 1),
 	}
-	r.handleParsed(&distributed.GatherBatchMsg{Payload: wshfInt64Payload(t, 100), RowCount: 100, WorkerID: "w"})
+	r.handleParsed(&distributed.GatherBatchMsg{Payload: wshfInt64Payload(t, 100, 0), RowCount: 100, WorkerID: "w"})
 	r.handleParsed(&distributed.GatherBatchMsg{Terminal: true, WorkerID: "w"})
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if r.overBudget || r.workerErr != "" {
-		t.Fatalf("under-budget receiver flagged: overBudget=%v err=%q", r.overBudget, r.workerErr)
+	if r.spillPath != "" || r.workerErr != "" {
+		t.Fatalf("under-budget receiver flagged: spill=%q err=%q", r.spillPath, r.workerErr)
 	}
 	if r.totalRows != 100 || len(r.batches) != 1 {
 		t.Fatalf("rows=%d batches=%d, want 100/1", r.totalRows, len(r.batches))
 	}
 	if r.columns == nil || r.columns[0] != "x" {
 		t.Fatalf("columns = %v, want [x]", r.columns)
+	}
+}
+
+// Renames recorded on the gather result must apply to REPLAYED batches the
+// same as to the in-memory prefix — schema names diverging mid-stream would
+// be silent wrong results for any over-budget query with SELECT aliases.
+func TestGatherReplayStream_AppliesRenames(t *testing.T) {
+	r := &gatherReceiver{
+		expectedTerminals: 1,
+		budget:            1,
+		done:              make(chan struct{}, 1),
+	}
+	for i := 0; i < 2; i++ {
+		r.handleParsed(&distributed.GatherBatchMsg{Payload: wshfInt64Payload(t, 8, 0), RowCount: 8, WorkerID: "w"})
+	}
+	r.handleParsed(&distributed.GatherBatchMsg{Terminal: true, WorkerID: "w"})
+	gr, err := r.wait(context.Background(), time.Second)
+	if err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	applyOutputRenames(gr, []physical.OutputRename{{From: "x", To: "alias_x"}})
+	if gr.columns[0] != "alias_x" {
+		t.Fatalf("columns after rename = %v", gr.columns)
+	}
+	if gr.renamer == nil {
+		t.Fatal("renamer not recorded on spilled gather result")
+	}
+	s := newGatherReplayStream(gr.batches, gr.spillPath, gr.renamer)
+	defer s.Close()
+	n := 0
+	for {
+		b, err := s.Next(context.Background())
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+		if b == nil {
+			break
+		}
+		n++
+		if b.Schema[0].Name != "alias_x" {
+			t.Fatalf("batch %d schema name = %q, want alias_x", n, b.Schema[0].Name)
+		}
+	}
+	if n != 2 {
+		t.Fatalf("replayed %d batches, want 2", n)
 	}
 }
 

--- a/internal/coordinator/gather_receiver.go
+++ b/internal/coordinator/gather_receiver.go
@@ -1,8 +1,11 @@
 package coordinator
 
 import (
+	"bufio"
 	"context"
+	"encoding/binary"
 	"fmt"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -17,11 +20,20 @@ import (
 // gatherResult is the terminal output of a gather receiver: the assembled
 // batches from all worker gather tasks, the column schema (copied from the
 // first batch), and any worker-reported error surfaced in a terminal message.
+//
+// When the result exceeded the gather budget, batches holds only the
+// in-memory prefix (≈budget bytes) and the remainder sits as raw payload
+// frames in the scratch file at spillPath, to be replayed lazily by
+// gatherReplayStream. The renamer, when set, must be applied to each
+// replayed batch (the prefix already has it applied).
 type gatherResult struct {
-	batches   []*batch.RecordBatch
-	columns   []string
-	totalRows int64
-	workerErr string
+	batches    []*batch.RecordBatch
+	columns    []string
+	totalRows  int64
+	workerErr  string
+	spillPath  string // "" = fully in memory
+	spillBytes int64
+	renamer    *batchRenamer
 }
 
 // gatherReceiver is a two-phase receiver: subscribeGather installs the NATS
@@ -31,11 +43,10 @@ type gatherResult struct {
 type gatherReceiver struct {
 	sub               *nats.Subscription
 	workers           *WorkerRegistry // nil-safe; used to mark worker liveness from gather batches
-	budget            int64           // max accumulated decoded bytes; <=0 = uncapped
+	budget            int64           // max decoded bytes held in memory; <=0 = uncapped
 	mu                sync.Mutex
 	batches           []*batch.RecordBatch
-	accBytes          int64 // decoded bytes accumulated (MemBytes sum)
-	overBudget        bool
+	accBytes          int64 // decoded bytes accumulated in memory (MemBytes sum)
 	totalRows         int64
 	columns           []string
 	workerErr         string
@@ -43,6 +54,15 @@ type gatherReceiver struct {
 	expectedTerminals int
 	done              chan struct{}
 	msgCount          atomic.Int64 // diagnostic: incremented on every message received
+
+	// Spill state: once accBytes reaches budget, raw payload frames are
+	// appended to a local scratch file instead of being decoded.
+	spillFile   *os.File
+	spillW      *bufio.Writer
+	spillPath   string
+	spillBytes  int64
+	spillFailed bool // scratch write failed → clean per-query fail (old behavior)
+	claimed     bool // wait() handed spill ownership to the gatherResult
 }
 
 // subscribeGather installs the NATS subscription. Must be called BEFORE
@@ -54,14 +74,19 @@ type gatherReceiver struct {
 // non-nil, every received gather batch updates LastSeen for the emitting
 // worker via WorkerRegistry.MarkWorkerSeen.
 //
-// budget caps the decoded bytes the receiver will accumulate (<=0 =
-// uncapped). The receiver was the last big uncharged coordinator
+// budget caps the decoded bytes the receiver holds in coordinator heap
+// (<=0 = uncapped). The receiver was the last big uncharged coordinator
 // accumulator: a distributed SELECT * or no-LIMIT high-cardinality GROUP
 // BY landed its entire result in coordinator heap and OOM-killed the
-// process — taking every in-flight query with it. Exceeding the budget
-// fails THIS query cleanly instead (the accumulated batches are dropped
-// immediately to relieve pressure; terminals keep counting so wait()
-// returns promptly).
+// process — taking every in-flight query with it. Past the budget the
+// receiver degrades gracefully: the remaining payload frames are appended
+// raw (still WSHF-encoded, not decoded) to a local scratch file, and the
+// result is replayed lazily disk→wire by gatherReplayStream. Only if the
+// scratch write itself fails does the query fail cleanly (the process
+// still must not die for one query's result size).
+//
+// The caller that successfully subscribes MUST `defer recv.discard()` so
+// scratch is removed on every path where wait() never claims the result.
 func subscribeGather(nc *nats.Conn, subject string, expectedTerminals int, workers *WorkerRegistry, budget int64) (*gatherReceiver, error) {
 	r := &gatherReceiver{
 		expectedTerminals: expectedTerminals,
@@ -120,9 +145,16 @@ func (r *gatherReceiver) handleParsed(msg *distributed.GatherBatchMsg) {
 	if len(msg.Payload) == 0 {
 		return
 	}
-	// Once over budget the query is already failing — skip the decode
-	// work for the remaining stream instead of burning CPU on it.
-	if r.overBudget {
+	// Once the query is failing (scratch write error) or the result has
+	// been claimed/discarded, skip the work for the remaining stream.
+	if r.spillFailed || r.claimed {
+		return
+	}
+	// In-memory prefix is full — spill the raw frame. The first payload
+	// always decodes (accBytes starts at 0 < budget), so columns are
+	// already resolved by the time spilling starts.
+	if r.budget > 0 && r.accBytes >= r.budget {
+		r.spillFrameLocked(msg)
 		return
 	}
 	decoded, err := readShuffleBatches(msg.Payload)
@@ -144,15 +176,79 @@ func (r *gatherReceiver) handleParsed(msg *distributed.GatherBatchMsg) {
 		r.accBytes += b.MemBytes()
 		r.batches = append(r.batches, b)
 	}
-	if r.budget > 0 && r.accBytes > r.budget {
-		r.overBudget = true
-		r.batches = nil // free what's accumulated — the query fails, the process must not
-		if r.workerErr == "" {
-			r.workerErr = fmt.Sprintf(
-				"result exceeded the coordinator gather budget (%d MB accumulated > %d MB): add a LIMIT, or raise the budget (Config.GatherResultBudget / GOMEMLIMIT)",
-				r.accBytes>>20, r.budget>>20)
+}
+
+// spillFrameLocked appends one raw payload frame ([uint32 LE length][WSHF
+// payload]) to the scratch file. Decode cost is paid once, at replay.
+// Row accounting uses the message's RowCount (stamped by the worker sink);
+// the actual sent-row count downstream comes from the replayed batches, so
+// a zero RowCount from an old worker only skews the TotalRows statistic.
+// Caller holds r.mu.
+func (r *gatherReceiver) spillFrameLocked(msg *distributed.GatherBatchMsg) {
+	if r.spillFile == nil {
+		f, err := os.CreateTemp("", "wadjet-gather-*.frames")
+		if err != nil {
+			r.failSpillLocked(fmt.Errorf("creating gather scratch: %w", err))
+			return
 		}
+		r.spillFile = f
+		r.spillPath = f.Name()
+		r.spillW = bufio.NewWriterSize(f, 1<<16)
 	}
+	var hdr [4]byte
+	binary.LittleEndian.PutUint32(hdr[:], uint32(len(msg.Payload)))
+	if _, err := r.spillW.Write(hdr[:]); err != nil {
+		r.failSpillLocked(fmt.Errorf("writing gather scratch: %w", err))
+		return
+	}
+	if _, err := r.spillW.Write(msg.Payload); err != nil {
+		r.failSpillLocked(fmt.Errorf("writing gather scratch: %w", err))
+		return
+	}
+	r.spillBytes += int64(len(msg.Payload))
+	r.totalRows += int64(msg.RowCount)
+}
+
+// failSpillLocked records a scratch failure: the query fails cleanly (the
+// accumulated result is dropped immediately to relieve pressure; terminals
+// keep counting so wait() returns promptly). Caller holds r.mu.
+func (r *gatherReceiver) failSpillLocked(err error) {
+	r.spillFailed = true
+	if r.workerErr == "" {
+		r.workerErr = fmt.Sprintf(
+			"result exceeded the coordinator gather budget (%d MB in memory) and spilling to scratch failed: %v — add a LIMIT, raise the budget (Config.GatherResultBudget / GOMEMLIMIT), or free local disk",
+			r.accBytes>>20, err)
+	}
+	r.batches = nil
+	r.dropSpillLocked()
+}
+
+// dropSpillLocked closes and removes the scratch file. Caller holds r.mu.
+func (r *gatherReceiver) dropSpillLocked() {
+	if r.spillFile != nil {
+		r.spillFile.Close()
+		r.spillFile = nil
+		r.spillW = nil
+	}
+	if r.spillPath != "" {
+		os.Remove(r.spillPath)
+		r.spillPath = ""
+	}
+}
+
+// discard releases everything the receiver still owns — buffered batches
+// and unclaimed spill scratch. No-op once wait() has handed the result
+// off. Idempotent; `defer recv.discard()` at every subscribe site is the
+// contract that keeps scratch from leaking when wait() is never reached.
+func (r *gatherReceiver) discard() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.claimed {
+		return
+	}
+	r.spillFailed = true // block any late frame from recreating scratch
+	r.batches = nil
+	r.dropSpillLocked()
 }
 
 // SetExpectedTerminals updates the terminal-count threshold after the
@@ -198,9 +294,14 @@ func (r *gatherReceiver) registerWithDataPlane(srv *dataplane.Server, queryID st
 }
 
 // wait blocks until all expected terminal messages arrive, ctx is done,
-// or the timeout fires. Always unsubscribes before returning.
+// or the timeout fires. Always unsubscribes before returning. On success
+// the returned gatherResult takes ownership of the spill scratch (if any);
+// on every error path the receiver keeps ownership and the caller's
+// deferred discard() removes it.
 func (r *gatherReceiver) wait(ctx context.Context, timeout time.Duration) (*gatherResult, error) {
-	defer r.sub.Unsubscribe()
+	if r.sub != nil {
+		defer r.sub.Unsubscribe()
+	}
 	select {
 	case <-r.done:
 	case <-time.After(timeout):
@@ -217,10 +318,29 @@ func (r *gatherReceiver) wait(ctx context.Context, timeout time.Duration) (*gath
 	if r.workerErr != "" {
 		return nil, fmt.Errorf("gather worker error: %s", r.workerErr)
 	}
-	return &gatherResult{
+	gr := &gatherResult{
 		batches:   r.batches,
 		columns:   r.columns,
 		totalRows: r.totalRows,
-	}, nil
+	}
+	if r.spillFile != nil {
+		if err := r.spillW.Flush(); err != nil {
+			r.dropSpillLocked()
+			return nil, fmt.Errorf("flushing gather scratch: %w", err)
+		}
+		if err := r.spillFile.Close(); err != nil {
+			r.spillFile = nil
+			r.spillW = nil
+			r.dropSpillLocked()
+			return nil, fmt.Errorf("closing gather scratch: %w", err)
+		}
+		r.spillFile = nil
+		r.spillW = nil
+		gr.spillPath = r.spillPath
+		gr.spillBytes = r.spillBytes
+		r.spillPath = ""
+	}
+	r.claimed = true
+	r.batches = nil
+	return gr, nil
 }
-

--- a/internal/coordinator/gather_replay.go
+++ b/internal/coordinator/gather_replay.go
@@ -1,0 +1,129 @@
+package coordinator
+
+import (
+	"bufio"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+)
+
+// maxGatherFrameBytes sanity-bounds a replayed frame's declared length.
+// Frames are single GatherBatchMsg payloads, themselves bounded by the
+// NATS payload limit (8 MB default); anything larger means scratch
+// corruption and must fail rather than allocate unbounded.
+const maxGatherFrameBytes = 64 << 20
+
+// gatherReplayStream is the lazy BatchStream behind an over-budget gather
+// result: the decoded in-memory prefix first (references dropped as they
+// are handed out), then the raw WSHF payload frames replayed one at a time
+// from the scratch file. The scratch file is deleted the moment it is
+// exhausted — or on Close, whichever comes first. Single consumer, not
+// goroutine-safe (same contract as BatchStream).
+type gatherReplayStream struct {
+	prefix  []*batch.RecordBatch
+	idx     int
+	path    string
+	f       *os.File
+	rd      *bufio.Reader
+	pending []*batch.RecordBatch // decoded batches from the current frame
+	pendIdx int
+	renamer *batchRenamer // applied to replayed batches; prefix is pre-applied
+	frame   []byte        // reusable frame read buffer
+}
+
+func newGatherReplayStream(prefix []*batch.RecordBatch, path string, renamer *batchRenamer) *gatherReplayStream {
+	return &gatherReplayStream{prefix: prefix, path: path, renamer: renamer}
+}
+
+func (s *gatherReplayStream) Next(_ context.Context) (*batch.RecordBatch, error) {
+	// In-memory prefix first.
+	for s.idx < len(s.prefix) {
+		b := s.prefix[s.idx]
+		s.prefix[s.idx] = nil
+		s.idx++
+		if b != nil {
+			return b, nil
+		}
+	}
+	s.prefix = nil
+	for {
+		// Hand out the rest of the current frame's batches.
+		for s.pendIdx < len(s.pending) {
+			b := s.pending[s.pendIdx]
+			s.pending[s.pendIdx] = nil
+			s.pendIdx++
+			if b != nil {
+				return b, nil
+			}
+		}
+		s.pending = nil
+		s.pendIdx = 0
+
+		if s.path == "" {
+			return nil, nil // exhausted (or never spilled)
+		}
+		if s.f == nil {
+			f, err := os.Open(s.path)
+			if err != nil {
+				return nil, fmt.Errorf("opening gather scratch: %w", err)
+			}
+			s.f = f
+			s.rd = bufio.NewReaderSize(f, 1<<16)
+		}
+		var hdr [4]byte
+		if _, err := io.ReadFull(s.rd, hdr[:]); err != nil {
+			if errors.Is(err, io.EOF) {
+				s.dropScratch()
+				return nil, nil
+			}
+			return nil, fmt.Errorf("reading gather scratch frame header: %w", err)
+		}
+		n := binary.LittleEndian.Uint32(hdr[:])
+		if n == 0 || n > maxGatherFrameBytes {
+			return nil, fmt.Errorf("gather scratch corrupt: frame length %d", n)
+		}
+		if cap(s.frame) < int(n) {
+			s.frame = make([]byte, n)
+		}
+		s.frame = s.frame[:n]
+		if _, err := io.ReadFull(s.rd, s.frame); err != nil {
+			return nil, fmt.Errorf("reading gather scratch frame: %w", err)
+		}
+		decoded, err := readShuffleBatches(s.frame)
+		if err != nil {
+			return nil, fmt.Errorf("decoding gather scratch frame: %w", err)
+		}
+		if s.renamer != nil {
+			for i, b := range decoded {
+				decoded[i] = s.renamer.apply(b)
+			}
+		}
+		s.pending = decoded
+	}
+}
+
+// dropScratch closes and removes the scratch file.
+func (s *gatherReplayStream) dropScratch() {
+	if s.f != nil {
+		s.f.Close()
+		s.f = nil
+		s.rd = nil
+	}
+	if s.path != "" {
+		os.Remove(s.path)
+		s.path = ""
+	}
+}
+
+// Close releases the prefix, pending batches, and scratch file. Idempotent.
+func (s *gatherReplayStream) Close() error {
+	s.prefix = nil
+	s.pending = nil
+	s.dropScratch()
+	return nil
+}

--- a/internal/coordinator/gather_spill_e2e_test.go
+++ b/internal/coordinator/gather_spill_e2e_test.go
@@ -1,0 +1,171 @@
+package coordinator
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/storage/catalog"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+	"github.com/citc-tech/wadjet/internal/worker"
+)
+
+// TestGatherBudgetSpill_E2E_RowIdentical is the end-to-end regression test
+// for the streaming-SQLResult refactor: a distributed no-LIMIT query whose
+// result exceeds Config.GatherResultBudget must (a) come back as a LAZY
+// SQLResult (in-memory prefix + scratch replay), not a hard failure (the
+// PR #142 interim behavior), and (b) yield exactly the same rows as the
+// uncapped run.
+func TestGatherBudgetSpill_E2E_RowIdentical(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	t.Cleanup(cancel)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	natsCfg := distributed.DefaultNATSConfig()
+	natsCfg.Port = -1
+	natsCfg.StoreDir = t.TempDir()
+	embeddedNATS, err := distributed.NewEmbeddedNATS(natsCfg, logger)
+	if err != nil {
+		t.Fatalf("starting NATS: %v", err)
+	}
+	t.Cleanup(embeddedNATS.Shutdown)
+
+	nc, err := distributed.ConnectInProcess(embeddedNATS.Server())
+	if err != nil {
+		t.Fatalf("connecting to NATS: %v", err)
+	}
+	t.Cleanup(func() { nc.Close() })
+
+	js, err := distributed.NewJetStream(nc)
+	if err != nil {
+		t.Fatalf("creating JetStream: %v", err)
+	}
+	if err := distributed.SetupStreams(ctx, js); err != nil {
+		t.Fatalf("setting up streams: %v", err)
+	}
+
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(ctx, "test"); err != nil {
+		t.Fatal(err)
+	}
+	kv, err := catalog.NewNATSKV(js)
+	if err != nil {
+		t.Fatalf("creating NATS KV: %v", err)
+	}
+	cat := catalog.New(kv, store, "test")
+	if err := cat.Init(ctx); err != nil {
+		t.Fatalf("catalog init: %v", err)
+	}
+
+	// One table, 20K rows ≈ several hundred KB decoded — far past the
+	// 32 KiB budget used below, far under the uncapped default.
+	schema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "n", Type: parquet.TypeInt64},
+		{Name: "s", Type: parquet.TypeString},
+	}}
+	const numRows = 20000
+	rows := make([]map[string]any, numRows)
+	for i := range rows {
+		rows[i] = map[string]any{"n": int64(i), "s": fmt.Sprintf("val-%06d", i)}
+	}
+	if err := cat.CreateTable(ctx, "nums", schema, nil); err != nil {
+		t.Fatalf("creating table: %v", err)
+	}
+	var buf bytes.Buffer
+	pw, err := parquet.NewWriter(&buf, schema, parquet.DefaultWriterConfig())
+	if err != nil {
+		t.Fatalf("parquet writer: %v", err)
+	}
+	if err := pw.WriteRows(rows); err != nil {
+		t.Fatalf("writing rows: %v", err)
+	}
+	if err := pw.Close(); err != nil {
+		t.Fatalf("closing writer: %v", err)
+	}
+	pdata := buf.Bytes()
+	const filePath = "tables/nums/chunk_0001.parquet"
+	if _, err := store.Put(ctx, "test", filePath, bytes.NewReader(pdata), int64(len(pdata)), "application/octet-stream"); err != nil {
+		t.Fatalf("storing parquet: %v", err)
+	}
+	if err := cat.AddFiles(ctx, "nums", map[string]string{}, "tables/nums/", []catalog.FileEntry{{
+		Path:      filePath,
+		SizeBytes: int64(len(pdata)),
+		NumRows:   numRows,
+		CreatedAt: time.Now(),
+	}}); err != nil {
+		t.Fatalf("adding to manifest: %v", err)
+	}
+
+	w := worker.New(worker.Config{
+		NATSUrl:       embeddedNATS.ClientURL(),
+		MaxConcurrent: 4,
+		CacheBytes:    64 * 1024 * 1024,
+	}, store, nc, js, logger)
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("starting worker: %v", err)
+	}
+	t.Cleanup(w.Stop)
+
+	coord := New(Config{
+		NATSUrl:            embeddedNATS.ClientURL(),
+		ResultBucket:       "test",
+		GatherResultBudget: -1, // uncapped baseline first
+	}, cat, nc, js, logger)
+	coord.workers.record(distributed.WorkerHeartbeat{WorkerID: "fake-worker-0", Timestamp: time.Now()})
+
+	const sql = "SELECT n, s FROM nums"
+	canon := func(rs []map[string]any) []string {
+		out := make([]string, len(rs))
+		for i, r := range rs {
+			out[i] = fmt.Sprintf("%v|%v", r["n"], r["s"])
+		}
+		sort.Strings(out)
+		return out
+	}
+
+	baseline, err := coord.ExecuteSQL(ctx, sql)
+	if err != nil {
+		t.Fatalf("uncapped ExecuteSQL: %v", err)
+	}
+	if baseline.stream != nil {
+		t.Fatal("uncapped result must be materialized, not lazy")
+	}
+	baseRows := canon(mustRows(t, baseline))
+	if len(baseRows) != numRows {
+		t.Fatalf("uncapped rows = %d, want %d", len(baseRows), numRows)
+	}
+
+	// Tiny budget: the same query must DEGRADE to the lazy spill-replay
+	// form and still return every row.
+	coord.config.GatherResultBudget = 32 * 1024
+	capped, err := coord.ExecuteSQL(ctx, sql)
+	if err != nil {
+		t.Fatalf("capped ExecuteSQL must degrade gracefully, got error: %v", err)
+	}
+	if capped.stream == nil {
+		t.Fatal("capped result is not lazy — budget did not trigger spill")
+	}
+	if capped.Batches != nil {
+		t.Fatal("lazy result must not also carry materialized Batches")
+	}
+	if capped.TotalRows != numRows {
+		t.Fatalf("capped TotalRows = %d, want %d", capped.TotalRows, numRows)
+	}
+	cappedRows := canon(mustRows(t, capped))
+	if len(cappedRows) != numRows {
+		t.Fatalf("capped rows = %d, want %d", len(cappedRows), numRows)
+	}
+	for i := range baseRows {
+		if baseRows[i] != cappedRows[i] {
+			t.Fatalf("row %d differs: uncapped %q vs capped %q", i, baseRows[i], cappedRows[i])
+		}
+	}
+}

--- a/internal/coordinator/grace_hash_distributed_repro_test.go
+++ b/internal/coordinator/grace_hash_distributed_repro_test.go
@@ -150,8 +150,8 @@ FROM micro_build b JOIN micro_probe p ON b.build_key = p.probe_key`
 	if res.Error != "" {
 		t.Fatalf("query error after %v: %s", elapsed, res.Error)
 	}
-	t.Logf("distributed in-process: %d rows in %v", len(res.Rows()), elapsed)
-	if len(res.Rows()) == 0 {
+	t.Logf("distributed in-process: %d rows in %v", len(mustRows(t, res)), elapsed)
+	if len(mustRows(t, res)) == 0 {
 		t.Fatal("expected non-zero rows")
 	}
 }

--- a/internal/coordinator/multi_worker_test.go
+++ b/internal/coordinator/multi_worker_test.go
@@ -170,7 +170,7 @@ func TestShuffleCorrectness(t *testing.T) {
 			if result.Error != "" {
 				t.Fatalf("Q%02d error: %s", tt.qNum, result.Error)
 			}
-			rows := result.Rows()
+			rows := mustRows(t, result)
 			t.Logf("Q%02d: %d rows in %v", tt.qNum, len(rows), elapsed)
 			if len(rows) > 0 {
 				t.Logf("  first row: %v", rows[0])
@@ -355,7 +355,7 @@ func TestDistributedFusedAgg(t *testing.T) {
 	if result.Error != "" {
 		t.Fatalf("Q01 error: %s", result.Error)
 	}
-	rows := result.Rows()
+	rows := mustRows(t, result)
 	t.Logf("Q01: %d rows (plan:\n%s)", len(rows), result.Plan)
 	if len(rows) != 6 {
 		// SF0.01 Q01 returns 6 rows (distinct l_returnflag × l_linestatus groups)

--- a/internal/coordinator/native_dag_count_avg_test.go
+++ b/internal/coordinator/native_dag_count_avg_test.go
@@ -90,7 +90,7 @@ func TestNativeDAG_CountMultiFile_MergesAsSum(t *testing.T) {
 		t.Fatalf("native DAG: %v", err)
 	}
 	got := map[int64]int64{}
-	for _, r := range res.Rows() {
+	for _, r := range mustRows(t, res) {
 		got[toInt64(r["k"])] = toInt64(r["n"])
 	}
 	want := map[int64]int64{1: 6, 2: 6}
@@ -133,7 +133,7 @@ func TestNativeDAG_SumMultiFile_MergesAsSum(t *testing.T) {
 		t.Fatalf("native DAG: %v", err)
 	}
 	got := map[int64]int64{}
-	for _, r := range res.Rows() {
+	for _, r := range mustRows(t, res) {
 		got[toInt64(r["k"])] = toInt64(r["s"])
 	}
 	want := map[int64]int64{1: 10, 2: 30} // 1: 1+2+3+4=10; 2: 10+20=30
@@ -184,7 +184,7 @@ func TestNativeDAG_AvgMultiFile_FallbackOrCorrect(t *testing.T) {
 		t.Fatalf("native DAG: %v", err)
 	}
 	got := map[int64]float64{}
-	for _, r := range res.Rows() {
+	for _, r := range mustRows(t, res) {
 		switch x := r["a"].(type) {
 		case float64:
 			got[toInt64(r["k"])] = x

--- a/internal/coordinator/native_dag_test.go
+++ b/internal/coordinator/native_dag_test.go
@@ -83,7 +83,7 @@ func TestNativeDAG_SumMerge(t *testing.T) {
 		t.Fatalf("native DAG: %v", err)
 	}
 	sums := map[int64]int64{}
-	for _, r := range res.Rows() {
+	for _, r := range mustRows(t, res) {
 		sums[toInt64(r["k"])] = toInt64(r["total"])
 	}
 	if sums[1] != 30 {
@@ -130,7 +130,7 @@ func TestNativeDAG_ScanAggregateWithFilter(t *testing.T) {
 		t.Fatalf("legacy ExecuteSQL: %v", err)
 	}
 	legacyCounts := map[int64]int64{}
-	for _, r := range legacyRes.Rows() {
+	for _, r := range mustRows(t, legacyRes) {
 		legacyCounts[toInt64(r["k"])] = toInt64(r["n"])
 	}
 
@@ -140,7 +140,7 @@ func TestNativeDAG_ScanAggregateWithFilter(t *testing.T) {
 		t.Fatalf("native DAG ExecuteSQL: %v", err)
 	}
 	natCounts := map[int64]int64{}
-	for _, r := range natRes.Rows() {
+	for _, r := range mustRows(t, natRes) {
 		natCounts[toInt64(r["k"])] = toInt64(r["n"])
 	}
 
@@ -202,7 +202,7 @@ func TestNativeDAG_CountMultiPartial(t *testing.T) {
 		t.Fatalf("native DAG: %v", err)
 	}
 	counts := map[int64]int64{}
-	for _, r := range res.Rows() {
+	for _, r := range mustRows(t, res) {
 		counts[toInt64(r["k"])] = toInt64(r["n"])
 	}
 	if counts[1] != 2 || counts[2] != 2 {
@@ -237,7 +237,7 @@ func TestNativeDAG_AvgFallback(t *testing.T) {
 		t.Fatalf("native DAG: %v", err)
 	}
 	avgs := map[int64]float64{}
-	for _, r := range res.Rows() {
+	for _, r := range mustRows(t, res) {
 		switch x := r["a"].(type) {
 		case float64:
 			avgs[toInt64(r["k"])] = x
@@ -304,7 +304,7 @@ func TestNativeDAG_BroadcastJoinProbeSplit(t *testing.T) {
 	}
 
 	got := map[string]int64{}
-	for _, r := range res.Rows() {
+	for _, r := range mustRows(t, res) {
 		got[r["label"].(string)] = toInt64(r["n"])
 	}
 	// Each chunk has 25 rows with fk values cycling 1,2,3,1,2,3,...
@@ -381,7 +381,7 @@ func TestNativeDAG_BroadcastJoinReplicateMaterialization(t *testing.T) {
 	}
 
 	got := map[string]int64{}
-	for _, r := range res.Rows() {
+	for _, r := range mustRows(t, res) {
 		got[r["label"].(string)] = toInt64(r["n"])
 	}
 	want := map[string]int64{"A": 1, "B": 2, "C": 3}

--- a/internal/coordinator/orchestrate_gather.go
+++ b/internal/coordinator/orchestrate_gather.go
@@ -18,15 +18,16 @@ import (
 // the legacy side-channel.
 func (c *Coordinator) orchestrateGather(
 	stage physical.Stage,
-	batches []*batch.RecordBatch,
+	in BatchStream,
 	columns []string,
 	mi *logical.MergeInfo,
 ) ([]*batch.RecordBatch, int64, error) {
 	if stage.Type != physical.StageExchangeGather {
+		in.Close()
 		return nil, 0, fmt.Errorf(
 			"orchestrate gather: wrong stage type %q (expected %q)",
 			stage.Type, physical.StageExchangeGather,
 		)
 	}
-	return c.mergeProbePartials(batches, columns, mi)
+	return c.mergeProbePartials(in, columns, mi)
 }

--- a/internal/coordinator/orchestrate_gather_test.go
+++ b/internal/coordinator/orchestrate_gather_test.go
@@ -13,7 +13,7 @@ func TestOrchestrateGather_WrongType(t *testing.T) {
 	coord := &Coordinator{}
 	_, _, err := coord.orchestrateGather(
 		physical.Stage{Type: physical.StageExchangeReplicate},
-		nil, nil, nil,
+		newSliceStream(nil), nil, nil,
 	)
 	if err == nil {
 		t.Fatal("expected error for wrong stage type")

--- a/internal/coordinator/pool_pressure_dispatch_test.go
+++ b/internal/coordinator/pool_pressure_dispatch_test.go
@@ -76,8 +76,8 @@ func TestExecuteStageDAG_NoPoolPressureDeadlock(t *testing.T) {
 		if r.res == nil || r.res.Error != "" {
 			t.Fatalf("query reported error: %+v", r.res)
 		}
-		if len(r.res.Rows()) != 1 {
-			t.Fatalf("expected 1 row, got %d", len(r.res.Rows()))
+		if len(mustRows(t, r.res)) != 1 {
+			t.Fatalf("expected 1 row, got %d", len(mustRows(t, r.res)))
 		}
 	case <-time.After(15 * time.Second):
 		t.Fatalf("query did not complete within 15s under high pool pressure — pool-pressure dispatch gate may have been reintroduced (see execute_stage_dag.go and feedback memory project_sf10_deploy_2026-04-29.md)")

--- a/internal/coordinator/q07_sf10_repro_test.go
+++ b/internal/coordinator/q07_sf10_repro_test.go
@@ -29,7 +29,7 @@ func TestQ07SF01InProcess(t *testing.T) {
 	if res.Error != "" {
 		t.Fatalf("Q07 error: %s", res.Error)
 	}
-	rows := res.Rows()
+	rows := mustRows(t, res)
 	t.Logf("Q07 in-process distributed SF0.1: %d rows", len(rows))
 	if len(rows) == 0 {
 		t.Errorf("Q07 returned 0 rows; expected at least one (FRANCE/GERMANY pairs by year)")

--- a/internal/coordinator/read_final_results_test.go
+++ b/internal/coordinator/read_final_results_test.go
@@ -28,7 +28,7 @@ func TestReadFinalResults_BudgetCap(t *testing.T) {
 		TaskID:     "t1",
 		Success:    true,
 		NumRows:    2048,
-		InlineData: wshfInt64Payload(t, 2048),
+		InlineData: wshfInt64Payload(t, 2048, 0),
 	})
 
 	c := &Coordinator{

--- a/internal/coordinator/tpch_native_dag_sf01_test.go
+++ b/internal/coordinator/tpch_native_dag_sf01_test.go
@@ -110,7 +110,7 @@ func TestTPCHNativeDAG_SF01(t *testing.T) {
 			}
 			elapsed := time.Since(start)
 
-			snap := canonResultSnapshot(res.Rows())
+			snap := canonResultSnapshot(mustRows(t, res))
 			goldenPath := filepath.Join("testdata", "sf01_native_dag", fmt.Sprintf("q%02d.golden", qNum))
 			if *updateSF01Golden {
 				if err := os.MkdirAll(filepath.Dir(goldenPath), 0o755); err != nil {

--- a/internal/server/async.go
+++ b/internal/server/async.go
@@ -139,10 +139,15 @@ func (s *Server) handleGetQueryResults(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	rows, rowsErr := result.Rows()
+	if rowsErr != nil {
+		writeError(w, http.StatusInternalServerError, "reading result batches: "+rowsErr.Error())
+		return
+	}
 	writeJSON(w, http.StatusOK, QueryResponse{
 		QueryID: result.QueryID,
 		Columns: result.Columns,
-		Rows:    result.Rows(),
+		Rows:    rows,
 		Stats: QueryStats{
 			Elapsed:     result.Elapsed.Round(time.Millisecond).String(),
 			RowsScanned: result.TotalRows,

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -127,10 +127,14 @@ func (g *GRPCServer) Query(ctx context.Context, req *wadjetv1.QueryRequest) (*wa
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "query error: %v", err)
 		}
+		rows, rowsErr := result.Rows()
+		if rowsErr != nil {
+			return nil, status.Errorf(codes.Internal, "reading result batches: %v", rowsErr)
+		}
 		return &wadjetv1.QueryResponse{
 			QueryId: result.QueryID,
 			Columns: result.Columns,
-			Rows:    rowsToProto(result.Rows()),
+			Rows:    rowsToProto(rows),
 			Stats: &wadjetv1.QueryStats{
 				TotalRows: result.TotalRows,
 				Elapsed:   durationpb.New(result.Elapsed),

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -215,14 +215,21 @@ func (g *GRPCServer) QueryStream(req *wadjetv1.QueryRequest, stream wadjetv1.Wad
 // SQLResult's own "prefer iterating Batches" contract on the default-on
 // :9090 server. Peak boxed residency is now one batch (~2K rows) plus the
 // one held-back chunk, and each batch reference is dropped after boxing so
-// the columnar copy can be reclaimed while the stream proceeds.
+// the columnar copy can be reclaimed while the stream proceeds. Lazy
+// (gather-spilled) results replay from local scratch one batch at a time.
 func streamResultBatches(cs *chunkStreamer, result *coordinator.SQLResult) error {
-	batches := result.Batches
-	result.Batches = nil
-	for i := range batches {
-		rows := batches[i].ToRows()
-		batches[i] = nil
-		if err := cs.pushRows(rows); err != nil {
+	stream := result.Stream()
+	defer stream.Close()
+	ctx := context.Background()
+	for {
+		b, err := stream.Next(ctx)
+		if err != nil {
+			return status.Errorf(codes.Internal, "reading result batches: %v", err)
+		}
+		if b == nil {
+			break
+		}
+		if err := cs.pushRows(b.ToRows()); err != nil {
 			return err
 		}
 	}

--- a/internal/server/pgwire/coord_query.go
+++ b/internal/server/pgwire/coord_query.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/coordinator"
 	"github.com/citc-tech/wadjet/wadjet"
 )
 
@@ -46,26 +46,25 @@ func (c *pgConn) canBypassDB() bool {
 	return c.authProvider == nil && c.identity == nil
 }
 
-// queryViaCoord executes sql through coord.ExecuteSQL. The columnar batches
-// are returned as-is, NOT boxed into QueryResult.Rows — the send path boxes
-// one batch (~2K rows) at a time via sendResultRows. The previous shape
-// (batchesToRows up front) materialized the full row set (~10x the columnar
-// footprint) on top of the already-held Batches before writing a single
-// DataRow, on the no-auth standalone/edge production profile — exactly what
-// SQLResult's doc forbids.
+// queryViaCoord executes sql through coord.ExecuteSQL. The result batches
+// are returned as a consuming BatchStream, NOT boxed into QueryResult.Rows
+// — the send path boxes one batch (~2K rows) at a time via sendResultRows.
+// Results that exceeded the coordinator gather budget arrive as a lazy
+// stream replaying from local scratch, so even an over-budget result never
+// materializes fully in coordinator heap. The caller owns the stream and
+// must drain it or Close it (spill scratch lives until then).
 //
 // For Q18 SF10 (60M intermediate rows reduced to 100 by LIMIT), boxing here
 // only ever sees the 100 final rows because coord's native-DAG executor
 // produces the post-LIMIT batches at Gather. Legacy db.Query materialized
 // the full pre-LIMIT pipeline output.
-func (c *pgConn) queryViaCoord(ctx context.Context, sql string) (*wadjet.QueryResult, []*batch.RecordBatch, error) {
+func (c *pgConn) queryViaCoord(ctx context.Context, sql string) (*wadjet.QueryResult, coordinator.BatchStream, error) {
 	res, err := c.coord.ExecuteSQL(ctx, sql)
 	if err != nil {
+		res.Close()
 		return nil, nil, err
 	}
-	batches := res.Batches
-	res.Batches = nil
-	return &wadjet.QueryResult{Columns: res.Columns}, batches, nil
+	return &wadjet.QueryResult{Columns: res.Columns}, res.Stream(), nil
 }
 
 // sendResultRows emits a DataRow per result row and returns the count sent.
@@ -73,7 +72,11 @@ func (c *pgConn) queryViaCoord(ctx context.Context, sql string) (*wadjet.QueryRe
 // batch reference once sent so peak boxed residency stays one batch; boxed
 // rows (legacy db path) are sent as-is. fmtCodes selects the formatted
 // variant used by the extended protocol; nil sends text-format rows.
-func (c *pgConn) sendResultRows(columns []string, batches []*batch.RecordBatch, rows []map[string]any, fmtCodes []int16) int {
+//
+// The stream is always fully closed before returning, including on a
+// mid-stream error — the error is returned so the caller can surface an
+// ErrorResponse after the partial DataRows (legal in the v3 protocol).
+func (c *pgConn) sendResultRows(columns []string, stream coordinator.BatchStream, rows []map[string]any, fmtCodes []int16) (int, error) {
 	sent := 0
 	send := func(row map[string]any) {
 		if len(fmtCodes) > 0 {
@@ -83,14 +86,36 @@ func (c *pgConn) sendResultRows(columns []string, batches []*batch.RecordBatch, 
 		}
 		sent++
 	}
-	for i := range batches {
-		for _, row := range batches[i].ToRows() {
-			send(row)
+	if stream != nil {
+		defer stream.Close()
+		ctx := context.Background()
+		for {
+			b, err := stream.Next(ctx)
+			if err != nil {
+				return sent, err
+			}
+			if b == nil {
+				break
+			}
+			for _, row := range b.ToRows() {
+				send(row)
+			}
 		}
-		batches[i] = nil
 	}
 	for _, row := range rows {
 		send(row)
 	}
-	return sent
+	return sent, nil
+}
+
+// closeDescribeCache releases a cached Describe result stream that Execute
+// never consumed (client error between Describe and Execute, statement
+// re-Parse, connection teardown). Without this an over-budget result's
+// spill scratch would outlive the portal.
+func (c *pgConn) closeDescribeCache() {
+	if c.describeStream != nil {
+		c.describeStream.Close()
+		c.describeStream = nil
+	}
+	c.describeResult = nil
 }

--- a/internal/server/pgwire/coord_query_test.go
+++ b/internal/server/pgwire/coord_query_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/citc-tech/wadjet/internal/coordinator"
 	"github.com/citc-tech/wadjet/internal/engine/batch"
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
 )
@@ -52,7 +53,10 @@ func TestSendResultRows_PerBatch(t *testing.T) {
 	c := &pgConn{conn: rc}
 
 	batches := []*batch.RecordBatch{mk(1, 2, 3), mk(4, 5)}
-	sent := c.sendResultRows([]string{"n"}, batches, nil, nil)
+	sent, err := c.sendResultRows([]string{"n"}, coordinator.NewSliceStream(batches), nil, nil)
+	if err != nil {
+		t.Fatalf("sendResultRows: %v", err)
+	}
 
 	if sent != 5 {
 		t.Errorf("sent = %d, want 5", sent)
@@ -72,7 +76,10 @@ func TestSendResultRows_LegacyRows(t *testing.T) {
 	c := &pgConn{conn: rc}
 
 	rows := []map[string]any{{"n": int64(1)}, {"n": int64(2)}}
-	sent := c.sendResultRows([]string{"n"}, nil, rows, nil)
+	sent, err := c.sendResultRows([]string{"n"}, nil, rows, nil)
+	if err != nil {
+		t.Fatalf("sendResultRows: %v", err)
+	}
 
 	if sent != 2 {
 		t.Errorf("sent = %d, want 2", sent)

--- a/internal/server/pgwire/server.go
+++ b/internal/server/pgwire/server.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/citc-tech/wadjet/internal/auth"
 	"github.com/citc-tech/wadjet/internal/coordinator"
-	"github.com/citc-tech/wadjet/internal/engine/batch"
 	"github.com/citc-tech/wadjet/internal/storage/ingest"
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
 	"github.com/citc-tech/wadjet/wadjet"
@@ -219,19 +218,23 @@ type pgConn struct {
 	sessionVars map[string]string
 
 	// Extended Query protocol state
-	preparedSQL     string               // last parsed statement SQL
-	portalSQL       string               // last bound portal SQL
-	stmts           map[string]string    // named prepared statements
-	described       bool                 // true if Describe was sent for current portal
-	resultFmtCodes  []int16              // result format codes from Bind (0=text, 1=binary)
-	describeResult  *wadjet.QueryResult  // cached Describe result for Execute reuse
-	describeBatches []*batch.RecordBatch // columnar half of describeResult (coord path)
+	preparedSQL    string                  // last parsed statement SQL
+	portalSQL      string                  // last bound portal SQL
+	stmts          map[string]string       // named prepared statements
+	described      bool                    // true if Describe was sent for current portal
+	resultFmtCodes []int16                 // result format codes from Bind (0=text, 1=binary)
+	describeResult *wadjet.QueryResult     // cached Describe result for Execute reuse
+	describeStream coordinator.BatchStream // columnar half of describeResult (coord path)
 
 	// Transaction state: 'I' = idle, 'T' = in transaction, 'E' = failed
 	txState byte
 }
 
 func (c *pgConn) run() {
+	// Release a cached Describe result stream the client never Executed —
+	// for over-budget results the stream pins spill scratch on disk.
+	defer c.closeDescribeCache()
+
 	// Phase 1: Startup
 	if err := c.handleStartup(); err != nil {
 		c.logger.Debug("pgwire startup failed", "err", err)
@@ -780,10 +783,10 @@ func (c *pgConn) handleQuery(sql string) {
 		return
 	}
 	var result *wadjet.QueryResult
-	var batches []*batch.RecordBatch
+	var stream coordinator.BatchStream
 	var err error
 	if c.coord != nil && c.canBypassDB() && shouldRouteThroughCoord(sql) {
-		result, batches, err = c.queryViaCoord(ctx, sql)
+		result, stream, err = c.queryViaCoord(ctx, sql)
 	} else {
 		result, err = c.db.Query(ctx, sql)
 	}
@@ -801,7 +804,13 @@ func (c *pgConn) handleQuery(sql string) {
 			columns = append(columns, k)
 		}
 	}
-	if len(columns) == 0 && len(result.Rows) == 0 && len(batches) == 0 {
+	// Coord-path results always carry columns when any batch exists (the
+	// gather receiver derives them from the first batch's schema), so an
+	// empty columns list means an empty result on both paths.
+	if len(columns) == 0 && len(result.Rows) == 0 {
+		if stream != nil {
+			stream.Close()
+		}
 		c.sendEmptyQuery()
 		c.sendReadyForQuery()
 		return
@@ -814,7 +823,14 @@ func (c *pgConn) handleQuery(sql string) {
 
 	// Send DataRow for each row — coord-path batches are boxed and sent
 	// one batch at a time, never materialized as a whole.
-	sent := c.sendResultRows(columns, batches, result.Rows, nil)
+	sent, sendErr := c.sendResultRows(columns, stream, result.Rows, nil)
+	if sendErr != nil {
+		// Partial DataRows followed by ErrorResponse is legal in the v3
+		// protocol; the client discards the partial result.
+		c.sendError("ERROR", "58030", "reading result batches: "+sendErr.Error())
+		c.sendReadyForQuery()
+		return
+	}
 
 	// Send CommandComplete
 	c.sendCommandComplete(fmt.Sprintf("SELECT %d", sent))
@@ -835,8 +851,7 @@ func (c *pgConn) handleParse(payload []byte) {
 		c.stmts[name] = sql
 	}
 	c.described = false
-	c.describeResult = nil // invalidate cached result for new statement
-	c.describeBatches = nil
+	c.closeDescribeCache() // invalidate cached result for new statement
 
 	// Send ParseComplete ('1')
 	c.sendMsg('1', nil)
@@ -975,10 +990,10 @@ func (c *pgConn) describeSQL(sql string) {
 	ctx, cancel := c.queryContext()
 	defer cancel()
 	var result *wadjet.QueryResult
-	var batches []*batch.RecordBatch
+	var stream coordinator.BatchStream
 	var err error
 	if c.coord != nil && c.canBypassDB() && shouldRouteThroughCoord(sql) {
-		result, batches, err = c.queryViaCoord(ctx, sql)
+		result, stream, err = c.queryViaCoord(ctx, sql)
 	} else {
 		result, err = c.db.Query(ctx, sql)
 	}
@@ -988,8 +1003,9 @@ func (c *pgConn) describeSQL(sql string) {
 		c.sendMsg('n', nil)
 		return
 	}
+	c.closeDescribeCache() // release any prior cached stream before overwriting
 	c.describeResult = result
-	c.describeBatches = batches
+	c.describeStream = stream
 
 	if len(result.ColumnMetas) > 0 {
 		c.sendTypedRowDescription(result.ColumnMetas)
@@ -1057,18 +1073,18 @@ func (c *pgConn) handleExecute(payload []byte) {
 	// RowDescription (critical for SELECT * where Go map iteration order
 	// is non-deterministic).
 	var result *wadjet.QueryResult
-	var batches []*batch.RecordBatch
+	var stream coordinator.BatchStream
 	if c.describeResult != nil {
 		result = c.describeResult
-		batches = c.describeBatches
+		stream = c.describeStream
 		c.describeResult = nil
-		c.describeBatches = nil
+		c.describeStream = nil
 	} else {
 		ctx, cancel := c.queryContext()
 		defer cancel()
 		var err error
 		if c.coord != nil && c.canBypassDB() && shouldRouteThroughCoord(sql) {
-			result, batches, err = c.queryViaCoord(ctx, sql)
+			result, stream, err = c.queryViaCoord(ctx, sql)
 		} else {
 			result, err = c.db.Query(ctx, sql)
 		}
@@ -1085,6 +1101,9 @@ func (c *pgConn) handleExecute(payload []byte) {
 		}
 	}
 	if len(columns) == 0 {
+		if stream != nil {
+			stream.Close()
+		}
 		c.sendCommandComplete("SELECT 0")
 		return
 	}
@@ -1092,7 +1111,11 @@ func (c *pgConn) handleExecute(payload []byte) {
 	// Extended query protocol: Execute sends only DataRow + CommandComplete.
 	// RowDescription was already sent by Describe. Do NOT send it again.
 	// Coord-path batches are boxed and sent one batch at a time.
-	sent := c.sendResultRows(columns, batches, result.Rows, c.resultFmtCodes)
+	sent, sendErr := c.sendResultRows(columns, stream, result.Rows, c.resultFmtCodes)
+	if sendErr != nil {
+		c.sendError("ERROR", "58030", "reading result batches: "+sendErr.Error())
+		return
+	}
 	c.sendCommandComplete(fmt.Sprintf("SELECT %d", sent))
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -387,7 +387,11 @@ func (s *Server) handleQuery(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		rows := result.Rows()
+		rows, rowsErr := result.Rows()
+		if rowsErr != nil {
+			writeError(w, http.StatusInternalServerError, "reading result batches: "+rowsErr.Error())
+			return
+		}
 
 		// Apply cell-level access policies (column masking/denial)
 		if identity != nil && len(rows) > 0 {


### PR DESCRIPTION
## Summary

Implements the streaming-SQLResult refactor (top item in the never-OOM backlog, follow-up to #142).

**SQLResult gains a lazy batch iterator** (`BatchStream` + `Stream()`/`Close()`), and the gather receiver now **degrades gracefully past `Config.GatherResultBudget`** instead of hard-failing the query:

- Under budget: unchanged — decode and accumulate in coordinator heap.
- Past budget: keep the decoded in-memory prefix (≈budget bytes), append the remaining gather payload **raw (WSHF frames, undecoded)** to local scratch, and return a lazy `SQLResult`. `gatherReplayStream` decodes frames one at a time as the consumer iterates — distributed results stream **disk → coordinator → wire** without full materialization. Decode cost for the spilled tail is paid once, at replay.
- Only a scratch-write failure still fails the query (cleanly; the coordinator process never OOMs for one query's result size).
- Scratch ownership is explicit: `wait()` → result, `discard()` reaps on non-claiming paths (deferred at both subscribe sites), Close/exhaustion deletes the file.

**Consumers converted to the iterator** (peak boxed residency stays one batch): pgwire `sendResultRows` + Describe→Execute cache (with cleanup on re-Parse and connection teardown, ErrorResponse on mid-stream replay errors), gRPC `streamResultBatches`, alerts `boxRowsUpTo` (early Close at the row cap releases scratch), `mergeProbePartials`/`deduplicatePartials` (DISTINCT path consumes streaming into the GroupByAll aggregate), and `SQLResult.Rows()` (now surfaces replay errors; stays repeatable on materialized results). `applyOutputRenames` is refactored into `batchRenamer` so SELECT-list projection applies identically to replayed batches.

## Tests

- Receiver spill + replay row-identical (arrival order), scratch lifecycle: claim / discard / Close-mid-replay / delete-on-exhaustion, late-frame-after-discard guard
- Spill-write failure → clean per-query fail (process survives)
- Renamer applied to replayed batches (schema names can't diverge mid-stream)
- **E2E**: 1-worker cluster, 20K-row no-LIMIT query, 32 KiB budget → lazy result, row-identical to the uncapped run
- BatchStream/SQLResult unit tests; pgwire/alerts/merge tests updated to the stream form

## Gates

- Full unit suite green (coordinator 225s incl. distributed E2Es), `-race` on coordinator/pgwire/server
- TPC-H SF0.01 correctness: pass
- `tpch-harness -mode=local`: **PASS** (22 queries + micros, distributed gate)

SF100 note: TPC-H result sets never trip the default budget (GOMEMLIMIT/2), so an SF100 run would not exercise the new path beyond what the local harness already does — recommending no dedicated A/B for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)