### PR TITLE
feat(embedding): Voyage AI + Ollama providers and SQL-level embed() batching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ SQL text
 | `internal/worker/` | Distributed task executor |
 | `internal/server/pgwire/` | PostgreSQL wire protocol |
 | `internal/auth/` | API keys, JWT, mTLS, RBAC, ABAC policy engine, identity enrichment |
-| `internal/embedding/` | embed() SQL function — OpenAI provider, LRU cache, pluggable interface |
+| `internal/embedding/` | embed() SQL function — OpenAI / Voyage AI / Ollama providers, SQL-level batching (one API call per record batch), LRU cache, pluggable interface. Anthropic has no native embeddings endpoint; Voyage AI is its recommended path. |
 | `internal/iceberg/` | Apache Iceberg metadata reader |
 | `benchmarks/tpch/` | TPC-H benchmark suite (22 queries) |
 

--- a/cmd/wadjet/main.go
+++ b/cmd/wadjet/main.go
@@ -1005,21 +1005,8 @@ func runStandalone(ctx context.Context, store objstore.Store, logger *slog.Logge
 		}
 	}
 
-	// Configure embedding provider if API key is set
-	if apiKey := os.Getenv("WADJET_OPENAI_API_KEY"); apiKey != "" {
-		embedModel := os.Getenv("WADJET_EMBED_MODEL")
-		if embedModel == "" {
-			embedModel = "text-embedding-3-small"
-		}
-		embedCache := embedding.NewCache(50000)
-		embedProvider := embedding.NewOpenAI(embedding.OpenAIConfig{
-			APIKey: apiKey,
-			Model:  embedModel,
-		}, embedCache)
-		embedding.SetProvider(embedProvider)
-		embedding.RegisterFunctions()
-		logger.Info("embedding provider configured", "model", embedModel, "dim", embedProvider.Dimension())
-	}
+	// Configure embedding provider for embed() if one is requested.
+	configureEmbeddingProvider(logger)
 
 	// Start HTTP server
 	srv := server.New(srvCfg, logger)
@@ -1276,20 +1263,7 @@ func runCoordinator(ctx context.Context, store objstore.Store, logger *slog.Logg
 	}
 
 	// Configure embedding provider for coordinator mode
-	if apiKey := os.Getenv("WADJET_OPENAI_API_KEY"); apiKey != "" {
-		embedModel := os.Getenv("WADJET_EMBED_MODEL")
-		if embedModel == "" {
-			embedModel = "text-embedding-3-small"
-		}
-		embedCache := embedding.NewCache(50000)
-		embedProvider := embedding.NewOpenAI(embedding.OpenAIConfig{
-			APIKey: apiKey,
-			Model:  embedModel,
-		}, embedCache)
-		embedding.SetProvider(embedProvider)
-		embedding.RegisterFunctions()
-		logger.Info("embedding provider configured", "model", embedModel, "dim", embedProvider.Dimension())
-	}
+	configureEmbeddingProvider(logger)
 
 	srv := server.New(srvCfg, logger)
 
