### PR TITLE
fix(coordinator): result-subscription flush + test-lifetime worker contexts (closes #143)

### DIFF
--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -2048,6 +2048,12 @@ func (c *Coordinator) subscribeResults(ctx context.Context, queryID string, done
 	if perr := sub.SetPendingLimits(coordSubMsgLimit, coordSubByteLimit); perr != nil {
 		c.logger.Warn("failed to bump query-result sub pending limits", "error", perr)
 	}
+	// Propagate the interest to the server before the caller publishes
+	// tasks — see subscribeTaskResults for the lost-result race this
+	// closes (issue #143).
+	if ferr := c.nc.Flush(); ferr != nil {
+		c.logger.Error("failed to flush result subscription", "error", ferr, "subject", subject)
+	}
 
 	c.mu.Lock()
 	cancelCtx, cancel := context.WithCancel(ctx)

--- a/internal/coordinator/coordinator_coverage_test.go
+++ b/internal/coordinator/coordinator_coverage_test.go
@@ -394,7 +394,13 @@ func setupWithNATSAndCatalog(t *testing.T) (context.Context, *Coordinator, objst
 		MaxConcurrent: 4,
 		CacheBytes:    64 * 1024 * 1024,
 	}, store, nc, js, logger)
-	if err := w.Start(ctx); err != nil {
+	// Workers must outlive the setup/query ctx: tying taskLoop to a
+	// short-lived ctx silently killed task consumption mid-test once
+	// the deadline passed (issue #143 — the -race "deadlock" was the
+	// worker dying at setupDistributed\'s 30s timeout).
+	workerCtx, workerCancel := context.WithCancel(context.Background())
+	t.Cleanup(workerCancel)
+	if err := w.Start(workerCtx); err != nil {
 		t.Fatalf("starting worker: %v", err)
 	}
 	t.Cleanup(w.Stop)
@@ -568,7 +574,6 @@ func TestGetQueryStatusWithStages(t *testing.T) {
 	// Should have at least one stage
 	t.Logf("Status: %s, stages: %d, elapsed: %s", status.State, len(status.Stages), status.Elapsed)
 }
-
 
 func TestCancelQueryRunning(t *testing.T) {
 	ctx, coord, store := setupDistributed(t)

--- a/internal/coordinator/distributed_test.go
+++ b/internal/coordinator/distributed_test.go
@@ -21,7 +21,11 @@ func setupDistributed(t *testing.T) (context.Context, *Coordinator, objstore.Sto
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)
 
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	lvl := slog.LevelWarn
+	if os.Getenv("WADJET_TEST_LOG") == "info" {
+		lvl = slog.LevelInfo
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: lvl}))
 
 	// Start embedded NATS with temp storage dir
 	natsCfg := distributed.DefaultNATSConfig()
@@ -71,7 +75,13 @@ func setupDistributed(t *testing.T) (context.Context, *Coordinator, objstore.Sto
 		MaxConcurrent: 4,
 		CacheBytes:    64 * 1024 * 1024,
 	}, store, nc, js, logger)
-	if err := w.Start(ctx); err != nil {
+	// Workers must outlive the setup/query ctx: tying taskLoop to a
+	// short-lived ctx silently killed task consumption mid-test once
+	// the deadline passed (issue #143 — the -race "deadlock" was the
+	// worker dying at setupDistributed\'s 30s timeout).
+	workerCtx, workerCancel := context.WithCancel(context.Background())
+	t.Cleanup(workerCancel)
+	if err := w.Start(workerCtx); err != nil {
 		t.Fatalf("starting worker: %v", err)
 	}
 	t.Cleanup(w.Stop)
@@ -294,7 +304,13 @@ func setupDistributedWithBudget(t *testing.T, memBudget int64, resultStoreBytes 
 		SpillDir:         t.TempDir(),
 		ResultStoreBytes: resultStoreBytes,
 	}, store, nc, js, logger)
-	if err := w.Start(ctx); err != nil {
+	// Workers must outlive the setup/query ctx: tying taskLoop to a
+	// short-lived ctx silently killed task consumption mid-test once
+	// the deadline passed (issue #143 — the -race "deadlock" was the
+	// worker dying at setupDistributed\'s 30s timeout).
+	workerCtx, workerCancel := context.WithCancel(context.Background())
+	t.Cleanup(workerCancel)
+	if err := w.Start(workerCtx); err != nil {
 		t.Fatalf("starting worker: %v", err)
 	}
 	t.Cleanup(w.Stop)

--- a/internal/coordinator/distributed_tpch_test.go
+++ b/internal/coordinator/distributed_tpch_test.go
@@ -159,7 +159,13 @@ func setupTPCHDistributedAtScale(t *testing.T, sf tpch.ScaleFactor) (context.Con
 			// too so tests exercise the same code path.
 			SpillDir: t.TempDir(),
 		}, store, nc, js, logger)
