### PR TITLE
fix(planner): CTE columnar spill-backed materialization + pushdown fence (closes #127)

### DIFF
--- a/internal/engine/exec/batch_collector.go
+++ b/internal/engine/exec/batch_collector.go
@@ -205,6 +205,109 @@ func (c *SpillableBatchCollector) NextReplay(_ context.Context) (*batch.RecordBa
 	return b, nil
 }
 
+// NewReplaySource returns an exec.Source that streams the collected batches
+// WITHOUT consuming the collector: spilled runs are re-read from disk (and
+// not deleted), in-memory batches are handed out as Sel-isolated shallow
+// clones so downstream operators cannot corrupt the cached data by setting
+// Sel in place (same pattern as catalogScanSource cache replay). Multiple
+// replay sources may be created and run concurrently — each re-reads the
+// spill scratch independently.
+//
+// Contract: the collector must be fully populated before the first replay
+// source is created, and must not be Consumed into or Released while any
+// replay is in flight. Spill scratch lives until Release.
+func (c *SpillableBatchCollector) NewReplaySource() *CollectorReplaySource {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return &CollectorReplaySource{
+		batches:    c.batches,
+		spillFiles: c.spillFiles,
+	}
+}
+
+// CollectorReplaySource is a non-consuming exec.Source over a populated
+// SpillableBatchCollector: spilled runs first (decoded fresh per replay),
+// then the in-memory tail as Sel-isolated shallow clones. Next is
+// mutex-guarded so a parallel pipeline can share one instance.
+type CollectorReplaySource struct {
+	batches    []*batch.RecordBatch
+	spillFiles []string
+
+	mu      sync.Mutex
+	fileIdx int
+	rd      *spillBatchReader
+	memIdx  int
+}
+
+func (s *CollectorReplaySource) Init(_ context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.rd != nil {
+		s.rd.Close()
+		s.rd = nil
+	}
+	s.fileIdx = 0
+	s.memIdx = 0
+	return nil
+}
+
+func (s *CollectorReplaySource) Next(_ context.Context) (*batch.RecordBatch, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for {
+		if s.rd != nil {
+			b, err := s.rd.Next()
+			if err != nil {
+				return nil, err
+			}
+			if b != nil {
+				return b, nil
+			}
+			s.rd.Close()
+			s.rd = nil
+			s.fileIdx++
+		}
+		if s.fileIdx >= len(s.spillFiles) {
+			break
+		}
+		rd, err := openSpillBatchReader(s.spillFiles[s.fileIdx])
+		if err != nil {
+			return nil, err
+		}
+		s.rd = rd
+	}
+	for s.memIdx < len(s.batches) {
+		b := s.batches[s.memIdx]
+		s.memIdx++
+		if b == nil {
+			continue
+		}
+		// Shallow clone: shared column vectors (read-only by operator
+		// contract), independent Sel copy so in-place Sel assignment by
+		// filters cannot clobber the cached batch or a concurrent replay.
+		clone := &batch.RecordBatch{
+			Schema:  b.Schema,
+			Columns: append([]*batch.Vector(nil), b.Columns...),
+			Len:     b.Len,
+		}
+		if b.Sel != nil {
+			clone.Sel = append([]uint32(nil), b.Sel...)
+		}
+		return clone, nil
+	}
+	return nil, nil
+}
+
+func (s *CollectorReplaySource) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.rd != nil {
+		s.rd.Close()
+		s.rd = nil
+	}
+	return nil
+}
+
 // Release frees everything still held: the open replay reader, remaining
 // spill scratch, buffered batch references, and the tracker reservation.
 // Idempotent — call from the owner's Close and every error path.

--- a/internal/engine/exec/batch_collector_test.go
+++ b/internal/engine/exec/batch_collector_test.go
@@ -195,3 +195,130 @@ func TestBloomAddBatch_MatchesOneShot(t *testing.T) {
 		}
 	}
 }