@@ -1539,6 +1513,64 @@ func catalogSnapshotCmd() *cobra.Command {
 func dynamicFiltersFromEnv() bool {
 	v := os.Getenv("WADJET_DYNAMIC_FILTERS")
 	return v == "1" || strings.EqualFold(v, "true")
+}
+
+// configureEmbeddingProvider wires the embed() SQL function to an embedding
+// provider selected by WADJET_EMBED_PROVIDER: "openai" (default), "voyage", or
+// "ollama". Each provider reads its own key/model env vars. If the selected
+// provider has no credentials, embed() is left unregistered (returns NULL).
+//
+// Note: Anthropic has no native embeddings endpoint — "voyage" is Anthropic's
+// officially recommended embeddings path.
+func configureEmbeddingProvider(logger *slog.Logger) {
+	provider := strings.ToLower(os.Getenv("WADJET_EMBED_PROVIDER"))
+	model := os.Getenv("WADJET_EMBED_MODEL")
+	cache := embedding.NewCache(50000)
+
+	// Default to OpenAI when no provider is named (back-compat: the only knob
+	// that previously existed was WADJET_OPENAI_API_KEY).
+	if provider == "" {
+		provider = "openai"
+	}
+
+	var p embedding.Provider
+	switch provider {
+	case "voyage":
+		apiKey := os.Getenv("WADJET_VOYAGE_API_KEY")
+		if apiKey == "" {
+			return
+		}
+		p = embedding.NewVoyage(embedding.VoyageConfig{
+			APIKey:    apiKey,
+			Model:     model,
+			InputType: os.Getenv("WADJET_VOYAGE_INPUT_TYPE"),
+		}, cache)
+	case "ollama":
+		// Ollama is local and keyless; enable it only when explicitly selected.
+		p = embedding.NewOllama(embedding.OllamaConfig{
+			Model:   model,
+			BaseURL: os.Getenv("WADJET_OLLAMA_URL"),
+		}, cache)
+	case "openai":
+		apiKey := os.Getenv("WADJET_OPENAI_API_KEY")
+		if apiKey == "" {
+			return
+		}
+		if model == "" {
+			model = "text-embedding-3-small"
+		}
+		p = embedding.NewOpenAI(embedding.OpenAIConfig{
+			APIKey: apiKey,
+			Model:  model,
+		}, cache)
+	default:
+		logger.Warn("unknown WADJET_EMBED_PROVIDER, embed() disabled", "provider", provider)
+		return
+	}
+
+	embedding.SetProvider(p)
+	embedding.RegisterFunctions()
+	logger.Info("embedding provider configured", "provider", provider, "model", p.Model(), "dim", p.Dimension())
 }
 
 func wireUDFPersistence(cat *catalog.Catalog, logger *slog.Logger) {

--- a/internal/embedding/func.go
+++ b/internal/embedding/func.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/citc-tech/wadjet/internal/engine/batch"
 	"github.com/citc-tech/wadjet/internal/engine/expr"
 )
 
@@ -32,6 +33,88 @@ func RegisterFunctions() {
 	expr.DefaultRegistry.Register("embed", fnEmbed)
 	expr.DefaultRegistry.Register("embed_model", fnEmbedModel)
 	expr.DefaultRegistry.Register("embed_dim", fnEmbedDim)
+
+	// SQL-level batching: the vectorized path collects every text in a record
+	// batch into a single provider.Embed() call instead of one call per row.
+	expr.DefaultRegistry.RegisterVec("embed", vecEmbed)
+	// Tell the planner embed() produces a VECTOR so the output column is typed
+	// correctly (and the batched VecEval path fires) rather than stringified.
+	expr.DefaultRegistry.RegisterVecReturn("embed", func() int {
+		if p := GetProvider(); p != nil {
+			return p.Dimension()
+		}
+		return 0
+	})
+}
+
+// vecEmbed is the vectorized implementation of embed(text) → VECTOR. It gathers
+// all non-null inputs in the batch and issues a single provider.Embed() call,
+// then scatters the results back into out (a TypeVector vector whose VectorDim
+// is set from the provider dimension at plan time). On any error every targeted
+// row is set NULL — matching the per-row fnEmbed null-on-failure behavior.
+func vecEmbed(args []*batch.Vector, out *batch.Vector, n int) {
+	if len(args) < 1 || n == 0 {
+		return
+	}
+	in := args[0]
+
+	p := GetProvider()
+	if p == nil {
+		for i := 0; i < n; i++ {
+			out.Nulls.SetNull(i)
+		}
+		return
+	}
+
+	// Ensure the output vector can hold dim-wide rows even if the schema left
+	// VectorDim unset (no provider at plan time, then one configured later).
+	if out.VectorDim <= 0 {
+		out.VectorDim = p.Dimension()
+	}
+	if out.VectorDim <= 0 {
+		for i := 0; i < n; i++ {
+			out.Nulls.SetNull(i)
+		}
+		return
+	}
+	if need := n * out.VectorDim; len(out.Float32Data) < need {
+		out.Float32Data = make([]float32, need)
+	}
+
+	texts := make([]string, 0, n)
+	rows := make([]int, 0, n)
+	for i := 0; i < n; i++ {
+		if in.Nulls.IsNullFast(i) {
+			out.Nulls.SetNull(i)
+			continue
+		}
+		s, ok := in.GetValue(i).(string)
+		if !ok {
+			s = fmt.Sprint(in.GetValue(i))
+		}
+		texts = append(texts, s)
+		rows = append(rows, i)
+	}
+	if len(texts) == 0 {
+		return
+	}
+
+	vectors, err := p.Embed(texts)
+	if err != nil {
+		for _, i := range rows {
+			out.Nulls.SetNull(i)
+		}
+		return
+	}
+
+	for k, i := range rows {
+		if k < len(vectors) && vectors[k] != nil {
+			out.SetVector(i, vectors[k])
+			out.Nulls.SetValid(i)
+		} else {
+			out.Nulls.SetNull(i)
+		}
+	}
 }
 
 // fnEmbed implements embed(text) → VECTOR.

--- a/internal/embedding/ollama.go
+++ b/internal/embedding/ollama.go
@@ -1,0 +1,165 @@
+package embedding
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// OllamaConfig configures the Ollama embedding provider for local, self-hosted
+// embedding models (no API key, runs on the user's machine).
+type OllamaConfig struct {
+	Model      string // default: nomic-embed-text
+	Dimensions int    // 0 = inferred from the model name (falls back to first response)
+	BaseURL    string // default: http://localhost:11434
+}
+
+// Ollama implements Provider using a local Ollama server's /api/embed endpoint.
+type Ollama struct {
+	config OllamaConfig
+	client *http.Client
+	cache  *Cache
+	dim    int
+}
+
+// NewOllama creates an Ollama embedding provider.
+func NewOllama(cfg OllamaConfig, cache *Cache) *Ollama {
+	if cfg.Model == "" {
+		cfg.Model = "nomic-embed-text"
+	}
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = "http://localhost:11434"
+	}
+
+	dim := cfg.Dimensions
+	if dim <= 0 {
+		switch cfg.Model {
+		case "mxbai-embed-large":
+			dim = 1024
+		case "all-minilm":
+			dim = 384
+		case "snowflake-arctic-embed":
+			dim = 1024
+		default:
+			// nomic-embed-text and most general-purpose models
+			dim = 768
+		}
+	}
+
+	return &Ollama{
+		config: cfg,
+		client: &http.Client{Timeout: 60 * time.Second},
+		cache:  cache,
+		dim:    dim,
+	}
+}
+
+func (o *Ollama) Model() string  { return o.config.Model }
+func (o *Ollama) Dimension() int { return o.dim }
+
+// Embed returns embeddings for the given texts, using cache where possible.
+// Uncached texts are batched into a single /api/embed call.
+func (o *Ollama) Embed(texts []string) ([][]float32, error) {
+	results := make([][]float32, len(texts))
+
+	var misses []int
+	for i, text := range texts {
+		if cached := o.cache.Get(o.config.Model, text); cached != nil {
+			results[i] = cached
+		} else {
+			misses = append(misses, i)
+		}
+	}
+
+	if len(misses) == 0 {
+		return results, nil
+	}
+
+	missTexts := make([]string, len(misses))
+	for i, idx := range misses {
+		missTexts[i] = texts[idx]
+	}
+
+	vectors, err := o.callAPI(missTexts)
+	if err != nil {
+		return nil, err
+	}
+
+	for i, idx := range misses {
+		if i < len(vectors) {
+			results[idx] = vectors[i]
+			o.cache.Put(o.config.Model, texts[idx], vectors[i])
+		}
+	}
+
+	return results, nil
+}
+
+type ollamaRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+type ollamaResponse struct {
+	Model      string      `json:"model"`
+	Embeddings [][]float32 `json:"embeddings"`
+	Error      string      `json:"error,omitempty"`
+}
+
+func (o *Ollama) callAPI(texts []string) ([][]float32, error) {
+	reqBody := ollamaRequest{
+		Model: o.config.Model,
+		Input: texts,
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", o.config.BaseURL+"/api/embed", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("API request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp ollamaResponse
+		json.Unmarshal(respBody, &errResp)
+		if errResp.Error != "" {
+			return nil, fmt.Errorf("Ollama API error (%d): %s", resp.StatusCode, errResp.Error)
+		}
+		return nil, fmt.Errorf("Ollama API error: status %d", resp.StatusCode)
+	}
+
+	var apiResp ollamaResponse
+	if err := json.Unmarshal(respBody, &apiResp); err != nil {
+		return nil, fmt.Errorf("unmarshal response: %w", err)
+	}
+	if apiResp.Error != "" {
+		return nil, fmt.Errorf("Ollama API error: %s", apiResp.Error)
+	}
+
+	// Ollama returns embeddings in input order. Keep the provider's declared
+	// dimension in sync with what the model actually returns (the model name →
+	// dimension table can't cover every custom model).
+	if len(apiResp.Embeddings) > 0 && len(apiResp.Embeddings[0]) > 0 {
+		o.dim = len(apiResp.Embeddings[0])
+	}
+
+	return apiResp.Embeddings, nil
+}

