### PR TITLE
fix(coordinator): deduplicate distributed SELECT DISTINCT (#163)

### DIFF
--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -621,6 +621,24 @@ func (c *Coordinator) ExecuteSQL(ctx context.Context, sql string) (*SQLResult, e
 			Plan:    planStr,
 		}, fmt.Errorf("native DAG: %w", gerr)
 	}
+	// #163: walkStages passes NodeDistinct through (no dedup stage), so a
+	// distributed SELECT DISTINCT arrives here un-deduplicated. The gather
+	// result is already projected to the SELECT list (applyOutputRenames), so
+	// deduplicate it now — then re-apply ORDER BY / LIMIT, since dedup does not
+	// preserve order. Single-node dedup (the same shape the probe-split path
+	// uses via mergeProbePartials); a sharded in-DAG dedup is the follow-up.
+	if gr != nil {
+		if mi := logical.ExtractMergeInfo(logicalPlan); mi != nil && mi.HasDistinct {
+			if err := c.dedupGatherResult(gr, mi); err != nil {
+				return &SQLResult{
+					QueryID: queryID,
+					Error:   err.Error(),
+					Elapsed: time.Since(start),
+					Plan:    planStr,
+				}, fmt.Errorf("distinct dedup: %w", err)
+			}
+		}
+	}
 	res := &SQLResult{
 		QueryID:   queryID,
 		Columns:   gr.columns,
@@ -1214,6 +1232,55 @@ func (c *Coordinator) mergeProbePartials(in BatchStream, columns []string, mi *l
 		totalRows += int64(b.ActiveLen())
 	}
 	return batches, totalRows, nil
+}
+
+// dedupGatherResult deduplicates a native-DAG gather result in place for
+// SELECT DISTINCT (#163). The gather batches are already projected to the
+// SELECT-list columns (applyOutputRenames), so deduplicatePartials' keys-only
+// GroupByAll dedup over them yields the correct distinct set. The (possibly
+// spilled) result is streamed through the dedup and replaced with the in-memory
+// deduped batches; ORDER BY / LIMIT are re-applied afterward because the dedup
+// does not preserve input order. Mirrors the dedup→sort→limit sequence the
+// probe-split path runs in mergeProbePartials.
+func (c *Coordinator) dedupGatherResult(gr *gatherResult, mi *logical.MergeInfo) error {
+	var src BatchStream
+	if gr.spillPath != "" {
+		// Renamer applies to spilled frames only; the in-memory prefix is
+		// already renamed (applyOutputRenames), so no double-rename.
+		src = newGatherReplayStream(gr.batches, gr.spillPath, gr.renamer)
+	} else {
+		src = newSliceStream(gr.batches)
+	}
+	deduped, err := c.deduplicatePartials(src, gr.columns)
+	if err != nil {
+		return err
+	}
+	// The stream (incl. any spilled scratch) is consumed; the result is now a
+	// small in-memory distinct set.
+	gr.batches = deduped
+	gr.spillPath = ""
+	gr.spillBytes = 0
+	gr.renamer = nil
+
+	if len(mi.OrderBy) > 0 || mi.Limit > 0 {
+		colIdx := make(map[string]int, len(gr.columns))
+		for i, col := range gr.columns {
+			colIdx[col] = i
+		}
+		if len(mi.OrderBy) > 0 {
+			c.sortBatches(gr.batches, gr.columns, colIdx, mi.OrderBy)
+		}
+		if mi.Limit > 0 {
+			gr.batches = limitBatches(gr.batches, mi.Limit)
+		}
+	}
+
+	var total int64
+	for _, b := range gr.batches {
+		total += int64(b.ActiveLen())
+	}
+	gr.totalRows = total
+	return nil
 }
 
 // deduplicatePartials removes duplicate rows across probe-split partial

