### PR TITLE
feat(planner): add ANALYZE TABLE SQL command

### DIFF
--- a/internal/planner/sql/parser.go
+++ b/internal/planner/sql/parser.go
@@ -33,6 +33,7 @@ type ParsedQuery struct {
 	DropFunction   *DropFunctionInfo
 	CreateTable    *CreateTableInfo
 	DropTable      *DropTableInfo
+	AnalyzeTable   *AnalyzeTableInfo
 	CreateView     *CreateViewInfo
 	DropView       *DropViewInfo
 	AlterTable     *AlterTableInfo
@@ -145,6 +146,11 @@ type DropTableInfo struct {
 	IfExists bool
 }
 
+// AnalyzeTableInfo holds details for an ANALYZE TABLE statement.
+type AnalyzeTableInfo struct {
+	Name string
+}
+
 // UpdateInfo holds details for an UPDATE statement.
 type UpdateInfo struct {
 	Table      string            // table name
@@ -209,6 +215,7 @@ const (
 	QueryShowFunctions
 	QueryCreateTable
 	QueryDropTable
+	QueryAnalyzeTable
 	QueryShowTables
 	QueryUpdate
 	QueryDelete
@@ -260,6 +267,9 @@ func Parse(sql string) (*ParsedQuery, error) {
 		return parseAlterTable(trimmed, l)
 	case TokenKWMerge:
 		return parseMerge(trimmed, l)
+	case TokenKWAnalyze:
+		l.nextToken() // consume ANALYZE
+		return lexParseAnalyze(trimmed, l)
 	}
 
 	// Pre-parse CTEs — extract WITH ... AS (...) clauses
@@ -683,6 +693,27 @@ func lexParseDropTable(sql string, l *lexer) (*ParsedQuery, error) {
 		DropTable: &DropTableInfo{
 			Name:     tok.val,
 			IfExists: ifExists,
+		},
+	}, nil
+}
+
+// lexParseAnalyze handles: ANALYZE [TABLE] <name>. The leading ANALYZE has
+// already been consumed. The TABLE keyword is optional (ANALYZE foo == ANALYZE
+// TABLE foo). EXPLAIN ANALYZE is a separate path (lexParseExplain) and is not
+// affected — only a statement that STARTS with ANALYZE reaches here.
+func lexParseAnalyze(sql string, l *lexer) (*ParsedQuery, error) {
+	tok := l.nextToken()
+	if tok.typ == TokenKWTable {
+		tok = l.nextToken()
+	}
+	if tok.typ != TokenIdent {
+		return nil, fmt.Errorf("ANALYZE: table name is required")
+	}
+	return &ParsedQuery{
+		Type: QueryAnalyzeTable,
+		SQL:  sql,
+		AnalyzeTable: &AnalyzeTableInfo{
+			Name: tok.val,
 		},
 	}, nil
 }

--- a/internal/planner/sql/parser_test.go
+++ b/internal/planner/sql/parser_test.go
@@ -214,6 +214,27 @@ func TestExtractJoin(t *testing.T) {
 	}
 }
 
+func TestParseAnalyzeTable(t *testing.T) {
+	for _, sql := range []string{"ANALYZE TABLE events", "ANALYZE events", "analyze table events"} {
+		parsed, err := Parse(sql)
+		if err != nil {
+			t.Fatalf("%q: %v", sql, err)
+		}
+		if parsed.Type != QueryAnalyzeTable {
+			t.Fatalf("%q: expected QueryAnalyzeTable, got %v", sql, parsed.Type)
+		}
+		if parsed.AnalyzeTable == nil || parsed.AnalyzeTable.Name != "events" {
+			t.Fatalf("%q: AnalyzeTable = %+v, want Name=events", sql, parsed.AnalyzeTable)
+		}
+	}
+}
+
+func TestParseAnalyzeTableMissingName(t *testing.T) {
+	if _, err := Parse("ANALYZE TABLE"); err == nil {
+		t.Fatal("ANALYZE TABLE without a name must error")
+	}
+}
+
 func TestParseExplain(t *testing.T) {
 	parsed, err := Parse("EXPLAIN SELECT * FROM events WHERE id > 5")
 	if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -272,6 +272,12 @@ func (s *Server) handleQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Handle ANALYZE TABLE
+	if parsed.Type == plansql.QueryAnalyzeTable {
+		s.handleAnalyzeTableSQL(w, r, parsed, start)
+		return
+	}
+
 	// Handle SHOW TABLES
 	if parsed.Type == plansql.QueryShowTables {
 		s.handleShowTables(w, r, start)
@@ -1365,6 +1371,33 @@ func (s *Server) handleCreateTableSQL(w http.ResponseWriter, r *http.Request, pa
 }
 
 // handleDropTableSQL handles DROP TABLE via SQL.
+// handleAnalyzeTableSQL refreshes planner column statistics (HLL NDV +
+// histograms) for a table — the SQL surface for catalog.AnalyzeTable.
+func (s *Server) handleAnalyzeTableSQL(w http.ResponseWriter, r *http.Request, parsed *plansql.ParsedQuery, start time.Time) {
+	at := parsed.AnalyzeTable
+
+	identity := auth.IdentityFromContext(r.Context())
+	if identity != nil {
+		if authz := s.getAuthz(); authz != nil && !authz.HasPermission(identity, "write") {
+			writeError(w, http.StatusForbidden, "insufficient permissions to analyze tables")
+			return
+		}
+	}
+
+	n, err := s.catalog.AnalyzeTable(r.Context(), at.Name)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, QueryResponse{
+		QueryID: fmt.Sprintf("q-%d", start.UnixMilli()),
+		Columns: []string{"result"},
+		Rows:    []map[string]any{{"result": fmt.Sprintf("Table %q analyzed (%d files)", at.Name, n)}},
+		Stats:   QueryStats{Elapsed: time.Since(start).String()},
+	})
+}
+
 func (s *Server) handleDropTableSQL(w http.ResponseWriter, r *http.Request, parsed *plansql.ParsedQuery, start time.Time) {
 	dt := parsed.DropTable
 

--- a/wadjet/analyze_table_test.go
+++ b/wadjet/analyze_table_test.go
@@ -1,0 +1,79 @@
+package wadjet
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/storage/ingest"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// TestAnalyzeTableSQL exercises the ANALYZE TABLE SQL command end-to-end: it
+// must parse, dispatch through DB.Query, run catalog.AnalyzeTable over the
+// table's parquet files, and leave the planner's column statistics (HLL NDV)
+// populated and accurate.
+func TestAnalyzeTableSQL(t *testing.T) {
+	ctx := context.Background()
+	db, err := Open(ctx, Config{Store: objstore.NewMemStore(), Bucket: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "grp", Type: parquet.TypeString, Nullable: true},
+	}}
+	if err := db.CreateTable(ctx, "metrics", schema, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	const nRows = 200
+	grps := []string{"a", "b", "c", "d"} // NDV 4
+	rows := make([]map[string]any, nRows)
+	for i := 0; i < nRows; i++ {
+		rows[i] = map[string]any{"id": int64(i), "grp": grps[i%len(grps)]} // id NDV 200
+	}
+	ing := db.NewIngester("metrics", schema, nil, ingest.Config{MaxBufferRows: 10000, RowGroupSize: 500})
+	if err := ing.Ingest(ctx, rows); err != nil {
+		t.Fatal(err)
+	}
+	if err := ing.FlushAll(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// The command itself.
+	res, err := db.Query(ctx, "ANALYZE TABLE metrics")
+	if err != nil {
+		t.Fatalf("ANALYZE TABLE: %v", err)
+	}
+	if len(res.Rows) != 1 || !strings.Contains(strings.ToLower(res.Rows[0]["result"].(string)), "analyzed") {
+		t.Fatalf("unexpected ANALYZE result: %+v", res.Rows)
+	}
+
+	// Planner-facing stats must now carry accurate NDV.
+	stats, err := db.Catalog().AggregateColumnStats(ctx, "metrics")
+	if err != nil {
+		t.Fatalf("AggregateColumnStats: %v", err)
+	}
+	if cs, ok := stats["grp"]; !ok || cs.NDV != 4 {
+		t.Errorf("grp NDV = %d (ok=%v), want 4", stats["grp"].NDV, ok)
+	}
+	if cs, ok := stats["id"]; !ok || cs.NDV < 190 || cs.NDV > 210 {
+		t.Errorf("id NDV = %d (ok=%v), want ~200 (HLL error bound)", stats["id"].NDV, ok)
+	}
+
+	// Bareword form (no TABLE keyword) also works.
+	if _, err := db.Query(ctx, "ANALYZE metrics"); err != nil {
+		t.Fatalf("ANALYZE metrics (bareword): %v", err)
+	}
+
+	// Unknown table errors, naming the table.
+	_, err = db.Query(ctx, "ANALYZE TABLE nope")
+	if err == nil {
+		t.Fatal("ANALYZE of a nonexistent table must error")
+	}
+	if !strings.Contains(err.Error(), "nope") {
+		t.Errorf("error should name the table: %v", err)
+	}
+}

--- a/wadjet/wadjet.go
+++ b/wadjet/wadjet.go
@@ -207,6 +207,8 @@ func (db *DB) Query(ctx context.Context, sql string) (*QueryResult, error) {
 		return db.createTableSQL(ctx, parsed.CreateTable)
 	case plansql.QueryDropTable:
 		return db.dropTableSQL(ctx, parsed.DropTable)
+	case plansql.QueryAnalyzeTable:
+		return db.analyzeTableSQL(ctx, parsed.AnalyzeTable)
 	case plansql.QueryShowTables:
 		return db.showTables(ctx)
 	case plansql.QueryCreateAlert:
@@ -699,6 +701,20 @@ func (db *DB) dropTableSQL(ctx context.Context, dt *plansql.DropTableInfo) (*Que
 	return &QueryResult{
 		Columns: []string{"result"},
 		Rows:    []map[string]any{{"result": fmt.Sprintf("Table %q dropped", dt.Name)}},
+	}, nil
+}
+
+// analyzeTableSQL refreshes the planner's column statistics (per-column HLL NDV
+// + reservoir-sample histograms) for a table by walking its parquet files. The
+// stats engine already exists (catalog.AnalyzeTable); this is its SQL surface.
+func (db *DB) analyzeTableSQL(ctx context.Context, at *plansql.AnalyzeTableInfo) (*QueryResult, error) {
+	n, err := db.catalog.AnalyzeTable(ctx, at.Name)
+	if err != nil {
+		return nil, err
+	}
+	return &QueryResult{
+		Columns: []string{"result"},
+		Rows:    []map[string]any{{"result": fmt.Sprintf("Table %q analyzed (%d files)", at.Name, n)}},
 	}, nil
 }
 


### PR DESCRIPTION
Exposes the cost-based optimizer's stats engine as SQL: **`ANALYZE [TABLE] <name>`**.

## Why
The CBO's column statistics — per-column HLL NDV + reservoir-sample histograms via `catalog.AnalyzeTable` — are fully built and consumed by the planner (NDV-aware join cardinality, histogram selectivity, dynamic-filter eligibility). But there was **no SQL surface**: the only caller was the benchmark harness (`cmd/tpch-bench/main.go`) invoking the Go method directly. An operator couldn't refresh planner stats after a bulk load. This adds the command so the already-shipped CBO is usable in production.

## What
- **Parser** (`internal/planner/sql/`): new `QueryAnalyzeTable` + `AnalyzeTableInfo`; `Parse` routes a leading `ANALYZE` token to `lexParseAnalyze` (optional `TABLE` keyword, then table name). `EXPLAIN ANALYZE` is unaffected — it enters via the `EXPLAIN` token and consumes `ANALYZE` internally; only a statement that *starts* with `ANALYZE` reaches the new path.
- **Execution**: wired into table-DDL dispatch at both front doors — `wadjet.DB.Query` (`analyzeTableSQL`, which also serves pgwire via `db.Query`) and the HTTP server (`handleAnalyzeTableSQL`, write-permission gated like `DROP TABLE`). Both call the existing `catalog.AnalyzeTable` and return a one-row status. The coordinator's `ExecuteSQL` handles only SELECT/alerts/snapshots, so non-SELECT `ANALYZE` routes through `db.Query` — nothing needed there.

## Tests & gates
- Parser: `ANALYZE TABLE` / bareword `ANALYZE` / lowercase → `QueryAnalyzeTable`; missing-name errors; **`EXPLAIN ANALYZE` still parses as explain** (regression).
- wadjet e2e: create + ingest + `ANALYZE TABLE` leaves accurate planner stats (`grp` NDV=4 exact, `id` NDV≈200 within HLL bound); unknown table errors naming the table.
- build · unit (sql/wadjet/catalog/server) · `-race` · TPC-H SF0.01 · `tpch-harness --mode=local` 25/25.

## Scope
Single-table only (matches the `AnalyzeTable(name)` API). Column-list `ANALYZE TABLE t (c1,c2)` and whole-DB `ANALYZE` are out of scope for v1.

Not tied to an open issue — CBO-roadmap follow-up that completes the stats feature surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)