--- a/internal/embedding/ollama_test.go
+++ b/internal/embedding/ollama_test.go
@@ -1,0 +1,69 @@
+package embedding
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestOllamaEmbed(t *testing.T) {
+	var lastReq ollamaRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/embed" {
+			t.Errorf("expected /api/embed, got %s", r.URL.Path)
+		}
+		json.NewDecoder(r.Body).Decode(&lastReq)
+
+		resp := ollamaResponse{
+			Model:      lastReq.Model,
+			Embeddings: make([][]float32, len(lastReq.Input)),
+		}
+		for i := range lastReq.Input {
+			vec := make([]float32, 3)
+			for j := range vec {
+				vec[j] = float32(i)*0.1 + float32(j)*0.01
+			}
+			resp.Embeddings[i] = vec
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	provider := NewOllama(OllamaConfig{Model: "nomic-embed-text", BaseURL: server.URL}, NewCache(100))
+
+	if provider.Dimension() != 768 {
+		t.Errorf("default nomic-embed-text dim = %d, want 768", provider.Dimension())
+	}
+
+	vecs, err := provider.Embed([]string{"a", "b"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vecs) != 2 || len(vecs[0]) != 3 {
+		t.Fatalf("got %d vecs of dim %d, want 2 of 3", len(vecs), len(vecs[0]))
+	}
+
+	// Dimension self-syncs to what the model actually returned.
+	if provider.Dimension() != 3 {
+		t.Errorf("dim after call = %d, want 3 (synced from response)", provider.Dimension())
+	}
+}
+
+func TestOllamaAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(ollamaResponse{Error: "model not found"})
+	}))
+	defer server.Close()
+
+	provider := NewOllama(OllamaConfig{Model: "missing", BaseURL: server.URL}, NewCache(10))
+	_, err := provider.Embed([]string{"hello"})
+	if err == nil {
+		t.Fatal("expected error for missing model")
+	}
+	if err.Error() != "Ollama API error (404): model not found" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/internal/embedding/voyage.go
+++ b/internal/embedding/voyage.go
@@ -1,0 +1,191 @@
+package embedding
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// VoyageConfig configures the Voyage AI embedding provider. Voyage AI is
+// Anthropic's officially recommended embeddings provider — Anthropic does not
+// serve a native embeddings endpoint, so "Anthropic embeddings" means Voyage.
+// See https://docs.claude.com/en/docs/build-with-claude/embeddings.
+type VoyageConfig struct {
+	APIKey     string // required
+	Model      string // default: voyage-3.5
+	Dimensions int    // 0 = model default (1024 for voyage-3.5 / voyage-3-large)
+	InputType  string // optional: "document" or "query" — improves retrieval quality
+	BaseURL    string // default: https://api.voyageai.com/v1
+}
+
+// Voyage implements Provider using the Voyage AI embeddings API.
+type Voyage struct {
+	config VoyageConfig
+	client *http.Client
+	cache  *Cache
+	dim    int
+}
+
+// NewVoyage creates a Voyage AI embedding provider.
+func NewVoyage(cfg VoyageConfig, cache *Cache) *Voyage {
+	if cfg.Model == "" {
+		cfg.Model = "voyage-3.5"
+	}
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = "https://api.voyageai.com/v1"
+	}
+
+	dim := cfg.Dimensions
+	if dim <= 0 {
+		switch cfg.Model {
+		case "voyage-3-lite":
+			dim = 512
+		case "voyage-code-2", "voyage-2":
+			dim = 1536
+		default:
+			// voyage-3.5, voyage-3.5-lite, voyage-3-large, voyage-3
+			dim = 1024
+		}
+	}
+
+	return &Voyage{
+		config: cfg,
+		client: &http.Client{Timeout: 30 * time.Second},
+		cache:  cache,
+		dim:    dim,
+	}
+}
+
+func (v *Voyage) Model() string  { return v.config.Model }
+func (v *Voyage) Dimension() int { return v.dim }
+
+// Embed returns embeddings for the given texts, using cache where possible.
+// Uncached texts are batched into a single API call.
+func (v *Voyage) Embed(texts []string) ([][]float32, error) {
+	results := make([][]float32, len(texts))
+
+	var misses []int
+	for i, text := range texts {
+		if cached := v.cache.Get(v.config.Model, text); cached != nil {
+			results[i] = cached
+		} else {
+			misses = append(misses, i)
+		}
+	}
+
+	if len(misses) == 0 {
+		return results, nil
+	}
+
+	missTexts := make([]string, len(misses))
+	for i, idx := range misses {
+		missTexts[i] = texts[idx]
+	}
+
+	vectors, err := v.callAPI(missTexts)
+	if err != nil {
+		return nil, err
+	}
+
+	for i, idx := range misses {
+		if i < len(vectors) {
+			results[idx] = vectors[i]
+			v.cache.Put(v.config.Model, texts[idx], vectors[i])
+		}
+	}
+
+	return results, nil
+}
+
+type voyageRequest struct {
+	Model           string   `json:"model"`
+	Input           []string `json:"input"`
+	InputType       string   `json:"input_type,omitempty"`
+	OutputDimension int      `json:"output_dimension,omitempty"`
+}
+
+type voyageResponse struct {
+	Data  []voyageEmbedding `json:"data"`
+	Error *voyageError      `json:"error,omitempty"`
+	// Voyage also returns top-level "detail" on some error shapes.
+	Detail string `json:"detail,omitempty"`
+}
+
+type voyageEmbedding struct {
+	Index     int       `json:"index"`
+	Embedding []float64 `json:"embedding"`
+}
+
+type voyageError struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+}
+
+func (v *Voyage) callAPI(texts []string) ([][]float32, error) {
+	reqBody := voyageRequest{
+		Model:     v.config.Model,
+		Input:     texts,
+		InputType: v.config.InputType,
+	}
+	if v.config.Dimensions > 0 {
+		reqBody.OutputDimension = v.config.Dimensions
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", v.config.BaseURL+"/embeddings", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+v.config.APIKey)
+
+	resp, err := v.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("API request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp voyageResponse
+		json.Unmarshal(respBody, &errResp)
+		switch {
+		case errResp.Error != nil && errResp.Error.Message != "":
+			return nil, fmt.Errorf("Voyage API error (%d): %s", resp.StatusCode, errResp.Error.Message)
+		case errResp.Detail != "":
+			return nil, fmt.Errorf("Voyage API error (%d): %s", resp.StatusCode, errResp.Detail)
+		default:
+			return nil, fmt.Errorf("Voyage API error: status %d", resp.StatusCode)
+		}
+	}
+
+	var apiResp voyageResponse
+	if err := json.Unmarshal(respBody, &apiResp); err != nil {
+		return nil, fmt.Errorf("unmarshal response: %w", err)
+	}
+
+	vectors := make([][]float32, len(texts))
+	for _, emb := range apiResp.Data {
+		if emb.Index < 0 || emb.Index >= len(vectors) {
+			continue
+		}
+		vec := make([]float32, len(emb.Embedding))
+		for j, f := range emb.Embedding {
+			vec[j] = float32(f)
+		}
+		vectors[emb.Index] = vec
+	}
+
+	return vectors, nil
+}

--- a/internal/embedding/voyage_test.go
+++ b/internal/embedding/voyage_test.go
@@ -1,0 +1,85 @@
+package embedding
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestVoyageEmbed(t *testing.T) {
+	var lastReq voyageRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			t.Errorf("bad auth header: %s", r.Header.Get("Authorization"))
+		}
+		json.NewDecoder(r.Body).Decode(&lastReq)
+
+		resp := voyageResponse{Data: make([]voyageEmbedding, len(lastReq.Input))}
+		for i := range lastReq.Input {
+			vec := make([]float64, 4)
+			for j := range vec {
+				vec[j] = float64(i)*0.1 + float64(j)*0.01
+			}
+			resp.Data[i] = voyageEmbedding{Index: i, Embedding: vec}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	cache := NewCache(100)
+	provider := NewVoyage(VoyageConfig{
+		APIKey:    "test-key",
+		Model:     "voyage-3.5",
+		InputType: "document",
+		BaseURL:   server.URL,
+	}, cache)
+
+	if provider.Dimension() != 1024 {
+		t.Errorf("default voyage-3.5 dim = %d, want 1024", provider.Dimension())
+	}
+
+	// Batch of 3 → single API call.
+	vecs, err := provider.Embed([]string{"a", "b", "c"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vecs) != 3 || len(vecs[0]) != 4 {
+		t.Fatalf("got %d vecs of dim %d, want 3 of 4", len(vecs), len(vecs[0]))
+	}
+	if lastReq.InputType != "document" {
+		t.Errorf("input_type not propagated: %q", lastReq.InputType)
+	}
+
+	// Cache hit: re-embedding "a" must not change the value.
+	again, err := provider.Embed([]string{"a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again[0][1] != vecs[0][1] {
+		t.Errorf("cache returned %v, want %v", again[0], vecs[0])
+	}
+}
+
+func TestVoyageAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(voyageResponse{
+			Error: &voyageError{Message: "invalid api key", Type: "auth"},
+		})
+	}))
+	defer server.Close()
+
+	provider := NewVoyage(VoyageConfig{APIKey: "bad", BaseURL: server.URL}, NewCache(10))
+	_, err := provider.Embed([]string{"hello"})
+	if err == nil {
+		t.Fatal("expected error for bad API key")
+	}
+	if err.Error() != "Voyage API error (401): invalid api key" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/internal/engine/exec/project.go
+++ b/internal/engine/exec/project.go
@@ -59,6 +59,7 @@ type ProjectColumn struct {
 	VecEval         VecExpression               // optional vectorized evaluation for any output type
 	SourceCol       string                      // source column name for type resolution on renames
 	DirectCopy      string                      // if set, bulk copy this input column (no per-row eval)
+	Dimension       int                         // VECTOR output dimensionality (e.g. embed()); 0 = not a vector
 }
 
 // Project is a UnaryOperator that selects and computes columns.
