### PR TITLE
perf(exec): pack per-group aggregate state structs for tighter GC scan regions

### DIFF
--- a/internal/engine/exec/aggregate.go
+++ b/internal/engine/exec/aggregate.go
@@ -237,9 +237,13 @@ var spillFileTargetBytes int64 = 64 * 1024 * 1024
 // (20M groups) and brings worker peak heap under GOMEMLIMIT at
 // max_concurrent=4.
 type groupState struct {
-	intKey int64 // single int64 key for int-keyed groups (avoids []any boxing)
-	setID  int32 // grouping set index (-1 = not a grouping set); 4 B of tail padding follows
+	// Pointer first so the GC pointer-scan region is 8 B, not 24 B. This struct
+	// is one-per-group, allocated in contiguous []groupState chunks (millions of
+	// groups at SF100), so shrinking the scanned prefix cuts GC mark work per
+	// cycle. Size is unchanged at 24 B (extras 8 + intKey 8 + setID 4 + 4 tail pad).
 	extras *groupStateExtras
+	intKey int64 // single int64 key for int-keyed groups (avoids []any boxing)
+	setID  int32 // grouping set index (-1 = not a grouping set)
 }
 
 // groupStateExtras holds the heavy per-group fields that are only needed by
@@ -368,8 +372,9 @@ func (h *HashAggregate) reconcileGroupMemory() {
 
 // stringAggState accumulates strings with a separator.
 type stringAggState struct {
-	parts []string
+	// sep first keeps the two pointer prefixes adjacent (scan region 24 B, not 32).
 	sep   string
+	parts []string
 }
 
 // varianceState tracks running variance using Welford's online algorithm.
@@ -451,9 +456,11 @@ type collectState struct {
 
 // minMaxByState tracks the row where a comparison column is min/max.
 type minMaxByState struct {
-	hasValue bool
-	bestCmp  float64 // the comparison column value (min or max)
+	// Field order packs this to 32 B (was 40) and puts the pointer prefix first:
+	// one per group for MIN_BY/MAX_BY.
 	bestVal  any     // the return column value at that row
+	bestCmp  float64 // the comparison column value (min or max)
+	hasValue bool
 	isMin    bool
 }
 


### PR DESCRIPTION
`fieldalignment` flagged the per-group aggregate state structs. These are allocated **one-per-group** (millions at SF100 `GROUP BY`/`DISTINCT`), so field order affects GC mark work per cycle.

| Struct | Change | Effect |
|---|---|---|
| `groupState` | `*groupStateExtras` moved first | GC pointer-scan region **24 B → 8 B/group** (size unchanged at 24 B). Used by every grouped aggregate + DISTINCT; allocated in contiguous `[]groupState` chunks. |
| `minMaxByState` | repacked | **40 B → 32 B/group** (MIN_BY/MAX_BY) |
| `stringAggState` | `sep` first | scan region **32 B → 24 B** (string_agg) |

Layout-only, correctness-neutral (structs accessed by field name, never by offset/`unsafe`). `groupState` is the meaningful one — it's on every grouping query and the reorder cuts GC-mark scan work per group without changing size, which targets the documented SF100 GC-mark pressure.

The many per-operator structs `fieldalignment` also flags (`HashJoin`, `Filter`, `Window`, `Pipeline`, `HashAggregate`) are one-instance-per-query — reordering saves tens of bytes total against a readability cost, so they're left as-is.

## Tests
exec unit tests + TPC-H SF0.01 (22 queries) pass unchanged. No A/B needed for a layout primitive (per project convention — correctness gates suffice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)