### PR TITLE
docs(internals): native-DAG execution map + GroupByAll groundwork for distributed DISTINCT (#163)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,7 @@ Network-native types (IPv4, IPv6, CIDR, MAC, Port, Protocol) are first-class wit
 - **Broadcast + probe-split**: Builds under `BroadcastBytesThreshold` replicate to all workers; the probe side's files are split across workers, each runs the full join, coordinator merges partial results (re-aggregation, sort, dedup).
 - **NATS JetStream**: Task queues with request/reply result delivery, metadata KV
 - **Federation**: NATS leaf nodes connect edge clusters to central
+- **Internals map**: `docs/internals/native-dag-execution.md` — file-anchored map of the native-DAG path (two coordinator entry paths, `walkStages` per-node stage emission, Stage→fragment conversion, the distribution-property/shuffle system, and inspection recipes). Start here before navigating coordinator/planner/worker distribution code.
 
 ## Commit Convention
 

--- a/docs/internals/native-dag-execution.md
+++ b/docs/internals/native-dag-execution.md
@@ -1,0 +1,122 @@
+# Native-DAG Distributed Execution — Internals Map
+
+> **Audience:** engineers and agents navigating the distributed query path. This
+> is a *machinery map* with `file:line` anchors, not a tutorial. Line numbers
+> drift — treat them as starting points and confirm against current source.
+> Last verified: 2026-06-29 (main, post-#161).
+
+## TL;DR
+
+A SQL query becomes a **DAG of `Stage`s** that workers execute as **fragments**
+(pipelines of `OpSpec` operators), with intermediate results materialized to the
+object store between stages and a terminal **gather** streaming the result back
+to the coordinator.
+
+```
+SQL → logical.Node → PlanDistributed → []Stage → executeStageDAG → worker fragments → gather
+```
+
+There are **two coordinator entry paths** — know which one you're in:
+
+| Path | Entry | Planner | Merge/dedup | Used by |
+|---|---|---|---|---|
+| **Native-DAG** (primary) | `Coordinator.ExecuteSQL` (`coordinator/coordinator.go:520`) | `PlanDistributed` → multi-stage DAG | inside the DAG (aggregate/sort/exchange stages); **no `MergeInfo` post-pass** | pgwire, gRPC, HTTP server, alerts, benches — **all production reads** |
+| **Probe-split pipeline** (legacy/secondary) | `Coordinator.SubmitSQL` (`coordinator/coordinator.go:~2160`) | collapses to one `pipeline-0` stage | `mergeProbePartials`/`deduplicatePartials` using `logical.MergeInfo` (`coordinator/coordinator.go:1154,1223`) | async submit path |
+
+⚠️ **These paths handle DISTINCT differently.** The probe-split path dedups via
+`MergeInfo.HasDistinct`; the native-DAG path does **not** (see Known Issues).
+
+## Planning pipeline (logical → stages)
+
+`PlanDistributed` (`planner/physical/plan.go:1579`):
+1. `AnnotateScanColumns` — scan column metadata for shuffle-key assignment.
+2. `generateStages` (`plan.go:2456`) → `walkStages` (`plan.go:2919`) builds the raw stage list, then `fuseJoinStages` / CTE flattening.
+3. `assignStageDistributions` + `EnsureDistribution` (`plan.go:1595,1612`) — the **distribution-property system**: each `Stage` gets a `Distribution` (Singleton / HashPartitioned{keys,count} / …); `EnsureDistribution` inserts `exchange-*` stages where a stage's input requirement isn't met by its child's output. This is *the* mechanism that introduces shuffles.
+4. Collapse/fuse passes: `collapseMergeTreesForNativeDAG`, `fuseSortIntoPredecessor`, `fuseScanAggregateShuffle` (`plan.go:1601-1659`).
+5. `applyDynamicFilters`, `AssertExchangeConsistency`, attach SELECT aliases to the terminal `exchange-gather`.
+
+### `walkStages` per-node behavior (`plan.go:2919`)
+
+| Logical node | Emits | Notes |
+|---|---|---|
+| `NodeScan` | `scan` stage (tasks = file/row-group split) | `buildScan` is the single-process analog |
+| `NodeJoin` | `hash_join`/`broadcast_join` (+ `exchange-repartition` shuffles for non-broadcast) | keys parsed at plan time (`plan.go:3145+`) |
+| `NodeAggregate` | `aggregate` (partial) → `final_aggregate` | two-phase (`plan.go:3034-3103`); the distribution pass adds the exchange |
+| `NodeSort` | `sort` → merge-sort tree | `plan.go:3105` |
+| `NodeWindow` | `window` | `plan.go:3384` |
+| `NodeFilter` | pushes predicates onto child stage | `plan.go:3323` |
+| **`NodeDistinct`** | **nothing — passthrough** | `default` case `plan.go:~3415`; walks children only |
+| **`NodeProject`** | **nothing — passthrough** | same `default` case; aliases recovered at gather |
+
+## Stage → worker fragment conversion
+
+Every stage dispatches as a **fragment**: a list of `distributed.OpSpec`
+operators (`distributed/messages.go:260`). The worker requires `Operators` to be
+non-empty (`worker/executor_stage.go:22`).
+
+Conversion lives in `coordinator/execute_stage_dag.go`:
+- `buildAggregateFragment` (`:2373`) → `OpShuffleSource` + `OpHashAggregate{GroupByCols, Aggregates, MergeMode}`. **`MergeMode = stage.Type=="final_aggregate"||"merge_aggregate"`** (`:2400`) — merge mode rewrites `InputCol→OutputCol` and `COUNT→SUM`.
+- `buildSortFragment` (`:2514`), shuffle dispatch `dispatchShuffleStage` (`:772`).
+- Terminal stage gets an `OpGatherSink` when `gatherReplySubject != ""`.
+
+Worker side: `buildFragmentUnary` (`worker/executor_fragment.go:952`) and
+`buildFragmentHashAggregate` (`:788`). **Gap:** the hash-aggregate fragment
+requires `len(GroupByCols)>0 || len(Aggregates)>0` and has **no `GroupByAll`**
+— the single-process `buildDistinct` (`plan.go:5583`) uses
+`HashAggregate.GroupByAll=true`, which has no distributed equivalent yet.
+
+## Shuffle internals
+
+- Stage type `StageExchangeRepartition = "exchange-repartition"` (`planner/physical/exchange.go:19`), `ExchangeStage{Keys, Count}` (`:33`). Sender op `OpExchangeSender{ShuffleKeys, NumPartitions}` (`distributed/messages.go:134,287`).
+- `partitionedShuffleSink.Consume` (`worker/partitioned_shuffle_sink.go:103`) resolves `keyIdxs` from key names on the first batch, then `hashRowsIntoPartitions` (`:611`) computes `fnv(col1||col2||…) % numParts`.
+- **Type coverage of the hash:** Int32/Port/Protocol/Date, Int64/Timestamp/IPv4/MAC/Duration, Float32, Float64, String/Bytes/IPv6/CIDR/UUID. **NOT covered** (hashed as a constant via the `default` arm): Bool, Decimal, Vector, Array, Row, Map. The planner only ever picks scalar key types for joins, so this is fine there.
+- **Collision-safety property:** because the hash is a deterministic function of the row bytes, *identical rows always hash identically* → same partition. Uncovered types therefore cause only **skew**, never incorrect partitioning — which is why an all-columns hash (for a future sharded DISTINCT) is correct even on tables with nested/decimal columns: the final per-partition dedup compares actual values.
+
+## Where dedup / aggregate / distinct happen
+
+- **Aggregate (with functions):** `aggregate` (partial, per scan task) → `final_aggregate` (merge). The distribution pass inserts a shuffle/gather so the final merges all partials. ✅ correct distributed.
+- **Sort:** `sort` → merge-sort tree, merged at the gather. ✅
+- **DISTINCT / bare GROUP BY (no agg fn):** `NodeDistinct` is passthrough and a no-aggregate `NodeAggregate` produces no merge — so the native-DAG emits `scan → gather` with **no dedup operator**. ❌ See Known Issues.
+
+## Known Issues
+
+### Distributed DISTINCT and aggregate-free GROUP BY are not deduplicated (native-DAG)
+
+`SELECT DISTINCT …` and `SELECT col … GROUP BY col` (no aggregate function)
+return **every input row** in distributed mode — no cross-task dedup. Confirmed
+2026-06-29 by stage dump (`scan → exchange-gather`, no dedup stage) and an
+end-to-end multi-worker run (`SELECT DISTINCT l_returnflag` → 60000 rows vs 3).
+The probe-split path dedups via `MergeInfo.HasDistinct`; the native-DAG path
+(every production entry point) does not. Masked because: standalone/single-
+process uses `buildDistinct` (works), and no test/TPC-H query exercises bare
+distinct or no-agg group-by distributed. Likely a native-DAG-unification
+regression. **Fix:** make `NodeDistinct` (and no-agg `NodeAggregate`) emit the
+two-phase dedup stages that the working aggregate path uses
+(`GroupByAll` partial → exchange(all-cols) → `GroupByAll` final). Tracked in the
+distributed-distinct workstream.
+
+## How to inspect this machinery (recipes)
+
+**Dump the stages a query plans to** — fastest way to see what the DAG looks
+like. Pattern (see `planner/physical/dynamic_filter_test.go` `sqlToStages` /
+`plan_tpch_test.go:setupTPCHCatalog`):
+
+```go
+cat, ctx := setupTPCHCatalog(t)
+for _, s := range sqlToStages(t, cat, ctx, "SELECT DISTINCT l_orderkey FROM lineitem", 3) {
+    fmt.Printf("id=%s type=%s tasks=%d dist=%v groupBy=%v aggs=%d deps=%v\n",
+        s.ID, s.Type, s.Tasks, s.Distribution, s.GroupByCols, len(s.AggSpecs), s.Dependencies)
+}
+```
+
+**End-to-end multi-worker run** (real NATS + 3 in-process workers + coordinator)
+— the pattern in `coordinator/multi_worker_test.go:TestShuffleCorrectness`:
+embedded NATS → MemStore + NATS-KV catalog → write parquet + `cat.AddFiles` →
+`worker.New(...).Start` ×N → `New(coordinator.Config{...})` → inject fake
+heartbeats → `coord.ExecuteSQL(ctx, sql)`. Use this to verify row-count
+correctness of a distributed change before EC2.
+
+## Related
+
+- `docs/architecture.md` §Distributed Execution (high level), `docs/distributed.md` (deployment).
+- Memory: `project-distributed-distinct-design-2026-06-29` (the sharded-distinct fix design + this investigation).

--- a/internal/coordinator/distinct_distributed_test.go
+++ b/internal/coordinator/distinct_distributed_test.go
@@ -1,0 +1,148 @@
+package coordinator
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/benchmarks/tpch"
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/storage/catalog"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+	"github.com/citc-tech/wadjet/internal/worker"
+)
+
+// TestDistributedDistinctDedup is the regression for #163: distributed
+// SELECT DISTINCT must deduplicate across scan tasks. Before the fix the
+// native-DAG path passed NodeDistinct through with no dedup stage, so
+// SELECT DISTINCT returned every input row. Ground truth is computed from the
+// source rows. Data is split into multiple files so several scan tasks each
+// see overlapping values — the condition a missing cross-task dedup needs.
+func TestDistributedDistinctDedup(t *testing.T) {
+	// #163: fix in progress. The planner now emits GroupByAll partial+final
+	// dedup stages for NodeDistinct, but the distinct input is not projected to
+	// its output columns before the dedup (the logical Project is a walkStages
+	// passthrough, so the scan output carries all columns) — so GroupByAll
+	// over-distinguishes and the dedup is a no-op. Unskip once the pre-dedup
+	// projection lands. See project-distributed-distinct-design-2026-06-29.
+	t.Skip("#163: distributed DISTINCT dedup — pre-dedup projection not yet wired")
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	t.Cleanup(cancel)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	natsCfg := distributed.DefaultNATSConfig()
+	natsCfg.Port = -1
+	natsCfg.StoreDir = t.TempDir()
+	embeddedNATS, err := distributed.NewEmbeddedNATS(natsCfg, logger)
+	if err != nil {
+		t.Fatalf("nats: %v", err)
+	}
+	t.Cleanup(embeddedNATS.Shutdown)
+	nc, err := distributed.ConnectInProcess(embeddedNATS.Server())
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { nc.Close() })
+	js, err := distributed.NewJetStream(nc)
+	if err != nil {
+		t.Fatalf("js: %v", err)
+	}
+	if err := distributed.SetupStreams(ctx, js); err != nil {
+		t.Fatalf("streams: %v", err)
+	}
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(ctx, "test"); err != nil {
+		t.Fatal(err)
+	}
+	kv, err := catalog.NewNATSKV(js)
+	if err != nil {
+		t.Fatalf("kv: %v", err)
+	}
+	cat := catalog.New(kv, store, "test")
+	if err := cat.Init(ctx); err != nil {
+		t.Fatalf("cat init: %v", err)
+	}
+
+	data := tpch.Generate(tpch.SF001)
+	schema := tpch.AllTables["lineitem"]
+	rows := data["lineitem"]
+	if err := cat.CreateTable(ctx, "lineitem", schema, nil); err != nil {
+		t.Fatal(err)
+	}
+	const chunks = 3
+	per := (len(rows) + chunks - 1) / chunks
+	for c := 0; c < chunks; c++ {
+		lo, hi := c*per, c*per+per
+		if hi > len(rows) {
+			hi = len(rows)
+		}
+		if lo >= hi {
+			break
+		}
+		var buf bytes.Buffer
+		pw, _ := parquet.NewWriter(&buf, schema, parquet.DefaultWriterConfig())
+		if err := pw.WriteRows(rows[lo:hi]); err != nil {
+			t.Fatal(err)
+		}
+		pw.Close()
+		fp := fmt.Sprintf("tables/lineitem/chunk_%04d.parquet", c)
+		pd := buf.Bytes()
+		store.Put(ctx, "test", fp, bytes.NewReader(pd), int64(len(pd)), "application/octet-stream")
+		cat.AddFiles(ctx, "lineitem", map[string]string{}, "tables/lineitem/", []catalog.FileEntry{{
+			Path: fp, SizeBytes: int64(len(pd)), NumRows: int64(hi - lo), CreatedAt: time.Now(),
+		}})
+	}
+
+	for i := 0; i < 3; i++ {
+		w := worker.New(worker.Config{NATSUrl: embeddedNATS.ClientURL(), MaxConcurrent: 4, CacheBytes: 64 << 20}, store, nc, js, logger)
+		wctx, wcancel := context.WithCancel(context.Background())
+		t.Cleanup(wcancel)
+		if err := w.Start(wctx); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(w.Stop)
+	}
+	coord := New(Config{NATSUrl: embeddedNATS.ClientURL(), ResultBucket: "test"}, cat, nc, js, logger)
+	for i := 0; i < 3; i++ {
+		coord.workers.record(distributed.WorkerHeartbeat{WorkerID: fmt.Sprintf("fake-%d", i), Timestamp: time.Now()})
+	}
+
+	// Ground truth from source rows.
+	rf := map[string]struct{}{}
+	rfls := map[string]struct{}{}
+	for _, r := range rows {
+		a := fmt.Sprint(r["l_returnflag"])
+		rf[a] = struct{}{}
+		rfls[a+"|"+fmt.Sprint(r["l_linestatus"])] = struct{}{}
+	}
+
+	cases := []struct {
+		sql  string
+		want int
+	}{
+		{"SELECT DISTINCT l_returnflag FROM lineitem", len(rf)},
+		{"SELECT DISTINCT l_returnflag, l_linestatus FROM lineitem", len(rfls)},
+		// Control: the aggregate path was already correct.
+		{"SELECT l_returnflag, COUNT(*) AS c FROM lineitem GROUP BY l_returnflag", len(rf)},
+	}
+	for _, tc := range cases {
+		res, err := coord.ExecuteSQL(ctx, tc.sql)
+		if err != nil {
+			t.Fatalf("%s: %v", tc.sql, err)
+		}
+		if res.Error != "" {
+			t.Fatalf("%s: %s", tc.sql, res.Error)
+		}
+		got := len(mustRows(t, res))
+		if got != tc.want {
+			t.Errorf("%s: got %d rows, want %d", tc.sql, got, tc.want)
+		} else {
+			t.Logf("%s: %d rows OK", tc.sql, got)
+		}
+	}
+}

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -2402,9 +2402,12 @@ func buildAggregateFragment(stage physical.Stage, t *distributed.Task, taskInput
 		Type:         distributed.OpHashAggregate,
 		GroupByCols:  append([]string(nil), stage.GroupByCols...),
 		Aggregates:   append([]distributed.AggSpec(nil), aggs...),
+		GroupByAll:   stage.GroupByAll,
 		MergeMode:    mergeMode,
-		FoldAvg:      stage.Type == "final_aggregate",
-		BuildProject: !mergeMode,
+		// GroupByAll (DISTINCT) has no derived-input expressions to project and
+		// no AVG synthetics to fold — keep both off regardless of stage role.
+		FoldAvg:      stage.Type == "final_aggregate" && !stage.GroupByAll,
+		BuildProject: !mergeMode && !stage.GroupByAll,
 	})
 	if len(t.PostFilterExprs) > 0 {
 		ops = append(ops, distributed.OpSpec{

--- a/internal/distributed/messages.go
+++ b/internal/distributed/messages.go
@@ -294,6 +294,7 @@ type OpSpec struct {
 	// OpHashAggregate (pipeline-breaker).
 	GroupByCols  []string  `json:"group_by_cols,omitempty"` // empty = scalar aggregate
 	Aggregates   []AggSpec `json:"aggregates,omitempty"`    // per-column aggregations
+	GroupByAll   bool      `json:"group_by_all,omitempty"`  // DISTINCT: group by every input column, key set resolved at runtime
 	MergeMode    bool      `json:"merge_mode,omitempty"`    // input is already partial-aggregated; rewrite InputCol → OutputCol and COUNT → SUM
 	FoldAvg      bool      `json:"fold_avg,omitempty"`      // collapse __avg_sum#X / __avg_count#X synthetics into AVG output (final aggregate only)
 	BuildProject bool      `json:"build_project,omitempty"` // construct a derived-input projection before the aggregate (skipped in merge mode — partial output already has OutputCol)

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -53,6 +53,11 @@ type Stage struct {
 	// Aggregate metadata
 	GroupByCols []string
 	AggSpecs   []AggSpec
+	// GroupByAll marks a keys-only hash aggregate over EVERY input column —
+	// the DISTINCT shape. The key set is resolved at runtime from the input
+	// schema (no plan-time column list), matching exec.HashAggregate.GroupByAll
+	// and the single-process buildDistinct path.
+	GroupByAll bool
 
 	// Sort metadata
 	SortKeys []SortKeySpec
@@ -3413,7 +3418,18 @@ func (p *Planner) walkStages(node *logical.Node, stages *[]Stage, parentID *stri
 		*stages = append(*stages, stage)
 
 	default:
-		// Passthrough nodes (Project, Distinct) — walk children
+		// Passthrough nodes (Project, Distinct) — walk children.
+		//
+		// NOTE (#163): Distinct being a passthrough here is the root of the
+		// distributed-DISTINCT correctness bug — no dedup stage is emitted, so
+		// distributed SELECT DISTINCT returns every row. The fix (emit a
+		// GroupByAll partial→final dedup) is NOT just adding a case here: the
+		// distinct input must first be projected to its output columns (the
+		// logical Project above the Distinct is itself a passthrough, so the
+		// scan output carries all columns and GroupByAll over-distinguishes).
+		// The GroupByAll plumbing (Stage/OpSpec/buildFragmentHashAggregate) is
+		// in place; wiring the pre-dedup projection is the remaining work. See
+		// project-distributed-distinct-design-2026-06-29.
 		for _, child := range node.Children {
 			p.walkStages(child, stages, parentID)
 		}

--- a/internal/worker/executor_fragment.go
+++ b/internal/worker/executor_fragment.go
@@ -786,8 +786,8 @@ func (e *Executor) buildFragmentSort(spec distributed.OpSpec) (*exec.Sort, error
 // (the partial-output column) and COUNT becomes SUM (counting partial rows
 // re-counts groups, not source rows).
 func (e *Executor) buildFragmentHashAggregate(spec distributed.OpSpec) (*exec.HashAggregate, error) {
-	if len(spec.Aggregates) == 0 && len(spec.GroupByCols) == 0 {
-		return nil, fmt.Errorf("hash_aggregate: at least one of GroupByCols or Aggregates is required")
+	if !spec.GroupByAll && len(spec.Aggregates) == 0 && len(spec.GroupByCols) == 0 {
+		return nil, fmt.Errorf("hash_aggregate: at least one of GroupByCols, Aggregates, or GroupByAll is required")
 	}
 	aggCols := make([]exec.AggColumn, len(spec.Aggregates))
 	for i, a := range spec.Aggregates {
@@ -809,6 +809,7 @@ func (e *Executor) buildFragmentHashAggregate(spec distributed.OpSpec) (*exec.Ha
 		}
 	}
 	hashAgg := exec.NewHashAggregate(spec.GroupByCols, aggCols)
+	hashAgg.GroupByAll = spec.GroupByAll
 	if e.sharedSpill != nil {
 		hashAgg.Spill = e.sharedSpill
 	}


### PR DESCRIPTION
Groundwork from the #163 investigation. Lands the reusable internals docs and the harmless scaffolding for the distributed-DISTINCT fix; the fix itself (pre-dedup projection wiring) follows in a subsequent PR.

## Docs
- **`docs/internals/native-dag-execution.md`** — file-anchored map of the native-DAG path: the two coordinator entry paths, `walkStages` per-node stage emission, Stage→fragment conversion, the distribution-property/shuffle system, where dedup/aggregate/distinct happen, the #163 Known Issue, and copy-paste inspection recipes (stage dump + multi-worker e2e harness). Purpose: let agents navigate this machinery in minutes.
- **CLAUDE.md** — pointer to the internals map from the Distribution section.

## GroupByAll groundwork (harmless)
`Stage.GroupByAll` → `OpSpec.GroupByAll`, honored by `buildFragmentHashAggregate`, threaded by `buildAggregateFragment`. Defaults false → **zero behavior change** until used. Sets up a keys-only GroupByAll dedup in the fragment path for the upcoming fix.

## Regression test (skipped)
`internal/coordinator/distinct_distributed_test.go` — multi-worker e2e asserting distributed `SELECT DISTINCT` deduplicates. `t.Skip("#163")` until the fix lands; documents the bug + provides the harness.

## Root cause (for the follow-up)
The logical `Project` above a `Distinct` is itself a `walkStages` passthrough, so the distinct input carries all columns and a `GroupByAll` dedup over-distinguishes (e.g. `SELECT DISTINCT l_returnflag` → 60000 rows instead of 3). The fix must apply the projection (including expressions) before the dedup. `walkStages` `NodeDistinct` stays a passthrough here — emitting dedup stages without the projection broke Q04/Q18/Q20/Q22 semi-dedup plans.

Full design + three candidate fix approaches: tracked for the follow-up. Does not fix #163 yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)