@@ -115,6 +116,13 @@ func (p *Project) Execute(_ context.Context, in *batch.RecordBatch) (*batch.Reco
 					col.Fields = in.Schema[srcIdx].Fields
 					col.ElementType = in.Schema[srcIdx].ElementType
 				}
+			}
+			// Computed VECTOR projections (e.g. embed(text)) don't resolve to an
+			// input column, so carry their dimension from the projection itself.
+			// This sizes the pooled output vector's Float32Data so both the
+			// batched VecEval path and the per-row SetVector path can write.
+			if col.Type == parquet.TypeVector && col.Dimension == 0 && proj.Dimension > 0 {
+				col.Dimension = proj.Dimension
 			}
 			schema[i] = col
 		}

--- a/internal/engine/expr/expr.go
+++ b/internal/engine/expr/expr.go
@@ -1122,16 +1122,18 @@ type VecScalarFunc func(args []*batch.Vector, out *batch.Vector, n int)
 
 // FuncRegistry is a concurrent-safe registry of scalar functions.
 type FuncRegistry struct {
-	mu       sync.RWMutex
-	funcs    map[string]ScalarFunc
-	vecFuncs map[string]VecScalarFunc
+	mu         sync.RWMutex
+	funcs      map[string]ScalarFunc
+	vecFuncs   map[string]VecScalarFunc
+	vecReturns map[string]func() int // funcs returning VECTOR; value yields the dimension
 }
 
 // NewFuncRegistry creates a new empty function registry.
 func NewFuncRegistry() *FuncRegistry {
 	return &FuncRegistry{
-		funcs:    make(map[string]ScalarFunc),
-		vecFuncs: make(map[string]VecScalarFunc),
+		funcs:      make(map[string]ScalarFunc),
+		vecFuncs:   make(map[string]VecScalarFunc),
+		vecReturns: make(map[string]func() int),
 	}
 }
 
