### PR TITLE
fix(planner): stream read_json/read_csv — incremental JSON reader, lazy globs, HTTP body direct (closes #130)

### DIFF
--- a/internal/planner/physical/table_func.go
+++ b/internal/planner/physical/table_func.go
@@ -73,21 +73,27 @@ func buildTableFunctionSource(funcName string, args []string, namedArgs map[stri
 	}
 }
 
-// jsonTableFuncSource reads a JSON file (local or HTTP) and produces batches.
-// Uses the direct-to-columnar byte scanner (8x faster, 32x fewer allocs than
-// the row-oriented reader).
+// jsonTableFuncSource reads JSON (local file, glob, or HTTP) and produces
+// batches. Streams through the incremental byte scanner: the previous shape
+// fetched the whole input into heap and then eagerly parsed EVERY batch up
+// front — a second full-size columnar copy held while the raw bytes were
+// still live, ~2-3× the input resident for any pgwire user (issue #130).
 type jsonTableFuncSource struct {
 	path   string
-	reader *jsonreader.ColumnarReader
+	reader *jsonreader.StreamReader
+	closer io.Closer
 }
 
 func (s *jsonTableFuncSource) Init(_ context.Context) error {
-	data, err := fetchData(s.path)
+	rc, err := openData(s.path)
 	if err != nil {
 		return fmt.Errorf("read_json: %w", err)
 	}
-	r, err := jsonreader.NewColumnarReader(data)
+	s.closer = rc
+	r, err := jsonreader.NewStreamReader(rc)
 	if err != nil {
+		rc.Close()
+		s.closer = nil
 		return fmt.Errorf("read_json: parsing: %w", err)
 	}
 	s.reader = r
@@ -98,7 +104,12 @@ func (s *jsonTableFuncSource) Next(_ context.Context) (*batch.RecordBatch, error
 	return s.reader.Next()
 }
 
-func (s *jsonTableFuncSource) Close() error { return nil }
+func (s *jsonTableFuncSource) Close() error {
+	if s.closer != nil {
+		return s.closer.Close()
+	}
+	return nil
+}
 
 // parquetTableFuncSource reads a Parquet file (local or HTTP) and produces batches.
 // Uses readBatchDirect for column-at-a-time page reading (no row reconstruction).
@@ -186,29 +197,19 @@ func (s *csvTableFuncSource) Init(_ context.Context) error {
 		cfg.HasHeader = hdr == "true" || hdr == "TRUE" || hdr == "1"
 	}
 
-	// Use streaming for local non-glob files to avoid loading into memory
-	if !isURL(s.path) && !isGlob(s.path) {
-		f, err := os.Open(s.path)
-		if err != nil {
-			return fmt.Errorf("read_csv: %w", err)
-		}
-		s.closer = f
-		r, err := csvreader.NewStreamReader(f, cfg)
-		if err != nil {
-			f.Close()
-			return fmt.Errorf("read_csv: %w", err)
-		}
-		s.reader = r
-		return nil
-	}
-
-	// Fallback to full read for URLs and globs
-	data, err := fetchData(s.path)
+	// Every source shape streams: local files directly, globs through the
+	// lazy multi-file reader, HTTP straight off the response body. The
+	// URL/glob paths previously buffered the full input (globs 2×) before
+	// the CSV reader saw a byte.
+	rc, err := openData(s.path)
 	if err != nil {
 		return fmt.Errorf("read_csv: %w", err)
 	}
-	r, err := csvreader.NewReader(data, cfg)
+	s.closer = rc
+	r, err := csvreader.NewStreamReader(rc, cfg)
 	if err != nil {
+		rc.Close()
+		s.closer = nil
 		return fmt.Errorf("read_csv: %w", err)
 	}
 	s.reader = r
@@ -226,9 +227,108 @@ func (s *csvTableFuncSource) Close() error {
 	return nil
 }
 
-// fetchData retrieves data from a local file path, glob pattern, or HTTP/HTTPS URL.
-// Glob patterns (e.g., "data/*.json") expand to multiple files whose contents
-// are concatenated.
+// openData opens a local file path, glob pattern, or HTTP/HTTPS URL as a
+// stream. Globs expand to multiple files concatenated lazily (each opened
+// only when the previous is exhausted, with a newline injected between
+// files for JSONL/CSV continuity — same framing fetchGlob produced, without
+// buffering every file at once). The caller owns the ReadCloser.
+func openData(path string) (io.ReadCloser, error) {
+	if isURL(path) {
+		return openHTTP(path)
+	}
+	if isGlob(path) {
+		matches, err := filepath.Glob(path)
+		if err != nil {
+			return nil, fmt.Errorf("glob %s: %w", path, err)
+		}
+		if len(matches) == 0 {
+			return nil, fmt.Errorf("glob %s: no matching files", path)
+		}
+		sort.Strings(matches)
+		return &multiFileReadCloser{paths: matches}, nil
+	}
+	return os.Open(path)
+}
+
+// multiFileReadCloser streams a sorted glob expansion file-by-file. At most
+// one file is open at a time; a '\n' is injected after any file that does
+// not end with one (matching fetchGlob's concatenation framing).
+type multiFileReadCloser struct {
+	paths     []string
+	idx       int
+	cur       *os.File
+	hadData   bool
+	lastByte  byte
+	pendingNL bool
+}
+
+func (m *multiFileReadCloser) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	for {
+		if m.pendingNL {
+			m.pendingNL = false
+			p[0] = '\n'
+			return 1, nil
+		}
+		if m.cur == nil {
+			if m.idx >= len(m.paths) {
+				return 0, io.EOF
+			}
+			f, err := os.Open(m.paths[m.idx])
+			if err != nil {
+				return 0, fmt.Errorf("reading %s: %w", m.paths[m.idx], err)
+			}
+			m.idx++
+			m.cur = f
+			m.hadData = false
+		}
+		n, err := m.cur.Read(p)
+		if n > 0 {
+			m.hadData = true
+			m.lastByte = p[n-1]
+			return n, nil
+		}
+		if err == io.EOF || err == nil {
+			m.cur.Close()
+			m.cur = nil
+			if m.hadData && m.lastByte != '\n' {
+				m.pendingNL = true
+			}
+			continue
+		}
+		m.cur.Close()
+		m.cur = nil
+		return 0, err
+	}
+}
+
+func (m *multiFileReadCloser) Close() error {
+	if m.cur != nil {
+		err := m.cur.Close()
+		m.cur = nil
+		return err
+	}
+	return nil
+}
+
+// openHTTP returns the response body as a stream — no io.ReadAll, so a
+// large remote file never lands in heap at once.
+func openHTTP(url string) (io.ReadCloser, error) {
+	store := objstore.NewHTTPStore(objstore.HTTPConfig{})
+	bucket, key := splitURL(url)
+	rc, _, err := store.Get(context.Background(), bucket, key)
+	if err != nil {
+		return nil, fmt.Errorf("fetching %s: %w", url, err)
+	}
+	return rc, nil
+}
+
+// fetchData retrieves data from a local file path, glob pattern, or
+// HTTP/HTTPS URL fully into memory. Only read_parquet still uses this for
+// URLs/globs — parquet needs random access (io.ReaderAt), so buffering is
+// inherent there; JSON/CSV stream via openData.
 func fetchData(path string) ([]byte, error) {
 	if isURL(path) {
 		return fetchHTTP(path)

--- a/internal/planner/physical/table_func_test.go
+++ b/internal/planner/physical/table_func_test.go
@@ -3,10 +3,15 @@ package physical
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/citc-tech/wadjet/internal/engine/exec"
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
 )
 
@@ -622,5 +627,138 @@ func TestSplitURL(t *testing.T) {
 		if b != tt.bucket || k != tt.key {
 			t.Errorf("splitURL(%q) = (%q, %q), want (%q, %q)", tt.url, b, k, tt.bucket, tt.key)
 		}
+	}
+}
+
+// Issue #130 regression tests: read_json/read_csv stream every source shape
+// (the previous shape buffered the whole input — globs twice — and parsed
+// every batch eagerly before the first Next).
+
+func drainTableFunc(t *testing.T, source exec.Source) []map[string]any {
+	t.Helper()
+	var rows []map[string]any
+	for {
+		b, err := source.Next(t.Context())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if b == nil {
+			return rows
+		}
+		rows = append(rows, b.ToRows()...)
+	}
+}
+
+func TestTableFuncReadJSON_GlobStreams(t *testing.T) {
+	dir := t.TempDir()
+	// Three files; the middle one lacks a trailing newline — the lazy
+	// multi-file reader must inject the separator like fetchGlob did.
+	files := map[string]string{
+		"a.json": `{"id":1}` + "\n" + `{"id":2}` + "\n",
+		"b.json": `{"id":3}`, // no trailing newline
+		"c.json": `{"id":4}` + "\n",
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	source, err := buildTableFunctionSource("read_json", []string{filepath.Join(dir, "*.json")}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := source.Init(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	defer source.Close()
+
+	rows := drainTableFunc(t, source)
+	if len(rows) != 4 {
+		t.Fatalf("rows = %d, want 4 (missing newline injection merges objects or drops a file)", len(rows))
+	}
+	for i, want := range []int64{1, 2, 3, 4} {
+		if rows[i]["id"] != want {
+			t.Fatalf("row %d id = %v, want %d", i, rows[i]["id"], want)
+		}
+	}
+}
+
+func TestTableFuncReadCSV_GlobStreams(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "x1.csv"), []byte("id,name\n1,a\n2,b"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "x2.csv"), []byte("3,c\n4,d\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	source, err := buildTableFunctionSource("read_csv", []string{filepath.Join(dir, "x*.csv")}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := source.Init(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	defer source.Close()
+
+	rows := drainTableFunc(t, source)
+	if len(rows) != 4 {
+		t.Fatalf("rows = %d, want 4", len(rows))
+	}
+	if fmt.Sprintf("%v", rows[2]["id"]) != "3" || fmt.Sprintf("%v", rows[2]["name"]) != "c" {
+		t.Fatalf("row 2 = %v", rows[2])
+	}
+}
+
+func TestTableFuncReadJSON_HTTPStreams(t *testing.T) {
+	var body strings.Builder
+	for i := 0; i < 3000; i++ {
+		fmt.Fprintf(&body, `{"id":%d,"v":"r%d"}`+"\n", i, i)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.Copy(w, strings.NewReader(body.String()))
+	}))
+	defer srv.Close()
+
+	source, err := buildTableFunctionSource("read_json", []string{srv.URL + "/data.json"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := source.Init(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	defer source.Close()
+
+	rows := drainTableFunc(t, source)
+	if len(rows) != 3000 {
+		t.Fatalf("rows = %d, want 3000", len(rows))
+	}
+	if rows[2999]["id"] != int64(2999) {
+		t.Fatalf("last row = %v", rows[2999])
+	}
+}
+
+func TestMultiFileReadCloser_NewlineFraming(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "p1"), []byte("abc"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "p2"), []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "p3"), []byte("def\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	m := &multiFileReadCloser{paths: []string{
+		filepath.Join(dir, "p1"), filepath.Join(dir, "p2"), filepath.Join(dir, "p3"),
+	}}
+	defer m.Close()
+	got, err := io.ReadAll(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// p1 lacks newline → injected; p2 empty → no separator; p3 keeps its own.
+	if string(got) != "abc\ndef\n" {
+		t.Fatalf("framing = %q, want %q", got, "abc\ndef\n")
 	}
 }

--- a/internal/storage/json/stream.go
+++ b/internal/storage/json/stream.go
@@ -1,0 +1,293 @@
+package json
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// Streaming limits. The window holds at most one refill chunk plus the
+// largest in-flight object; maxObjectBytes is a corruption backstop, not a
+// tuning knob — a single 64 MB JSON object means the input isn't the
+// row-oriented data this reader exists for.
+const (
+	streamChunkBytes = 256 << 10
+	maxSampleBytes   = 8 << 20
+	maxObjectBytes   = 64 << 20
+)
+
+// StreamReader is the incremental counterpart of ColumnarReader: it parses
+// JSON (top-level array of objects, or JSONL/concatenated objects) from an
+// io.Reader one batch at a time, holding only a bounded byte window instead
+// of the whole file plus a full columnar copy (issue #130 — read_json
+// materialized ~2-3× the input in heap).
+//
+// Schema semantics match the eager reader exactly: inferred from the first
+// defaultSampleSize complete objects (the eager path samples the same
+// prefix), capped at maxSampleBytes of buffered input. Values are parsed by
+// the same scanObjectInto byte scanner, so output batches are identical to
+// NewColumnarReader's for the same input.
+type StreamReader struct {
+	r      io.Reader
+	schema []parquet.Column
+	colIdx map[string]int
+	seen   []bool
+
+	buf    []byte // window; buf[start:filled] is unconsumed input
+	start  int
+	filled int
+	eof    bool
+
+	isArray     bool
+	openSkipped bool // leading '[' consumed
+	done        bool
+
+	chunkSize int // test hook; defaults to streamChunkBytes
+}
+
+// NewStreamReader buffers just enough input to infer the schema, then
+// parses lazily. The caller retains ownership of r (close it after the
+// reader is exhausted or abandoned).
+func NewStreamReader(r io.Reader) (*StreamReader, error) {
+	return newStreamReaderSized(r, streamChunkBytes)
+}
+
+func newStreamReaderSized(r io.Reader, chunkSize int) (*StreamReader, error) {
+	sr := &StreamReader{r: r, chunkSize: chunkSize}
+
+	// Fill until the window covers defaultSampleSize complete objects, EOF,
+	// or the sample cap. Schema inference sees the same prefix the eager
+	// reader sampled.
+	for {
+		sr.skipLeadingSpace()
+		end, count := sr.completeValuesEnd()
+		if count >= defaultSampleSize || sr.eof || sr.filled-sr.start >= maxSampleBytes {
+			_ = end
+			break
+		}
+		if err := sr.refill(); err != nil {
+			return nil, err
+		}
+	}
+	sr.skipLeadingSpace()
+	if sr.start >= sr.filled {
+		sr.done = true // empty input → zero-column reader, like the eager path
+		return sr, nil
+	}
+
+	sr.isArray = sr.buf[sr.start] == '['
+	prefixEnd, nObjs := sr.completeValuesEnd()
+	if nObjs == 0 {
+		// No complete object buffered ("[]", or a truncated head): give
+		// inference the whole window, exactly what the eager reader saw —
+		// its token loop degrades gracefully at the cut.
+		prefixEnd = sr.filled
+	}
+	schema, err := inferSchemaTokens(sr.buf[sr.start:prefixEnd], sr.isArray, defaultSampleSize)
+	if err != nil {
+		return nil, fmt.Errorf("schema inference: %w", err)
+	}
+	if len(schema) == 0 {
+		sr.done = true
+		return sr, nil
+	}
+	sr.schema = schema
+	sr.colIdx = make(map[string]int, len(schema))
+	for i, col := range schema {
+		sr.colIdx[col.Name] = i
+	}
+	sr.seen = make([]bool, len(schema))
+	return sr, nil
+}
+
+// Schema returns the inferred schema (nil for empty input).
+func (sr *StreamReader) Schema() []parquet.Column { return sr.schema }
+
+// Next parses and returns the next batch, or nil when exhausted.
+func (sr *StreamReader) Next() (*batch.RecordBatch, error) {
+	if sr.done {
+		return nil, nil
+	}
+	rb := batch.NewRecordBatch(sr.schema, defaultBatchSize)
+	row := 0
+	for row < defaultBatchSize {
+		objStart, objEnd, err := sr.nextObjectSpan()
+		if err != nil {
+			return nil, err
+		}
+		if objStart < 0 {
+			sr.done = true
+			break
+		}
+		sc := &jsonScanner{data: sr.buf[:objEnd], pos: objStart}
+		if err := scanObjectInto(sc, rb, row, sr.schema, sr.colIdx, sr.seen); err != nil {
+			return nil, fmt.Errorf("row %d: %w", row, err)
+		}
+		sr.start = objEnd
+		row++
+	}
+	if row == 0 {
+		return nil, nil
+	}
+	if row < defaultBatchSize {
+		rb.Len = row
+		for _, col := range rb.Columns {
+			col.Len = row
+		}
+	}
+	return rb, nil
+}
+
+// nextObjectSpan positions the window on the next complete top-level
+// object, refilling as needed, and returns its [start, end) offsets in
+// sr.buf. Returns objStart=-1 at clean end of input (']', non-object
+// content, or EOF — same termination rules as parseColumnarDirect).
+func (sr *StreamReader) nextObjectSpan() (int, int, error) {
+	for {
+		// Skip inter-object separators.
+		i := sr.start
+		for i < sr.filled {
+			c := sr.buf[i]
+			if c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == ',' {
+				i++
+				continue
+			}
+			if c == '[' && sr.isArray && !sr.openSkipped {
+				sr.openSkipped = true
+				i++
+				continue
+			}
+			break
+		}
+		sr.start = i
+		if i >= sr.filled {
+			if sr.eof {
+				return -1, 0, nil
+			}
+			if err := sr.refill(); err != nil {
+				return -1, 0, err
+			}
+			continue
+		}
+		if sr.buf[i] != '{' {
+			// ']' (array close), or anything the eager parser stops at.
+			return -1, 0, nil
+		}
+		end, ok := completeObjectEnd(sr.buf[i:sr.filled])
+		if ok {
+			return i, i + end, nil
+		}
+		if sr.eof {
+			return -1, 0, fmt.Errorf("truncated JSON object at end of input")
+		}
+		if sr.filled-i > maxObjectBytes {
+			return -1, 0, fmt.Errorf("JSON object exceeds %d bytes", maxObjectBytes)
+		}
+		if err := sr.refill(); err != nil {
+			return -1, 0, err
+		}
+	}
+}
+
+// refill compacts the window and reads one more chunk.
+func (sr *StreamReader) refill() error {
+	if sr.start > 0 {
+		copy(sr.buf, sr.buf[sr.start:sr.filled])
+		sr.filled -= sr.start
+		sr.start = 0
+	}
+	if sr.filled+sr.chunkSize > len(sr.buf) {
+		grown := make([]byte, sr.filled+sr.chunkSize)
+		copy(grown, sr.buf[:sr.filled])
+		sr.buf = grown
+	}
+	n, err := io.ReadFull(sr.r, sr.buf[sr.filled:sr.filled+sr.chunkSize])
+	sr.filled += n
+	if err == io.EOF || err == io.ErrUnexpectedEOF {
+		sr.eof = true
+		return nil
+	}
+	return err
+}
+
+// skipLeadingSpace advances start past whitespace.
+func (sr *StreamReader) skipLeadingSpace() {
+	for sr.start < sr.filled {
+		switch sr.buf[sr.start] {
+		case ' ', '\t', '\n', '\r':
+			sr.start++
+		default:
+			return
+		}
+	}
+}
+
+// completeValuesEnd scans buf[start:filled] and returns the offset (in buf
+// coordinates) just past the last complete top-level object, plus the count
+// of complete objects. Understands strings/escapes and nesting; leading
+// '[' and separators belong to the prefix.
+func (sr *StreamReader) completeValuesEnd() (int, int) {
+	end := sr.start
+	count := 0
+	i := sr.start
+	openSkipped := sr.openSkipped
+	for i < sr.filled {
+		c := sr.buf[i]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == ',' {
+			i++
+			continue
+		}
+		if c == '[' && !openSkipped {
+			openSkipped = true
+			i++
+			continue
+		}
+		if c != '{' {
+			break
+		}
+		objEnd, ok := completeObjectEnd(sr.buf[i:sr.filled])
+		if !ok {
+			break
+		}
+		i += objEnd
+		end = i
+		count++
+	}
+	return end, count
+}
+
+// completeObjectEnd returns the length of the complete JSON object starting
+// at data[0] (which must be '{'), or ok=false if the object is not yet
+// fully buffered. String/escape aware.
+func completeObjectEnd(data []byte) (int, bool) {
+	depth := 0
+	inStr := false
+	esc := false
+	for i := 0; i < len(data); i++ {
+		c := data[i]
+		if inStr {
+			if esc {
+				esc = false
+			} else if c == '\\' {
+				esc = true
+			} else if c == '"' {
+				inStr = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inStr = true
+		case '{', '[':
+			depth++
+		case '}', ']':
+			depth--
+			if depth == 0 {
+				return i + 1, true
+			}
+		}
+	}
+	return 0, false
+}

--- a/internal/storage/json/stream_test.go
+++ b/internal/storage/json/stream_test.go
@@ -1,0 +1,161 @@
+package json
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// drainReader pulls all rows from either reader type via a Next() func.
+func drainBatches(tb testing.TB, next func() (interface {
+	ToRows() []map[string]any
+}, error)) []map[string]any {
+	tb.Helper()
+	var rows []map[string]any
+	for {
+		b, err := next()
+		if err != nil {
+			tb.Fatal(err)
+		}
+		if b == nil || len(b.ToRows()) == 0 {
+			return rows
+		}
+		rows = append(rows, b.ToRows()...)
+	}
+}
+
+// streamRows drains a StreamReader.
+func streamRows(tb testing.TB, sr *StreamReader) []map[string]any {
+	tb.Helper()
+	var rows []map[string]any
+	for {
+		b, err := sr.Next()
+		if err != nil {
+			tb.Fatal(err)
+		}
+		if b == nil {
+			return rows
+		}
+		rows = append(rows, b.ToRows()...)
+	}
+}
+
+// eagerRows drains the eager ColumnarReader.
+func eagerRows(tb testing.TB, data []byte) []map[string]any {
+	tb.Helper()
+	r, err := NewColumnarReader(data)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	var rows []map[string]any
+	for {
+		b, err := r.Next()
+		if err != nil {
+			tb.Fatal(err)
+		}
+		if b == nil {
+			return rows
+		}
+		rows = append(rows, b.ToRows()...)
+	}
+}
+
+// Issue #130 regression: the stream reader must produce batches identical
+// to the eager reader's for the same input — including nested values with
+// interior nulls (the PR #123 corpus), across every chunk boundary. Tiny
+// chunk sizes force objects to split mid-string, mid-escape, and mid-nest.
+func TestStreamReader_MatchesEagerAcrossChunkBoundaries(t *testing.T) {
+	corpora := map[string]string{
+		"jsonl_flat": `{"a":1,"b":"x"}
+{"a":2,"b":"y"}
+{"a":3,"b":null}`,
+		"array_flat": `[{"a":1,"b":"x"},{"a":2,"b":"y"},{"a":3}]`,
+		"nested_null_corpus": `[{"meta":{"name":"alpha"}},{"meta":null},{"meta":{"name":"beta"}},{"other":1}]`,
+		"arrays_and_escapes": `[{"tags":["a","b"],"s":"he said \"hi\\\" there"},{"tags":[],"s":","},{"tags":null,"s":"}{"}]`,
+		"deep_nesting":       `{"r":{"x":{"y":[1,2,{"z":"w"}]}}}` + "\n" + `{"r":null}`,
+	}
+	// Many rows so multiple batches + many refills happen.
+	var big strings.Builder
+	for i := 0; i < 5000; i++ {
+		fmt.Fprintf(&big, `{"id":%d,"name":"row-%d","vals":[%d,%d],"meta":{"grp":"g%d"}}`+"\n", i, i, i, i*2, i%5)
+	}
+	corpora["large_multibatch"] = big.String()
+
+	for name, input := range corpora {
+		for _, chunk := range []int{7, 64, 1024, streamChunkBytes} {
+			t.Run(fmt.Sprintf("%s_chunk%d", name, chunk), func(t *testing.T) {
+				want := eagerRows(t, []byte(input))
+				sr, err := newStreamReaderSized(strings.NewReader(input), chunk)
+				if err != nil {
+					t.Fatalf("NewStreamReader: %v", err)
+				}
+				got := streamRows(t, sr)
+				if len(got) != len(want) {
+					t.Fatalf("rows = %d, want %d", len(got), len(want))
+				}
+				for i := range want {
+					if fmt.Sprintf("%v", got[i]) != fmt.Sprintf("%v", want[i]) {
+						t.Fatalf("row %d:\n got %#v\nwant %#v", i, got[i], want[i])
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestStreamReader_EmptyAndTruncated(t *testing.T) {
+	for _, input := range []string{"", "   \n\t", "[]"} {
+		sr, err := newStreamReaderSized(strings.NewReader(input), 16)
+		if err != nil {
+			t.Fatalf("empty input %q: %v", input, err)
+		}
+		b, err := sr.Next()
+		if err != nil || b != nil {
+			t.Fatalf("empty input %q: Next = %v, %v", input, b, err)
+		}
+	}
+
+	// Truncated object must error, not silently drop the tail.
+	sr, err := newStreamReaderSized(strings.NewReader(`{"a":1}`+"\n"+`{"a":2,"b":"trunc`), 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = sr.Next()
+	if err == nil {
+		t.Fatal("truncated tail object must surface an error (silent row drop)")
+	}
+}
+
+// The whole point of #130: the buffered window stays bounded by
+// chunk + largest object, regardless of total input size.
+func TestStreamReader_WindowStaysBounded(t *testing.T) {
+	const chunk = 4 << 10
+	var big bytes.Buffer
+	for i := 0; i < 20000; i++ {
+		fmt.Fprintf(&big, `{"id":%d,"pad":"%s"}`+"\n", i, strings.Repeat("x", 100))
+	}
+	total := big.Len()
+	sr, err := newStreamReaderSized(bytes.NewReader(big.Bytes()), chunk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	maxWindow := 0
+	for {
+		b, err := sr.Next()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(sr.buf) > maxWindow {
+			maxWindow = len(sr.buf)
+		}
+		if b == nil {
+			break
+		}
+	}
+	// Sample phase buffers ~100 objects (~12KB here); afterwards the window
+	// must never approach the input size.
+	if maxWindow > total/10 {
+		t.Fatalf("window grew to %d bytes for a %d-byte input — not streaming", maxWindow, total)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #130 (sweep finding 16, the last open OOM-vector from the 2026-06-12 never-OOM sweep). `SELECT * FROM read_json('logs/*.json')` over multi-GB input held ~2-3× the input in heap: `fetchData` loaded everything (`os.ReadFile` / uncapped HTTP `io.ReadAll` / globs double-buffered), and read_json then eagerly parsed every batch up front while the raw bytes were still live.

**`json.StreamReader`** (`24e3692`): incremental counterpart of the eager ColumnarReader — parses from an `io.Reader` one batch at a time with a bounded window (one 256 KiB refill chunk + the largest in-flight object). Schema semantics are byte-identical to the eager path (same first-100-objects sample prefix, same `scanObjectInto` scanner). String/escape-aware boundary scanning reassembles objects split across refills; a truncated tail errors instead of silently dropping rows.

**Table functions** (`08fa77c`): `openData` streams every source shape — local files directly, globs through a lazy one-file-at-a-time reader (newline injected after files lacking one, fetchGlob's exact framing), HTTP straight off the response body. read_csv now streams URLs and globs too (only local files streamed before). read_parquet keeps buffering remote input — random access is inherent — documented on the remaining `fetchData`.

## Tests
- Eager/stream equivalence over five corpora (incl. the PR #123 nested-null regression corpus) at chunk sizes down to **7 bytes**, plus a 5000-row multi-batch input
- Window-boundedness assertion (a 2 MB input must never pull more than a fraction into the window)
- Truncated-tail error, empty/array-only inputs
- Glob framing (file without trailing newline must not merge objects), CSV glob continuation, 3000-row HTTP stream via httptest

## Gates
- Full unit suite green (37 packages), `-race` on json/csv/physical
- TPC-H SF0.01 pass; `tpch-harness -mode=local` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)