-		if err := w.Start(ctx); err != nil {
+		// Workers must outlive the setup/query ctx: tying taskLoop to a
+		// short-lived ctx silently killed task consumption mid-test once
+		// the deadline passed (issue #143 — the -race "deadlock" was the
+		// worker dying at setupDistributed\'s 30s timeout).
+		workerCtx, workerCancel := context.WithCancel(context.Background())
+		t.Cleanup(workerCancel)
+		if err := w.Start(workerCtx); err != nil {
 			t.Fatalf("starting worker %d: %v", i, err)
 		}
 		t.Cleanup(w.Stop)
@@ -322,7 +328,13 @@ func setupTPCHDistributed(t *testing.T) (context.Context, *Coordinator) {
 			// tests too so cache pre-scans exercise the production path.
 			SpillDir: t.TempDir(),
 		}, store, nc, js, logger)
-		if err := w.Start(ctx); err != nil {
+		// Workers must outlive the setup/query ctx: tying taskLoop to a
+		// short-lived ctx silently killed task consumption mid-test once
+		// the deadline passed (issue #143 — the -race "deadlock" was the
+		// worker dying at setupDistributed\'s 30s timeout).
+		workerCtx, workerCancel := context.WithCancel(context.Background())
+		t.Cleanup(workerCancel)
+		if err := w.Start(workerCtx); err != nil {
 			t.Fatalf("starting worker %d: %v", i, err)
 		}
 		t.Cleanup(w.Stop)
@@ -577,7 +589,13 @@ func setupTPCHDistributedPolars(t *testing.T) (context.Context, *Coordinator) {
 			SpillDir:      t.TempDir(),
 			MemoryBudget:  256 * 1024 * 1024, // small budget so spill paths fire
 		}, store, nc, js, logger)
-		if err := w.Start(ctx); err != nil {
+		// Workers must outlive the setup/query ctx: tying taskLoop to a
+		// short-lived ctx silently killed task consumption mid-test once
+		// the deadline passed (issue #143 — the -race "deadlock" was the
+		// worker dying at setupDistributed\'s 30s timeout).
+		workerCtx, workerCancel := context.WithCancel(context.Background())
+		t.Cleanup(workerCancel)
+		if err := w.Start(workerCtx); err != nil {
 			t.Fatalf("starting worker %d: %v", i, err)
 		}
 		t.Cleanup(w.Stop)
@@ -807,7 +825,13 @@ func TestDistributedTPCHBuildCacheSF100Sample(t *testing.T) {
 			SpillDir:      t.TempDir(),
 			MemoryBudget:  2 * 1024 * 1024 * 1024, // 2 GB per worker
 		}, store, nc, js, logger)
-		if err := w.Start(ctx); err != nil {
+		// Workers must outlive the setup/query ctx: tying taskLoop to a
+		// short-lived ctx silently killed task consumption mid-test once
+		// the deadline passed (issue #143 — the -race "deadlock" was the
+		// worker dying at setupDistributed\'s 30s timeout).
+		workerCtx, workerCancel := context.WithCancel(context.Background())
+		t.Cleanup(workerCancel)
+		if err := w.Start(workerCtx); err != nil {
 			t.Fatalf("worker %d: %v", i, err)
 		}
 		t.Cleanup(w.Stop)
@@ -1002,7 +1026,13 @@ func sf100SampleClusterN(t *testing.T, memoryBudget int64, wantWorkers, maxConcu
 			SpillDir:      t.TempDir(),
 			MemoryBudget:  memoryBudget,
 		}, store, nc, js, logger)