@@ -1172,6 +1174,27 @@ func (r *FuncRegistry) LookupVec(name string) VecScalarFunc {
 	fn := r.vecFuncs[strings.ToLower(name)]
 	r.mu.RUnlock()
 	return fn
+}
+
+// RegisterVecReturn marks a function as returning a VECTOR. dimFn is evaluated
+// lazily (at plan time) to obtain the output dimensionality — embed(), for
+// example, derives it from the configured embedding provider.
+func (r *FuncRegistry) RegisterVecReturn(name string, dimFn func() int) {
+	r.mu.Lock()
+	r.vecReturns[strings.ToLower(name)] = dimFn
+	r.mu.Unlock()
+}
+
+// VecReturnDim reports whether the named function returns a VECTOR and, if so,
+// its current output dimension. ok is false for non-vector-returning functions.
+func (r *FuncRegistry) VecReturnDim(name string) (dim int, ok bool) {
+	r.mu.RLock()
+	dimFn := r.vecReturns[strings.ToLower(name)]
+	r.mu.RUnlock()
+	if dimFn == nil {
+		return 0, false
+	}
+	return dimFn(), true
 }
 
 // Has returns true if a function with the given name exists.

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -4797,6 +4797,16 @@ func (p *Planner) buildProject(ctx context.Context, node *logical.Node) (exec.So
 			Type: outType, // Will be resolved at runtime if input column matches
 			Expr: expression,
 		}