--- a/internal/coordinator/distinct_distributed_test.go
+++ b/internal/coordinator/distinct_distributed_test.go
@@ -24,13 +24,6 @@ import (
 // source rows. Data is split into multiple files so several scan tasks each
 // see overlapping values — the condition a missing cross-task dedup needs.
 func TestDistributedDistinctDedup(t *testing.T) {
-	// #163: fix in progress. The planner now emits GroupByAll partial+final
-	// dedup stages for NodeDistinct, but the distinct input is not projected to
-	// its output columns before the dedup (the logical Project is a walkStages
-	// passthrough, so the scan output carries all columns) — so GroupByAll
-	// over-distinguishes and the dedup is a no-op. Unskip once the pre-dedup
-	// projection lands. See project-distributed-distinct-design-2026-06-29.
-	t.Skip("#163: distributed DISTINCT dedup — pre-dedup projection not yet wired")
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	t.Cleanup(cancel)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
@@ -127,6 +120,8 @@ func TestDistributedDistinctDedup(t *testing.T) {
 	}{
 		{"SELECT DISTINCT l_returnflag FROM lineitem", len(rf)},
 		{"SELECT DISTINCT l_returnflag, l_linestatus FROM lineitem", len(rfls)},
+		// DISTINCT + ORDER BY: dedup must run before the sort is re-applied.
+		{"SELECT DISTINCT l_returnflag FROM lineitem ORDER BY l_returnflag", len(rf)},
 		// Control: the aggregate path was already correct.
 		{"SELECT l_returnflag, COUNT(*) AS c FROM lineitem GROUP BY l_returnflag", len(rf)},
 	}

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -1876,7 +1876,11 @@ func findOutputProjectionsForRename(n *logical.Node) []logical.Projection {
 		switch n.Type {
 		case logical.NodeProject:
 			return n.Projections
-		case logical.NodeSort, logical.NodeLimit, logical.NodeFilter:
+		case logical.NodeSort, logical.NodeLimit, logical.NodeFilter, logical.NodeDistinct:
+			// Descend through Distinct too: the gather must project to the
+			// SELECT-list columns (the Project under the Distinct) so the
+			// coordinator's distinct dedup runs over the output columns, not
+			// the full upstream schema (#163).
 			if len(n.Children) == 1 {
 				n = n.Children[0]
 				continue


### PR DESCRIPTION
Fixes #163.

Native-DAG distributed `SELECT DISTINCT` returned **every input row** — `walkStages` passes `NodeDistinct` through (no dedup stage) and the native-DAG path applied no dedup. E.g. `SELECT DISTINCT l_returnflag FROM lineitem` returned 60000 rows instead of 3. Standalone/single-process was fine; the bug was masked because no test or TPC-H query exercises bare distinct distributed (a native-DAG-unification regression).

## Fix (single-node first cut)
Mirrors the probe-split path's existing `HasDistinct` dedup:
1. **`findOutputProjectionsForRename` now descends through `NodeDistinct`** — so the gather **projects** a DISTINCT result to its SELECT-list columns. Previously it emitted all upstream columns, so any dedup over it over-distinguished (every row unique). This was the missing piece.
2. **`ExecuteSQL` dedups the gather result** when `ExtractMergeInfo` reports `HasDistinct`: new `dedupGatherResult` streams the (now projected) result through `deduplicatePartials` (keys-only `GroupByAll`), then re-applies ORDER BY / LIMIT since the dedup doesn't preserve order. Spilled results stream via `newGatherReplayStream`.

## Tests
- `internal/coordinator/distinct_distributed_test.go` (multi-worker e2e, added in #164 as skipped) **unskipped + extended**: `DISTINCT`, 2-column `DISTINCT`, `DISTINCT + ORDER BY`, and a `COUNT(*)` control. All pass.
- TPC-H SF0.01 (22 queries) + planner snapshot tests green — Q04/Q18/Q20/Q22 semi/anti-dedup `Distinct`s unaffected (their plan root isn't a Distinct).
- `go vet` + full `coordinator`/`worker`/`distributed` suites green.

## Follow-ups (not in this PR)
- Sharded in-DAG dedup to avoid the single-node coordinator funnel (the `GroupByAll` plumbing from #164 sets this up).
- Verify DISTINCT+LIMIT pushdown and DISTINCT over SELECT-list expressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)