### PR TITLE
perf(coordinator): parallel key-sharded final re-aggregation (#22)

### DIFF
--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"math"
+	"runtime"
 	"runtime/debug"
 	"slices"
 	"strconv"
@@ -1512,61 +1513,107 @@ func (c *Coordinator) reAggregatePartials(batches []*batch.RecordBatch, columns 
 	// materializing a []any per group. The source row's typed values are
 	// copied out at finalize time (one type-switch per group, not per row),
 	// avoiding the boxing allocation that dominated GC pressure at SF100.
+	// rank is the global flat-row index of the group's first occurrence; it
+	// reproduces the sequential insertion order after the parallel merge.
 	type mergedRow struct {
 		sourceBatch *batch.RecordBatch
 		sourceRow   int
 		aggVals     []float64
+		rank        int
 	}
-	groups := make(map[string]*mergedRow)
-	var groupOrder []string // preserve insertion order
 
-	keyBuf := make([]byte, 0, 256)
+	// Per-batch global row offset, so a group's first-occurrence position has a
+	// single monotonic index across all batches.
+	totalRows := 0
+	batchStart := make([]int, len(batches))
+	for i, b := range batches {
+		batchStart[i] = totalRows
+		totalRows += b.ActiveLen()
+	}
 
-	for _, b := range batches {
-		nRows := b.ActiveLen()
-		sel := b.Sel
-		for ri := 0; ri < nRows; ri++ {
-			row := ri
-			if sel != nil {
-				row = int(sel[ri])
-			}
-
-			keyBuf = keyBuf[:0]
-			for gi, enc := range keyEncoders {
-				if gi > 0 {
-					keyBuf = append(keyBuf, 0)
+	// accumulate folds one source row into a shard-local group map, identical
+	// for the serial and parallel paths. `owns` decides whether this scanner
+	// owns the row's key (always true for the single-shard serial path); when
+	// it returns false the row is skipped so another shard handles it.
+	accumulate := func(groups map[string]*mergedRow, ordered *[]*mergedRow, keyBuf []byte, owns func(key []byte) bool) []byte {
+		for bi, b := range batches {
+			nRows := b.ActiveLen()
+			sel := b.Sel
+			for ri := 0; ri < nRows; ri++ {
+				row := ri
+				if sel != nil {
+					row = int(sel[ri])
 				}
-				keyBuf = enc(b, row, keyBuf)
-			}
-			key := string(keyBuf)
-
-			mr, exists := groups[key]
-			if !exists {
-				aggVals := make([]float64, len(aggCols))
+				keyBuf = keyBuf[:0]
+				for gi, enc := range keyEncoders {
+					if gi > 0 {
+						keyBuf = append(keyBuf, 0)
+					}
+					keyBuf = enc(b, row, keyBuf)
+				}
+				if owns != nil && !owns(keyBuf) {
+					continue
+				}
+				key := string(keyBuf)
+				mr, exists := groups[key]
+				if !exists {
+					aggVals := make([]float64, len(aggCols))
+					for ai, ext := range aggExtractors {
+						aggVals[ai] = ext(b, row)
+					}
+					mr = &mergedRow{sourceBatch: b, sourceRow: row, aggVals: aggVals, rank: batchStart[bi] + ri}
+					groups[key] = mr
+					*ordered = append(*ordered, mr)
+					continue
+				}
 				for ai, ext := range aggExtractors {
-					aggVals[ai] = ext(b, row)
+					mr.aggVals[ai] = aggCols[ai].mergeFn(mr.aggVals[ai], ext(b, row))
 				}
-				groups[key] = &mergedRow{
-					sourceBatch: b,
-					sourceRow:   row,
-					aggVals:     aggVals,
-				}
-				groupOrder = append(groupOrder, key)
-				continue
-			}
-
-			for ai, ext := range aggExtractors {
-				mr.aggVals[ai] = aggCols[ai].mergeFn(mr.aggVals[ai], ext(b, row))
 			}
 		}
+		return keyBuf
+	}
+
+	var ordered []*mergedRow
+	shards := mergeShardCount(totalRows)
+	if shards <= 1 {
+		groups := make(map[string]*mergedRow)
+		accumulate(groups, &ordered, make([]byte, 0, 256), nil)
+	} else {
+		// Parallel key-sharded merge. Each worker scans ALL rows in global
+		// order but accumulates only keys it owns (hash(key)%shards == w).
+		// Because every key lives in exactly one shard and is accumulated in
+		// global (batch,row) order, per-key SUM/MIN/MAX order is identical to
+		// the serial path → byte-identical float results. Group output order is
+		// restored below by sorting on the global first-occurrence rank.
+		shardOrdered := make([][]*mergedRow, shards)
+		var wg sync.WaitGroup
+		for w := 0; w < shards; w++ {
+			wg.Add(1)
+			go func(w int) {
+				defer wg.Done()
+				groups := make(map[string]*mergedRow)
+				var local []*mergedRow
+				accumulate(groups, &local, make([]byte, 0, 256), func(key []byte) bool {
+					return mergeShardOf(key, shards) == w
+				})
+				shardOrdered[w] = local
+			}(w)
+		}
+		wg.Wait()
+		for w := 0; w < shards; w++ {
+			ordered = append(ordered, shardOrdered[w]...)
+		}
+		// ranks are unique (each group first-occurs at a distinct global row),
+		// so this reproduces the exact sequential insertion order.
+		slices.SortFunc(ordered, func(a, b *mergedRow) int { return a.rank - b.rank })
 	}
 
 	// Build result batch from merged groups. Group-by values are copied
 	// directly from the captured source batch+row using typed copy
 	// helpers — this is one type-switch per (group, column), not per row.
-	result := batch.NewRecordBatch(schema, len(groupOrder))
-	for ri, key := range groupOrder {
-		mr := groups[key]
+	result := batch.NewRecordBatch(schema, len(ordered))
+	for ri, mr := range ordered {
 		for _, ci := range groupByIdx {
 			copyVectorValue(result.Columns[ci], ri, mr.sourceBatch.Columns[ci], mr.sourceRow, schema[ci].Type)
 		}
@@ -1585,9 +1632,41 @@ func (c *Coordinator) reAggregatePartials(batches []*batch.RecordBatch, columns 
 			}
 		}
 	}
-	result.Len = len(groupOrder)
+	result.Len = len(ordered)
 
 	return []*batch.RecordBatch{result}
+}
+
+// parallelMergeMinRows is the partial-row count below which reAggregatePartials
+// stays single-threaded — goroutine setup isn't worth it for small merges.
+const parallelMergeMinRows = 8192
+
+// mergeShardCount returns how many parallel shards reAggregatePartials should
+// use for a merge of totalRows partial rows: 1 (serial) below the threshold or
+// on a single core, otherwise GOMAXPROCS.
+func mergeShardCount(totalRows int) int {
+	if totalRows < parallelMergeMinRows {
+		return 1
+	}
+	n := runtime.GOMAXPROCS(0)
+	if n < 1 {
+		return 1
+	}
+	return n
+}
+
+// mergeShardOf maps a group key to one of `shards` shards via FNV-1a. It is a
+// pure function of the key bytes, so a key's rows are always owned by the same
+// shard — required for byte-identical per-key accumulation order. The shard
+// assignment itself does not affect results (output is rank-sorted and per-key
+// accumulation is global-order regardless of which shard owns the key).
+func mergeShardOf(key []byte, shards int) int {
+	var h uint64 = 1469598103934665603
+	for _, c := range key {
+		h ^= uint64(c)
+		h *= 1099511628211
+	}
+	return int(h % uint64(shards))
 }
 
 // copyVectorValue copies a single typed value from src[srcRow] to dst[dstRow].

--- a/internal/coordinator/reaggregate_parallel_test.go
+++ b/internal/coordinator/reaggregate_parallel_test.go
@@ -1,0 +1,149 @@
+package coordinator
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/planner/logical"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// makeAggPartial builds one partial batch: one (g, v) row per group, where
+// g is the group key and v is that group's value for this partial.
+func makeAggPartial(t *testing.T, groups int, valueFor func(g int) float64) *batch.RecordBatch {
+	t.Helper()
+	schema := []parquet.Column{
+		{Name: "g", Type: parquet.TypeInt64, Nullable: true},
+		{Name: "v", Type: parquet.TypeFloat64, Nullable: true},
+	}
+	b := batch.NewRecordBatch(schema, groups)
+	for g := 0; g < groups; g++ {
+		b.Columns[0].Int64Data[g] = int64(g)
+		b.Columns[0].Nulls.SetValid(g)
+		b.Columns[1].Float64Data[g] = valueFor(g)
+		b.Columns[1].Nulls.SetValid(g)
+	}
+	b.Len = groups
+	return b
+}
+
+// TestReAggregatePartials_ParallelByteIdentical is the #22 gate: the parallel
+// key-sharded merge must produce output BIT-IDENTICAL to the serial path,
+// including float64 SUM values (accumulation order) and group output order.
+//
+// The parallel path only engages at >= parallelMergeMinRows partial rows with
+// GOMAXPROCS > 1 — a scale neither the SF0.01 TPC-H test nor the small-scale
+// harness reaches — so this is the only thing that exercises it locally. The
+// per-group values below are order-sensitive (a large term, then small terms,
+// then its negation): if the parallel merge summed a group's partials in any
+// order other than the global one, the float result would diverge in the low
+// bits and this test would fail.
+func TestReAggregatePartials_ParallelByteIdentical(t *testing.T) {
+	const groups = 3000 // 4 partials * 3000 = 12000 rows >= parallelMergeMinRows
+	values := [][]float64{
+		func() []float64 {
+			v := make([]float64, groups)
+			for g := range v {
+				v[g] = 1e15
+			}
+			return v
+		}(),
+		func() []float64 {
+			v := make([]float64, groups)
+			for g := range v {
+				v[g] = float64(g) + 0.5
+			}
+			return v
+		}(),
+		func() []float64 {
+			v := make([]float64, groups)
+			for g := range v {
+				v[g] = -1e15
+			}
+			return v
+		}(),
+		func() []float64 {
+			v := make([]float64, groups)
+			for g := range v {
+				v[g] = float64(g) + 0.25
+			}
+			return v
+		}(),
+	}
+	makeBatches := func() []*batch.RecordBatch {
+		bs := make([]*batch.RecordBatch, len(values))
+		for p := range values {
+			vp := values[p]
+			bs[p] = makeAggPartial(t, groups, func(g int) float64 { return vp[g] })
+		}
+		return bs
+	}
+
+	columns := []string{"g", "v"}
+	colIdx := map[string]int{"g": 0, "v": 1}
+	mi := &logical.MergeInfo{
+		GroupBy:      []string{"g"},
+		AggExprs:     []logical.AggExpr{{Func: "sum", InputCol: "v", OutputCol: "v"}},
+		HasAggregate: true,
+	}
+
+	c := &Coordinator{}
+
+	// Serial reference: force a single shard.
+	prev := runtime.GOMAXPROCS(1)
+	if got := mergeShardCount(groups * len(values)); got != 1 {
+		runtime.GOMAXPROCS(prev)
+		t.Fatalf("expected serial merge at GOMAXPROCS=1, got shards=%d", got)
+	}
+	serial := c.reAggregatePartials(makeBatches(), columns, colIdx, mi)
+
+	// Parallel: ensure > 1 shard actually engages.
+	runtime.GOMAXPROCS(maxInt(2, runtime.NumCPU()))
+	shards := mergeShardCount(groups * len(values))
+	parallel := c.reAggregatePartials(makeBatches(), columns, colIdx, mi)
+	runtime.GOMAXPROCS(prev)
+
+	if shards <= 1 {
+		t.Fatalf("parallel path did not engage (shards=%d); test would not cover it", shards)
+	}
+
+	// Both must be a single result batch of `groups` rows.
+	if len(serial) != 1 || len(parallel) != 1 {
+		t.Fatalf("expected 1 result batch each, got serial=%d parallel=%d", len(serial), len(parallel))
+	}
+	sb, pb := serial[0], parallel[0]
+	if sb.Len != groups || pb.Len != groups {
+		t.Fatalf("row count mismatch: serial=%d parallel=%d want=%d", sb.Len, pb.Len, groups)
+	}
+
+	// Bit-identical: same group order (g) and same SUM (v), exact float equality.
+	for ri := 0; ri < groups; ri++ {
+		sg := sb.Columns[0].Int64Data[ri]
+		pg := pb.Columns[0].Int64Data[ri]
+		if sg != pg {
+			t.Fatalf("row %d: group order differs serial g=%d parallel g=%d", ri, sg, pg)
+		}
+		sv := sb.Columns[1].Float64Data[ri]
+		pv := pb.Columns[1].Float64Data[ri]
+		if sv != pv {
+			t.Fatalf("row %d (g=%d): SUM differs serial=%v parallel=%v (accumulation order changed)", ri, sg, sv, pv)
+		}
+	}
+
+	// Sanity: serial result for a sample group equals the global-order sum.
+	want := ((1e15 + (0.0 + 0.5)) + -1e15) + (0.0 + 0.25) // group g=0
+	if sb.Columns[0].Int64Data[0] != 0 {
+		t.Fatalf("expected first group g=0, got %d", sb.Columns[0].Int64Data[0])
+	}
+	if got := sb.Columns[1].Float64Data[0]; got != want {
+		t.Fatalf("group 0 sum = %v, want %v (global accumulation order)", got, want)
+	}
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
Parallelizes the coordinator's final merge of worker partial aggregates — the single-threaded bottleneck for high-cardinality GROUP BY.

## Problem
`reAggregatePartials` merged all worker partials in one goroutine: for N partials × K groups, N×K sequential key-encode + hashmap ops on a single core.

## Change
Merge across `GOMAXPROCS` shards. Each worker scans **all** partial rows in global `(batch, row)` order but only accumulates keys it owns (`fnv(key) % shards == w`).

## Why it's byte-identical (the hard constraint)
The TPC-H gate is **exact**, and float64 accumulation order changes the low bits. This design preserves it:
- Every key lives in exactly **one** shard and is accumulated in **global order**, so each group's SUM/MIN/MAX is summed in the same sequence as the serial path ⇒ identical float result.
- Group **output order** is restored by recording each group's global first-occurrence flat-row index and sorting on it (ranks are unique ⇒ deterministic).
- Shard assignment (fnv) is arbitrary but does **not** affect results — output is rank-sorted and per-key accumulation is global-order regardless of which shard owns a key.

The redundant key-encoding (each worker encodes every row to decide ownership) runs in parallel, so wall-time ≈ 1× encoding + hashmap-work/shards — and the hashmap work is exactly the high-cardinality cost being parallelized.

Serial path (single map) is kept below `parallelMergeMinRows` (8192) or on a single core — a uniform guard, not a per-query special case. Serial and parallel share one `accumulate` closure and one finalize, so output is constructed identically. Scalar-aggregate and DISTINCT paths are untouched.

## Coverage note
The parallel branch only engages at ≥8192 partial rows with >1 core — a scale neither SF0.01 TPC-H (single-process, doesn't import this path) nor the small-scale harness reaches. So the gate is a dedicated unit test:

`TestReAggregatePartials_ParallelByteIdentical` — 12k partial rows × 3k groups, **order-sensitive** float values (large term, small terms, then its negation). Runs the same input through serial (`GOMAXPROCS=1`) and parallel paths and asserts **bit-identical** output (group order + exact SUM), with a guard that shards>1 actually engaged. Any reordering bug diverges in the low bits and fails it.

## Gates
- `-race ./internal/coordinator/` (incl. the new test ×3) ✅
- TPC-H SF0.01 **22/22** ✅ · harness `--mode=local` **25/25** ✅

Per project policy (validated byte-identical shape), correctness gates suffice — no EC2 A/B.

Closes #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)