### PR TITLE
test(tpch): nested-types + Decimal correctness gate — 7 wrong-results fixes (closes #144)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,24 @@ jobs:
         # the rest of the suite in parallel.
         # -p 2 caps test-package parallelism so two heavy packages don't
         # overlap on the runner's RAM.
-        run: go test -short -p 2 ./internal/... -timeout 5m
+        # ./wadjet/ carries the embeddable-API E2E suites (CTE, nested
+        # types, Decimal) — it was previously not run in CI at all.
+        run: go test -short -p 2 ./internal/... ./wadjet/ -timeout 8m
 
       - name: TPC-H Correctness (SF0.01)
         run: go test -v -run TestTPCHQueries ./benchmarks/tpch/ -timeout 5m
+
+      - name: Nested Types + Decimal Correctness
+        # The gate TPC-H is structurally blind to (issue #144): TPC-H has
+        # no ARRAY/MAP/ROW columns, no Decimal in the merge path, and no
+        # NULL group keys, so an entire class of silent wrong-results bugs
+        # shipped SF100-green until found by code sweep. These suites run
+        # the nested+Decimal battery end-to-end (embeddable API and
+        # distributed) plus the operator-level regression corpus.
+        run: |
+          go test -v -run 'TestNestedDecimalCorrectness' ./wadjet/ -timeout 5m
+          go test -v -run 'TestDistributedDecimalAndNullGroups' ./internal/coordinator/ -timeout 5m
+          go test -v -run 'TestReadRowGroupNative_DecimalValues|TestReadRowGroupNative_ArrayErrorsLoudly|TestShuffleFormatDecimalScaleRoundTrip|TestStringGroupKey_NullGroupAggregates|TestDecimal' ./internal/engine/scan/ ./internal/worker/ ./internal/engine/exec/ ./internal/storage/parquet/ -timeout 5m
 
   benchmark:
     runs-on: ubuntu-latest

--- a/internal/coordinator/nested_decimal_distributed_test.go
+++ b/internal/coordinator/nested_decimal_distributed_test.go
@@ -1,0 +1,210 @@
+package coordinator
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/storage/catalog"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+	"github.com/citc-tech/wadjet/internal/worker"
+)
+
+// TestDistributedDecimalAndNullGroups is the distributed half of the
+// issue #144 correctness gate: Decimal values and NULL group keys through
+// the full dispatch → worker pipeline → WSHF shuffle encode/decode →
+// gather → coordinator path. TPC-H stores money as Float64 and its group
+// keys are never NULL, so SF0.01/SF1/SF100 never exercised either (the
+// sweep's coordinator Decimal-merge collapse and the PR #142 NULL-group
+// drop both shipped SF100-green).
+func TestDistributedDecimalAndNullGroups(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	t.Cleanup(cancel)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	natsCfg := distributed.DefaultNATSConfig()
+	natsCfg.Port = -1
+	natsCfg.StoreDir = t.TempDir()
+	embeddedNATS, err := distributed.NewEmbeddedNATS(natsCfg, logger)
+	if err != nil {
+		t.Fatalf("starting NATS: %v", err)
+	}
+	t.Cleanup(embeddedNATS.Shutdown)
+
+	nc, err := distributed.ConnectInProcess(embeddedNATS.Server())
+	if err != nil {
+		t.Fatalf("connecting to NATS: %v", err)
+	}
+	t.Cleanup(func() { nc.Close() })
+
+	js, err := distributed.NewJetStream(nc)
+	if err != nil {
+		t.Fatalf("creating JetStream: %v", err)
+	}
+	if err := distributed.SetupStreams(ctx, js); err != nil {
+		t.Fatalf("setting up streams: %v", err)
+	}
+
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(ctx, "test"); err != nil {
+		t.Fatal(err)
+	}
+	kv, err := catalog.NewNATSKV(js)
+	if err != nil {
+		t.Fatalf("creating NATS KV: %v", err)
+	}
+	cat := catalog.New(kv, store, "test")
+	if err := cat.Init(ctx); err != nil {
+		t.Fatalf("catalog init: %v", err)
+	}
+
+	schema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "grp", Type: parquet.TypeString, Nullable: true},
+		{Name: "amount", Type: parquet.TypeDecimal, Nullable: true, Precision: 12, Scale: 2},
+	}}
+	const numRows = 4000
+	rows := make([]map[string]any, numRows)
+	type oracle struct {
+		count int64
+		sum   float64
+	}
+	want := map[string]*oracle{}
+	for i := range rows {
+		id := int64(i)
+		var grp any
+		key := "<null>"
+		if id%7 != 3 {
+			g := fmt.Sprintf("g%d", id%3)
+			grp = g
+			key = g
+		}
+		var amt any
+		if id%11 != 5 {
+			amt = float64(id%40) + 0.25
+		}
+		rows[i] = map[string]any{"id": id, "grp": grp, "amount": amt}
+		o := want[key]
+		if o == nil {
+			o = &oracle{}
+			want[key] = o
+		}
+		o.count++
+		if amt != nil {
+			o.sum += amt.(float64)
+		}
+	}
+
+	if err := cat.CreateTable(ctx, "ledger", schema, nil); err != nil {
+		t.Fatalf("creating table: %v", err)
+	}
+	var buf bytes.Buffer
+	pw, err := parquet.NewWriter(&buf, schema, parquet.DefaultWriterConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := pw.WriteRows(rows); err != nil {
+		t.Fatal(err)
+	}
+	if err := pw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	pdata := buf.Bytes()
+	const filePath = "tables/ledger/chunk_0001.parquet"
+	if _, err := store.Put(ctx, "test", filePath, bytes.NewReader(pdata), int64(len(pdata)), "application/octet-stream"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cat.AddFiles(ctx, "ledger", map[string]string{}, "tables/ledger/", []catalog.FileEntry{{
+		Path: filePath, SizeBytes: int64(len(pdata)), NumRows: numRows, CreatedAt: time.Now(),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	w := worker.New(worker.Config{
+		NATSUrl:       embeddedNATS.ClientURL(),
+		MaxConcurrent: 4,
+		CacheBytes:    64 * 1024 * 1024,
+	}, store, nc, js, logger)
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("starting worker: %v", err)
+	}
+	t.Cleanup(w.Stop)
+
+	coord := New(Config{NATSUrl: embeddedNATS.ClientURL(), ResultBucket: "test"}, cat, nc, js, logger)
+	coord.workers.record(distributed.WorkerHeartbeat{WorkerID: "fake-worker-0", Timestamp: time.Now()})
+
+	t.Run("null_group_and_decimal_sum", func(t *testing.T) {
+		res, err := coord.ExecuteSQL(ctx, `SELECT grp, COUNT(*) AS c, SUM(amount) AS s FROM ledger GROUP BY grp`)
+		if err != nil {
+			t.Fatalf("ExecuteSQL: %v", err)
+		}
+		got := map[string]*oracle{}
+		for _, row := range mustRows(t, res) {
+			key := "<null>"
+			if row["grp"] != nil {
+				key = fmt.Sprintf("%v", row["grp"])
+			}
+			var c int64
+			fmt.Sscanf(fmt.Sprintf("%v", row["c"]), "%d", &c)
+			var s float64
+			if row["s"] != nil {
+				fmt.Sscanf(fmt.Sprintf("%v", row["s"]), "%f", &s)
+			}
+			got[key] = &oracle{count: c, sum: s}
+		}
+		if len(got) != len(want) {
+			t.Fatalf("groups = %d (%v), want %d incl. NULL group", len(got), got, len(want))
+		}
+		for k, w := range want {
+			g := got[k]
+			if g == nil {
+				t.Fatalf("group %q missing (NULL group dropped in distributed path?)", k)
+			}
+			if g.count != w.count {
+				t.Fatalf("group %q count = %d, want %d", k, g.count, w.count)
+			}
+			if diff := g.sum - w.sum; diff > 0.01 || diff < -0.01 {
+				t.Fatalf("group %q sum = %v, want %v", k, g.sum, w.sum)
+			}
+		}
+	})
+
+	t.Run("decimal_group_keys_distinct", func(t *testing.T) {
+		res, err := coord.ExecuteSQL(ctx, `SELECT amount, COUNT(*) AS c FROM ledger GROUP BY amount`)
+		if err != nil {
+			t.Fatalf("ExecuteSQL: %v", err)
+		}
+		rows := mustRows(t, res)
+		// 40 distinct fractional amounts + the NULL amount group. A scale
+		// or key-encoding loss collapses or truncates them (".25" gone).
+		if len(rows) != 41 {
+			t.Fatalf("distinct amount groups = %d, want 41", len(rows))
+		}
+		sawFraction := false
+		for _, row := range rows {
+			if row["amount"] == nil {
+				continue
+			}
+			var f float64
+			fmt.Sscanf(fmt.Sprintf("%v", row["amount"]), "%f", &f)
+			frac := f - float64(int64(f))
+			if frac > 0.24 && frac < 0.26 {
+				sawFraction = true
+			} else {
+				t.Fatalf("amount key %v lost its fraction (want x.25)", row["amount"])
+			}
+		}
+		if !sawFraction {
+			t.Fatal("no fractional decimal keys came back")
+		}
+	})
+}
+
+

--- a/internal/coordinator/shuffle_reader.go
+++ b/internal/coordinator/shuffle_reader.go
@@ -49,6 +49,17 @@ func readShuffleBatches(data []byte) ([]*batch.RecordBatch, error) {
 		schema[i].Type = parquet.TypeID(data[pos])
 		schema[i].Nullable = true
 		pos++
+		// Decimal columns carry scale+precision after the type byte (see
+		// worker shuffleWriter.writeHeader) — without them the decoded
+		// vector renders the raw scaled integer (fraction lost).
+		if schema[i].Type == parquet.TypeDecimal {
+			if pos+2 > len(data) {
+				return nil, fmt.Errorf("truncated decimal schema at column %d", i)
+			}
+			schema[i].Scale = int(data[pos])
+			schema[i].Precision = int(data[pos+1])
+			pos += 2
+		}
 	}
 
 	batches := make([]*batch.RecordBatch, 0, numChunks)

--- a/internal/engine/exec/aggregate.go
+++ b/internal/engine/exec/aggregate.go
@@ -92,6 +92,7 @@ type HashAggregate struct {
 	aggColIdx         []int
 	aggColIdx2        []int // second column indices for two-column aggregates
 	groupColTypes     []batch.TypeID
+	groupColMeta      []parquet.Column // full input column metadata per group col (Decimal Scale/Precision survive into outputSchema)
 	aggUpdaters       []kernel.RowAggUpdater  // resolved typed updaters
 	aggUpdatersNoNull []kernel.RowAggUpdater  // no-null-check variants
 	batchUpdaters     []kernel.RowAggUpdater  // per-batch updater selection (reusable)
@@ -132,6 +133,15 @@ type HashAggregate struct {
 	// Two-phase approach like consumeBatchIntGroup but with string key hashing.
 	useStrGroupKey bool
 	strGroupKeyCol int // column index for the string group-by key
+	// strNullGroupIdx is the NULL-key group's slot in strGroupStates (-1 =
+	// none yet). The NULL group is created inline WITH a flat-accumulator
+	// slot: the previous shape diverted null-key rows to processRow, whose
+	// groups skip appendGroup — strGroupStates and intFlatAccs went out of
+	// alignment and the NULL group emitted with zeroed aggregates
+	// (COUNT(*)=0 over 700 rows; issue #144 suite finding). Kept out of
+	// strGroupIndex entirely so it can never collide with a real 1-byte
+	// string key.
+	strNullGroupIdx int32
 
 	// Multi-column generic GROUP BY SoA fast path: binary key serialization
 	// with strHashTable lookup and SoA flat accumulator scatter.
@@ -480,6 +490,7 @@ func NewHashAggregate(groupByCols []string, aggs []AggColumn) *HashAggregate {
 func (h *HashAggregate) Init(_ context.Context) error {
 	h.strGroupIndex = newStrHashTable(4096)
 	h.strGroupStates = nil
+	h.strNullGroupIdx = -1
 	h.keys = nil
 	h.serializedKeys = nil
 	h.resolved = false
@@ -625,11 +636,15 @@ func (h *HashAggregate) resolveIndices(b *batch.RecordBatch) {
 	}
 	h.groupColIdx = make([]int, len(h.GroupByCols))
 	h.groupColTypes = make([]batch.TypeID, len(h.GroupByCols))
+	h.groupColMeta = make([]parquet.Column, len(h.GroupByCols))
 	for i, col := range h.GroupByCols {
 		idx := columnIndexFallback(b, col)
 		h.groupColIdx[i] = idx
 		if idx >= 0 {
 			h.groupColTypes[i] = b.Columns[idx].Type
+			if idx < len(b.Schema) {
+				h.groupColMeta[i] = b.Schema[idx]
+			}
 		}
 	}
 	h.aggColIdx = make([]int, len(h.Aggs))
@@ -1504,11 +1519,17 @@ func (h *HashAggregate) consumeBatchStrGroup(b *batch.RecordBatch) {
 		h.intFlatAccs[ai].ensureCapacity(batchRows)
 	}
 
-	// Phase 1: Hash lookup — build group index array.
+	// Phase 1: Hash lookup — build group index array. NULL keys get their
+	// own first-class group slot (strNullGroupIdx) so the typed scatter in
+	// Phase 2 updates its flat accumulators like any other group. The
+	// previous shape diverted null-key rows to processRow, which appends a
+	// groupState WITHOUT a flat-accumulator slot — strGroupStates and
+	// intFlatAccs went out of alignment and the NULL group emitted zeroed
+	// aggregates (and a 1-byte "\x01" string key could collide with the
+	// binary null sentinel in the shared hash table).
 	var gi []int32
 	var sel []uint32
 	var iterLen int
-	hasNullKeys := false
 
 	if b.Sel != nil {
 		iterLen = len(b.Sel)
@@ -1517,8 +1538,7 @@ func (h *HashAggregate) consumeBatchStrGroup(b *batch.RecordBatch) {
 		for si, selIdx := range b.Sel {
 			row := int(selIdx)
 			if hasNulls && gkVec.Nulls.IsNullFast(row) {
-				gi[si] = -1
-				hasNullKeys = true
+				gi[si] = h.strNullGroupSlot()
 				continue
 			}
 			key := gkVec.BytesData.Value(row)
@@ -1543,8 +1563,7 @@ func (h *HashAggregate) consumeBatchStrGroup(b *batch.RecordBatch) {
 		gi = h.ensureGroupIndexBuf(iterLen)
 		for row := 0; row < iterLen; row++ {
 			if hasNulls && gkVec.Nulls.IsNullFast(row) {
-				gi[row] = -1
-				hasNullKeys = true
+				gi[row] = h.strNullGroupSlot()
 				continue
 			}
 			key := gkVec.BytesData.Value(row)
@@ -1577,22 +1596,29 @@ func (h *HashAggregate) consumeBatchStrGroup(b *batch.RecordBatch) {
 		}
 	}
 
-	// Handle null-key rows via generic path.
-	if hasNullKeys {
-		if sel != nil {
-			for si, selIdx := range sel {
-				if gi[si] < 0 {
-					h.processRow(b, int(selIdx))
-				}
-			}
-		} else {
-			for row := 0; row < iterLen; row++ {
-				if gi[row] < 0 {
-					h.processRow(b, row)
-				}
-			}
-		}
+}
+
+// strNullGroupSlot returns the NULL-key group's flat-accumulator slot for
+// the single-string fast path, creating it on first use. The group lives in
+// strGroupStates with an aligned slot in every flat accumulator, but is
+// deliberately NOT inserted into strGroupIndex — a raw 1-byte string key
+// could otherwise collide with any in-band null sentinel. serializedKeys
+// gets the generic binary form (single 0x01 null flag) so spill/merge
+// round-trips distinguish the NULL group from every real string.
+func (h *HashAggregate) strNullGroupSlot() int32 {
+	if h.strNullGroupIdx >= 0 {
+		return h.strNullGroupIdx
 	}
+	gs := h.gsPool.alloc()
+	gs.ensureExtras().keyValues = []any{nil}
+	h.strNullGroupIdx = int32(len(h.strGroupStates))
+	h.strGroupStates = append(h.strGroupStates, gs)
+	h.keys = append(h.keys, []any{nil})
+	h.serializedKeys = append(h.serializedKeys, "\x01")
+	for ai := range h.intFlatAccs {
+		h.intFlatAccs[ai].appendGroup()
+	}
+	return h.strNullGroupIdx
 }
 
 // consumeBatchGenericSoA is the SoA fast path for multi-column GROUP BY
@@ -2616,6 +2642,7 @@ func (h *HashAggregate) Next(_ context.Context) (*batch.RecordBatch, error) {
 		h.serializedKeys = nil
 		h.strGroupStates = nil
 		h.strGroupIndex = nil
+		h.strNullGroupIdx = -1
 		// Drop SoA arrays now that the SoA-direct path has finished reading
 		// from them. materializeFlatAccums used to do this implicitly (it
 		// nil'd intFlatAccs on the way through); since Next() no longer calls
@@ -2663,7 +2690,21 @@ func (h *HashAggregate) outputSchema() []parquet.Column {
 		if i < len(h.groupColTypes) && h.groupColTypes[i] != 0 {
 			typ = parquet.TypeID(h.groupColTypes[i])
 		}
-		cols = append(cols, parquet.Column{Name: name, Type: typ, Nullable: true})
+		out := parquet.Column{Name: name, Type: typ, Nullable: true}
+		// Decimal group keys need the source Scale/Precision: the output
+		// vector parses keyValues with its OWN scale, so a scale-0 column
+		// stored 0.25 as 0 — every fractional decimal key truncated
+		// (issue #144 suite finding). Nested key columns likewise need
+		// their Fields/ElementType to reconstruct children.
+		if i < len(h.groupColMeta) && h.groupColMeta[i].Type == typ {
+			meta := h.groupColMeta[i]
+			out.Precision = meta.Precision
+			out.Scale = meta.Scale
+			out.Fields = meta.Fields
+			out.ElementType = meta.ElementType
+			out.Dimension = meta.Dimension
+		}
+		cols = append(cols, out)
 	}
 	for _, agg := range h.Aggs {
 		cols = append(cols, parquet.Column{Name: agg.OutputCol, Type: agg.OutputType, Nullable: true})
@@ -2685,6 +2726,7 @@ func (h *HashAggregate) CloneSink() SinkSource {
 		NullGroupCols: h.NullGroupCols,
 		GroupingSets:  h.GroupingSets,
 		// No spill manager — partial aggregates are small enough
+		strNullGroupIdx: -1, // defensive: Init sets it, but the zero value is a VALID slot
 	}
 	return clone
 }
@@ -2708,6 +2750,7 @@ func (h *HashAggregate) MergeSink(other SinkSource) {
 	// the workers'.
 	if len(h.groupColTypes) == 0 && len(o.groupColTypes) > 0 {
 		h.groupColTypes = o.groupColTypes
+		h.groupColMeta = o.groupColMeta
 		if len(h.groupColIdx) == 0 {
 			h.groupColIdx = o.groupColIdx
 		}

--- a/internal/engine/exec/aggregate_null_group_test.go
+++ b/internal/engine/exec/aggregate_null_group_test.go
@@ -216,3 +216,74 @@ func TestIntGroupKey_Int32NullMigrationKeysMatch(t *testing.T) {
 		t.Errorf("group 3 sum = %v, want 5 (int32 key format mismatch across migration)", sums["3"])
 	}
 }
+
+// Regression test for the single-STRING fast path's NULL group (issue #144
+// suite finding): null-key rows were diverted to processRow, whose groups
+// skip intFlatAccs.appendGroup — strGroupStates and the flat accumulators
+// went out of alignment and the NULL group emitted with ZEROED aggregates
+// (COUNT(*)=0, SUM=NULL over hundreds of rows) while real groups stayed
+// correct. The NULL group must be a first-class flat-accumulator slot.
+func TestStringGroupKey_NullGroupAggregates(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "k", Type: parquet.TypeString, Nullable: true},
+		{Name: "v", Type: parquet.TypeInt64},
+	}
+	h := NewHashAggregate([]string{"k"}, []AggColumn{
+		{Func: AggCount, OutputCol: "c", OutputType: parquet.TypeInt64},
+		{Func: AggSum, InputCol: "v", OutputCol: "s", OutputType: parquet.TypeInt64},
+	})
+	if err := h.Init(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Interleave null keys with real ones, across two batches so the NULL
+	// group accumulates after other groups exist on both sides.
+	mk := func(vals ...any) *batch.RecordBatch {
+		rows := make([]map[string]any, 0, len(vals)/2)
+		for i := 0; i < len(vals); i += 2 {
+			rows = append(rows, map[string]any{"k": vals[i], "v": vals[i+1]})
+		}
+		return batch.FromRows(schema, rows)
+	}
+	ctx := context.Background()
+	if err := h.Consume(ctx, mk("a", int64(1), nil, int64(10), "b", int64(2), nil, int64(20))); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.Consume(ctx, mk(nil, int64(30), "a", int64(3), "\x01", int64(100))); err != nil {
+		t.Fatal(err)
+	}
+
+	rows := aggRows(t, h)
+	if len(rows) != 4 {
+		t.Fatalf("groups = %d (%v), want 4 (a, b, \\x01, NULL)", len(rows), rows)
+	}
+	byKey := map[string]map[string]any{}
+	for _, r := range rows {
+		k := "<null>"
+		if r["k"] != nil {
+			k = r["k"].(string)
+		}
+		byKey[k] = r
+	}
+	if got := byKey["<null>"]; got == nil {
+		t.Fatal("NULL group missing")
+	} else {
+		if fmt.Sprintf("%v", got["c"]) != "3" {
+			t.Fatalf("NULL group COUNT = %v, want 3 (flat-accumulator misalignment)", got["c"])
+		}
+		if fmt.Sprintf("%v", got["s"]) != "60" {
+			t.Fatalf("NULL group SUM = %v, want 60", got["s"])
+		}
+	}
+	// A real 1-byte "\x01" string key must remain distinct from the NULL
+	// group (no in-band sentinel collision in the shared hash table).
+	if got := byKey["\x01"]; got == nil || fmt.Sprintf("%v", got["c"]) != "1" {
+		t.Fatalf("\\x01 key group = %v, want count 1 distinct from NULL group", got)
+	}
+	if got := byKey["a"]; got == nil || fmt.Sprintf("%v", got["s"]) != "4" {
+		t.Fatalf("group a = %v, want sum 4", got)
+	}
+	if got := byKey["b"]; got == nil || fmt.Sprintf("%v", got["s"]) != "2" {
+		t.Fatalf("group b = %v, want sum 2", got)
+	}
+}

--- a/internal/engine/exec/aggregate_partial_spill.go
+++ b/internal/engine/exec/aggregate_partial_spill.go
@@ -1597,6 +1597,7 @@ func (h *HashAggregate) resetGroupStateAfterSpill() {
 	}
 	h.intGroupStates = nil
 	h.strGroupStates = nil
+	h.strNullGroupIdx = -1
 	h.keys = nil
 	h.serializedKeys = nil
 	h.compactKeys = nil

--- a/internal/engine/exec/join_spill.go
+++ b/internal/engine/exec/join_spill.go
@@ -444,6 +444,15 @@ func writeColumnarBatch(w *bufio.Writer, b *batch.RecordBatch) error {
 		w.Write(buf[:2])
 		w.WriteString(name)
 
+		// DECIMAL scale+precision: the data section stores raw scaled
+		// integers, so a reader without the scale rebuilds a scale-0
+		// vector and every spilled decimal renders 10^scale too large
+		// (same class as the WSHF header fix — issue #144).
+		if col.Type == batch.TypeDecimal {
+			w.WriteByte(byte(col.DecimalData.Scale))
+			w.WriteByte(byte(b.Schema[i].Precision))
+		}
+
 		// Nullable flag from schema
 		if b.Schema[i].Nullable {
 			w.WriteByte(1)
@@ -601,6 +610,11 @@ func writeNestedVector(w *bufio.Writer, v *batch.Vector, n int, buf []byte) erro
 		return nil
 	}
 	w.WriteByte(byte(v.Type))
+	// DECIMAL children carry their scale (same rationale as the top-level
+	// column header — the data section is raw scaled integers).
+	if v.Type == batch.TypeDecimal {
+		w.WriteByte(byte(v.DecimalData.Scale))
+	}
 	if v.Nulls.HasNulls() {
 		w.WriteByte(1)
 		bitmapLen := (n + 7) / 8
@@ -629,7 +643,15 @@ func readNestedVector(r *bufio.Reader, n int, buf []byte) (*batch.Vector, error)
 		}
 		return nil, nil
 	}
-	v := batch.NewVector(parquet.TypeID(typeByte), n)
+	scale := 0
+	if parquet.TypeID(typeByte) == parquet.TypeDecimal {
+		sb, err := r.ReadByte()
+		if err != nil {
+			return nil, fmt.Errorf("reading nested decimal scale: %w", err)
+		}
+		scale = int(sb)
+	}
+	v := batch.NewVectorWithScale(parquet.TypeID(typeByte), n, scale)
 	hasNulls, err := r.ReadByte()
 	if err != nil {
 		return nil, fmt.Errorf("reading nested hasNulls: %w", err)
@@ -688,21 +710,39 @@ func readColumnarBatch(r *bufio.Reader) (*batch.RecordBatch, error) {
 			return nil, fmt.Errorf("reading column name: %w", err)
 		}
 
+		typeID := parquet.TypeID(typeByte)
+
+		// DECIMAL scale+precision (written after the name — see
+		// writeColumnarBatch).
+		scale, precision := 0, 0
+		if typeID == parquet.TypeDecimal {
+			sb, err := r.ReadByte()
+			if err != nil {
+				return nil, fmt.Errorf("reading decimal scale: %w", err)
+			}
+			pb, err := r.ReadByte()
+			if err != nil {
+				return nil, fmt.Errorf("reading decimal precision: %w", err)
+			}
+			scale, precision = int(sb), int(pb)
+		}
+
 		// Nullable
 		nullable, err := r.ReadByte()
 		if err != nil {
 			return nil, fmt.Errorf("reading nullable flag: %w", err)
 		}
 
-		typeID := parquet.TypeID(typeByte)
 		schema[i] = parquet.Column{
-			Name:     string(nameBuf),
-			Type:     typeID,
-			Nullable: nullable == 1,
+			Name:      string(nameBuf),
+			Type:      typeID,
+			Nullable:  nullable == 1,
+			Scale:     scale,
+			Precision: precision,
 		}
 
 		// Create vector for this column
-		col := batch.NewVector(typeID, numRows)
+		col := batch.NewVectorWithScale(typeID, numRows, scale)
 		cols[i] = col
 
 		// Null bitmap

--- a/internal/engine/scan/columnar_native.go
+++ b/internal/engine/scan/columnar_native.go
@@ -81,6 +81,14 @@ func rowGroupRangeForShard(total, shardIdx, shardCount int) (int, int) {
 // ReadRowGroupNative reads a row group using our custom page reader,
 // bypassing parquet-go entirely for the data path.
 func ReadRowGroupNative(fr *pqt.FileReader, rgIdx int, schema []pqt.Column, pool *batch.BatchPool) (*batch.RecordBatch, error) {
+	// ARRAY/MAP leaves don't resolve by column name here; without this
+	// guard the column lookup missed and the "schema evolution" branch
+	// silently emitted ALL-NULL values for the array column — valid-looking
+	// rows with the data gone. Callers must route such schemas to the
+	// row-based fallback (readFileBatchesViaRows / readBatchViaRows).
+	if HasUnsupportedColumnarTypes(schema) {
+		return nil, fmt.Errorf("native reader does not support ARRAY/MAP columns")
+	}
 	numRows := int(fr.RowGroupNumRows(rgIdx))
 	if numRows == 0 {
 		return nil, nil
@@ -202,6 +210,16 @@ func readColumnNative(vec *batch.Vector, fr *pqt.FileReader, rgIdx, colIdx, numR
 		fileType = catalogType
 	}
 
+	// DECIMAL: the native decoder handles the INT64 physical encoding our
+	// writer produces. Externally-written files (PyArrow decimal128) use
+	// FIXED_LEN_BYTE_ARRAY — fail loudly rather than mis-cast the bytes;
+	// callers fall back to the row-based reader on error.
+	if fileType == pqt.TypeDecimal && colIdx < len(leaves) {
+		if pt := leaves[colIdx].Type; pt == nil || *pt != pqt.PhysicalInt64 {
+			return fmt.Errorf("decimal column %q: unsupported physical encoding (want INT64)", leaves[colIdx].Name)
+		}
+	}
+
 	// Get max definition level from schema.
 	maxDefLevel := 0
 	if colIdx < len(leaves) {
@@ -273,7 +291,7 @@ func resolveNativeDictionary(dict *pqt.DictionaryData, page pqt.Values, fileType
 	n := page.Count()
 
 	switch fileType {
-	case pqt.TypeInt64, pqt.TypeTimestamp, pqt.TypeIPv4, pqt.TypeMAC, pqt.TypeDuration:
+	case pqt.TypeInt64, pqt.TypeTimestamp, pqt.TypeIPv4, pqt.TypeMAC, pqt.TypeDuration, pqt.TypeDecimal:
 		src := dict.Data.Int64()
 		dst := make([]int64, n)
 		for i := 0; i < n; i++ {
@@ -352,6 +370,15 @@ func copyNativeDataDirect(vec *batch.Vector, offset int, data pqt.Values, n int,
 		src := data.Int64()
 		copy(vec.Int64Data[offset:offset+n], src[:n])
 
+	case pqt.TypeDecimal:
+		// Scaled-integer INT64 physical → Int128 storage. Without this
+		// case the switch fell through and every decimal column scanned
+		// as zeros, silently (issue #144 suite finding).
+		src := data.Int64()
+		for i := 0; i < n; i++ {
+			vec.DecimalData.Data[offset+i] = batch.Int128From(src[i])
+		}
+
 	case pqt.TypeInt32, pqt.TypePort, pqt.TypeProtocol, pqt.TypeDate:
 		src := data.Int32()
 		copy(vec.Int32Data[offset:offset+n], src[:n])
@@ -423,6 +450,16 @@ func copyNativeDataScatter(vec *batch.Vector, offset int, data pqt.Values, defLe
 		src := data.Int64()
 		scatterRunsNative(defLevels, maxDefLevel, n, func(dstStart, srcStart, count int) {
 			copy(vec.Int64Data[offset+dstStart:offset+dstStart+count], src[srcStart:srcStart+count])
+		}, func(dstStart, count int) {
+			vec.Nulls.SetNullRange(offset+dstStart, count)
+		})
+
+	case pqt.TypeDecimal:
+		src := data.Int64()
+		scatterRunsNative(defLevels, maxDefLevel, n, func(dstStart, srcStart, count int) {
+			for i := 0; i < count; i++ {
+				vec.DecimalData.Data[offset+dstStart+i] = batch.Int128From(src[srcStart+i])
+			}
 		}, func(dstStart, count int) {
 			vec.Nulls.SetNullRange(offset+dstStart, count)
 		})

--- a/internal/engine/scan/native_decimal_nested_test.go
+++ b/internal/engine/scan/native_decimal_nested_test.go
@@ -1,0 +1,80 @@
+package scan
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// Regression tests for the native row-group decoder (issue #144 suite
+// findings): DECIMAL pages decoded to all-zeros (no TypeDecimal case in the
+// copy switch), and ARRAY columns were silently emitted as ALL-NULL (the
+// leaf-name lookup missed and fell into the schema-evolution branch)
+// instead of erroring so callers fall back to the row-based reader.
+
+func writeOneRG(tb testing.TB, schema parquet.Schema, rows []map[string]any) *parquet.Reader {
+	tb.Helper()
+	var buf bytes.Buffer
+	w, err := parquet.NewWriter(&buf, schema, parquet.DefaultWriterConfig())
+	if err != nil {
+		tb.Fatal(err)
+	}
+	if err := w.WriteRows(rows); err != nil {
+		tb.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		tb.Fatal(err)
+	}
+	data := buf.Bytes()
+	r, err := parquet.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return r
+}
+
+func TestReadRowGroupNative_DecimalValues(t *testing.T) {
+	schema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "d", Type: parquet.TypeDecimal, Nullable: true, Precision: 12, Scale: 2},
+	}}
+	rows := []map[string]any{
+		{"d": 3.25}, {"d": nil}, {"d": -1.5}, {"d": int64(7)}, {"d": "12.34"},
+	}
+	r := writeOneRG(t, schema, rows)
+	b, err := ReadRowGroupNative(r.FileReader(), 0, schema.Columns, nil)
+	if err != nil {
+		t.Fatalf("ReadRowGroupNative: %v", err)
+	}
+	want := []float64{3.25, 0, -1.5, 7, 12.34}
+	isNull := []bool{false, true, false, false, false}
+	for i := range want {
+		if isNull[i] {
+			if !b.Columns[0].Nulls.IsNullFast(i) {
+				t.Fatalf("row %d: want NULL, got %v", i, b.Columns[0].GetValue(i))
+			}
+			continue
+		}
+		// The null-interleaved page exercises the scatter path; values
+		// must land in their own slots, not shift into null positions.
+		got, err := strconv.ParseFloat(fmt.Sprintf("%v", b.Columns[0].GetValue(i)), 64)
+		if err != nil || got != want[i] {
+			t.Fatalf("row %d: got %v, want %v (decimal page decoded to zeros or misaligned)",
+				i, b.Columns[0].GetValue(i), want[i])
+		}
+	}
+}
+
+func TestReadRowGroupNative_ArrayErrorsLoudly(t *testing.T) {
+	schema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "tags", Type: parquet.TypeArray, Nullable: true,
+			ElementType: &parquet.Column{Name: "element", Type: parquet.TypeString, Nullable: true}},
+	}}
+	r := writeOneRG(t, schema, []map[string]any{{"tags": []any{"a", "b"}}})
+	_, err := ReadRowGroupNative(r.FileReader(), 0, schema.Columns, nil)
+	if err == nil {
+		t.Fatal("ARRAY through the native reader must error (callers fall back to the row reader); silent all-NULL output is wrong results")
+	}
+}

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -7460,6 +7460,14 @@ func (s *scannerExecSource) Init(ctx context.Context) error {
 		memTracker:    s.memTracker,
 		spillMgr:      s.spillMgr,
 	}
+	// Nested (ARRAY/MAP/ROW) schemas must take the file-level scan whose
+	// readBatchDirect falls back to the row-based reader. This MUST be
+	// decided HERE: the eager branch only learned about nested types
+	// inside buildRGUnits, which runs after the branch was already taken —
+	// the early return left zero rgUnits and every query against a nested
+	// table returned 0 rows with no error (issue #144 suite finding).
+	innerSchema := parquet.Schema{Columns: inner.schema}
+	inner.hasNestedTypes = innerSchema.HasNestedColumns()
 	s.scanner = inner
 
 	if inner.rowLimit > 0 || inner.hasNestedTypes {

--- a/internal/planner/physical/util.go
+++ b/internal/planner/physical/util.go
@@ -872,6 +872,14 @@ func (inner *scanSourceInner) readRG(ctx context.Context, unit rgUnit) *batch.Re
 	b, err := scan.ReadRowGroupNative(rdr, unit.rgIndex, inner.readSchema(), inner.pool)
 	unit.slot.releaseRG(inner)
 	if err != nil {
+		// Surface the first decode error so the scan FAILS instead of
+		// silently dropping this row group's rows — a swallowed error here
+		// is indistinguishable from a correct partial result (the same
+		// silent-0-rows class as the nested-branch bug, issue #144).
+		select {
+		case inner.errCh <- fmt.Errorf("decoding %s row group %d: %w", unit.slot.entry.Path, unit.rgIndex, err):
+		default:
+		}
 		return nil
 	}
 	inner.trackScanBatch(b)

--- a/internal/storage/parquet/decimal_roundtrip_test.go
+++ b/internal/storage/parquet/decimal_roundtrip_test.go
@@ -1,0 +1,151 @@
+package parquet
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+)
+
+// Regression tests for the DECIMAL write path (issue #144 suite finding):
+// toInt64's float64 branch truncated 3.25 → 3 instead of scaling to 325,
+// destroying every non-integer decimal value at write time, and the read
+// side dropped Precision/Scale when rebuilding the schema from the file's
+// LogicalType — so even correctly-written values decoded at the wrong
+// magnitude. TPC-H stores money as Float64, so no existing gate saw it.
+
+func writeDecimalFile(tb testing.TB, scale int, vals []any) []byte {
+	tb.Helper()
+	schema := Schema{Columns: []Column{
+		{Name: "d", Type: TypeDecimal, Nullable: true, Precision: 18, Scale: scale},
+	}}
+	var buf bytes.Buffer
+	w, err := NewWriter(&buf, schema, DefaultWriterConfig())
+	if err != nil {
+		tb.Fatal(err)
+	}
+	rows := make([]map[string]any, len(vals))
+	for i, v := range vals {
+		rows[i] = map[string]any{"d": v}
+	}
+	if err := w.WriteRows(rows); err != nil {
+		tb.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		tb.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func TestDecimalScaledInt64(t *testing.T) {
+	tests := []struct {
+		val   any
+		scale int
+		want  int64
+	}{
+		{3.25, 2, 325},
+		{-1.5, 2, -150},
+		{0.0, 2, 0},
+		{int64(7), 2, 700},
+		{int(7), 2, 700},
+		{int32(-3), 2, -300},
+		{"12.34", 2, 1234},
+		{"-0.01", 2, -1},
+		{"7", 2, 700},
+		{2.675, 2, 268}, // half rounds away from zero (float repr permitting)
+		{1.005e10, 2, 1005000000000},
+		{99.999, 2, 10000}, // rounds up across the integer boundary
+		{3.25, 0, 3},       // scale 0 keeps integer part, rounded
+		{"garbage", 2, 0},  // unparseable stores 0 (matches toInt64 default)
+		{float32(1.5), 1, 15},
+	}
+	for _, tc := range tests {
+		if got := decimalScaledInt64(tc.val, tc.scale); got != tc.want {
+			t.Errorf("decimalScaledInt64(%v, %d) = %d, want %d", tc.val, tc.scale, got, tc.want)
+		}
+	}
+	// Non-finite floats must not poison the column.
+	if got := decimalScaledInt64(nan(), 2); got != 0 {
+		t.Errorf("NaN = %d, want 0", got)
+	}
+}
+
+func nan() float64 {
+	f := 0.0
+	return f / f
+}
+
+func TestDecimalSchemaRoundTrip(t *testing.T) {
+	data := writeDecimalFile(t, 2, []any{3.25})
+	r, err := NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	col := r.Schema().Columns[0]
+	if col.Type != TypeDecimal {
+		t.Fatalf("read type = %v, want DECIMAL", col.Type)
+	}
+	if col.Precision != 18 || col.Scale != 2 {
+		t.Fatalf("read precision/scale = %d/%d, want 18/2 (lost → values decode at the wrong magnitude)",
+			col.Precision, col.Scale)
+	}
+}
+
+func TestDecimalValueRoundTrip(t *testing.T) {
+	// ReadRows returns the RAW SCALED integer for DECIMAL columns (325 for
+	// 3.25 at scale 2); the batch layer (Vector.SetValue Int128From) stores
+	// it unscaled and FormatDecimal renders with the column scale. This
+	// test pins the write-side scaling: before the fix the file held the
+	// TRUNCATED integer part (3, not 325) for every non-integer input.
+	vals := []any{3.25, -1.5, 0.0, int64(7), "12.34", nil, 0.01, -9999999.99}
+	want := []float64{325, -150, 0, 700, 1234, 0, 1, -999999999}
+	isNull := []bool{false, false, false, false, false, true, false, false}
+	data := writeDecimalFile(t, 2, vals)
+	r, err := NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := r.ReadRows(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != len(vals) {
+		t.Fatalf("rows = %d, want %d", len(rows), len(vals))
+	}
+	for i := range vals {
+		got := rows[i]["d"]
+		if isNull[i] {
+			if got != nil {
+				t.Errorf("row %d: got %v, want NULL", i, got)
+			}
+			continue
+		}
+		if got == nil {
+			t.Errorf("row %d: got NULL, want %v", i, want[i])
+			continue
+		}
+		f, ok := toFloat(got)
+		if !ok {
+			t.Errorf("row %d: unboxable decimal %#v (%T)", i, got, got)
+			continue
+		}
+		if diff := f - want[i]; diff > 1e-9 || diff < -1e-9 {
+			t.Errorf("row %d: got %v, want %v (write-side scaling or read-side scale lost)", i, f, want[i])
+		}
+	}
+}
+
+func toFloat(v any) (float64, bool) {
+	switch x := v.(type) {
+	case float64:
+		return x, true
+	case float32:
+		return float64(x), true
+	case int64:
+		return float64(x), true
+	case string:
+		f, err := strconv.ParseFloat(x, 64)
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}

--- a/internal/storage/parquet/file_reader.go
+++ b/internal/storage/parquet/file_reader.go
@@ -289,6 +289,19 @@ func nodeToColumn(n *SchemaNode) Column {
 		if col.Type == TypeVector && col.Dimension <= 0 && n.TypeLength > 0 {
 			col.Dimension = int(n.TypeLength) / 4 // TypeLength = dim × sizeof(float32)
 		}
+		if col.Type == TypeDecimal {
+			// Without precision/scale the read-side vector decodes the
+			// scaled integer with scale 0 — every decimal value silently
+			// off by 10^scale (issue #144 suite finding).
+			if n.LogicalType != nil {
+				col.Precision = n.LogicalType.Precision
+				col.Scale = n.LogicalType.Scale
+			}
+			if col.Precision == 0 && n.Precision > 0 {
+				col.Precision = int(n.Precision)
+				col.Scale = int(n.Scale)
+			}
+		}
 		return col
 	}
 

--- a/internal/storage/parquet/file_writer.go
+++ b/internal/storage/parquet/file_writer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"strconv"
 	"time"
 
 	"github.com/klauspost/compress/gzip"
@@ -879,7 +880,16 @@ func (lb *leafBuffer) appendEntryWithValue(defLevel, repLevel int32, val any) {
 		v := toInt32(val, lb.col.Type)
 		lb.appendInt32(v)
 	case PhysicalInt64:
-		v := toInt64(val, lb.col.Type)
+		var v int64
+		if lb.col.Type == TypeDecimal {
+			// DECIMAL stores the SCALED integer (3.25 at scale 2 → 325).
+			// toInt64's float64 branch truncated to the unscaled integer
+			// part, so every non-integer decimal value was destroyed on
+			// write (issue #144 suite finding).
+			v = decimalScaledInt64(val, int(lb.col.Scale))
+		} else {
+			v = toInt64(val, lb.col.Type)
+		}
 		lb.appendInt64(v)
 	case PhysicalFloat:
 		v := toFloat32(val)
@@ -1104,6 +1114,41 @@ func toInt32(v any, colType TypeID) int32 {
 			return parseDateForWrite(t)
 		}
 		return 0
+	default:
+		return 0
+	}
+}
+
+// decimalScaledInt64 converts an ingest value to the scaled integer a
+// DECIMAL(p,s) column stores physically (INT64): value × 10^scale, rounded
+// half away from zero. Integer inputs are whole decimal values; float and
+// numeric-string inputs carry fractional digits. Non-finite floats and
+// unparseable strings store 0 (matching toInt64's default for garbage).
+func decimalScaledInt64(v any, scale int) int64 {
+	pow := 1.0
+	for i := 0; i < scale; i++ {
+		pow *= 10
+	}
+	switch t := v.(type) {
+	case int:
+		return int64(t) * int64(pow)
+	case int32:
+		return int64(t) * int64(pow)
+	case int64:
+		return t * int64(pow)
+	case float64:
+		if math.IsNaN(t) || math.IsInf(t, 0) {
+			return 0
+		}
+		return int64(math.Round(t * pow))
+	case float32:
+		return decimalScaledInt64(float64(t), scale)
+	case string:
+		f, err := strconv.ParseFloat(t, 64)
+		if err != nil {
+			return 0
+		}
+		return decimalScaledInt64(f, scale)
 	default:
 		return 0
 	}

--- a/internal/worker/shuffle_format.go
+++ b/internal/worker/shuffle_format.go
@@ -90,6 +90,19 @@ func (sw *shuffleWriter) writeHeader() error {
 		if _, err := sw.w.Write(sw.buf[:1]); err != nil {
 			return err
 		}
+		// DECIMAL carries scale+precision: the chunk data is the raw
+		// scaled integer, so a reader without the scale rebuilds a
+		// scale-0 vector and every value renders 10^scale too large
+		// (distributed GROUP BY decimal keys lost their fraction —
+		// issue #144 suite finding). Written only for decimal columns;
+		// all WSHF readers consume it conditionally on the type byte.
+		if col.Type == parquet.TypeDecimal {
+			sw.buf[0] = uint8(col.Scale)
+			sw.buf[1] = uint8(col.Precision)
+			if _, err := sw.w.Write(sw.buf[:2]); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }
@@ -359,9 +372,18 @@ func (sw *shuffleWriter) writeDecimalData(vec *batch.Vector, sel []uint32, numRo
 		_, err := sw.w.Write(gb[:nbytes])
 		return err
 	}
-	// Int128 struct {Lo uint64; Hi int64} has matching little-endian layout.
-	raw := unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(vec.DecimalData.Data[:numRows]))), nbytes)
-	_, err := sw.w.Write(raw)
+	// Wire order is (Lo, Hi), matching the sel path above, the
+	// coordinator's readShuffleColumn, and the exec spill format. The
+	// previous unsafe memcpy assumed the struct was {Lo, Hi} — it is
+	// {Hi, Lo} — so no-sel chunks hit explicit-order readers field-swapped
+	// and every decimal decoded as garbage (issue #144 suite finding).
+	gb := sw.ensureGather(nbytes)
+	for i := 0; i < numRows; i++ {
+		d := vec.DecimalData.Data[i]
+		binary.LittleEndian.PutUint64(gb[i*16:], d.Lo)
+		binary.LittleEndian.PutUint64(gb[i*16+8:], uint64(d.Hi))
+	}
+	_, err := sw.w.Write(gb[:nbytes])
 	return err
 }
 
@@ -409,6 +431,14 @@ func newShuffleChunkReader(data []byte) (*shuffleChunkReader, error) {
 		schema[i].Type = parquet.TypeID(data[pos])
 		schema[i].Nullable = true
 		pos++
+		if schema[i].Type == parquet.TypeDecimal {
+			if pos+2 > len(data) {
+				return nil, fmt.Errorf("truncated decimal schema at column %d", i)
+			}
+			schema[i].Scale = int(data[pos])
+			schema[i].Precision = int(data[pos+1])
+			pos += 2
+		}
 	}
 
 	return &shuffleChunkReader{
@@ -483,6 +513,14 @@ func shuffleReadBatches(data []byte) ([]*batch.RecordBatch, error) {
 		schema[i].Type = parquet.TypeID(data[pos])
 		schema[i].Nullable = true
 		pos++
+		if schema[i].Type == parquet.TypeDecimal {
+			if pos+2 > len(data) {
+				return nil, fmt.Errorf("truncated decimal schema at column %d", i)
+			}
+			schema[i].Scale = int(data[pos])
+			schema[i].Precision = int(data[pos+1])
+			pos += 2
+		}
 	}
 
 	// Read chunks
@@ -623,8 +661,16 @@ func readDecimalData(data []byte, pos int, vec *batch.Vector, numRows int) (int,
 	if vec.DecimalData.Data == nil {
 		return pos + nbytes, nil
 	}
-	dstBytes := unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(vec.DecimalData.Data[:numRows]))), nbytes)
-	copy(dstBytes, data[pos:pos+nbytes])
+	// Wire order is (Lo, Hi) — see shuffleWriter.writeDecimalData. The
+	// previous raw struct memcpy assumed (Hi, Lo) and field-swapped any
+	// chunk produced by the explicit-order writer paths.
+	for i := 0; i < numRows; i++ {
+		off := pos + i*16
+		vec.DecimalData.Data[i] = batch.Int128{
+			Lo: binary.LittleEndian.Uint64(data[off:]),
+			Hi: int64(binary.LittleEndian.Uint64(data[off+8:])),
+		}
+	}
 	return pos + nbytes, nil
 }
 

--- a/internal/worker/shuffle_format_test.go
+++ b/internal/worker/shuffle_format_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/citc-tech/wadjet/internal/engine/batch"
@@ -279,4 +280,63 @@ func BenchmarkShuffleWriteVsParquet(b *testing.B) {
 		}
 	})
 
+}
+
+// Regression test for the WSHF decimal schema header (issue #144 suite
+// finding): the header carried only (name, type), so the receiving side
+// rebuilt decimal columns at scale 0 and every value rendered as its raw
+// scaled integer — distributed GROUP BY decimal keys came back as "25"
+// instead of "0.25". Scale+precision now ride the header for decimal
+// columns only.
+func TestShuffleFormatDecimalScaleRoundTrip(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "amount", Type: parquet.TypeDecimal, Nullable: true, Precision: 12, Scale: 2},
+	}
+	b := batch.NewRecordBatch(schema, 3)
+	for i, v := range []int64{325, -150, 1234} { // 3.25, -1.50, 12.34 at scale 2
+		b.Columns[0].Int64Data[i] = int64(i)
+		b.Columns[0].Nulls.SetValid(i)
+		b.Columns[1].DecimalData.Data[i] = batch.Int128From(v)
+		b.Columns[1].Nulls.SetValid(i)
+	}
+	b.Len = 3
+
+	var buf bytes.Buffer
+	sw := newShuffleWriter(&buf, schema)
+	if err := sw.writeHeader(); err != nil {
+		t.Fatal(err)
+	}
+	sel := []uint32{0, 1, 2}
+	if err := sw.writeChunk(b.Columns, sel, 3); err != nil {
+		t.Fatal(err)
+	}
+	payload := buf.Bytes()
+	payload[4] = 1 // patch chunk count like the gather sink does
+
+	out, err := shuffleReadBatches(payload)
+	if err != nil {
+		t.Fatalf("shuffleReadBatches: %v", err)
+	}
+	if len(out) != 1 || out[0].Len != 3 {
+		t.Fatalf("got %d batches", len(out))
+	}
+	if got := out[0].Schema[1].Scale; got != 2 {
+		t.Fatalf("decoded schema scale = %d, want 2 (header lost it)", got)
+	}
+	want := []string{"3.25", "-1.5", "12.34"}
+	for i, w := range want {
+		if got := fmt.Sprintf("%v", out[0].Columns[1].GetValue(i)); got != w {
+			t.Fatalf("row %d: %v, want %s", i, got, w)
+		}
+	}
+
+	// The streaming chunk reader parses the same header.
+	cr, err := newShuffleChunkReader(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cr.schema[1].Scale; got != 2 {
+		t.Fatalf("chunk reader schema scale = %d, want 2", got)
+	}
 }

--- a/wadjet/nested_decimal_correctness_test.go
+++ b/wadjet/nested_decimal_correctness_test.go
@@ -1,0 +1,531 @@
+package wadjet
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/storage/ingest"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// Nested-types + Decimal correctness gate (issue #144).
+//
+// TPC-H exercises neither nested types (ARRAY/MAP/ROW) nor Decimal in the
+// merge path, so every prior gate (SF0.01/SF1/SF100, the local harness) was
+// structurally blind to the wrong-results class the 2026-06-12 sweep found
+// (the advance-on-NULL family fixed in PR #123, the Decimal merge collapse,
+// the NULL-group GROUP BY drop fixed in PR #142). This suite is the missing
+// gate: a deterministic dataset with nested columns, interior AND trailing
+// NULLs at batch boundaries, a nullable group key, and a Decimal measure,
+// pushed through the full SQL surface — every expectation computed
+// independently in Go from the same source rows.
+//
+// The dataset spans multiple 2048-row batches on purpose: pooled-batch
+// reuse and offset bookkeeping bugs only fire on the second batch.
+
+const ndRows = 5000 // > 2×2048 so the scan recycles pooled batches twice
+
+type ndRow struct {
+	id    int64
+	grp   any // string or nil (NULL group key — the PR #142 class)
+	amt   any // float64 or nil; DECIMAL(12,2) column
+	tags  any // []any of string or nil (NULL array, incl. trailing rows)
+	attrs any // map[string]any{name, score} or nil (NULL row)
+}
+
+func ndSource() []ndRow {
+	rows := make([]ndRow, ndRows)
+	for i := range rows {
+		id := int64(i)
+		r := ndRow{id: id}
+		if id%7 != 3 {
+			r.grp = fmt.Sprintf("g%d", id%3)
+		}
+		if id%11 != 5 {
+			r.amt = float64(id%50) + 0.25
+		}
+		if id%5 != 4 { // id%5==4 → NULL array; hits the final row (4999)
+			n := int(id % 3) // lengths 0,1,2 — zero-length ≠ NULL
+			tags := make([]any, n)
+			for j := 0; j < n; j++ {
+				tags[j] = fmt.Sprintf("t%d-%d", id%4, j)
+			}
+			r.tags = tags
+		}
+		if id%6 != 2 { // id%6==2 → NULL row
+			attrs := map[string]any{"score": id % 100}
+			if id%13 != 7 { // id%13==7 → NULL name field inside a valid row
+				attrs["name"] = fmt.Sprintf("n%d", id%10)
+			}
+			r.attrs = attrs
+		}
+		rows[i] = r
+	}
+	return rows
+}
+
+func ndOpen(t *testing.T) (*DB, []ndRow) {
+	t.Helper()
+	ctx := context.Background()
+	db, err := Open(ctx, Config{Store: objstore.NewMemStore(), Bucket: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "grp", Type: parquet.TypeString, Nullable: true},
+		{Name: "amount", Type: parquet.TypeDecimal, Nullable: true, Precision: 12, Scale: 2},
+		{Name: "tags", Type: parquet.TypeArray, Nullable: true,
+			ElementType: &parquet.Column{Name: "element", Type: parquet.TypeString, Nullable: true}},
+		{Name: "attrs", Type: parquet.TypeRow, Nullable: true, Fields: []parquet.Column{
+			{Name: "name", Type: parquet.TypeString, Nullable: true},
+			{Name: "score", Type: parquet.TypeInt64, Nullable: true},
+		}},
+	}}
+	if err := db.CreateTable(ctx, "events", schema, nil); err != nil {
+		t.Fatal(err)
+	}
+	src := ndSource()
+	boxed := make([]map[string]any, len(src))
+	for i, r := range src {
+		boxed[i] = map[string]any{
+			"id": r.id, "grp": r.grp, "amount": r.amt, "tags": r.tags, "attrs": r.attrs,
+		}
+	}
+	ing := db.NewIngester("events", schema, nil, ingest.Config{MaxBufferRows: 10000, RowGroupSize: 1500})
+	if err := ing.Ingest(ctx, boxed); err != nil {
+		t.Fatal(err)
+	}
+	if err := ing.FlushAll(ctx); err != nil {
+		t.Fatal(err)
+	}
+	return db, src
+}
+
+func TestNestedDecimalCorrectness(t *testing.T) {
+	ctx := context.Background()
+	db, src := ndOpen(t)
+
+	t.Run("full_round_trip", func(t *testing.T) {
+		res, err := db.Query(ctx, `SELECT id, grp, amount, tags, attrs FROM events`)
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		if len(res.Rows) != ndRows {
+			t.Fatalf("rows = %d, want %d", len(res.Rows), ndRows)
+		}
+		byID := make(map[int64]map[string]any, len(res.Rows))
+		for _, row := range res.Rows {
+			byID[row["id"].(int64)] = row
+		}
+		for _, want := range src {
+			got, ok := byID[want.id]
+			if !ok {
+				t.Fatalf("id %d missing from result", want.id)
+			}
+			// grp (nullable flat string)
+			if want.grp == nil {
+				if got["grp"] != nil {
+					t.Fatalf("id %d: grp = %v, want NULL", want.id, got["grp"])
+				}
+			} else if got["grp"] != want.grp {
+				t.Fatalf("id %d: grp = %v, want %v", want.id, got["grp"], want.grp)
+			}
+			// amount (Decimal boxes as its formatted string)
+			if want.amt == nil {
+				if got["amount"] != nil {
+					t.Fatalf("id %d: amount = %v, want NULL", want.id, got["amount"])
+				}
+			} else {
+				wantStr := fmt.Sprintf("%.2f", want.amt.(float64))
+				if fmt.Sprintf("%v", got["amount"]) != wantStr {
+					t.Fatalf("id %d: amount = %v, want %s", want.id, got["amount"], wantStr)
+				}
+			}
+			// tags (nullable ARRAY(STRING)) — NULL vs empty must be distinct,
+			// and element values exact (offset corruption reads neighbors'
+			// bytes, so any drift shows up as concatenated garbage).
+			if want.tags == nil {
+				if got["tags"] != nil {
+					t.Fatalf("id %d: tags = %#v, want NULL (trailing/interior null array)", want.id, got["tags"])
+				}
+			} else {
+				wantTags := want.tags.([]any)
+				gotTags, ok := got["tags"].([]any)
+				if !ok {
+					t.Fatalf("id %d: tags = %#v (%T), want []any", want.id, got["tags"], got["tags"])
+				}
+				if len(gotTags) != len(wantTags) {
+					t.Fatalf("id %d: tags len = %d (%v), want %d (%v)", want.id, len(gotTags), gotTags, len(wantTags), wantTags)
+				}
+				for j := range wantTags {
+					if fmt.Sprintf("%v", gotTags[j]) != wantTags[j].(string) {
+						t.Fatalf("id %d: tags[%d] = %v, want %v", want.id, j, gotTags[j], wantTags[j])
+					}
+				}
+			}
+			// attrs (nullable ROW with nullable bytes-typed child)
+			if want.attrs == nil {
+				if got["attrs"] != nil {
+					t.Fatalf("id %d: attrs = %#v, want NULL row", want.id, got["attrs"])
+				}
+			} else {
+				wantAttrs := want.attrs.(map[string]any)
+				gotAttrs, ok := got["attrs"].(map[string]any)
+				if !ok {
+					t.Fatalf("id %d: attrs = %#v (%T), want map", want.id, got["attrs"], got["attrs"])
+				}
+				if wn, ok := wantAttrs["name"]; ok {
+					if fmt.Sprintf("%v", gotAttrs["name"]) != wn.(string) {
+						t.Fatalf("id %d: attrs.name = %v, want %v", want.id, gotAttrs["name"], wn)
+					}
+				} else if gotAttrs["name"] != nil {
+					t.Fatalf("id %d: attrs.name = %v, want NULL field", want.id, gotAttrs["name"])
+				}
+				if fmt.Sprintf("%v", gotAttrs["score"]) != fmt.Sprintf("%v", wantAttrs["score"]) {
+					t.Fatalf("id %d: attrs.score = %v, want %v", want.id, gotAttrs["score"], wantAttrs["score"])
+				}
+			}
+		}
+	})
+
+	t.Run("null_group_key_aggregate", func(t *testing.T) {
+		// The PR #142 class: NULL group keys silently dropped by the
+		// int/dual-int fast paths. Count per grp INCLUDING the NULL group.
+		res, err := db.Query(ctx, `SELECT grp, COUNT(*) AS c FROM events GROUP BY grp`)
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		wantCounts := map[string]int64{}
+		for _, r := range src {
+			key := "<null>"
+			if r.grp != nil {
+				key = r.grp.(string)
+			}
+			wantCounts[key]++
+		}
+		gotCounts := map[string]int64{}
+		for _, row := range res.Rows {
+			key := "<null>"
+			if row["grp"] != nil {
+				key = fmt.Sprintf("%v", row["grp"])
+			}
+			gotCounts[key] += toI64(t, row["c"])
+		}
+		if len(gotCounts) != len(wantCounts) {
+			t.Fatalf("groups = %v, want %v (NULL group dropped?)", gotCounts, wantCounts)
+		}
+		for k, want := range wantCounts {
+			if gotCounts[k] != want {
+				t.Fatalf("group %q count = %d, want %d", k, gotCounts[k], want)
+			}
+		}
+	})
+
+	t.Run("decimal_group_key", func(t *testing.T) {
+		// Distinct Decimal keys must stay distinct (the sweep's extractValue
+		// collapse encoded every Decimal key as "<nil>" — one merge group).
+		res, err := db.Query(ctx, `SELECT amount, COUNT(*) AS c FROM events GROUP BY amount`)
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		want := map[string]int64{}
+		for _, r := range src {
+			key := "<null>"
+			if r.amt != nil {
+				key = fmt.Sprintf("%.2f", r.amt.(float64))
+			}
+			want[key]++
+		}
+		got := map[string]int64{}
+		for _, row := range res.Rows {
+			key := "<null>"
+			if row["amount"] != nil {
+				key = fmt.Sprintf("%v", row["amount"])
+			}
+			got[key] += toI64(t, row["c"])
+		}
+		if len(got) != len(want) {
+			t.Fatalf("distinct decimal groups = %d, want %d", len(got), len(want))
+		}
+		for k, w := range want {
+			if got[k] != w {
+				t.Fatalf("amount %q count = %d, want %d", k, got[k], w)
+			}
+		}
+	})
+
+	t.Run("filter_on_row_field", func(t *testing.T) {
+		// row_field() is the supported ROW accessor in predicates. (Dotted
+		// `attrs.score` parses but resolves as an unknown table-qualified
+		// column and silently evaluates NULL — tracked separately along
+		// with unknown-column-silently-empty strictness.)
+		res, err := db.Query(ctx, `SELECT id FROM events WHERE row_field(attrs, 'score') > 90`)
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		want := 0
+		for _, r := range src {
+			if r.attrs != nil && r.attrs.(map[string]any)["score"].(int64) > 90 {
+				want++
+			}
+		}
+		if len(res.Rows) != want {
+			t.Fatalf("rows = %d, want %d (NULL rows must not match)", len(res.Rows), want)
+		}
+	})
+
+	t.Run("project_nested_accessors", func(t *testing.T) {
+		res, err := db.Query(ctx, `SELECT id, element_at(tags, 1) AS t1, array_length(tags) AS n FROM events WHERE id < 20`)
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		if len(res.Rows) != 20 {
+			t.Fatalf("rows = %d, want 20", len(res.Rows))
+		}
+		for _, row := range res.Rows {
+			id := row["id"].(int64)
+			r := src[id]
+			if r.tags == nil {
+				if row["t1"] != nil || row["n"] != nil {
+					t.Fatalf("id %d: t1=%v n=%v, want NULLs for NULL array", id, row["t1"], row["n"])
+				}
+				continue
+			}
+			tags := r.tags.([]any)
+			// Expression outputs box numerics as strings (evaluator
+			// convention) — compare formatted, but NULL must stay NULL.
+			if row["n"] == nil || fmt.Sprintf("%v", row["n"]) != fmt.Sprintf("%d", len(tags)) {
+				t.Fatalf("id %d: array_length = %v, want %d", id, row["n"], len(tags))
+			}
+			if len(tags) == 0 {
+				if row["t1"] != nil {
+					t.Fatalf("id %d: element_at on empty = %v, want NULL", id, row["t1"])
+				}
+			} else if fmt.Sprintf("%v", row["t1"]) != tags[0].(string) {
+				t.Fatalf("id %d: element_at(tags,1) = %v, want %v", id, row["t1"], tags[0])
+			}
+		}
+	})
+
+	t.Run("left_join_unmatched_nested", func(t *testing.T) {
+		// The setVectorNull class: LEFT JOIN unmatched rows interleaved with
+		// matched ones corrupted nested build columns ("aaabbb" instead of
+		// "bbb"). Join a probe table where only some ids match.
+		ctx := context.Background()
+		probeSchema := parquet.Schema{Columns: []parquet.Column{
+			{Name: "pid", Type: parquet.TypeInt64},
+		}}
+		if err := db.CreateTable(ctx, "probe", probeSchema, nil); err != nil {
+			t.Fatal(err)
+		}
+		probe := make([]map[string]any, 0, 300)
+		for i := 0; i < 300; i++ {
+			probe = append(probe, map[string]any{"pid": int64(i * 20)}) // ids 0..5980, half miss (>= ndRows)
+		}
+		ing := db.NewIngester("probe", probeSchema, nil, ingest.Config{MaxBufferRows: 1000, RowGroupSize: 1000})
+		if err := ing.Ingest(ctx, probe); err != nil {
+			t.Fatal(err)
+		}
+		if err := ing.FlushAll(ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		res, err := db.Query(ctx, `
+			SELECT p.pid, e.attrs, e.tags FROM probe p
+			LEFT JOIN events e ON p.pid = e.id`)
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		if len(res.Rows) != 300 {
+			t.Fatalf("rows = %d, want 300", len(res.Rows))
+		}
+		for _, row := range res.Rows {
+			pid := row["pid"].(int64)
+			if pid >= ndRows {
+				// Unmatched: every build-side column must be NULL.
+				if row["attrs"] != nil || row["tags"] != nil {
+					t.Fatalf("pid %d unmatched: attrs=%#v tags=%#v, want NULLs", pid, row["attrs"], row["tags"])
+				}
+				continue
+			}
+			want := src[pid]
+			if want.attrs == nil {
+				if row["attrs"] != nil {
+					t.Fatalf("pid %d: attrs = %#v, want NULL row", pid, row["attrs"])
+				}
+			} else {
+				gotAttrs, ok := row["attrs"].(map[string]any)
+				if !ok {
+					t.Fatalf("pid %d: attrs = %#v (%T)", pid, row["attrs"], row["attrs"])
+				}
+				wantAttrs := want.attrs.(map[string]any)
+				if wn, ok := wantAttrs["name"]; ok && fmt.Sprintf("%v", gotAttrs["name"]) != wn.(string) {
+					t.Fatalf("pid %d: joined attrs.name = %v, want %v (matched/unmatched interleave corruption)",
+						pid, gotAttrs["name"], wn)
+				}
+			}
+			if want.tags == nil {
+				if row["tags"] != nil {
+					t.Fatalf("pid %d: tags = %#v, want NULL", pid, row["tags"])
+				}
+			} else if wantTags := want.tags.([]any); len(wantTags) > 0 {
+				gotTags, ok := row["tags"].([]any)
+				if !ok || len(gotTags) != len(wantTags) {
+					t.Fatalf("pid %d: tags = %#v, want %v", pid, row["tags"], wantTags)
+				}
+				for j := range wantTags {
+					if fmt.Sprintf("%v", gotTags[j]) != wantTags[j].(string) {
+						t.Fatalf("pid %d: tags[%d] = %v, want %v", pid, j, gotTags[j], wantTags[j])
+					}
+				}
+			}
+		}
+	})
+
+	t.Run("sort_keeps_nested_attached", func(t *testing.T) {
+		// The gatherVector class: sort/join gather wrote NOTHING for nested
+		// columns — rows came back valid-marked with zeros or another row's
+		// leftovers. Sort descending and verify nested values still belong
+		// to their id.
+		res, err := db.Query(ctx, `SELECT id, attrs, tags FROM events WHERE id < 1000 ORDER BY id DESC`)
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		if len(res.Rows) != 1000 {
+			t.Fatalf("rows = %d, want 1000", len(res.Rows))
+		}
+		if res.Rows[0]["id"].(int64) != 999 {
+			t.Fatalf("first id = %v, want 999", res.Rows[0]["id"])
+		}
+		for _, row := range res.Rows {
+			id := row["id"].(int64)
+			want := src[id]
+			if (want.attrs == nil) != (row["attrs"] == nil) {
+				t.Fatalf("id %d after sort: attrs null mismatch (got %#v)", id, row["attrs"])
+			}
+			if want.attrs != nil {
+				wantAttrs := want.attrs.(map[string]any)
+				gotAttrs := row["attrs"].(map[string]any)
+				if wn, ok := wantAttrs["name"]; ok && fmt.Sprintf("%v", gotAttrs["name"]) != wn.(string) {
+					t.Fatalf("id %d after sort: attrs.name = %v, want %v", id, gotAttrs["name"], wn)
+				}
+			}
+		}
+	})
+
+	t.Run("decimal_sum_by_group", func(t *testing.T) {
+		res, err := db.Query(ctx, `SELECT grp, SUM(amount) AS s FROM events GROUP BY grp`)
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		want := map[string]float64{}
+		for _, r := range src {
+			key := "<null>"
+			if r.grp != nil {
+				key = r.grp.(string)
+			}
+			if r.amt != nil {
+				want[key] += r.amt.(float64)
+			}
+		}
+		got := map[string]float64{}
+		for _, row := range res.Rows {
+			key := "<null>"
+			if row["grp"] != nil {
+				key = fmt.Sprintf("%v", row["grp"])
+			}
+			got[key] = toF64(t, row["s"])
+		}
+		for k, w := range want {
+			g, ok := got[k]
+			if !ok {
+				t.Fatalf("group %q missing from SUM result (groups: %v)", k, keys(got))
+			}
+			if diff := g - w; diff > 0.01 || diff < -0.01 {
+				t.Fatalf("group %q SUM = %v, want %v", k, g, w)
+			}
+		}
+	})
+
+	t.Run("distinct_nullable_and_decimal", func(t *testing.T) {
+		res, err := db.Query(ctx, `SELECT DISTINCT grp, amount FROM events WHERE id < 700`)
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		want := map[string]bool{}
+		for _, r := range src[:700] {
+			g, a := "<null>", "<null>"
+			if r.grp != nil {
+				g = r.grp.(string)
+			}
+			if r.amt != nil {
+				a = fmt.Sprintf("%.2f", r.amt.(float64))
+			}
+			want[g+"|"+a] = true
+		}
+		got := map[string]bool{}
+		for _, row := range res.Rows {
+			g, a := "<null>", "<null>"
+			if row["grp"] != nil {
+				g = fmt.Sprintf("%v", row["grp"])
+			}
+			if row["amount"] != nil {
+				a = fmt.Sprintf("%v", row["amount"])
+			}
+			got[g+"|"+a] = true
+		}
+		if len(got) != len(want) {
+			t.Fatalf("DISTINCT cardinality = %d, want %d", len(got), len(want))
+		}
+		for k := range want {
+			if !got[k] {
+				t.Fatalf("DISTINCT missing combination %q", k)
+			}
+		}
+	})
+}
+
+func toI64(tb testing.TB, v any) int64 {
+	tb.Helper()
+	switch x := v.(type) {
+	case int64:
+		return x
+	case int32:
+		return int64(x)
+	case float64:
+		return int64(x)
+	default:
+		tb.Fatalf("not numeric: %#v (%T)", v, v)
+		return 0
+	}
+}
+
+func toF64(tb testing.TB, v any) float64 {
+	tb.Helper()
+	switch x := v.(type) {
+	case float64:
+		return x
+	case int64:
+		return float64(x)
+	case string:
+		var f float64
+		fmt.Sscanf(x, "%f", &f)
+		return f
+	default:
+		tb.Fatalf("not numeric: %#v (%T)", v, v)
+		return 0
+	}
+}
+
+func keys(m map[string]float64) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}


### PR DESCRIPTION
## Summary

Builds the gate issue #144 asked for — and the gate earned its keep immediately: **its first run found 7 wrong-results bugs**, all silent, all invisible to every existing gate (TPC-H has no nested columns, no Decimal in the merge path, no NULL group keys).

## Bugs found and fixed (one commit each layer)

**parquet** (`ab80ecb`)
1. DECIMAL values destroyed at write: `toInt64` truncated 3.25 → 3 instead of scaling to 325.
2. Read schema dropped Precision/Scale from the file's LogicalType — values decoded at the wrong magnitude.

**scan** (`a6f78e8`)
3. **Every query against a table with an ARRAY/MAP/ROW column returned 0 rows, no error**: the nested-fallback flag was checked before the only code that sets it ever ran. (Plus: `readRG` swallowed decode errors — silent row loss; `ReadRowGroupNative` silently emitted ALL-NULL arrays instead of erroring.)
4. The native page decoder had no Decimal case — decimal columns scanned as zeros.

**exec** (`8a89a96`)
5. String-keyed GROUP BY emitted the NULL group with **zeroed aggregates** (COUNT(*)=0 over 714 rows) — null-key rows were diverted to a path that skips flat-accumulator allocation, misaligning group state. Completes the PR #142 NULL-group family.
6. Decimal GROUP BY keys truncated their fraction — the aggregate's output schema dropped Scale/Precision.

**worker/wire** (`71fbde8`)
7. **Int128 field-swap on the shuffle wire**: the no-sel writer and worker reader memcpy'd raw struct memory under a comment claiming the struct is `{Lo, Hi}` — it's `{Hi, Lo}` — while the sel-writer/coordinator/spill paths use explicit (Lo, Hi). Any mixed pair decoded decimals as garbage. Also: WSHF and the exec spill format (top-level and nested children) now carry decimal scale, so distributed decimal group keys stop coming back as "25" for 0.25.

## The gate (`d7a6218`)
- **wadjet E2E battery**: 5000 rows across multiple pooled batches, interior+trailing NULLs in arrays/rows/bytes children, nullable group key, DECIMAL(12,2); round-trip, NULL-group aggregates, decimal keys/SUM/DISTINCT, row_field filters, nested accessors, LEFT JOIN matched/unmatched interleaving, ORDER BY attachment — all oracle-checked in Go.
- **Distributed battery**: same invariants through dispatch → worker → WSHF → gather.
- **CI**: `./wadjet/` added to the unit-test step (it was never run in CI), plus a named **Nested Types + Decimal Correctness** step running both batteries and the operator-level regression corpus.

Filed separately: #147 (unknown columns / dotted ROW access silently evaluate NULL).

## Gates
- Full unit suite green (37 packages incl. ./wadjet/), `-race` on exec/worker/scan/parquet
- TPC-H SF0.01: pass; `tpch-harness -mode=local`: **PASS** (shuffle wire change → distributed gate mandatory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)