### PR TITLE
fix(planner): validate column references in JOIN conditions

### DIFF
--- a/internal/planner/physical/validate.go
+++ b/internal/planner/physical/validate.go
@@ -212,6 +212,13 @@ func (b *binder) validateBlock(ctx context.Context, info *plansql.SelectInfo, ou
 	if err := b.checkExpr(info.WhereExpr, resolve); err != nil {
 		return err
 	}
+	// JOIN conditions reference columns from the joined sources (all already in
+	// `resolve`). USING/NATURAL/CROSS joins have no CondExpr → skipped.
+	for i := range info.Joins {
+		if err := b.checkExpr(info.Joins[i].CondExpr, resolve); err != nil {
+			return err
+		}
+	}
 	// SELECT expressions (skip stars and window functions — window outputs and
 	// star expansion add no enumerable refs the binder can reason about safely).
 	for i := range info.Columns {
@@ -390,6 +397,9 @@ func (b *binder) blockSubqueries(info *plansql.SelectInfo) []string {
 	for i := range info.Columns {
 		walkExpr(info.Columns[i].ASTExpr, nil, &subs)
 		walkExpr(info.Columns[i].AggArgExpr, nil, &subs)
+	}
+	for i := range info.Joins {
+		walkExpr(info.Joins[i].CondExpr, nil, &subs)
 	}
 	return subs
 }

--- a/internal/planner/physical/validate_test.go
+++ b/internal/planner/physical/validate_test.go
@@ -81,6 +81,9 @@ func TestValidateColumns(t *testing.T) {
 		{"join bare cols valid", "SELECT id, val FROM events JOIN other ON id = eid", false},
 		{"join qualified valid", "SELECT a.id, b.val FROM events a JOIN other b ON a.id = b.eid", false},
 		{"join bare typo", "SELECT id, badcol FROM events a JOIN other b ON a.id = b.eid", true},
+		{"join condition typo", "SELECT a.id FROM events a JOIN other b ON a.id = b.nope", true},
+		{"join condition valid", "SELECT a.id FROM events a JOIN other b ON a.id = b.eid", false},
+		{"join condition subquery typo", "SELECT a.id FROM events a JOIN other b ON a.id = b.eid AND a.amount > (SELECT max(nope) FROM other)", true},
 
 		// --- open schema (escape hatch) ---
 		{"unregistered table is open", "SELECT anything FROM mystery_table", false},


### PR DESCRIPTION
Follow-up to the #147 plan-time column binder (PR #152).

JOIN `ON` conditions were the one expression site the binder didn't check — neither their column references nor any embedded subqueries — so `... JOIN t ON a.x = b.typo` and a typo inside an `ON`-clause subquery slipped through to runtime.

## Fix
- `checkExpr` now runs over each join's `CondExpr`, resolved against the full FROM scope (which already contains every joined source).
- `blockSubqueries` collects `ON`-clause subqueries for recursive validation.
- USING/NATURAL/CROSS joins carry no `CondExpr` → skipped (same conservative posture).

## Tests & gates
- New cases: join-condition typo, valid join condition, `ON`-clause subquery typo (`internal/planner/physical/validate_test.go`)
- Validator unit suite ✅ · `-race` (physical) ✅ · **TPC-H SF0.01 22/22** ✅ · `tpch-harness --mode=local` **25/25** ✅ (both join-heavy — the false-positive smoke test for `ON`-clause validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)