+		// VECTOR-returning functions (embed()) need their output dimension
+		// carried so the runtime sizes the output vector. Resolve it from the
+		// registry at plan time (embed() derives it from the live provider).
+		if outType == parquet.TypeVector {
+			if fc, ok := proj.ASTExpr.(*plansql.FuncCallNode); ok {
+				if dim, ok := expr.DefaultRegistry.VecReturnDim(fc.Name); ok {
+					pc.Dimension = dim
+				}
+			}
+		}
 		// For column renames (e.g., l_suppkey AS supplier_no), record the
 		// source column so Project.Execute can resolve the correct type.
 		if name != colRef {
@@ -5073,6 +5083,9 @@ func inferProjectionType(node plansql.Node, fallback parquet.TypeID) parquet.Typ
 	case *plansql.FuncCallNode:
 		if isNumericFunc(n.Name) {
 			return parquet.TypeFloat64
+		}
+		if _, ok := expr.DefaultRegistry.VecReturnDim(n.Name); ok {
+			return parquet.TypeVector
 		}
 	case *plansql.CastNode:
 		return inferCastType(n.TypeName)

--- a/wadjet/embed_sql_test.go
+++ b/wadjet/embed_sql_test.go
@@ -1,0 +1,143 @@
+package wadjet
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/embedding"
+	"github.com/citc-tech/wadjet/internal/storage/ingest"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// countingProvider returns deterministic embeddings and records how many
+// provider.Embed() calls were made, so the test can assert SQL-level batching.
+type countingProvider struct {
+	dim   int
+	calls int
+	rows  int
+}
+
+func (p *countingProvider) Embed(texts []string) ([][]float32, error) {
+	p.calls++
+	p.rows += len(texts)
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		v := make([]float32, p.dim)
+		seed := float32(0.1)
+		if len(t) > 0 {
+			seed = float32(t[0]) / 256.0
+		}
+		for j := range v {
+			v[j] = seed + float32(j)*0.01
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+func (p *countingProvider) Dimension() int { return p.dim }
+func (p *countingProvider) Model() string  { return "counting-test" }
+
+// TestEmbedSQLEndToEnd exercises embed() through the full SQL pipeline: it must
+// (1) produce a real VECTOR column (not a stringified slice), (2) batch a whole
+// record batch into a single provider call rather than one call per row,
+// (3) pass NULL text through as NULL, and (4) compose with the VECTOR functions.
+func TestEmbedSQLEndToEnd(t *testing.T) {
+	ctx := context.Background()
+	prov := &countingProvider{dim: 8}
+	embedding.SetProvider(prov)
+	defer embedding.SetProvider(nil)
+	embedding.RegisterFunctions()
+
+	db, err := Open(ctx, Config{Store: objstore.NewMemStore(), Bucket: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	schema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "txt", Type: parquet.TypeString, Nullable: true},
+	}}
+	if err := db.CreateTable(ctx, "docs", schema, nil); err != nil {
+		t.Fatal(err)
+	}
+	rows := []map[string]any{
+		{"id": int64(1), "txt": "hello"},
+		{"id": int64(2), "txt": "world"},
+		{"id": int64(3), "txt": nil}, // NULL text → NULL embedding
+	}
+	ing := db.NewIngester("docs", schema, nil, ingest.Config{MaxBufferRows: 10000, RowGroupSize: 500})
+	if err := ing.Ingest(ctx, rows); err != nil {
+		t.Fatal(err)
+	}
+	if err := ing.FlushAll(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := db.Query(ctx, "SELECT id, embed(txt) AS v FROM docs ORDER BY id")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(res.Rows) != 3 {
+		t.Fatalf("got %d rows, want 3", len(res.Rows))
+	}
+
+	// (1) VECTOR output: the value is a []float32 of the provider's dimension,
+	//     not a string rendering of one.
+	v1, ok := res.Rows[0]["v"].([]float32)
+	if !ok {
+		t.Fatalf("embed() output is %T, want []float32", res.Rows[0]["v"])
+	}
+	if len(v1) != 8 {
+		t.Fatalf("embedding dim = %d, want 8", len(v1))
+	}
+
+	// Distinct inputs → distinct embeddings.
+	v2 := res.Rows[1]["v"].([]float32)
+	if v1[0] == v2[0] {
+		t.Errorf("expected different embeddings for 'hello' vs 'world'")
+	}
+
+	// (3) NULL text → NULL embedding.
+	if res.Rows[2]["v"] != nil {
+		t.Errorf("embed(NULL) = %v, want nil", res.Rows[2]["v"])
+	}
+
+	// (2) SQL-level batching: the two non-null rows were embedded in a single
+	//     provider call, not one per row.
+	if prov.calls != 1 {
+		t.Errorf("provider.Embed called %d times, want 1 (batched)", prov.calls)
+	}
+	if prov.rows != 2 {
+		t.Errorf("provider embedded %d texts, want 2 (NULL excluded)", prov.rows)
+	}
+
+	// (4) Composition: embed() output feeds the VECTOR similarity functions.
+	res2, err := db.Query(ctx, "SELECT cosine_similarity(embed(txt), embed(txt)) AS sim FROM docs WHERE id = 1")
+	if err != nil {
+		t.Fatalf("cosine query: %v", err)
+	}
+	if len(res2.Rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(res2.Rows))
+	}
+	sim, ok := toFloat(res2.Rows[0]["sim"])
+	if !ok || sim < 0.999 {
+		t.Errorf("cosine_similarity of a vector with itself = %v, want ~1.0", res2.Rows[0]["sim"])
+	}
+}
+
+func toFloat(v any) (float64, bool) {
+	switch x := v.(type) {
+	case float64:
+		return x, true
+	case float32:
+		return float64(x), true
+	case string:
+		f, err := strconv.ParseFloat(x, 64)
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}


### PR DESCRIPTION
Closes #15.

## What

`embed()` previously shipped with only an OpenAI provider, ran **one API call per row**, and silently **stringified** its output instead of producing a real `VECTOR` column. This completes the issue.

### Providers
- **Voyage AI** (`internal/embedding/voyage.go`) — Anthropic has **no native embeddings endpoint**; Voyage is its [officially recommended](https://docs.claude.com/en/docs/build-with-claude/embeddings) path. Batched + LRU-cached, `voyage-3.5` default (1024-dim).
- **Ollama** (`ollama.go`) — local/keyless via the batched `/api/embed` endpoint; model→dimension defaults self-correct from the first response.

### SQL-level batching + VECTOR typing
- New `expr.FuncRegistry.RegisterVecReturn`/`VecReturnDim` lets the planner learn `embed()` returns `VECTOR(dim)` (dimension from the live provider).
- `inferProjectionType` types `embed()` as `VECTOR`; `ProjectColumn.Dimension` carries the width into the output schema so the pooled vector has `VectorDim`.
- `vecEmbed` gathers a whole record batch into a **single** `provider.Embed()` call and scatters results into a real VECTOR column. `NULL` text → `NULL` embedding.

### CLI
`WADJET_EMBED_PROVIDER` selects `openai` (default, back-compat) / `voyage` / `ollama`, each reading its own key/model env vars.

## Tests
- httptest unit tests for both new providers (success + API-error paths).
- `wadjet/embed_sql_test.go`: end-to-end `SELECT embed()` asserting VECTOR output type, **single batched call**, NULL passthrough, and composition with `cosine_similarity()`.
- Full `go test ./internal/...`, `go vet`, and the **22-query TPC-H SF0.01 correctness gate** pass. The new planner/project branches only fire for VECTOR-returning funcs, so TPC-H is structurally unaffected.

## Note
The issue asked for an "Anthropic provider" — that can't be built literally (no Anthropic embeddings endpoint), so the Voyage provider stands in as Anthropic's recommended path. CLAUDE.md updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)