### PR TITLE
fix(embedding): address multi-agent review findings on embed() PR #160

### DIFF
--- a/cmd/wadjet/main.go
+++ b/cmd/wadjet/main.go
@@ -1527,6 +1527,17 @@ func configureEmbeddingProvider(logger *slog.Logger) {
 	model := os.Getenv("WADJET_EMBED_MODEL")
 	cache := embedding.NewCache(50000)
 
+	// Optional explicit output dimension. Required for any provider/model whose
+	// true width isn't in the provider's built-in table (notably custom Ollama
+	// models) — vecEmbed validates the returned width and NULLs mismatched rows,
+	// so a wrong/missing dimension fails loudly rather than corrupting vectors.
+	dim := 0
+	if d := os.Getenv("WADJET_EMBED_DIM"); d != "" {
+		if v, err := strconv.Atoi(d); err == nil && v > 0 {
+			dim = v
+		}
+	}
+
 	// Default to OpenAI when no provider is named (back-compat: the only knob
 	// that previously existed was WADJET_OPENAI_API_KEY).
 	if provider == "" {
@@ -1541,15 +1552,17 @@ func configureEmbeddingProvider(logger *slog.Logger) {
 			return
 		}
 		p = embedding.NewVoyage(embedding.VoyageConfig{
-			APIKey:    apiKey,
-			Model:     model,
-			InputType: os.Getenv("WADJET_VOYAGE_INPUT_TYPE"),
+			APIKey:     apiKey,
+			Model:      model,
+			Dimensions: dim,
+			InputType:  os.Getenv("WADJET_VOYAGE_INPUT_TYPE"),
 		}, cache)
 	case "ollama":
 		// Ollama is local and keyless; enable it only when explicitly selected.
 		p = embedding.NewOllama(embedding.OllamaConfig{
-			Model:   model,
-			BaseURL: os.Getenv("WADJET_OLLAMA_URL"),
+			Model:      model,
+			Dimensions: dim,
+			BaseURL:    os.Getenv("WADJET_OLLAMA_URL"),
 		}, cache)
 	case "openai":
 		apiKey := os.Getenv("WADJET_OPENAI_API_KEY")
@@ -1560,8 +1573,9 @@ func configureEmbeddingProvider(logger *slog.Logger) {
 			model = "text-embedding-3-small"
 		}
 		p = embedding.NewOpenAI(embedding.OpenAIConfig{
-			APIKey: apiKey,
-			Model:  model,
+			APIKey:     apiKey,
+			Model:      model,
+			Dimensions: dim,
 		}, cache)
 	default:
 		logger.Warn("unknown WADJET_EMBED_PROVIDER, embed() disabled", "provider", provider)

--- a/internal/embedding/func.go
+++ b/internal/embedding/func.go
@@ -66,21 +66,6 @@ func vecEmbed(args []*batch.Vector, out *batch.Vector, n int) {
 		return
 	}
 
-	// Ensure the output vector can hold dim-wide rows even if the schema left
-	// VectorDim unset (no provider at plan time, then one configured later).
-	if out.VectorDim <= 0 {
-		out.VectorDim = p.Dimension()
-	}
-	if out.VectorDim <= 0 {
-		for i := 0; i < n; i++ {
-			out.Nulls.SetNull(i)
-		}
-		return
-	}
-	if need := n * out.VectorDim; len(out.Float32Data) < need {
-		out.Float32Data = make([]float32, need)
-	}
-
 	texts := make([]string, 0, n)
 	rows := make([]int, 0, n)
 	for i := 0; i < n; i++ {
@@ -88,9 +73,10 @@ func vecEmbed(args []*batch.Vector, out *batch.Vector, n int) {
 			out.Nulls.SetNull(i)
 			continue
 		}
-		s, ok := in.GetValue(i).(string)
+		v := in.GetValue(i)
+		s, ok := v.(string)
 		if !ok {
-			s = fmt.Sprint(in.GetValue(i))
+			s = fmt.Sprint(v)
 		}
 		texts = append(texts, s)
 		rows = append(rows, i)
@@ -107,8 +93,33 @@ func vecEmbed(args []*batch.Vector, out *batch.Vector, n int) {
 		return
 	}
 
+	// The authoritative width is what the provider actually returned. When the
+	// plan-time dimension is unset, derive it from the first non-empty vector;
+	// otherwise honor the plan-time width. Either way, a row whose vector
+	// doesn't match that width is set NULL rather than truncated or left
+	// holding stale data from a previous batch in the pooled output buffer.
+	dim := out.VectorDim
+	if dim <= 0 {
+		for _, vec := range vectors {
+			if len(vec) > 0 {
+				dim = len(vec)
+				break
+			}
+		}
+	}
+	if dim <= 0 {
+		for _, i := range rows {
+			out.Nulls.SetNull(i)
+		}
+		return
+	}
+	out.VectorDim = dim
+	if need := n * dim; len(out.Float32Data) < need {
+		out.Float32Data = make([]float32, need)
+	}
+
 	for k, i := range rows {
-		if k < len(vectors) && vectors[k] != nil {
+		if k < len(vectors) && len(vectors[k]) == dim {
 			out.SetVector(i, vectors[k])
 			out.Nulls.SetValid(i)
 		} else {

--- a/internal/embedding/ollama.go
+++ b/internal/embedding/ollama.go
@@ -63,39 +63,7 @@ func (o *Ollama) Dimension() int { return o.dim }
 // Embed returns embeddings for the given texts, using cache where possible.
 // Uncached texts are batched into a single /api/embed call.
 func (o *Ollama) Embed(texts []string) ([][]float32, error) {
-	results := make([][]float32, len(texts))
-
-	var misses []int
-	for i, text := range texts {
-		if cached := o.cache.Get(o.config.Model, text); cached != nil {
-			results[i] = cached
-		} else {
-			misses = append(misses, i)
-		}
-	}
-
-	if len(misses) == 0 {
-		return results, nil
-	}
-
-	missTexts := make([]string, len(misses))
-	for i, idx := range misses {
-		missTexts[i] = texts[idx]
-	}
-
-	vectors, err := o.callAPI(missTexts)
-	if err != nil {
-		return nil, err
-	}
-
-	for i, idx := range misses {
-		if i < len(vectors) {
-			results[idx] = vectors[i]
-			o.cache.Put(o.config.Model, texts[idx], vectors[i])
-		}
-	}
-
-	return results, nil
+	return embedWithCache(o.cache, o.config.Model, texts, o.callAPI)
 }
 
 type ollamaRequest struct {
@@ -154,12 +122,12 @@ func (o *Ollama) callAPI(texts []string) ([][]float32, error) {
 		return nil, fmt.Errorf("Ollama API error: %s", apiResp.Error)
 	}
 
-	// Ollama returns embeddings in input order. Keep the provider's declared
-	// dimension in sync with what the model actually returns (the model name →
-	// dimension table can't cover every custom model).
-	if len(apiResp.Embeddings) > 0 && len(apiResp.Embeddings[0]) > 0 {
-		o.dim = len(apiResp.Embeddings[0])
-	}
-
+	// NOTE: we deliberately do NOT mutate o.dim from the response here. The
+	// output VECTOR width is fixed at plan time from Dimension(), so a runtime
+	// update would (a) race with concurrent Dimension() reads on this shared
+	// singleton and (b) arrive too late to affect the query that triggered it.
+	// For a model whose true dimension isn't in the table above, set it
+	// explicitly via OllamaConfig.Dimensions (WADJET_EMBED_DIM); vecEmbed
+	// validates the returned width and NULLs any row that doesn't match.
 	return apiResp.Embeddings, nil
 }

--- a/internal/embedding/ollama_test.go
+++ b/internal/embedding/ollama_test.go
@@ -45,9 +45,18 @@ func TestOllamaEmbed(t *testing.T) {
 		t.Fatalf("got %d vecs of dim %d, want 2 of 3", len(vecs), len(vecs[0]))
 	}
 
-	// Dimension self-syncs to what the model actually returned.
-	if provider.Dimension() != 3 {
-		t.Errorf("dim after call = %d, want 3 (synced from response)", provider.Dimension())
+	// Dimension() is fixed at construction (no runtime self-mutation — that
+	// raced with concurrent reads on the shared singleton). vecEmbed validates
+	// the returned width and NULLs mismatched rows; an explicit Dimensions
+	// override is the way to declare a non-table model's width.
+	if provider.Dimension() != 768 {
+		t.Errorf("dim after call = %d, want 768 (stable, no self-sync)", provider.Dimension())
+	}
+
+	// Explicit dimension override is honored.
+	p2 := NewOllama(OllamaConfig{Model: "custom", Dimensions: 1024, BaseURL: server.URL}, NewCache(10))
+	if p2.Dimension() != 1024 {
+		t.Errorf("explicit dim = %d, want 1024", p2.Dimension())
 	}
 }
 

--- a/internal/embedding/openai.go
+++ b/internal/embedding/openai.go
@@ -58,42 +58,7 @@ func (o *OpenAI) Dimension() int   { return o.dim }
 // Embed returns embeddings for the given texts, using cache where possible.
 // Uncached texts are batched into a single API call.
 func (o *OpenAI) Embed(texts []string) ([][]float32, error) {
-	results := make([][]float32, len(texts))
-
-	// Check cache first, collect misses
-	var misses []int
-	for i, text := range texts {
-		if cached := o.cache.Get(o.config.Model, text); cached != nil {
-			results[i] = cached
-		} else {
-			misses = append(misses, i)
-		}
-	}
-
-	if len(misses) == 0 {
-		return results, nil
-	}
-
-	// Batch API call for cache misses
-	missTexts := make([]string, len(misses))
-	for i, idx := range misses {
-		missTexts[i] = texts[idx]
-	}
-
-	vectors, err := o.callAPI(missTexts)
-	if err != nil {
-		return nil, err
-	}
-
-	// Store results and update cache
-	for i, idx := range misses {
-		if i < len(vectors) {
-			results[idx] = vectors[i]
-			o.cache.Put(o.config.Model, texts[idx], vectors[i])
-		}
-	}
-
-	return results, nil
+	return embedWithCache(o.cache, o.config.Model, texts, o.callAPI)
 }
 
 type openAIRequest struct {

--- a/internal/embedding/provider.go
+++ b/internal/embedding/provider.go
@@ -76,3 +76,42 @@ func (c *Cache) Len() int {
 	defer c.mu.Unlock()
 	return len(c.entries)
 }
+
+// embedWithCache resolves embeddings for texts: cache hits are served directly
+// and the uncached misses are issued as a single batched callAPI. nil vectors
+// (the provider returned no embedding for a slot) are left nil in the result
+// and NOT cached — caching nil would persist a permanent miss for that text.
+// Shared by every Provider so the cache/batch policy lives in one place.
+func embedWithCache(cache *Cache, model string, texts []string, callAPI func([]string) ([][]float32, error)) ([][]float32, error) {
+	results := make([][]float32, len(texts))
+
+	var misses []int
+	for i, text := range texts {
+		if cached := cache.Get(model, text); cached != nil {
+			results[i] = cached
+		} else {
+			misses = append(misses, i)
+		}
+	}
+	if len(misses) == 0 {
+		return results, nil
+	}
+
+	missTexts := make([]string, len(misses))
+	for i, idx := range misses {
+		missTexts[i] = texts[idx]
+	}
+
+	vectors, err := callAPI(missTexts)
+	if err != nil {
+		return nil, err
+	}
+
+	for i, idx := range misses {
+		if i < len(vectors) && vectors[i] != nil {
+			results[idx] = vectors[i]
+			cache.Put(model, texts[idx], vectors[i])
+		}
+	}
+	return results, nil
+}

--- a/internal/embedding/voyage.go
+++ b/internal/embedding/voyage.go
@@ -43,10 +43,10 @@ func NewVoyage(cfg VoyageConfig, cache *Cache) *Voyage {
 		switch cfg.Model {
 		case "voyage-3-lite":
 			dim = 512
-		case "voyage-code-2", "voyage-2":
+		case "voyage-code-2":
 			dim = 1536
 		default:
-			// voyage-3.5, voyage-3.5-lite, voyage-3-large, voyage-3
+			// voyage-3.5, voyage-3.5-lite, voyage-3-large, voyage-3, voyage-2
 			dim = 1024
 		}
 	}
@@ -65,39 +65,7 @@ func (v *Voyage) Dimension() int { return v.dim }
 // Embed returns embeddings for the given texts, using cache where possible.
 // Uncached texts are batched into a single API call.
 func (v *Voyage) Embed(texts []string) ([][]float32, error) {
-	results := make([][]float32, len(texts))
-
-	var misses []int
-	for i, text := range texts {
-		if cached := v.cache.Get(v.config.Model, text); cached != nil {
-			results[i] = cached
-		} else {
-			misses = append(misses, i)
-		}
-	}
-
-	if len(misses) == 0 {
-		return results, nil
-	}
-
-	missTexts := make([]string, len(misses))
-	for i, idx := range misses {
-		missTexts[i] = texts[idx]
-	}
-
-	vectors, err := v.callAPI(missTexts)
-	if err != nil {
-		return nil, err
-	}
-
-	for i, idx := range misses {
-		if i < len(vectors) {
-			results[idx] = vectors[i]
-			v.cache.Put(v.config.Model, texts[idx], vectors[i])
-		}
-	}
-
-	return results, nil
+	return embedWithCache(v.cache, v.config.Model, texts, v.callAPI)
 }
 
 type voyageRequest struct {

--- a/internal/engine/exec/project.go
+++ b/internal/engine/exec/project.go
@@ -64,11 +64,30 @@ type ProjectColumn struct {
 
 // Project is a UnaryOperator that selects and computes columns.
 type Project struct {
-	Projections    []ProjectColumn
-	cachedSchema   []parquet.Column // reused across batches after first resolution
-	outPool        *batch.BatchPool // output batch pool — eliminates per-batch allocation
-	directSrcIdx   []int            // resolved source col indices for DirectCopy (-1 = per-row eval)
-	directResolved bool
+	Projections       []ProjectColumn
+	cachedSchema      []parquet.Column // reused across batches after first resolution
+	outPool           *batch.BatchPool // output batch pool — eliminates per-batch allocation
+	directSrcIdx      []int            // resolved source col indices for DirectCopy (-1 = per-row eval)
+	directResolved    bool
+	vecCompact        bool // true if a VecEval-only projection requires compacting away input selection
+	vecCompactChecked bool
+}
+
+// needsVecCompaction reports whether any projection has a vectorized evaluator
+// but no per-row typed path (e.g. embed() → VECTOR). Such a projection can only
+// run through the batched VecEval path (non-sel branch); under a selection
+// vector it would otherwise fall back to per-row Expr eval. Computed once.
+func (p *Project) needsVecCompaction() bool {
+	if !p.vecCompactChecked {
+		for _, proj := range p.Projections {
+			if proj.VecEval != nil && proj.Float64Eval == nil && proj.Int64Eval == nil {
+				p.vecCompact = true
+				break
+			}
+		}
+		p.vecCompactChecked = true
+	}
+	return p.vecCompact
 }
 
 func NewProject(projections []ProjectColumn) *Project {
@@ -127,6 +146,18 @@ func (p *Project) Execute(_ context.Context, in *batch.RecordBatch) (*batch.Reco
 			schema[i] = col
 		}
 		p.cachedSchema = schema
+	}
+
+	// VecEval-only projections (e.g. embed() → VECTOR) have no per-row typed
+	// path, so the selection-vector branch below would fall back to one-row-at-
+	// a-time Expr eval — for embed() that is one provider API call per row,
+	// defeating SQL-level batching, and the per-row SetVector cannot self-
+	// correct the output dimension (leaving rows valid-but-empty). Compact the
+	// selection away so the batched VecEval path runs. The copy is paid only
+	// when such a projection is present (the common filtered-numeric case is
+	// untouched).
+	if in.Sel != nil && p.needsVecCompaction() {
+		in = in.Compact()
 	}
 
 	activeLen := in.ActiveLen()

--- a/wadjet/embed_sql_test.go
+++ b/wadjet/embed_sql_test.go
@@ -128,6 +128,148 @@ func TestEmbedSQLEndToEnd(t *testing.T) {
 	}
 }
 
+// fixedDimProvider reports one dimension but returns vectors of a different
+// width — simulating a misconfigured/unknown model. vecEmbed must NULL the
+// mismatched rows rather than truncate or leave stale pooled data.
+type fixedDimProvider struct {
+	reportDim int
+	returnDim int
+}
+
+func (p *fixedDimProvider) Embed(texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i := range texts {
+		v := make([]float32, p.returnDim)
+		for j := range v {
+			v[j] = float32(j) + 1
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+func (p *fixedDimProvider) Dimension() int { return p.reportDim }
+func (p *fixedDimProvider) Model() string  { return "fixed-dim-test" }
+
+// TestEmbedSQLBatchedUnderFilter is the regression for the review finding that
+// a selection vector (from a WHERE filter) made embed() fall back to one
+// provider call per row. With multiple non-null rows surviving the filter, a
+// batched embed() makes exactly one call; the pre-fix per-row path made N.
+func TestEmbedSQLBatchedUnderFilter(t *testing.T) {
+	ctx := context.Background()
+	prov := &countingProvider{dim: 8}
+	embedding.SetProvider(prov)
+	defer embedding.SetProvider(nil)
+	embedding.RegisterFunctions()
+
+	db, err := Open(ctx, Config{Store: objstore.NewMemStore(), Bucket: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	schema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "txt", Type: parquet.TypeString, Nullable: true},
+	}}
+	if err := db.CreateTable(ctx, "docs", schema, nil); err != nil {
+		t.Fatal(err)
+	}
+	rows := make([]map[string]any, 6)
+	for i := 0; i < 6; i++ {
+		var txt any = "word" + strconv.Itoa(i)
+		if i == 4 {
+			txt = nil // a NULL survivor inside the filter
+		}
+		rows[i] = map[string]any{"id": int64(i), "txt": txt}
+	}
+	ing := db.NewIngester("docs", schema, nil, ingest.Config{MaxBufferRows: 10000, RowGroupSize: 500})
+	if err := ing.Ingest(ctx, rows); err != nil {
+		t.Fatal(err)
+	}
+	if err := ing.FlushAll(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// WHERE forces a selection vector. Survivors: id 2,3,4,5 (4 rows; id4 is NULL).
+	res, err := db.Query(ctx, "SELECT id, embed(txt) AS v FROM docs WHERE id >= 2 ORDER BY id")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(res.Rows) != 4 {
+		t.Fatalf("got %d rows, want 4", len(res.Rows))
+	}
+
+	// The whole filtered batch must be embedded in ONE call (3 non-null texts),
+	// not one call per row.
+	if prov.calls != 1 {
+		t.Errorf("provider.Embed called %d times under a filter, want 1 (batched)", prov.calls)
+	}
+	if prov.rows != 3 {
+		t.Errorf("provider embedded %d texts, want 3 (NULL excluded)", prov.rows)
+	}
+
+	// Correct values + NULL passthrough survive the filtered/compacted path.
+	for _, r := range res.Rows {
+		if r["id"].(int64) == 4 {
+			if r["v"] != nil {
+				t.Errorf("embed(NULL) under filter = %v, want nil", r["v"])
+			}
+			continue
+		}
+		v, ok := r["v"].([]float32)
+		if !ok || len(v) != 8 {
+			t.Errorf("id=%v embed output %T len mismatch, want []float32 dim 8", r["id"], r["v"])
+		}
+	}
+}
+
+// TestEmbedSQLDimMismatch is the regression for the review finding that a
+// provider returning a width different from its declared Dimension() silently
+// corrupted output (truncation / stale pooled tail) while marking rows valid.
+// The mismatched rows must come back NULL.
+func TestEmbedSQLDimMismatch(t *testing.T) {
+	ctx := context.Background()
+	prov := &fixedDimProvider{reportDim: 8, returnDim: 4} // declares 8, returns 4
+	embedding.SetProvider(prov)
+	defer embedding.SetProvider(nil)
+	embedding.RegisterFunctions()
+
+	db, err := Open(ctx, Config{Store: objstore.NewMemStore(), Bucket: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	schema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "txt", Type: parquet.TypeString, Nullable: true},
+	}}
+	if err := db.CreateTable(ctx, "docs", schema, nil); err != nil {
+		t.Fatal(err)
+	}
+	rows := []map[string]any{
+		{"id": int64(1), "txt": "alpha"},
+		{"id": int64(2), "txt": "beta"},
+	}
+	ing := db.NewIngester("docs", schema, nil, ingest.Config{MaxBufferRows: 10000, RowGroupSize: 500})
+	if err := ing.Ingest(ctx, rows); err != nil {
+		t.Fatal(err)
+	}
+	if err := ing.FlushAll(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := db.Query(ctx, "SELECT id, embed(txt) AS v FROM docs ORDER BY id")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	for _, r := range res.Rows {
+		if r["v"] != nil {
+			t.Errorf("id=%v: width-mismatched embedding = %v, want nil (no corruption)", r["id"], r["v"])
+		}
+	}
+}
+
 func toFloat(v any) (float64, bool) {
 	switch x := v.(type) {
 	case float64:


### PR DESCRIPTION
Follow-up to #160. A multi-agent adversarial code review (5 dimension reviewers → 3 independent skeptics per finding, majority-vote to confirm) flagged **13 confirmed findings** and correctly refuted 9 (including all the planner-typing safety concerns — the core typing change verified sound). This fixes the confirmed ones.

## HIGH
- **Selection-vector path bypassed batching** (`exec/project.go`) — found by 3 reviewers. After any `WHERE`/`JOIN`, the batch carries a `Sel` and `embed()` fell through to per-row `fnEmbed` = **one API call per row**, and could mark rows valid with empty vectors. Project now compacts the selection away when a VecEval-only projection is present, so the batched path runs.
- **No dimension validation in `vecEmbed`** (`embedding/func.go`) — found by 3. Output `VectorDim` was locked to the plan-time guess; a width mismatch silently **truncated** (long) or left **stale pooled tail data** (short) while marking the row valid. Now the width comes from the returned data when unset, and any row whose vector ≠ that width is set **NULL** rather than corrupted.
- **Ollama `o.dim` data race** (`embedding/ollama.go`) — found by 2. Removed the unsynchronized `o.dim` self-mutation (raced with `Dimension()` on the shared singleton; also too late to help the triggering query). Width is fixed at construction; `WADJET_EMBED_DIM` covers non-table models.

## MEDIUM / LOW
- `voyage-2` default dimension corrected 1536 → **1024**.
- nil embeddings are no longer cached (would persist a permanent miss).
- collapsed the duplicate `GetValue` call on the non-string path.
- extracted `embedWithCache` — the cache/batch loop was triplicated across openai/voyage/ollama; centralizes the nil-skip.
- `WADJET_EMBED_DIM` env lets any provider/model declare an explicit width.

## Tests
- New regression tests: batched `embed()` **under a `WHERE` filter** (was per-row), and **width-mismatch NULL** safety.
- `go test -race ./internal/embedding/` clean (confirms the Ollama race fix), all touched packages pass, `go vet` clean, **TPC-H SF0.01 22-query gate** passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)