-		if err := w.Start(ctx); err != nil {
+		// Workers must outlive the setup/query ctx: tying taskLoop to a
+		// short-lived ctx silently killed task consumption mid-test once
+		// the deadline passed (issue #143 — the -race "deadlock" was the
+		// worker dying at setupDistributed\'s 30s timeout).
+		workerCtx, workerCancel := context.WithCancel(context.Background())
+		t.Cleanup(workerCancel)
+		if err := w.Start(workerCtx); err != nil {
 			t.Fatalf("worker %d: %v", i, err)
 		}
 		t.Cleanup(w.Stop)

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -122,6 +122,31 @@ func sortKeysEqual(a, b []physical.SortKeySpec) bool {
 	return true
 }
 
+// subscribeTaskResults installs a result-subject subscription AND flushes
+// the connection so the server has registered the interest before the
+// caller publishes the task. Subscribe alone only creates the client-side
+// record; the interest reaches the NATS server on the next flush. Without
+// the explicit flush, a fast worker (in-process at SF0.01, or any worker
+// when the coordinator's flusher loses the scheduling race) can complete
+// the task and publish its result to a raw subject with NO subscriber —
+// the result is dropped, the task finished too fast to ever enter
+// heartbeat liveness (watchStuckTasks has nothing to reap), and the stage
+// idles out after 30 minutes. The race detector's scheduling perturbation
+// made this reliably reachable (issue #143, TestTPCHNativeDAG_SF01 Q04
+// hang), but the window exists in production whenever publish-to-result
+// round-trips beat interest propagation. Mirrors subscribeGather's flush.
+func (c *Coordinator) subscribeTaskResults(subject string, handler nats.MsgHandler) (*nats.Subscription, error) {
+	sub, err := c.nc.Subscribe(subject, handler)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.nc.Flush(); err != nil {
+		sub.Unsubscribe()
+		return nil, fmt.Errorf("flushing subscription %q: %w", subject, err)
+	}
+	return sub, nil
+}
+
 // awaitStageProgress blocks until either every dispatched task has reported
 // a result (signalled via allDone) or progress has stalled for longer than
 // stageIdleTimeout. Each task-completion subscription handler should send
@@ -971,7 +996,7 @@ func (c *Coordinator) materializeReplicate(
 		}
 	}, c.logger, stage.ID)
 	defer c.watchStuckTasks(ctx, retrier)()