+
+// drainReplaySource pulls every key from a CollectorReplaySource.
+func drainReplaySource(tb testing.TB, s *CollectorReplaySource) []int64 {
+	tb.Helper()
+	if err := s.Init(context.Background()); err != nil {
+		tb.Fatal(err)
+	}
+	var keys []int64
+	for {
+		b, err := s.Next(context.Background())
+		if err != nil {
+			tb.Fatal(err)
+		}
+		if b == nil {
+			if err := s.Close(); err != nil {
+				tb.Fatal(err)
+			}
+			return keys
+		}
+		for _, r := range b.ToRows() {
+			keys = append(keys, r["k"].(int64))
+		}
+	}
+}
+
+// Regression tests for issue #127 (CTE columnar materialization): the
+// replay source must stream the collected batches WITHOUT consuming the
+// collector — every CTE reference replays the same data, spill scratch
+// survives until Release, and handed-out batches are Sel-isolated so a
+// downstream filter cannot corrupt the cache or a concurrent replay.
+func TestCollectorReplaySource_NonConsumingTwice(t *testing.T) {
+	c := &SpillableBatchCollector{}
+	ctx := context.Background()
+	if err := c.Consume(ctx, collectorBatch(t, 0, 5)); err != nil {
+		t.Fatal(err)
+	}
+	sel := collectorBatch(t, 5, 4)
+	sel.Sel = []uint32{1, 3} // keys 6, 8
+	if err := c.Consume(ctx, sel); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []int64{0, 1, 2, 3, 4, 6, 8}
+	for pass := 0; pass < 2; pass++ {
+		keys := drainReplaySource(t, c.NewReplaySource())
+		if len(keys) != len(want) {
+			t.Fatalf("pass %d: replayed %d rows, want %d (%v)", pass, len(keys), len(want), keys)
+		}
+		for i := range want {
+			if keys[i] != want[i] {
+				t.Fatalf("pass %d: keys[%d] = %d, want %d", pass, i, keys[i], want[i])
+			}
+		}
+	}
+	if c.Rows() != 7 {
+		t.Fatal("replay sources consumed the collector")
+	}
+	c.Release()
+}
+
+func TestCollectorReplaySource_SpilledTwiceAndScratchSurvives(t *testing.T) {
+	forceTinyRuns(t)
+	tracker := memory.NewTracker("collector-test", 1)
+	sm, err := memory.NewSpillManager(t.TempDir(), tracker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := &SpillableBatchCollector{Spill: sm}
+	ctx := context.Background()
+	const total = 10_000
+	for start := 0; start < total; start += 500 {
+		if err := c.Consume(ctx, collectorBatch(t, start, 500)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	spillGlob := filepath.Join(sm.SpillDir(), "bridge-collect-*.bin")
+	if files, _ := filepath.Glob(spillGlob); len(files) == 0 {
+		t.Fatal("expected spill files under pressure, found none")
+	}
+
+	for pass := 0; pass < 2; pass++ {
+		keys := drainReplaySource(t, c.NewReplaySource())
+		if len(keys) != total {
+			t.Fatalf("pass %d: replayed %d rows, want %d", pass, len(keys), total)
+		}
+		for i, k := range keys {
+			if k != int64(i) {
+				t.Fatalf("pass %d: keys[%d] = %d; order or content corrupted", pass, i, k)
+			}
+		}
+	}
+	// Replay must NOT delete scratch — only Release does.
+	if files, _ := filepath.Glob(spillGlob); len(files) == 0 {
+		t.Fatal("replay source deleted spill scratch; multi-reference replay broken")
+	}
+	c.Release()
+	if files, _ := filepath.Glob(spillGlob); len(files) != 0 {
+		t.Errorf("Release left spill scratch behind: %v", files)
+	}
+	if got := tracker.Used(); got != 0 {
+		t.Errorf("tracker still charged %d bytes after Release", got)
+	}
+}
+
+func TestCollectorReplaySource_SelIsolation(t *testing.T) {
+	c := &SpillableBatchCollector{}
+	ctx := context.Background()
+	b := collectorBatch(t, 0, 4)
+	b.Sel = []uint32{0, 1, 2, 3}
+	if err := c.Consume(ctx, b); err != nil {
+		t.Fatal(err)
+	}
+
+	s1 := c.NewReplaySource()
+	got, err := s1.Next(ctx)
+	if err != nil || got == nil {
+		t.Fatalf("Next = %v, %v", got, err)
+	}
+	// Downstream filter narrows the clone's Sel in place.
+	got.Sel = got.Sel[:1]
+	got.Sel[0] = 3
+
+	keys := drainReplaySource(t, c.NewReplaySource())
+	if len(keys) != 4 || keys[0] != 0 {
+		t.Fatalf("second replay saw corrupted Sel: keys = %v", keys)
+	}
+}

--- a/internal/planner/logical/optimizer.go
+++ b/internal/planner/logical/optimizer.go
@@ -1027,7 +1027,13 @@ func pushdownPredicates(n *Node) *Node {
 	// If this is a Filter above a Scan, keep it (already at leaf)
 	if n.Type == NodeFilter && len(n.Children) == 1 {
 		child := n.Children[0]
-		if child.Type == NodeProject {
+		// A CTEName tag marks a materialization fence: the physical
+		// planner substitutes the cached CTE result for the ENTIRE tagged
+		// subtree, so a predicate pushed below the tag is silently dropped
+		// on replay (outer `WHERE` over a CTE reference returned the full
+		// CTE — wrong results). Predicates stay above the fence and are
+		// applied to the replayed batches instead.
+		if child.Type == NodeProject && child.CTEName == "" {
 			// Filter-Project -> Project-Filter (push filter below project)
 			n.Children[0] = child.Children[0]
 			child.Children[0] = n

--- a/internal/planner/logical/optimizer_test.go
+++ b/internal/planner/logical/optimizer_test.go
@@ -679,3 +679,36 @@ func TestDecorrelateExists_MultiTableNotExists(t *testing.T) {
 		t.Fatalf("expected anti join type, got %q", result.JoinType)
 	}
 }
+
+// Regression test for the CTE materialization fence (issue #127 follow-on,
+// pre-existing wrong-results): pushdownPredicates swapped Filter-above-
+// Project unconditionally, so an outer WHERE over a CTE reference was
+// pushed BELOW the CTEName-tagged subtree root. The physical planner then
+// substituted the cached (unfiltered) CTE result for the whole tagged
+// subtree, silently dropping the predicate — `WITH m AS (...) SELECT ...
+// FROM m WHERE grp = 'x'` returned every CTE row. Predicates must stay
+// above the fence.
+func TestPushdownStopsAtCTEFence(t *testing.T) {
+	scan := NewScan("metrics", "")
+	cteRoot := NewProject(scan, []Projection{{Column: "grp", Expr: "grp"}})
+	cteRoot.CTEName = "m"
+	filter := NewFilter(cteRoot, []Predicate{{Column: "grp", Op: "=", Value: "'g1'"}})
+
+	got := pushdownPredicates(filter)
+	if got.Type != NodeFilter {
+		t.Fatalf("filter was pushed through the CTE fence: root = %s", got.Type)
+	}
+	if len(got.Children) != 1 || got.Children[0].CTEName != "m" {
+		t.Fatalf("expected Filter(CTE-tagged Project), got %s over %v", got.Type, got.Children)
+	}
+
+	// Control: without the tag, the swap must still happen (the whole
+	// point of the pushdown).
+	scan2 := NewScan("metrics", "")
+	proj2 := NewProject(scan2, []Projection{{Column: "grp", Expr: "grp"}})
+	filter2 := NewFilter(proj2, []Predicate{{Column: "grp", Op: "=", Value: "'g1'"}})
+	got2 := pushdownPredicates(filter2)
+	if got2.Type != NodeProject || got2.Children[0].Type != NodeFilter {
+		t.Fatalf("untagged Filter-Project swap broken: root = %s", got2.Type)
+	}
+}

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -399,10 +399,16 @@ func (p *Planner) getMemTracker() *memory.Tracker {
 	return p.memTracker
 }
 
-// cteMaterialized stores the pre-computed results of a CTE.
+// cteMaterialized stores the pre-computed results of a CTE in one of two
+// forms. The columnar form (coll) is the production shape: batches held in
+// a tracker-charged, spill-backed collector and replayed without consuming
+// it, so a multi-gigabyte CTE never sits boxed in heap (sweep finding #13 /
+// issue #127). The boxed form (rows) remains for the recursive work table —
+// one iteration's delta, re-seeded into the cache each fixed-point step.
 type cteMaterialized struct {
 	schema []parquet.Column
-	rows   []map[string]any
+	rows   []map[string]any              // boxed form; nil when coll is set
+	coll   *exec.SpillableBatchCollector // columnar form; nil when rows is set
 }
 
 // scanCached stores columnar scan results for a table that is scanned multiple
@@ -438,16 +444,19 @@ func (p *Planner) makeSubqueryRunner() expr.SubqueryRunner {
 	}
 }
 
-// executeSubquery parses and executes a SQL subquery, returning result rows.
-func (p *Planner) executeSubquery(ctx context.Context, sql string) ([]map[string]any, error) {
+// buildSubqueryPipeline parses, plans, and builds (but does not run) the
+// physical pipeline for a SQL subquery, merging the enclosing WITH clause's
+// CTEs so the subquery can reference them. Shared by executeSubquery (boxed
+// results) and materializeCTEColumnar (columnar collection).
+func (p *Planner) buildSubqueryPipeline(ctx context.Context, sql string) (exec.Source, []exec.UnaryOperator, exec.Sink, error) {
 	// Parse using our SQL parser
 	pq, err := plansql.Parse(sql)
 	if err != nil {
-		return nil, fmt.Errorf("subquery parse error: %w", err)
+		return nil, nil, nil, fmt.Errorf("subquery parse error: %w", err)
 	}
 	info, err := plansql.ExtractSelect(pq)
 	if err != nil {
-		return nil, fmt.Errorf("subquery extract error: %w", err)
+		return nil, nil, nil, fmt.Errorf("subquery extract error: %w", err)
 	}
 
 	// Build logical plan — merge outer CTEs so subqueries can reference
@@ -460,7 +469,7 @@ func (p *Planner) executeSubquery(ctx context.Context, sql string) ([]map[string
 		logicalPlan, err = logical.BuildFromSelect(info)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("subquery plan error: %w", err)
+		return nil, nil, nil, fmt.Errorf("subquery plan error: %w", err)
 	}
 
 	// Annotate scan nodes with column metadata so the optimizer can resolve
@@ -476,7 +485,16 @@ func (p *Planner) executeSubquery(ctx context.Context, sql string) ([]map[string
 	// Build physical pipeline
 	source, ops, sink, err := p.buildPipeline(ctx, logicalPlan)
 	if err != nil {
-		return nil, fmt.Errorf("subquery execution plan error: %w", err)
+		return nil, nil, nil, fmt.Errorf("subquery execution plan error: %w", err)
+	}
+	return source, ops, sink, nil
+}
+
+// executeSubquery parses and executes a SQL subquery, returning result rows.
+func (p *Planner) executeSubquery(ctx context.Context, sql string) ([]map[string]any, error) {
+	source, ops, sink, err := p.buildSubqueryPipeline(ctx, sql)
+	if err != nil {
+		return nil, err
 	}
 
 	// Ensure a CollectSink — buildPipeline may return nil sink for
@@ -810,16 +828,182 @@ func (p *Planner) materializeCTEs(ctx context.Context, root *logical.Node) {
 		if refCounts[cte.Name] < 2 {
 			continue
 		}
-		// Build and execute the CTE pipeline to materialize its results
-		rows, err := p.executeSubquery(ctx, cte.SQL)
+		// Materialize columnar into a tracker-charged, spill-backed
+		// collector. The previous shape boxed the whole result via
+		// CollectSink.ToRows (one map[string]any per row, entirely outside
+		// the budget/spill machinery) — `WITH x AS (SELECT * FROM lineitem)`
+		// held the full table in coordinator-process heap.
+		coll, schema, err := p.materializeCTEColumnar(ctx, cte.SQL)
 		if err != nil {
 			continue // fall back to inline expansion
 		}
-		schema := p.inferCTESchema(cte.SQL, rows)
 		if schema == nil {
+			coll.Release()
 			continue
 		}
-		p.cteCache[cte.Name] = &cteMaterialized{schema: schema, rows: rows}
+		p.cteCache[cte.Name] = &cteMaterialized{schema: schema, coll: coll}
+	}
+}
+
+// materializeCTEColumnar runs a CTE body into a spill-backed collector,
+// applying the same first-row string→numeric coercion the boxed path did
+// (see cteCoercingSink). Returns the collector and the (possibly coerced)
+// output schema; the caller owns the collector and must Release it —
+// normally via PhysicalPlan.Cleanup through releaseCTECache.
+func (p *Planner) materializeCTEColumnar(ctx context.Context, sql string) (*exec.SpillableBatchCollector, []parquet.Column, error) {
+	source, ops, _, err := p.buildSubqueryPipeline(ctx, sql)
+	if err != nil {
+		return nil, nil, err
+	}
+	coll := &exec.SpillableBatchCollector{Spill: p.getSpillManager()}
+	sink := &cteCoercingSink{coll: coll}
+	pipeline := &exec.Pipeline{Source: source, Ops: ops, Sink: sink}
+	if err := pipeline.Run(ctx); err != nil {
+		coll.Release()
+		return nil, nil, err
+	}
+	schema := sink.schema
+	if schema == nil {
+		// Empty result: no batch ever arrived, so derive column names from
+		// the SQL like the boxed path did — downstream projection still
+		// needs the names to resolve.
+		schema = p.inferCTESchema(sql, nil)
+	}
+	return coll, schema, nil
+}
+
+// releaseCTECache frees every columnar CTE collector (tracker charge +
+// spill scratch). Idempotent; wired into PhysicalPlan.Cleanup and Plan's
+// error paths.
+func (p *Planner) releaseCTECache() {
+	for _, mat := range p.cteCache {
+		if mat.coll != nil {
+			mat.coll.Release()
+		}
+	}
+	p.cteCache = nil
+}
+
+// cteCacheHasCollectors reports whether any cached CTE holds spill-backed
+// state that requires an explicit release at query end.
+func (p *Planner) cteCacheHasCollectors() bool {
+	for _, mat := range p.cteCache {
+		if mat.coll != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// cteCoercingSink wraps the CTE collector with the columnar equivalent of
+// inferCTESchema's first-row coercion: the expression evaluator emits
+// numeric literals as strings ("SELECT 1" produces "1"), and the boxed CTE
+// path coerced such columns to Int64/Float64 by inspecting the first row.
+// The plan is decided once, from the first non-empty batch, and every batch
+// is transformed BEFORE it reaches the collector — so spilled runs already
+// hold coerced data and replays need no per-reference transform. Columns
+// whose first value does not parse stay strings (real string data is never
+// touched: "CEO" doesn't parse).
+type cteCoercingSink struct {
+	coll    *exec.SpillableBatchCollector
+	planned bool
+	coerce  []parquet.TypeID // per-column target; TypeString = leave as-is
+	any     bool             // true when at least one column coerces
+	schema  []parquet.Column // output schema (coerced types); nil until first non-empty batch
+}
+
+func (s *cteCoercingSink) Init(ctx context.Context) error { return s.coll.Init(ctx) }
+
+func (s *cteCoercingSink) Consume(ctx context.Context, b *batch.RecordBatch) error {
+	if !s.planned && b.ActiveLen() > 0 {
+		s.planBatch(b)
+	}
+	if s.any {
+		b = s.applyCoercions(b)
+	}
+	return s.coll.Consume(ctx, b)
+}
+
+func (s *cteCoercingSink) Finalize(ctx context.Context) error { return s.coll.Finalize(ctx) }
+func (s *cteCoercingSink) Close() error                       { return s.coll.Close() }
+
+// planBatch decides per-column coercions from the first active row,
+// mirroring inferCTESchema's rule: int64 first, then float64.
+func (s *cteCoercingSink) planBatch(b *batch.RecordBatch) {
+	s.planned = true
+	row0 := 0
+	if b.Sel != nil {
+		row0 = int(b.Sel[0])
+	}
+	s.coerce = make([]parquet.TypeID, len(b.Schema))
+	s.schema = append([]parquet.Column(nil), b.Schema...)
+	for ci, col := range b.Schema {
+		s.coerce[ci] = parquet.TypeString // sentinel: no coercion
+		if col.Type != parquet.TypeString {
+			continue
+		}
+		vec := b.Columns[ci]
+		if vec.Nulls.IsNullFast(row0) {
+			continue
+		}
+		v := string(vec.BytesData.Value(row0))
+		if _, err := strconv.ParseInt(v, 10, 64); err == nil {
+			s.coerce[ci] = parquet.TypeInt64
+		} else if _, err := strconv.ParseFloat(v, 64); err == nil {
+			s.coerce[ci] = parquet.TypeFloat64
+		}
+		if s.coerce[ci] != parquet.TypeString {
+			s.any = true
+			s.schema[ci].Type = s.coerce[ci]
+			s.schema[ci].Nullable = true
+		}
+	}
+}
+
+// applyCoercions rebuilds the coerced columns as typed vectors. All Len
+// slots are converted (Sel-agnostic — inactive slots become null, which is
+// harmless because Sel guards every read downstream); unparseable values
+// become null, matching what FromRows produced when the boxed path's
+// coerced schema met a non-numeric string.
+func (s *cteCoercingSink) applyCoercions(b *batch.RecordBatch) *batch.RecordBatch {
+	cols := append([]*batch.Vector(nil), b.Columns...)
+	for ci, target := range s.coerce {
+		if target == parquet.TypeString || ci >= len(cols) {
+			continue
+		}
+		src := cols[ci]
+		dst := batch.NewVector(target, b.Len)
+		for i := 0; i < b.Len; i++ {
+			if src.Nulls.IsNullFast(i) {
+				dst.Nulls.SetNull(i)
+				continue
+			}
+			v := string(src.BytesData.Value(i))
+			switch target {
+			case parquet.TypeInt64:
+				iv, err := strconv.ParseInt(v, 10, 64)
+				if err != nil {
+					dst.Nulls.SetNull(i)
+					continue
+				}
+				dst.Int64Data[i] = iv
+			case parquet.TypeFloat64:
+				fv, err := strconv.ParseFloat(v, 64)
+				if err != nil {
+					dst.Nulls.SetNull(i)
+					continue
+				}
+				dst.Float64Data[i] = fv
+			}
+			dst.Nulls.SetValid(i)
+		}
+		cols[ci] = dst
+	}
+	return &batch.RecordBatch{
+		Schema:  s.schema,
+		Columns: cols,
+		Len:     b.Len,
+		Sel:     b.Sel,
 	}
 }
 
@@ -891,15 +1075,17 @@ const maxRecursiveIterations = 1000
 func (p *Planner) materializeRecursiveCTE(ctx context.Context, cte plansql.CTEDef) {
 	anchorSQL, recursiveSQL, ok := splitRecursiveUnion(cte.SQL)
 	if !ok {
-		// No UNION ALL found — fall back to non-recursive execution
-		rows, err := p.executeSubquery(ctx, cte.SQL)
+		// No UNION ALL found — fall back to non-recursive (columnar)
+		// materialization.
+		coll, schema, err := p.materializeCTEColumnar(ctx, cte.SQL)
 		if err != nil {
 			return
 		}
-		schema := p.inferCTESchema(cte.SQL, rows)
-		if schema != nil {
-			p.cteCache[cte.Name] = &cteMaterialized{schema: schema, rows: rows}
+		if schema == nil {
+			coll.Release()
+			return
 		}
+		p.cteCache[cte.Name] = &cteMaterialized{schema: schema, coll: coll}
 		return
 	}
 
@@ -930,9 +1116,30 @@ func (p *Planner) materializeRecursiveCTE(ctx context.Context, cte plansql.CTEDe
 		}
 	}
 
-	// Accumulate all results
-	allRows := make([]map[string]any, len(anchorRows))
-	copy(allRows, anchorRows)
+	// Accumulate iteration results columnar into a tracker-charged,
+	// spill-backed collector instead of an unbounded boxed slice — the
+	// iteration count was bounded (1000) but the row count was not, and
+	// every accumulated row lived as a map[string]any until Plan returned.
+	// The per-iteration work table stays boxed: it is one iteration's
+	// delta (inherent to the fixed-point algorithm) and is re-seeded into
+	// the cache each step for the recursive query's self-reference.
+	coll := &exec.SpillableBatchCollector{Spill: p.getSpillManager()}
+	appendRowsColumnar := func(rs []map[string]any) error {
+		for off := 0; off < len(rs); off += batch.DefaultBatchSize {
+			end := off + batch.DefaultBatchSize
+			if end > len(rs) {
+				end = len(rs)
+			}
+			if err := coll.Consume(ctx, batch.FromRows(schema, rs[off:end])); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if err := appendRowsColumnar(anchorRows); err != nil {
+		coll.Release()
+		return
+	}
 
 	// Derive the expected column names from the schema (aliases already applied).
 	schemaNames := make([]string, len(schema))
@@ -976,12 +1183,19 @@ func (p *Planner) materializeRecursiveCTE(ctx context.Context, cte plansql.CTEDe
 		// produce different column names (e.g., "n + 1" vs "n").
 		newRows = renameRowColumnsFromTo(newRows, recursiveColNames, schemaNames)
 
-		allRows = append(allRows, newRows...)
+		if err := appendRowsColumnar(newRows); err != nil {
+			// Spill scratch failure mid-iteration: abandon materialization.
+			// Without a cache entry the recursive reference cannot resolve
+			// and the query errors — same failure mode as an anchor error.
+			coll.Release()
+			delete(p.cteCache, cte.Name)
+			return
+		}
 		workTable = newRows
 	}
 
-	// Store final accumulated results
-	p.cteCache[cte.Name] = &cteMaterialized{schema: schema, rows: allRows}
+	// Store final accumulated results (columnar; replayed per reference).
+	p.cteCache[cte.Name] = &cteMaterialized{schema: schema, coll: coll}
 }
 
 // stageTypeCTEAlias marks a phantom stage that walkStages emits in place of
@@ -1289,6 +1503,7 @@ func (p *Planner) Plan(ctx context.Context, node *logical.Node) (*PhysicalPlan, 
 	p.scanCache = nil // reset per-query scan cache
 	p.spillMgr = nil  // reset per-query spill manager
 	p.memTracker = nil
+	p.releaseCTECache() // reset per-query CTE cache (frees stale spill scratch)
 	// Propagate CTE definitions from the logical plan so scalar subqueries
 	// (e.g., in WHERE/HAVING) can resolve CTE table references.
 	if len(node.CTEs) > 0 {
@@ -1307,6 +1522,7 @@ func (p *Planner) Plan(ctx context.Context, node *logical.Node) (*PhysicalPlan, 
 
 	source, ops, sink, err := p.buildPipeline(ctx, node)
 	if err != nil {
+		p.releaseCTECache() // free CTE spill scratch on the no-Cleanup path
 		return nil, err
 	}
 
@@ -1333,15 +1549,25 @@ func (p *Planner) Plan(ctx context.Context, node *logical.Node) (*PhysicalPlan, 
 		},
 	}
 
-	// Attach spill file cleanup
+	// Attach spill file cleanup. CTE collectors release first (tracker
+	// charge + their scratch files) so the SpillManager sweep that follows
+	// never races their removal.
 	if sm := p.spillMgr; sm != nil {
-		plan.Cleanup = func() { sm.Cleanup() }
+		plan.Cleanup = func() {
+			p.releaseCTECache()
+			sm.Cleanup()
+		}
+	} else if p.cteCacheHasCollectors() {
+		// Shared (worker-injected) spill manager: its dir outlives this
+		// query, so the collectors' scratch must be released explicitly.
+		plan.Cleanup = func() { p.releaseCTECache() }
 	}
 
 	// Generate distributed stages for coordinator dispatch
 	plan.Stages = p.generateStages(node)
 
 	if err := p.enforceQueryLimits(plan.Stages, node); err != nil {
+		p.releaseCTECache()
 		return nil, err
 	}
 
@@ -3274,9 +3500,15 @@ func findScanNode(n *logical.Node) *logical.Node {
 
 func (p *Planner) buildPipeline(ctx context.Context, node *logical.Node) (exec.Source, []exec.UnaryOperator, exec.Sink, error) {
 	// If this subtree is a materialized CTE, serve from cache instead of
-	// re-executing the full sub-plan.
+	// re-executing the full sub-plan. The columnar form replays from the
+	// collector (disk-backed past budget) without consuming it, so every
+	// reference — main pipeline, subqueries, recursive steps — streams the
+	// same data; the boxed form (recursive work table) keeps SliceSource.
 	if node.CTEName != "" && p.cteCache != nil {
 		if mat, ok := p.cteCache[node.CTEName]; ok {
+			if mat.coll != nil {
+				return mat.coll.NewReplaySource(), nil, &exec.CollectSink{}, nil
+			}
 			source := exec.NewSliceSource(mat.schema, mat.rows)
 			return source, nil, &exec.CollectSink{}, nil
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1193,6 +1193,11 @@ func (s *Server) handleExplain(w http.ResponseWriter, r *http.Request, parsed *p
 			writeError(w, http.StatusInternalServerError, "physical plan error: "+err.Error())
 			return
 		}
+		// The pipeline is never run for EXPLAIN, but planning may have
+		// materialized CTEs to spill scratch — release it now.
+		if physPlan.Cleanup != nil {
+			physPlan.Cleanup()
+		}
 		planStr += "\n\n-- Physical Plan --\n" + physPlan.PrettyPrint()
 	}
 

--- a/wadjet/wadjet.go
+++ b/wadjet/wadjet.go
@@ -322,6 +322,11 @@ func (db *DB) explain(ctx context.Context, parsed *plansql.ParsedQuery) (*QueryR
 		if err != nil {
 			return nil, fmt.Errorf("building physical plan: %w", err)
 		}
+		// The pipeline is never run for EXPLAIN, but planning may have
+		// materialized CTEs to spill scratch - release it now.
+		if physPlan.Cleanup != nil {
+			physPlan.Cleanup()
+		}
 		plan += "\n\n-- Physical Plan --\n" + physPlan.PrettyPrint()
 	}
 

--- a/wadjet/wadjet_test.go
+++ b/wadjet/wadjet_test.go
@@ -1003,3 +1003,121 @@ func TestLiteralProjectionType(t *testing.T) {
 }
 
 
+
+// TestCTEColumnarMaterialization is the regression suite for issue #127:
+// materialized CTEs moved from boxed map[string]any rows (unbounded heap)
+// to a columnar spill-backed collector replayed per reference. These tests
+// pin the behaviors the conversion must preserve: multi-reference replay
+// sees identical data, and the boxed path's first-row string→numeric
+// coercion (expression-evaluator literals) still applies.
+func TestCTEColumnarMaterialization(t *testing.T) {
+	ctx := context.Background()
+	store := objstore.NewMemStore()
+	db, err := Open(ctx, Config{Store: store, Bucket: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	schema := parquet.Schema{
+		Columns: []parquet.Column{
+			{Name: "id", Type: parquet.TypeInt64},
+			{Name: "grp", Type: parquet.TypeString},
+			{Name: "val", Type: parquet.TypeFloat64},
+		},
+	}
+	if err := db.CreateTable(ctx, "metrics", schema, nil); err != nil {
+		t.Fatal(err)
+	}
+	ing := db.NewIngester("metrics", schema, nil, ingest.Config{MaxBufferRows: 1000, RowGroupSize: 1000})
+	rows := make([]map[string]any, 0, 600)
+	for i := 0; i < 600; i++ {
+		rows = append(rows, map[string]any{
+			"id":  int64(i),
+			"grp": fmt.Sprintf("g%d", i%3),
+			"val": float64(i),
+		})
+	}
+	if err := ing.Ingest(ctx, rows); err != nil {
+		t.Fatal(err)
+	}
+	if err := ing.FlushAll(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("multi_reference_replays_identical", func(t *testing.T) {
+		// Two references to the same CTE — each replays the collector
+		// without consuming it, so both branches must see all 600 rows.
+		result, err := db.Query(ctx, `
+			WITH m AS (
+				SELECT id, grp, val FROM metrics
+			)
+			SELECT id FROM m UNION ALL SELECT id FROM m
+		`)
+		if err != nil {
+			t.Fatalf("query failed: %v", err)
+		}
+		if len(result.Rows) != 1200 {
+			t.Fatalf("expected 1200 rows (600 per reference), got %d", len(result.Rows))
+		}
+	})
+
+	t.Run("cte_with_filter_and_aggregate_ref", func(t *testing.T) {
+		// A filtered CTE feeding an aggregate — replayed batches carry
+		// selection vectors through the collector round-trip.
+		result, err := db.Query(ctx, `
+			WITH filtered AS (
+				SELECT id, val FROM metrics WHERE id < 100
+			)
+			SELECT COUNT(*) AS c FROM filtered
+		`)
+		if err != nil {
+			t.Fatalf("query failed: %v", err)
+		}
+		if len(result.Rows) != 1 {
+			t.Fatalf("expected 1 row, got %d", len(result.Rows))
+		}
+		if fmt.Sprintf("%v", result.Rows[0]["c"]) != "100" {
+			t.Fatalf("COUNT = %v, want 100", result.Rows[0]["c"])
+		}
+	})
+
+	t.Run("literal_cte_numeric_coercion", func(t *testing.T) {
+		// The expression evaluator can emit numeric literals as strings;
+		// the boxed CTE path coerced them via inferCTESchema's first-row
+		// rule. The columnar path must preserve that (cteCoercingSink) so
+		// arithmetic over a literal CTE still works.
+		result, err := db.Query(ctx, `
+			WITH t AS (SELECT 7 AS n)
+			SELECT n + 1 AS m FROM t
+		`)
+		if err != nil {
+			t.Fatalf("query failed: %v", err)
+		}
+		if len(result.Rows) != 1 {
+			t.Fatalf("expected 1 row, got %d", len(result.Rows))
+		}
+		if got := fmt.Sprintf("%v", result.Rows[0]["m"]); got != "8" {
+			t.Fatalf("n + 1 = %v, want 8", result.Rows[0]["m"])
+		}
+	})
+
+	t.Run("string_data_not_coerced", func(t *testing.T) {
+		// Real string columns must never be touched by the literal
+		// coercion ("g0" doesn't parse; and a numeric-looking string
+		// column would only coerce if its FIRST row parses — same rule
+		// as the boxed path).
+		result, err := db.Query(ctx, `
+			WITH m AS (SELECT grp FROM metrics)
+			SELECT grp FROM m WHERE grp = 'g1'
+		`)
+		if err != nil {
+			t.Fatalf("query failed: %v", err)
+		}
+		if len(result.Rows) != 200 {
+			t.Fatalf("expected 200 rows, got %d", len(result.Rows))
+		}
+		if result.Rows[0]["grp"] != "g1" {
+			t.Fatalf("grp = %v (%T), want string g1", result.Rows[0]["grp"], result.Rows[0]["grp"])
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Two commits:

**1. Wrong-results fix (pre-existing, surfaced by this work):** an outer `WHERE` over a CTE reference was silently dropped. `pushdownPredicates` swapped Filter-above-Project unconditionally, pushing the predicate below the `CTEName`-tagged subtree root; `buildPipeline` then substituted the cached (unfiltered) CTE result for the whole tagged subtree. `WITH m AS (SELECT grp FROM metrics) SELECT grp FROM m WHERE grp = 'g1'` returned **every** CTE row on the local Plan() path. The tag now acts as a materialization fence — predicates stay above it and apply to the replayed batches. (This is also a hard requirement for multi-reference CTEs: one cache serves all references, so per-reference predicates can never live below the tag.)

**2. Issue #127 (sweep finding 13):** materialized CTEs were cached fully as boxed `map[string]any` rows outside all budget/spill machinery — `WITH x AS (SELECT * FROM lineitem)` boxed the whole table; recursive CTEs accumulated unbounded rows over up to 1000 iterations.

- Non-recursive CTEs now collect into a tracker-charged `exec.SpillableBatchCollector`; each reference replays via the new **non-consuming `CollectorReplaySource`** — spilled runs re-read from disk per replay (scratch survives until `Release`), in-memory batches handed out as **Sel-isolated shallow clones** (the `catalogScanSource` cache-replay pattern).
- Recursive CTEs keep the boxed per-iteration work table (one iteration's delta — inherent to fixed-point) but accumulate results into the same spillable collector.
- The boxed path's first-row string→numeric coercion (expression-evaluator literals) is preserved by `cteCoercingSink`, applied **before** collection so spilled runs hold coerced data and replays are transform-free. Real string data is never touched.
- Lifecycle: collectors release via `PhysicalPlan.Cleanup` (chained before the SpillManager sweep), on Plan error paths, on per-query reset, and at the EXPLAIN VERBOSE sites that never run the pipeline.

## Tests
- Optimizer: fence regression + untagged-swap control
- exec: non-consuming twice-replay (in-memory and spilled; scratch survives replay, dies on Release), Sel isolation across replays
- wadjet E2E: multi-reference UNION ALL row counts, filtered-CTE aggregate (Sel round-trip), literal coercion (`SELECT 7 AS n` → `n+1 = 8`), string data untouched, existing recursive CTE suite

## Gates
- Full unit suite green (37 packages incl. coordinator distributed E2Es), `-race` on exec/logical/physical/wadjet
- TPC-H SF0.01 correctness: pass
- `tpch-harness -mode=local`: **PASS** — Q15 (the CTE query) row-correct, wall flat (106ms vs 112ms baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)