### PR TITLE
fix(planner): dotted ROW-field access + strict filter/projection column resolution (#147)

### DIFF
--- a/internal/engine/exec/coverage_test.go
+++ b/internal/engine/exec/coverage_test.go
@@ -396,11 +396,14 @@ func TestKernelFilterMissingColumn(t *testing.T) {
 	kf := NewKernelFilter("nonexistent", OpEq, int64(1))
 	kf.Init(context.Background())
 	out, err := kf.Execute(context.Background(), b)
-	if err != nil {
-		t.Fatal(err)
+	// Issue #147: a missing filter column must ERROR — the old contract
+	// (silently match nothing) made a typo'd WHERE clause look exactly
+	// like an empty result.
+	if err == nil {
+		t.Fatal("expected error for missing filter column, got silent empty result")
 	}
 	if out != nil {
-		t.Fatal("expected nil for missing column")
+		t.Fatal("expected nil batch alongside the error")
 	}
 }
 

--- a/internal/engine/exec/filter.go
+++ b/internal/engine/exec/filter.go
@@ -334,13 +334,22 @@ func compareString(a, b string, op CompareOp) bool {
 // KernelFilter is a UnaryOperator that uses a pre-resolved typed filter kernel.
 // The type dispatch happens once on first Execute; the inner loop has no type switches.
 type KernelFilter struct {
-	ColName  string
-	Op       CompareOp
-	Value    any
-	colIdx   int
-	kern     kernel.FilterKernel
-	outSel   []uint32
-	resolved bool
+	ColName string
+	Op      CompareOp
+	Value   any
+	// RowFallback, when non-nil, evaluates the original comparison row-at-
+	// a-time. Used when ColName is a ROW-field access ("attrs.score") that
+	// the typed kernel cannot evaluate — the planner attaches the compiled
+	// expression's predicate, and resolution delegates to it instead of
+	// silently matching nothing (issue #147).
+	RowFallback Predicate
+
+	colIdx      int
+	kern        kernel.FilterKernel
+	outSel      []uint32
+	resolved    bool
+	useFallback bool
+	inner       *Filter
 }
 
 // NewKernelFilter creates a filter that uses typed kernels for comparison.
@@ -350,13 +359,22 @@ func NewKernelFilter(colName string, op CompareOp, value any) *KernelFilter {
 
 func (f *KernelFilter) Init(_ context.Context) error { return nil }
 
-func (f *KernelFilter) Execute(_ context.Context, in *batch.RecordBatch) (*batch.RecordBatch, error) {
+func (f *KernelFilter) Execute(ctx context.Context, in *batch.RecordBatch) (*batch.RecordBatch, error) {
 	if !f.resolved {
 		f.colIdx = in.ColumnIndex(f.ColName)
 		if f.colIdx < 0 && strings.Contains(f.ColName, ".") {
 			// Strip table alias qualifier (e.g. "n1.n_name" → "n_name")
 			parts := strings.SplitN(f.ColName, ".", 2)
 			f.colIdx = in.ColumnIndex(parts[1])
+			if f.colIdx < 0 && f.RowFallback != nil {
+				// ROW-field access: the qualifier names a ROW column whose
+				// field the typed kernel cannot reach — delegate to the
+				// row-at-a-time predicate.
+				if pi := in.ColumnIndex(parts[0]); pi >= 0 && in.Columns[pi].Type == batch.TypeRow {
+					f.useFallback = true
+					f.inner = NewFilter(f.RowFallback)
+				}
+			}
 		}
 		if f.colIdx >= 0 {
 			typ := in.Columns[f.colIdx].Type
@@ -366,8 +384,14 @@ func (f *KernelFilter) Execute(_ context.Context, in *batch.RecordBatch) (*batch
 		f.resolved = true
 	}
 
+	if f.useFallback {
+		return f.inner.Execute(ctx, in)
+	}
 	if f.colIdx < 0 || f.kern == nil {
-		return nil, nil
+		// An unresolvable filter column previously matched NOTHING — a
+		// typo'd WHERE clause silently returned an empty result,
+		// indistinguishable from genuinely empty data (issue #147).
+		return nil, fmt.Errorf("filter column %q does not exist in the input schema", f.ColName)
 	}
 
 	// When the batch already has a selection vector (e.g. from a prior filter
@@ -394,7 +418,7 @@ func (f *KernelFilter) Close() error { return nil }
 // Clone returns a new KernelFilter with the same parameters but fresh
 // resolution state and scratch buffers for concurrent Execute calls.
 func (f *KernelFilter) Clone() UnaryOperator {
-	return &KernelFilter{ColName: f.ColName, Op: f.Op, Value: f.Value}
+	return &KernelFilter{ColName: f.ColName, Op: f.Op, Value: f.Value, RowFallback: f.RowFallback}
 }
 
 // InFilter uses a vectorized kernel for set membership testing (IN / NOT IN).

--- a/internal/engine/exec/project.go
+++ b/internal/engine/exec/project.go
@@ -2,6 +2,8 @@ package exec
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/citc-tech/wadjet/internal/engine/batch"
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
@@ -50,13 +52,13 @@ type ProjectColumn struct {
 	Name            string
 	Type            parquet.TypeID
 	Expr            Expression
-	Float64Eval     Float64Expression    // optional typed path (avoids interface{} boxing)
-	Int64Eval       Int64Expression      // optional typed path
-	VecFloat64Eval  VecFloat64Expression // optional vectorized path (entire column at once)
+	Float64Eval     Float64Expression           // optional typed path (avoids interface{} boxing)
+	Int64Eval       Int64Expression             // optional typed path
+	VecFloat64Eval  VecFloat64Expression        // optional vectorized path (entire column at once)
 	VecFloat64Clone func() VecFloat64Expression // creates a clone with independent scratch buffers
-	VecEval         VecExpression            // optional vectorized evaluation for any output type
-	SourceCol       string               // source column name for type resolution on renames
-	DirectCopy      string               // if set, bulk copy this input column (no per-row eval)
+	VecEval         VecExpression               // optional vectorized evaluation for any output type
+	SourceCol       string                      // source column name for type resolution on renames
+	DirectCopy      string                      // if set, bulk copy this input column (no per-row eval)
 }
 
 // Project is a UnaryOperator that selects and computes columns.
@@ -136,6 +138,14 @@ func (p *Project) Execute(_ context.Context, in *batch.RecordBatch) (*batch.Reco
 			if proj.DirectCopy != "" {
 				if idx := in.ColumnIndex(proj.DirectCopy); idx >= 0 {
 					p.directSrcIdx[j] = idx
+				} else if !plainColumnReachable(in, proj.DirectCopy) {
+					// A projected plain column that resolves to NOTHING —
+					// not bare, not qualifier-stripped, not a ROW field —
+					// previously emitted an all-NULL column, so a typo'd
+					// SELECT item looked like a real (empty) column
+					// (issue #147). Expression projections and the
+					// fallback resolutions stay on the per-row eval path.
+					return nil, fmt.Errorf("column %q does not exist in the input schema", proj.DirectCopy)
 				}
 			}
 		}
@@ -223,6 +233,28 @@ func (p *Project) Execute(_ context.Context, in *batch.RecordBatch) (*batch.Reco
 }
 
 func (p *Project) Close() error { return nil }
+
+// plainColumnReachable reports whether name resolves in b through any of
+// the runtime fallbacks expr.ColRef applies: exact match, qualifier-strip
+// ("t.col" → "col"), or ROW-field access ("attrs.score" → field of ROW
+// column "attrs"). Used to distinguish a typo (error) from a projection
+// the per-row eval path can serve.
+func plainColumnReachable(b *batch.RecordBatch, name string) bool {
+	if b.ColumnIndex(name) >= 0 {
+		return true
+	}
+	dot := strings.IndexByte(name, '.')
+	if dot <= 0 {
+		return false
+	}
+	if b.ColumnIndex(name[dot+1:]) >= 0 {
+		return true
+	}
+	if pi := b.ColumnIndex(name[:dot]); pi >= 0 && b.Columns[pi].Type == batch.TypeRow {
+		return true
+	}
+	return false
+}
 
 // Clone returns a new Project that shares the same (immutable) projections.
 // Each clone gets its own pool (created lazily on first Execute).

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -6160,6 +6160,19 @@ func flattenAnds(e expr.Expr) []expr.Expr {
 }
 
 // extractFilterOps recursively extracts vectorizable filter ops from AND combinations.
+// kernelFilterWithRowFallback builds a typed kernel filter; for dotted
+// column names ("attrs.score") it attaches the compiled comparison as a
+// row-at-a-time fallback so ROW-field access works (the kernel resolves
+// qualified table refs by stripping the prefix, but cannot reach into ROW
+// children — issue #147).
+func kernelFilterWithRowFallback(name string, op exec.CompareOp, val any, cmp expr.Expr) *exec.KernelFilter {
+	kf := exec.NewKernelFilter(name, op, val)
+	if strings.Contains(name, ".") {
+		kf.RowFallback = wrapPredicate(cmp)
+	}
+	return kf
+}
+
 func extractFilterOps(e expr.Expr) []exec.UnaryOperator {
 	switch v := e.(type) {
 	case *expr.Cmp:
@@ -6167,39 +6180,50 @@ func extractFilterOps(e expr.Expr) []exec.UnaryOperator {
 		// col op col
 		if lc, lok := v.Left.(*expr.ColRef); lok {
 			if rc, rok := v.Right.(*expr.ColRef); rok {
+				if strings.Contains(lc.Name, ".") || strings.Contains(rc.Name, ".") {
+					// Possible ROW-field access — the col-col kernel can't
+					// evaluate it; leave this comparison row-at-a-time.
+					return nil
+				}
 				return []exec.UnaryOperator{exec.NewColColFilter(lc.Name, rc.Name, op)}
 			}
 		}
 		// col op const
 		if lc, lok := v.Left.(*expr.ColRef); lok {
 			if lit, rok := v.Right.(*expr.Lit); rok {
-				return []exec.UnaryOperator{exec.NewKernelFilter(lc.Name, op, lit.Val)}
+				return []exec.UnaryOperator{kernelFilterWithRowFallback(lc.Name, op, lit.Val, v)}
 			}
 		}
 		// const op col → flip
 		if lit, lok := v.Left.(*expr.Lit); lok {
 			if rc, rok := v.Right.(*expr.ColRef); rok {
-				return []exec.UnaryOperator{exec.NewKernelFilter(rc.Name, flipOp(op), lit.Val)}
+				return []exec.UnaryOperator{kernelFilterWithRowFallback(rc.Name, flipOp(op), lit.Val, v)}
 			}
 		}
 	case *expr.CmpInt64:
 		op := cmpToExecOp(v.Op)
 		if lc, lok := v.Left.(*expr.ColRef); lok {
 			if rc, rok := v.Right.(*expr.ColRef); rok {
+				if strings.Contains(lc.Name, ".") || strings.Contains(rc.Name, ".") {
+					return nil
+				}
 				return []exec.UnaryOperator{exec.NewColColFilter(lc.Name, rc.Name, op)}
 			}
 			if lit, rok := v.Right.(*expr.Lit); rok {
-				return []exec.UnaryOperator{exec.NewKernelFilter(lc.Name, op, lit.Val)}
+				return []exec.UnaryOperator{kernelFilterWithRowFallback(lc.Name, op, lit.Val, v)}
 			}
 		}
 	case *expr.CmpFloat64:
 		op := cmpToExecOp(v.Op)
 		if lc, lok := v.Left.(*expr.ColRef); lok {
 			if rc, rok := v.Right.(*expr.ColRef); rok {
+				if strings.Contains(lc.Name, ".") || strings.Contains(rc.Name, ".") {
+					return nil
+				}
 				return []exec.UnaryOperator{exec.NewColColFilter(lc.Name, rc.Name, op)}
 			}
 			if lit, rok := v.Right.(*expr.Lit); rok {
-				return []exec.UnaryOperator{exec.NewKernelFilter(lc.Name, op, lit.Val)}
+				return []exec.UnaryOperator{kernelFilterWithRowFallback(lc.Name, op, lit.Val, v)}
 			}
 		}
 	case *expr.And:

--- a/internal/planner/physical/util.go
+++ b/internal/planner/physical/util.go
@@ -196,7 +196,11 @@ func readBatchDirect(pqReader *parquet.Reader, schema []parquet.Column, required
 // which handles nested types (LIST, MAP, STRUCT) natively. Used as fallback
 // when the schema contains nested columns.
 func readBatchViaRows(pqReader *parquet.Reader, schema []parquet.Column, requiredCols []string) *batch.RecordBatch {
-	selectedCols := requiredCols
+	// Dotted ROW-field references require their parent column — see
+	// buildReadSchema (issue #147). ReadRows matches file columns by
+	// exact name, so "attrs.score" must become "attrs" here or the
+	// parent is never read and every downstream field access is NULL.
+	selectedCols := expandRowFieldRequirements(schema, requiredCols)
 	if len(selectedCols) == 0 {
 		selectedCols = make([]string, len(schema))
 		for i, c := range schema {
@@ -210,9 +214,9 @@ func readBatchViaRows(pqReader *parquet.Reader, schema []parquet.Column, require
 
 	// Build the read schema (only columns we're reading)
 	readSchema := schema
-	if len(requiredCols) > 0 {
-		needed := make(map[string]bool, len(requiredCols))
-		for _, c := range requiredCols {
+	if len(selectedCols) > 0 {
+		needed := make(map[string]bool, len(selectedCols))
+		for _, c := range selectedCols {
 			needed[c] = true
 		}
 		filtered := make([]parquet.Column, 0, len(requiredCols))
@@ -920,12 +924,22 @@ func buildReadSchema(schema []parquet.Column, requiredCols []string) []parquet.C
 		return schema
 	}
 	needed := make(map[string]bool, len(requiredCols))
+	// Dotted references: "attrs.score" must pull in the parent column when
+	// the qualifier names a ROW column ("attrs"), or the field access in a
+	// downstream filter/projection silently evaluated NULL because the
+	// parent was pruned from the scan (issue #147). Qualifiers that are
+	// table aliases ("lineitem.l_quantity") never match a column name, so
+	// this adds nothing for them.
+	prefixNeeded := make(map[string]bool, 2)
 	for _, c := range requiredCols {
 		needed[c] = true
+		if dot := strings.IndexByte(c, '.'); dot > 0 {
+			prefixNeeded[c[:dot]] = true
+		}
 	}
 	filtered := make([]parquet.Column, 0, len(requiredCols))
 	for _, col := range schema {
-		if needed[col.Name] {
+		if needed[col.Name] || (prefixNeeded[col.Name] && col.Type == parquet.TypeRow) {
 			filtered = append(filtered, col)
 		}
 	}
@@ -933,4 +947,33 @@ func buildReadSchema(schema []parquet.Column, requiredCols []string) []parquet.C
 		return filtered
 	}
 	return schema
+}
+
+// expandRowFieldRequirements rewrites required column names of the form
+// "parent.field" to "parent" when parent names a ROW column in schema, so
+// row-level readers (which match by exact name) pull the parent in.
+// Non-matching entries pass through unchanged.
+func expandRowFieldRequirements(schema []parquet.Column, requiredCols []string) []string {
+	if len(requiredCols) == 0 {
+		return requiredCols
+	}
+	rowCols := make(map[string]bool, 2)
+	for _, col := range schema {
+		if col.Type == parquet.TypeRow {
+			rowCols[col.Name] = true
+		}
+	}
+	out := make([]string, 0, len(requiredCols))
+	seen := make(map[string]bool, len(requiredCols))
+	for _, c := range requiredCols {
+		name := c
+		if dot := strings.IndexByte(c, '.'); dot > 0 && rowCols[c[:dot]] {
+			name = c[:dot]
+		}
+		if !seen[name] {
+			seen[name] = true
+			out = append(out, name)
+		}
+	}
+	return out
 }

--- a/wadjet/row_field_resolution_test.go
+++ b/wadjet/row_field_resolution_test.go
@@ -1,0 +1,97 @@
+package wadjet
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// Regression tests for issue #147 (partial: filter strictness + dotted ROW
+// access). Previously `attrs.score` parsed as a table-qualified reference,
+// resolved nothing, and silently evaluated NULL in both SELECT and WHERE —
+// and a typo'd WHERE column silently matched nothing, indistinguishable
+// from an empty result.
+func TestRowFieldResolutionAndFilterStrictness(t *testing.T) {
+	ctx := context.Background()
+	db, src := ndOpen(t)
+
+	t.Run("dotted_select", func(t *testing.T) {
+		res, err := db.Query(ctx, `SELECT id, attrs.score AS sc FROM events WHERE id < 30`)
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		if len(res.Rows) != 30 {
+			t.Fatalf("rows = %d, want 30", len(res.Rows))
+		}
+		for _, row := range res.Rows {
+			id := row["id"].(int64)
+			want := src[id]
+			if want.attrs == nil {
+				if row["sc"] != nil {
+					t.Fatalf("id %d: sc = %v, want NULL (NULL row)", id, row["sc"])
+				}
+				continue
+			}
+			wantScore := want.attrs.(map[string]any)["score"].(int64)
+			if fmt.Sprintf("%v", row["sc"]) != fmt.Sprintf("%d", wantScore) {
+				t.Fatalf("id %d: attrs.score = %v, want %d (dotted access silently NULL?)", id, row["sc"], wantScore)
+			}
+		}
+	})
+
+	t.Run("dotted_where", func(t *testing.T) {
+		res, err := db.Query(ctx, `SELECT id FROM events WHERE attrs.score > 90`)
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		want := 0
+		for _, r := range src {
+			if r.attrs != nil && r.attrs.(map[string]any)["score"].(int64) > 90 {
+				want++
+			}
+		}
+		if len(res.Rows) != want {
+			t.Fatalf("rows = %d, want %d (kernel filter can't see ROW fields?)", len(res.Rows), want)
+		}
+	})
+
+	t.Run("dotted_where_conjunction_keeps_vectorized_half", func(t *testing.T) {
+		// AND of a kernelizable comparison and a ROW-field comparison —
+		// partial vectorization must not drop either predicate.
+		res, err := db.Query(ctx, `SELECT id FROM events WHERE id < 1000 AND attrs.score > 90`)
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		want := 0
+		for _, r := range src[:1000] {
+			if r.attrs != nil && r.attrs.(map[string]any)["score"].(int64) > 90 {
+				want++
+			}
+		}
+		if len(res.Rows) != want {
+			t.Fatalf("rows = %d, want %d", len(res.Rows), want)
+		}
+	})
+
+	t.Run("unknown_filter_column_errors", func(t *testing.T) {
+		_, err := db.Query(ctx, `SELECT id FROM events WHERE nosuchcol > 90`)
+		if err == nil {
+			t.Fatal("typo'd WHERE column must error, not silently match nothing")
+		}
+		if !strings.Contains(err.Error(), "nosuchcol") {
+			t.Fatalf("error should name the column: %v", err)
+		}
+	})
+
+	t.Run("qualified_table_refs_still_resolve", func(t *testing.T) {
+		// Qualifier-strip fallback must keep working for real table aliases.
+		res, err := db.Query(ctx, `SELECT e.id FROM events e WHERE e.grp = 'g1' LIMIT 5`)
+		if err != nil {
+			t.Fatalf("qualified ref query: %v", err)
+		}
+		if len(res.Rows) != 5 {
+			t.Fatalf("rows = %d, want 5", len(res.Rows))
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Ships the high-value two-thirds of #147; the issue stays open for the documented remainder.

**Dotted ROW access works** — `SELECT attrs.score`, `WHERE attrs.score > 90` now return real values instead of silently evaluating NULL. Three layers each lost it independently:
1. Required-columns never pulled the parent ROW column into the scan projection (`buildReadSchema` prefix pull + `expandRowFieldRequirements` for the row-fallback reader).
2. The typed kernel filter can't reach ROW children — dotted comparisons now carry the compiled expression as a `RowFallback`, engaged **only** when resolution lands on a ROW parent. Plain and qualifier-stripped names keep the vectorized path untouched (zero deopt for `t.col` filters).
3. Dotted col-col comparisons skip vectorization (row path evaluates them correctly).

**Strictness** — an unresolvable column previously **matched nothing** in WHERE (`KernelFilter` returned nil,nil: a typo was indistinguishable from an empty result) and projected ALL-NULL columns. Both now error naming the column, after every runtime fallback (exact / qualifier-strip / ROW field) misses. The pre-existing test pinning silent-empty is updated to pin the error.

**Remaining on #147** (follow-up; commented on the issue): SELECT-list typos through the legacy row path still emit NULL columns, and full unknown-column rejection needs name binding in the logical builder — the column-needs design pushes merged multi-table needs to every scan, so scan-level validation can't tell typos from other tables' columns.

## Tests
Dotted SELECT/WHERE oracle-checked against the #144 nested suite's dataset, partial vectorization with a ROW-field conjunct, typo'd WHERE errors naming the column, qualified table refs still resolve.

## Gates
Full unit suite green, `-race` exec/physical/wadjet, TPC-H SF0.01 pass, `tpch-harness -mode=local` PASS (every TPC-H filter shape exercised against the new strict resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)