-	sub, err := c.nc.Subscribe(subject, func(msg *nats.Msg) {
+	sub, err := c.subscribeTaskResults(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
 		if uerr := distributed.Unmarshal(msg.Data, &r); uerr != nil {
 			return
@@ -1374,7 +1399,7 @@ func (c *Coordinator) dispatchScanAggregateStage(
 		}
 	}, c.logger, stage.ID)
 	defer c.watchStuckTasks(ctx, retrier)()
-	sub, err := c.nc.Subscribe(subject, func(msg *nats.Msg) {
+	sub, err := c.subscribeTaskResults(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
 		if uerr := distributed.Unmarshal(msg.Data, &r); uerr != nil {
 			return
@@ -1635,7 +1660,7 @@ func (c *Coordinator) dispatchScanFilterStage(
 		}
 	}, c.logger, stage.ID)
 	defer c.watchStuckTasks(ctx, retrier)()
-	sub, err := c.nc.Subscribe(subject, func(msg *nats.Msg) {
+	sub, err := c.subscribeTaskResults(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
 		if uerr := distributed.Unmarshal(msg.Data, &r); uerr != nil {
 			return
@@ -2101,7 +2126,7 @@ func (c *Coordinator) dispatchComputeStage(
 		}
 	}, c.logger, stage.ID)
 	defer c.watchStuckTasks(ctx, retrier)()
-	sub, err := c.nc.Subscribe(subject, func(msg *nats.Msg) {
+	sub, err := c.subscribeTaskResults(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
 		if err := distributed.Unmarshal(msg.Data, &r); err != nil {
 			return
@@ -2812,7 +2837,7 @@ func (c *Coordinator) runStageTasks(
 		}
 	}, c.logger, stageLabel)
 	defer c.watchStuckTasks(ctx, retrier)()
-	sub, err := c.nc.Subscribe(subject, func(msg *nats.Msg) {
+	sub, err := c.subscribeTaskResults(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
 		if uerr := distributed.Unmarshal(msg.Data, &r); uerr != nil {
 			return

--- a/internal/coordinator/gather_spill_e2e_test.go
+++ b/internal/coordinator/gather_spill_e2e_test.go
@@ -109,7 +109,13 @@ func TestGatherBudgetSpill_E2E_RowIdentical(t *testing.T) {
 		MaxConcurrent: 4,
 		CacheBytes:    64 * 1024 * 1024,
 	}, store, nc, js, logger)
-	if err := w.Start(ctx); err != nil {
+	// Workers must outlive the setup/query ctx: tying taskLoop to a
+	// short-lived ctx silently killed task consumption mid-test once
+	// the deadline passed (issue #143 — the -race "deadlock" was the
+	// worker dying at setupDistributed\'s 30s timeout).
+	workerCtx, workerCancel := context.WithCancel(context.Background())
+	t.Cleanup(workerCancel)
+	if err := w.Start(workerCtx); err != nil {
 		t.Fatalf("starting worker: %v", err)
 	}
 	t.Cleanup(w.Stop)

--- a/internal/coordinator/grace_hash_distributed_repro_test.go
+++ b/internal/coordinator/grace_hash_distributed_repro_test.go
@@ -124,7 +124,13 @@ func TestGraceHashJoinDistributedRepro(t *testing.T) {
 			NATSUrl: embeddedNATS.ClientURL(), MaxConcurrent: 4, CacheBytes: 64 * 1024 * 1024,
 			SpillDir: t.TempDir(),
 		}, store, nc, js, logger)
-		if err := w.Start(ctx); err != nil {
+		// Workers must outlive the setup/query ctx: tying taskLoop to a
+		// short-lived ctx silently killed task consumption mid-test once
+		// the deadline passed (issue #143 — the -race "deadlock" was the
+		// worker dying at setupDistributed\'s 30s timeout).
+		workerCtx, workerCancel := context.WithCancel(context.Background())
+		t.Cleanup(workerCancel)
+		if err := w.Start(workerCtx); err != nil {
 			t.Fatal(err)
 		}
 		t.Cleanup(w.Stop)

--- a/internal/coordinator/multi_worker_test.go
+++ b/internal/coordinator/multi_worker_test.go
@@ -104,7 +104,13 @@ func TestShuffleCorrectness(t *testing.T) {
 			MaxConcurrent: 4,
 			CacheBytes:    64 * 1024 * 1024,
 		}, store, nc, js, logger)
-		if err := w.Start(ctx); err != nil {
+		// Workers must outlive the setup/query ctx: tying taskLoop to a
+		// short-lived ctx silently killed task consumption mid-test once
+		// the deadline passed (issue #143 — the -race "deadlock" was the
+		// worker dying at setupDistributed\'s 30s timeout).
+		workerCtx, workerCancel := context.WithCancel(context.Background())
+		t.Cleanup(workerCancel)
+		if err := w.Start(workerCtx); err != nil {
 			t.Fatalf("starting worker %d: %v", i, err)
 		}
 		t.Cleanup(w.Stop)
@@ -323,7 +329,13 @@ func TestDistributedFusedAgg(t *testing.T) {
 			MaxConcurrent: 4,
 			CacheBytes:    64 * 1024 * 1024,
 		}, store, nc, js, logger)
-		if err := w.Start(ctx); err != nil {
+		// Workers must outlive the setup/query ctx: tying taskLoop to a
+		// short-lived ctx silently killed task consumption mid-test once
+		// the deadline passed (issue #143 — the -race "deadlock" was the
+		// worker dying at setupDistributed\'s 30s timeout).
+		workerCtx, workerCancel := context.WithCancel(context.Background())
+		t.Cleanup(workerCancel)
+		if err := w.Start(workerCtx); err != nil {
 			t.Fatalf("starting worker %d: %v", i, err)
 		}
 		t.Cleanup(w.Stop)

--- a/internal/coordinator/nested_decimal_distributed_test.go
+++ b/internal/coordinator/nested_decimal_distributed_test.go
@@ -132,7 +132,13 @@ func TestDistributedDecimalAndNullGroups(t *testing.T) {
 		MaxConcurrent: 4,
 		CacheBytes:    64 * 1024 * 1024,
 	}, store, nc, js, logger)
-	if err := w.Start(ctx); err != nil {
+	// Workers must outlive the setup/query ctx: tying taskLoop to a
+	// short-lived ctx silently killed task consumption mid-test once
+	// the deadline passed (issue #143 — the -race "deadlock" was the
+	// worker dying at setupDistributed\'s 30s timeout).
+	workerCtx, workerCancel := context.WithCancel(context.Background())
+	t.Cleanup(workerCancel)
+	if err := w.Start(workerCtx); err != nil {
 		t.Fatalf("starting worker: %v", err)
 	}
 	t.Cleanup(w.Stop)
@@ -206,5 +212,3 @@ func TestDistributedDecimalAndNullGroups(t *testing.T) {
 		}
 	})
 }
-
-

--- a/internal/coordinator/orchestrate_repartition.go
+++ b/internal/coordinator/orchestrate_repartition.go
@@ -247,7 +247,7 @@ func (c *Coordinator) runShuffleSide(
 	}, c.logger, stageID)
 	defer c.watchStuckTasks(ctx, retrier)()
 
-	sub, err := c.nc.Subscribe(subject, func(msg *nats.Msg) {
+	sub, err := c.subscribeTaskResults(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
 		if unmarshalErr := distributed.Unmarshal(msg.Data, &r); unmarshalErr != nil {
 			return

--- a/internal/coordinator/subscribe_flush_test.go
+++ b/internal/coordinator/subscribe_flush_test.go
@@ -1,0 +1,78 @@
+package coordinator
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+)
+
+// Regression test for issue #143: result-subject subscriptions were
+// installed with bare nc.Subscribe — the interest only reaches the NATS
+// server on the next flush, so a worker completing a task faster than the
+// coordinator's background flusher could publish its result to a subject
+// with no registered subscriber. The result was dropped, the task was too
+// fast to ever enter heartbeat liveness, and the stage idled out (the
+// TestTPCHNativeDAG_SF01 Q04 hang under -race). subscribeTaskResults must
+// flush before returning, so a publish from ANOTHER connection issued
+// immediately after it returns is always delivered.
+func TestSubscribeTaskResults_InterestRegisteredBeforeReturn(t *testing.T) {
+	logger := slog.Default()
+	natsCfg := distributed.DefaultNATSConfig()
+	natsCfg.Port = -1
+	natsCfg.StoreDir = t.TempDir()
+	srv, err := distributed.NewEmbeddedNATS(natsCfg, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(srv.Shutdown)
+
+	coordConn, err := distributed.ConnectInProcess(srv.Server())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(coordConn.Close)
+	workerConn, err := distributed.ConnectInProcess(srv.Server())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(workerConn.Close)
+
+	c := &Coordinator{nc: coordConn, logger: logger}
+
+	// Tight loop: subscribe-then-immediately-publish from the other
+	// connection. Without the flush inside subscribeTaskResults this
+	// drops messages whenever the publish beats interest propagation
+	// (reliably, under -race scheduling).
+	const rounds = 50
+	for i := 0; i < rounds; i++ {
+		subject := distributed.QueryResultSubject(t.Name() + string(rune('a'+i%26)))
+		got := make(chan struct{}, 1)
+		sub, err := c.subscribeTaskResults(subject, func(_ *nats.Msg) {
+			select {
+			case got <- struct{}{}:
+			default:
+			}
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Worker-side publish the instant the coordinator's subscribe
+		// returns — the lost-result window this test pins shut.
+		if err := workerConn.Publish(subject, []byte("r")); err != nil {
+			t.Fatal(err)
+		}
+		if err := workerConn.Flush(); err != nil {
+			t.Fatal(err)
+		}
+		select {
+		case <-got:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("round %d: result published immediately after subscribeTaskResults was dropped — interest not flushed", i)
+		}
+		sub.Unsubscribe()
+	}
+}


### PR DESCRIPTION
## Summary

Root-causes and fixes the `-race` deadlock in TestTPCHNativeDAG_SF01 (#143) — and hardens a real production window found on the way.

## The actual root cause: test fixture, not a dispatch race

`setupDistributed` (and 12 sibling test sites) started workers with the **setup/query context** — a 30-second timeout in setupDistributed's case. The worker's `taskLoop` silently returns when its ctx expires, so 30s into any test the worker stops consuming tasks. Non-race runs finish inside the deadline and never noticed; under `-race` the suite outlives it and every subsequent stage starves until the test times out with the signature dump (coordinator in `awaitStageProgress`, **zero** worker goroutines).

The diagnostic log shows the exact moment: tasks published at `20:46:46` execute within 1 ms; the publish at `20:46:48.804` (ctx expiry) and everything after are never picked up.

All 13 `w.Start(ctx)` test sites now use `context.WithCancel` tied to `t.Cleanup`. **Validated: the previously-hung -race run passes in 78 s** (was: timeout at 5/8/12 m); `-race` TestShuffleCorrectness passes in 12 s. Also adds `WADJET_TEST_LOG=info` to flip fixture loggers for future hang diagnosis.

## Production hardening found en route: lost-result window

Every per-stage result subscription was installed with bare `nc.Subscribe` — interest only reaches the server on the next client flush. A worker finishing a task faster than the flusher publishes its result to a subject with **no registered subscriber**: dropped. A task that fast never enters heartbeat liveness, so `watchStuckTasks` can't recover it, and the worker side can't either — its result `Request` is ACKed by the **JetStream results-stream PubAck**, not the coordinator, so "delivered" means delivered-to-stream with nothing replaying the durable copy.

`subscribeTaskResults` now mirrors `subscribeGather`'s documented Subscribe+Flush at all six dispatch sites (plus the legacy async path). Regression test: publish from another connection the instant subscribe returns must be delivered, ×50 rounds.

## Gates
- `-race` TestTPCHNativeDAG_SF01: **PASS 78 s** (the issue's repro); `-race` TestShuffleCorrectness + the new flush test: pass
- Full unit suite green (37 packages), TPC-H SF0.01 pass, `tpch-harness -mode=local` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)