### PR TITLE
fix(worker): broadcast-build panic no longer strands probe tasks (#101)

### DIFF
--- a/internal/coordinator/scheduler.go
+++ b/internal/coordinator/scheduler.go
@@ -96,9 +96,18 @@ type preparedTask struct {
 // via gRPC TaskDispatch (data-plane server) when configured, otherwise
 // falls back to NATS JetStream publish. Tasks are serialized in batch
 // before publishing to minimize time spent holding the transport.
-func (s *Scheduler) PublishTasks(_ context.Context, tasks []distributed.Task) error {
+func (s *Scheduler) PublishTasks(ctx context.Context, tasks []distributed.Task) error {
 	if len(tasks) == 0 {
 		return nil
+	}
+
+	// Carry the query deadline to workers so a dispatched task is bounded by
+	// the same budget the coordinator enforces — a worker that wedges on a
+	// task then releases its slot at the deadline instead of holding it until
+	// the whole query times out (#101). 0 = no deadline rides the dispatch.
+	var deadlineNano int64
+	if dl, ok := ctx.Deadline(); ok {
+		deadlineNano = dl.UnixNano()
 	}
 
 	batch := make([]preparedTask, 0, len(tasks))
@@ -122,7 +131,7 @@ func (s *Scheduler) PublishTasks(_ context.Context, tasks []distributed.Task) er
 	}
 
 	if s.dpSrv != nil {
-		return s.publishViaDataPlane(batch)
+		return s.publishViaDataPlane(batch, deadlineNano)
 	}
 
 	// Publish all pre-serialized messages
@@ -146,20 +155,20 @@ func (s *Scheduler) PublishTasks(_ context.Context, tasks []distributed.Task) er
 // Send blocks on HTTP/2 flow control when a worker is saturated, applying
 // backpressure to the scheduler. The full set is rejected if no worker
 // is connected — there is no NATS fallback in gRPC mode.
-func (s *Scheduler) publishViaDataPlane(batch []preparedTask) error {
+func (s *Scheduler) publishViaDataPlane(batch []preparedTask, deadlineNano int64) error {
 	for _, p := range batch {
 		workerID, ok := s.pickWorkerFor(p.task)
 		if !ok {
 			return fmt.Errorf("dispatching task %s: %w", p.task.ID, dataplane.ErrNoWorkers)
 		}
-		if err := s.dpSrv.SendTaskDispatch(workerID, p.task.ID, p.task.QueryID, p.task.StageID, p.data, 0); err != nil {
+		if err := s.dpSrv.SendTaskDispatch(workerID, p.task.ID, p.task.QueryID, p.task.StageID, p.data, deadlineNano); err != nil {
 			if errors.Is(err, dataplane.ErrNotConnected) {
 				// Worker dropped between Pick and Send; one retry on the
 				// next round-robin position keeps the path lossless when
 				// the cluster has more than one worker.
 				workerID2, ok2 := s.dpSrv.PickWorker()
 				if ok2 && workerID2 != workerID {
-					if err2 := s.dpSrv.SendTaskDispatch(workerID2, p.task.ID, p.task.QueryID, p.task.StageID, p.data, 0); err2 == nil {
+					if err2 := s.dpSrv.SendTaskDispatch(workerID2, p.task.ID, p.task.QueryID, p.task.StageID, p.data, deadlineNano); err2 == nil {
 						s.noteInflight(p.task, workerID2)
 						continue
 					}

--- a/internal/worker/broadcast_join_cache.go
+++ b/internal/worker/broadcast_join_cache.go
@@ -1,9 +1,11 @@
 package worker
 
 import (
+	"context"
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
+	"runtime/debug"
 	"sort"
 	"sync"
 
@@ -76,12 +78,22 @@ func computeBroadcastJoinKey(queryID string, spec distributed.OpSpec) string {
 //
 // On builder error the entry is evicted before this call returns; the caller
 // receives (nil, nil, err) and must NOT call release.
-func (c *broadcastJoinCache) Acquire(key, queryID string, build func() (*exec.HashJoin, error)) (*exec.HashJoin, func(), error) {
+//
+// ctx cancellation aborts a waiter's block on the builder (it releases its
+// refcount and returns ctx.Err()), so a cancelled or deadlined probe task can
+// never strand a goroutine — or its concurrency slot — on a build that hangs.
+func (c *broadcastJoinCache) Acquire(ctx context.Context, key, queryID string, build func() (*exec.HashJoin, error)) (*exec.HashJoin, func(), error) {
 	c.mu.Lock()
 	if e, ok := c.entries[key]; ok {
 		e.refcount++
 		c.mu.Unlock()
-		<-e.ready
+		select {
+		case <-e.ready:
+		case <-ctx.Done():
+			// Abandon the wait without leaking the refcount we just claimed.
+			c.release(key)
+			return nil, nil, ctx.Err()
+		}
 		if e.err != nil {
 			// The builder failed; this waiter inherits the error and decrements
 			// the refcount it just claimed. When refcount hits zero the entry
@@ -100,7 +112,12 @@ func (c *broadcastJoinCache) Acquire(key, queryID string, build func() (*exec.Ha
 	c.entries[key] = e
 	c.mu.Unlock()
 
-	hj, err := build()
+	// buildGuarded converts a panic in build() into an error so the path below
+	// ALWAYS reaches close(e.ready). A panic that unwound past close() would
+	// strand every concurrent and future waiter on this key forever (each
+	// holding a worker concurrency slot) — the root of the Q07 final_aggregate
+	// stall (#101).
+	hj, err := buildGuarded(build)
 
 	c.mu.Lock()
 	e.hj = hj
@@ -115,6 +132,19 @@ func (c *broadcastJoinCache) Acquire(key, queryID string, build func() (*exec.Ha
 		return nil, nil, err
 	}
 	return hj, c.releaseFnFor(key), nil
+}
+
+// buildGuarded runs build, recovering a panic into an error (with stack) so the
+// caller can always signal completion to waiters. The panicking builder task
+// then fails cleanly via the normal error path instead of stranding waiters.
+func buildGuarded(build func() (*exec.HashJoin, error)) (hj *exec.HashJoin, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			hj = nil
+			err = fmt.Errorf("broadcast build panicked: %v\n%s", r, debug.Stack())
+		}
+	}()
+	return build()
 }
 
 func (c *broadcastJoinCache) releaseFnFor(key string) func() {

--- a/internal/worker/broadcast_join_cache_test.go
+++ b/internal/worker/broadcast_join_cache_test.go
@@ -1,10 +1,12 @@
 package worker
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/citc-tech/wadjet/internal/distributed"
 	"github.com/citc-tech/wadjet/internal/engine/exec"
@@ -13,7 +15,7 @@ import (
 func TestBroadcastJoinCache_SingleAcquireRelease(t *testing.T) {
 	c := newBroadcastJoinCache()
 	var built int32
-	hj, release, err := c.Acquire("k1", "q1", func() (*exec.HashJoin, error) {
+	hj, release, err := c.Acquire(context.Background(), "k1", "q1", func() (*exec.HashJoin, error) {
 		atomic.AddInt32(&built, 1)
 		return exec.NewHashJoin(exec.InnerJoin, []string{"a"}, []string{"b"}), nil
 	})
@@ -49,7 +51,7 @@ func TestBroadcastJoinCache_ConcurrentAcquireSharesBuild(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-start
-			hj, release, err := c.Acquire("shared-key", "q1", func() (*exec.HashJoin, error) {
+			hj, release, err := c.Acquire(context.Background(), "shared-key", "q1", func() (*exec.HashJoin, error) {
 				atomic.AddInt32(&built, 1)
 				return exec.NewHashJoin(exec.InnerJoin, []string{"a"}, []string{"b"}), nil
 			})
@@ -98,7 +100,7 @@ func TestBroadcastJoinCache_ConcurrentAcquireSharesBuild(t *testing.T) {
 func TestBroadcastJoinCache_BuilderErrorDoesNotLeak(t *testing.T) {
 	c := newBroadcastJoinCache()
 	wantErr := errors.New("build failed")
-	hj, release, err := c.Acquire("k1", "q1", func() (*exec.HashJoin, error) {
+	hj, release, err := c.Acquire(context.Background(), "k1", "q1", func() (*exec.HashJoin, error) {
 		return nil, wantErr
 	})
 	if !errors.Is(err, wantErr) {
@@ -115,6 +117,96 @@ func TestBroadcastJoinCache_BuilderErrorDoesNotLeak(t *testing.T) {
 	}
 }
 
+// TestBroadcastJoinCache_BuilderPanicDoesNotStrandWaiters is the #101
+// regression: a panic inside build() must not leave e.ready unclosed. Before
+// the fix, the panic unwound past close(e.ready), so every concurrent waiter
+// blocked on <-e.ready forever — each holding a worker concurrency slot, which
+// eventually wedged the worker's task intake (the Q07 final_aggregate stall).
+func TestBroadcastJoinCache_BuilderPanicDoesNotStrandWaiters(t *testing.T) {
+	c := newBroadcastJoinCache()
+	const waiters = 4
+	var wg sync.WaitGroup
+	builderEntered := make(chan struct{})
+	panicNow := make(chan struct{})
+
+	// Builder enters build(), then blocks until we trigger the panic — this
+	// holds the entry un-ready so the waiters below deterministically attach
+	// and block on <-e.ready (the exact scenario the bug stranded forever).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _, err := c.Acquire(context.Background(), "boom", "q1", func() (*exec.HashJoin, error) {
+			close(builderEntered)
+			<-panicNow
+			panic("simulated build panic")
+		})
+		if err == nil {
+			t.Error("builder Acquire should return an error after a build panic")
+		}
+	}()
+	<-builderEntered
+
+	for i := 0; i < waiters; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Must not hang. Whichever way it returns — inheriting the builder's
+			// error, or (if it lands after eviction) succeeding as a fresh
+			// builder — it MUST return rather than strand on e.ready.
+			_, release, _ := c.Acquire(context.Background(), "boom", "q1", func() (*exec.HashJoin, error) {
+				return exec.NewHashJoin(exec.InnerJoin, []string{"a"}, []string{"b"}), nil
+			})
+			if release != nil {
+				release()
+			}
+		}()
+	}
+	// Give the waiters a moment to attach to the in-flight entry, then panic.
+	time.Sleep(25 * time.Millisecond)
+	close(panicNow)
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Acquire waiters hung after a build panic (stranded on e.ready) — #101 regression")
+	}
+	if c.Count() != 0 {
+		t.Errorf("Count=%d, want 0 (poisoned entry must be evicted)", c.Count())
+	}
+}
+
+// TestBroadcastJoinCache_WaiterContextCancel verifies a waiter abandons its
+// block (and releases its refcount/slot) when its context is cancelled, so a
+// build that hangs can never strand a deadlined probe task.
+func TestBroadcastJoinCache_WaiterContextCancel(t *testing.T) {
+	c := newBroadcastJoinCache()
+	builderBlock := make(chan struct{})
+	builderEntered := make(chan struct{})
+
+	go func() {
+		// Builder holds the entry un-ready until we let it finish, after the
+		// waiter has already given up.
+		_, _, _ = c.Acquire(context.Background(), "slow", "q1", func() (*exec.HashJoin, error) {
+			close(builderEntered)
+			<-builderBlock
+			return exec.NewHashJoin(exec.InnerJoin, []string{"a"}, []string{"b"}), nil
+		})
+	}()
+	<-builderEntered
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, err := c.Acquire(ctx, "slow", "q1", func() (*exec.HashJoin, error) {
+		return exec.NewHashJoin(exec.InnerJoin, []string{"a"}, []string{"b"}), nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err=%v, want context.Canceled (waiter must abandon the wait on ctx cancel)", err)
+	}
+	close(builderBlock)
+}
+
 func TestBroadcastJoinCache_CleanupQuery(t *testing.T) {
 	c := newBroadcastJoinCache()
 	// Two distinct broadcasts in q1 (different keys), one in q2.
@@ -124,7 +216,7 @@ func TestBroadcastJoinCache_CleanupQuery(t *testing.T) {
 		{"q2", "q2:a"},
 	}
 	for _, tc := range cases {
-		_, _, err := c.Acquire(tc.k, tc.q, func() (*exec.HashJoin, error) {
+		_, _, err := c.Acquire(context.Background(), tc.k, tc.q, func() (*exec.HashJoin, error) {
 			return exec.NewHashJoin(exec.InnerJoin, []string{"a"}, []string{"b"}), nil
 		})
 		if err != nil {

--- a/internal/worker/executor_fragment.go
+++ b/internal/worker/executor_fragment.go
@@ -986,7 +986,7 @@ func (e *Executor) buildFragmentJoinProbe(ctx context.Context, task distributed.
 	)
 	if spec.Type == distributed.OpBroadcastProbe && e.broadcastCache != nil {
 		key := computeBroadcastJoinKey(task.QueryID, spec)
-		built, release, err := e.broadcastCache.Acquire(key, task.QueryID, buildHJ)
+		built, release, err := e.broadcastCache.Acquire(ctx, key, task.QueryID, buildHJ)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -37,6 +37,12 @@ type Config struct {
 	WorkerID         string
 	ClusterID        string // cluster this worker belongs to (for federated routing)
 	MaxConcurrent    int    // max concurrent tasks
+	// MaxTaskDuration caps how long a single task may run before its context
+	// is cancelled, guaranteeing its concurrency slot is eventually released
+	// even if it wedges. The coordinator's per-task DeadlineUnixNano (the
+	// query deadline) takes precedence when supplied; this is the floor for
+	// the gRPC dispatch path when no deadline rides the dispatch. 0 = no cap.
+	MaxTaskDuration  time.Duration
 	CacheBytes       int64  // local LRU cache size
 	MemoryBudget     int64  // per-task memory budget in bytes (0 = unlimited, no spill); used as legacy fallback when SharedPoolBudget is unset
 	SharedPoolBudget int64  // worker-wide memory pool in bytes (0 = derived as MemoryBudget*MaxConcurrent). All concurrent tasks Reserve against this pool; spill triggers fire on cumulative worker pressure.
@@ -78,6 +84,7 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		MaxConcurrent:    4,
+		MaxTaskDuration:  30 * time.Minute, // matches the coordinator's default query timeout
 		CacheBytes:       256 * 1024 * 1024, // 256 MB
 		ResultStoreBytes: 512 * 1024 * 1024, // 512 MB — avoids S3 round-trips for inter-stage results
 	}
@@ -92,6 +99,10 @@ func DefaultConfig() Config {
 const (
 	poolPressurePullThreshold = 0.70
 	poolPressurePullBackoff   = 100 * time.Millisecond
+	// dispatchBackpressureWarn is how often a saturated worker logs that it is
+	// holding a dispatched task it has no free slot for. Makes a wedged worker
+	// visible in its own logs instead of stalling silently (#101).
+	dispatchBackpressureWarn = 15 * time.Second
 )
 
 type Worker struct {
@@ -144,6 +155,12 @@ func New(cfg Config, store objstore.Store, nc *nats.Conn, js jetstream.JetStream
 	}
 	if cfg.MaxConcurrent <= 0 {
 		cfg.MaxConcurrent = 4
+	}
+	if cfg.MaxTaskDuration <= 0 {
+		// Floor so a wedged task always releases its slot even when no
+		// per-dispatch deadline rides the task (e.g. the NATS path). Matches
+		// the coordinator's default query timeout.
+		cfg.MaxTaskDuration = 30 * time.Minute
 	}
 	if cfg.CacheBytes <= 0 {
 		cfg.CacheBytes = 256 * 1024 * 1024
@@ -413,9 +430,32 @@ func (w *Worker) Start(ctx context.Context) error {
 		// recv → coord's stream.Send blocks → backpressure propagates.
 		pending := make(chan dataplane.TaskDispatch, w.config.MaxConcurrent)
 		w.dpClient.RegisterDispatchHandler(func(td dataplane.TaskDispatch) {
+			// Fast path: the bounded queue has room.
 			select {
 			case pending <- td:
+				return
 			case <-ctx.Done():
+				return
+			default:
+			}
+			// Queue full — the worker is at MaxConcurrent. We still block (which
+			// applies HTTP/2 flow-control backpressure to coord), but we no
+			// longer do so silently: a worker wedged on stuck tasks used to
+			// swallow the next dispatch with zero visibility, the invisible half
+			// of the Q07 final_aggregate stall (#101). Surface it periodically.
+			warn := time.NewTicker(dispatchBackpressureWarn)
+			defer warn.Stop()
+			for {
+				select {
+				case pending <- td:
+					return
+				case <-ctx.Done():
+					return
+				case <-warn.C:
+					w.logger.Warn("dispatch queue full; worker saturated, holding dispatched task",
+						"task_id", td.TaskID, "query_id", td.QueryID, "stage_id", td.StageID,
+						"max_concurrent", w.config.MaxConcurrent)
+				}
 			}
 		})
 		w.wg.Add(1)
@@ -481,13 +521,33 @@ func (w *Worker) dispatchLoop(ctx context.Context, in <-chan dataplane.TaskDispa
 			// backstop.
 			w.waitForPoolHeadroom(ctx, task.EstimatedBytes)
 			w.wg.Add(1)
-			go func(t distributed.Task) {
+			go func(t distributed.Task, deadlineNano int64) {
 				defer w.wg.Done()
 				defer func() { <-sem }()
-				w.executeIncomingTask(ctx, t, noopAcker{})
-			}(task)
+				// Bound the task's lifetime so a wedged task (e.g. one stranded
+				// on a dependency) always releases its concurrency slot rather
+				// than permanently starving the dispatch loop (#101).
+				taskCtx, cancel := w.taskContext(ctx, deadlineNano)
+				defer cancel()
+				w.executeIncomingTask(taskCtx, t, noopAcker{})
+			}(task, td.DeadlineUnixNano)
 		}
 	}
+}
+
+// taskContext derives the execution context for one dispatched task, applying a
+// deadline so a wedged task always releases its concurrency slot. Precedence:
+// the coordinator-supplied DeadlineUnixNano (the query deadline), then the
+// worker's MaxTaskDuration floor; if neither is set the parent context is used
+// unchanged.
+func (w *Worker) taskContext(parent context.Context, deadlineUnixNano int64) (context.Context, context.CancelFunc) {
+	if deadlineUnixNano > 0 {
+		return context.WithDeadline(parent, time.Unix(0, deadlineUnixNano))
+	}
+	if w.config.MaxTaskDuration > 0 {
+		return context.WithTimeout(parent, w.config.MaxTaskDuration)
+	}
+	return context.WithCancel(parent)
 }
 
 // poolHeadroomMaxWait caps how long dispatchLoop delays a task start while


### PR DESCRIPTION
## Root cause (Q07 SF10 stall on `final_aggregate-14`, #101)

A worker-side deadlock that silently wedges task intake — found by code analysis, no EC2 repro needed.

In `broadcastJoinCache.Acquire`, the first arrival builds the shared `HashJoin`; concurrent arrivals for the same key block on `e.ready`. `close(e.ready)` sat *after* `build()` and was **not deferred**, so a panic inside `build()` (decode edge cases / schema mismatches — the per-task `recover()` keeps the worker alive and heartbeating) unwound *past* the close. `e.ready` was never closed and the entry stayed in the map, so **every concurrent and future waiter blocked forever on a bare `<-e.ready`, each holding a worker concurrency slot.**

Once `MaxConcurrent` (=2 at SF10) slots leaked: `dispatchLoop` blocks acquiring the semaphore → stops draining `pending` → the gRPC recv-loop handler blocks on the full queue → the next dispatched task (`final_aggregate-14`) sits unread in the HTTP/2 buffer. Coord logged `published tasks count=1` (the small envelope fit the flow-control window), the worker never logged `executing task`, heartbeats continued. **Exact symptom match.** ~20% on full 22Q runs, only at SF10 where the build panic actually fires (not SF0.1).

## Fix

**Layer 1 — remove the strand** (`broadcast_join_cache.go`):
- `buildGuarded` converts a `build()` panic into an error so `Acquire` **always** reaches `close(e.ready)`; the panicking task fails cleanly via the normal error path.
- The waiter's `<-e.ready` is now a `select` on `ctx.Done()` — a cancelled/deadlined probe task abandons the wait and releases its slot, covering a build that *hangs* (not just panics).

**Layer 2 — contain any future "task blocks forever"** so one stuck task can't silently wedge the worker:
- Per-task deadline: `dispatchLoop` derives the task ctx from `DeadlineUnixNano` with a `MaxTaskDuration` floor (default 30m, normalized in `worker.New`), guaranteeing slot release.
- Coordinator now propagates the query deadline (`ctx.Deadline()`) into `TaskDispatch.DeadlineUnixNano` (the field was plumbed but always sent `0`).
- The gRPC dispatch handler now logs when it holds a task because the queue is full — a saturated/wedged worker becomes visible in its own logs instead of stalling silently (the invisible half of #101).

## Tests & gates
- Regression: a panicking build must not hang waiters + must evict the poisoned entry; a ctx-cancelled waiter abandons the wait (`broadcast_join_cache_test.go`)
- `-race ./internal/worker/... ./internal/coordinator/... ./internal/dataplane/...` ✅
- TPC-H SF0.01 ✅ · `tpch-harness --mode=local` **25/25 incl. Q07** (distributed DAG path — exercises coord→worker deadline propagation) ✅

## Confidence
High-confidence root cause derived from code (refutes the earlier "gRPC handler-not-registered" theory, which can't explain a stall on the *last* stage mid-run). It can't be 100% confirmed as *the* SF10 stall without a captured goroutine stack, but it's an unambiguous latent deadlock matching every symptom, and the fix needs no spend. Recommend validating opportunistically on the next SF10 run.

Closes #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)