### PR TITLE
perf: sharded distributed DISTINCT + fix aggregate-free GROUP BY dedup (#166)

### DIFF
--- a/docs/internals/native-dag-execution.md
+++ b/docs/internals/native-dag-execution.md
@@ -45,7 +45,7 @@ There are **two coordinator entry paths** — know which one you're in:
 | `NodeSort` | `sort` → merge-sort tree | `plan.go:3105` |
 | `NodeWindow` | `window` | `plan.go:3384` |
 | `NodeFilter` | pushes predicates onto child stage | `plan.go:3323` |
-| **`NodeDistinct`** | **nothing — passthrough** | `default` case `plan.go:~3415`; walks children only |
+| **`NodeDistinct`** | **nothing — passthrough** | `default` case `plan.go:~3415`; walks children only. Top-level DISTINCT never reaches here — `logical.rewriteDistinctAsGroupBy` (optimizer) turns it into an aggregate-free `NodeAggregate` first, so it rides the aggregate stages. Remaining NodeDistincts (semi/anti build-side dedup, fallback shapes) stay passthrough. |
 | **`NodeProject`** | **nothing — passthrough** | same `default` case; aliases recovered at gather |
 
 ## Stage → worker fragment conversion
@@ -76,24 +76,27 @@ requires `len(GroupByCols)>0 || len(Aggregates)>0` and has **no `GroupByAll`**
 
 - **Aggregate (with functions):** `aggregate` (partial, per scan task) → `final_aggregate` (merge). The distribution pass inserts a shuffle/gather so the final merges all partials. ✅ correct distributed.
 - **Sort:** `sort` → merge-sort tree, merged at the gather. ✅
-- **DISTINCT / bare GROUP BY (no agg fn):** `NodeDistinct` is passthrough and a no-aggregate `NodeAggregate` produces no merge — so the native-DAG emits `scan → gather` with **no dedup operator**. ❌ See Known Issues.
+- **Bare GROUP BY (no agg fn):** same stages as aggregates — the fused scan runs the partial dedup and hash-partitions on the group keys; the `final_aggregate` fans out one task per disjoint partition. The dispatch gate that routes a fused scan into `dispatchScanAggregateStage` accepts `FusedAggGroupBy`-only stages (`execute_stage_dag.go`, was `FusedAggSpecs`-only — issue #166). ✅ sharded.
+- **Top-level DISTINCT:** rewritten at logical-optimize time to an aggregate-free GROUP BY over the SELECT list (`logical.rewriteDistinctAsGroupBy`, `planner/logical/distinct_rewrite.go`) — bare columns AND scalar expressions (derived group-bys are evaluated by the worker's `buildAggInputProjection`). Rides the sharded path above; the coordinator does no dedup (`MergeInfo.HasDistinct` is false post-rewrite). ✅ sharded.
+- **DISTINCT fallback shapes** (`SELECT DISTINCT *`, DISTINCT with aggregate projections, subquery expressions): not rewritten; `ExecuteSQL` applies `dedupGatherResult` over the projected gather output (`MergeInfo.HasDistinct`). Correct but single-node at the coordinator.
 
 ## Known Issues
 
-### Distributed DISTINCT and aggregate-free GROUP BY are not deduplicated (native-DAG)
+### DISTINCT over a non-decorrelatable scalar-subquery projection (fallback, distributed)
 
-`SELECT DISTINCT …` and `SELECT col … GROUP BY col` (no aggregate function)
-return **every input row** in distributed mode — no cross-task dedup. Confirmed
-2026-06-29 by stage dump (`scan → exchange-gather`, no dedup stage) and an
-end-to-end multi-worker run (`SELECT DISTINCT l_returnflag` → 60000 rows vs 3).
-The probe-split path dedups via `MergeInfo.HasDistinct`; the native-DAG path
-(every production entry point) does not. Masked because: standalone/single-
-process uses `buildDistinct` (works), and no test/TPC-H query exercises bare
-distinct or no-agg group-by distributed. Likely a native-DAG-unification
-regression. **Fix:** make `NodeDistinct` (and no-agg `NodeAggregate`) emit the
-two-phase dedup stages that the working aggregate path uses
-(`GroupByAll` partial → exchange(all-cols) → `GroupByAll` final). Tracked in the
-distributed-distinct workstream.
+The coordinator-dedup fallback dedups the *gather output*, and the gather
+cannot compute expression projections — so a `SELECT DISTINCT (<subquery>) …`
+whose subquery survives decorrelation dedups over raw upstream columns
+(over-distinguishes). Decorrelated subqueries become column refs and take the
+sharded rewrite, so this is a narrow residual shape.
+
+### History
+
+**Fixed 2026-07:** distributed `SELECT DISTINCT` and aggregate-free `GROUP BY`
+returned every input row (no cross-task dedup) — #163 (first-cut coordinator
+dedup, PR #165) then #166 + the sharded rewrite (partial-dedup at scan →
+hash-partition exchange → per-partition final tasks). Regression coverage:
+`coordinator/distinct_distributed_test.go` (multi-worker e2e, 9 query shapes).
 
 ## How to inspect this machinery (recipes)
 

--- a/internal/coordinator/distinct_distributed_test.go
+++ b/internal/coordinator/distinct_distributed_test.go
@@ -124,6 +124,19 @@ func TestDistributedDistinctDedup(t *testing.T) {
 		{"SELECT DISTINCT l_returnflag FROM lineitem ORDER BY l_returnflag", len(rf)},
 		// Control: the aggregate path was already correct.
 		{"SELECT l_returnflag, COUNT(*) AS c FROM lineitem GROUP BY l_returnflag", len(rf)},
+		// #166: aggregate-free GROUP BY must dedup across scan tasks.
+		// Before the fix the fused scan (group cols, zero agg specs)
+		// dispatched as a plain scan — no partial dedup, no hash-partition
+		// exchange — so the N final tasks re-emitted every group (3×3=9).
+		{"SELECT l_returnflag FROM lineitem GROUP BY l_returnflag", len(rf)},
+		{"SELECT l_returnflag, l_linestatus FROM lineitem GROUP BY l_returnflag, l_linestatus", len(rfls)},
+		// Aliased bare column still takes the sharded GROUP BY rewrite.
+		{"SELECT DISTINCT l_returnflag AS flag FROM lineitem", len(rf)},
+		// DISTINCT over an expression is NOT rewritten — it exercises the
+		// coordinator-side dedup fallback (MergeInfo.HasDistinct).
+		{"SELECT DISTINCT lower(l_returnflag) AS flag FROM lineitem", len(rf)},
+		// Control for the expression case: the equivalent explicit GROUP BY.
+		{"SELECT lower(l_returnflag) AS flag FROM lineitem GROUP BY lower(l_returnflag)", len(rf)},
 	}
 	for _, tc := range cases {
 		res, err := coord.ExecuteSQL(ctx, tc.sql)

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -1085,7 +1085,14 @@ func (c *Coordinator) dispatchPipelineStage(
 		// leaf scan ran on ONE worker reading all scan files serially —
 		// at SF10 that was the dominant cost on Q01 (87s of 87s wall
 		// time was the single-worker lineitem scan).
-		if len(stage.FusedAggSpecs) > 0 {
+		// FusedAggGroupBy alone (no aggregate functions) is a bare
+		// GROUP BY — grouping IS the work, so it must route through the
+		// scan-aggregate path too. Falling through to a plain scan here
+		// skipped the partial dedup AND the fused hash-partition
+		// exchange, so the downstream final_aggregate's N tasks each
+		// read overlapping raw-row file slices and re-emitted every
+		// group per task (#166: 3 groups × 3 tasks = 9 rows).
+		if len(stage.FusedAggSpecs) > 0 || len(stage.FusedAggGroupBy) > 0 {
 			return c.dispatchScanAggregateStage(ctx, queryID, stage, workerCount)
 		}
 		// Plain scan with no fused aggregate. When the planner pushed

--- a/internal/planner/logical/distinct_rewrite.go
+++ b/internal/planner/logical/distinct_rewrite.go
@@ -1,0 +1,108 @@
+package logical
+
+import (
+	"regexp"
+
+	plansql "github.com/citc-tech/wadjet/internal/planner/sql"
+)
+
+// rewriteDistinctAsGroupBy rewrites a top-level SELECT DISTINCT into an
+// aggregate-free GROUP BY over the projection's expressions:
+//
+//	Distinct → Project[e1 [AS a1], …] → child
+//	⇒ Project[e1 [AS a1], …] → Aggregate{GroupBy: [e1, …]} → child
+//
+// This is the tree BuildFromSelect produces for the equivalent
+// `SELECT e1 … GROUP BY e1, …`, so DISTINCT rides the distributed aggregate
+// machinery (fused partial dedup at the scan → hash-partition exchange →
+// sharded final merge over disjoint key ranges) instead of the
+// coordinator-side dedup fallback, which funnels every pre-dedup row to a
+// single node — and which cannot project expression output at the gather.
+//
+// Scope:
+//   - Only the root-path Distinct (ancestors Sort/Limit only) is rewritten.
+//     Semi/anti build-side dedup Distincts sit under joins and keep their
+//     dedicated handling.
+//   - Aggregate projections (SELECT DISTINCT a, SUM(b) …), SELECT DISTINCT *
+//     and subquery expressions fall through to the coordinator dedup
+//     (MergeInfo.HasDistinct).
+func rewriteDistinctAsGroupBy(n *Node) *Node {
+	if n == nil {
+		return n
+	}
+	switch n.Type {
+	case NodeSort, NodeLimit:
+		if len(n.Children) == 1 {
+			n.Children[0] = rewriteDistinctAsGroupBy(n.Children[0])
+		}
+		return n
+	case NodeDistinct:
+		if len(n.Children) != 1 {
+			return n
+		}
+		proj := n.Children[0]
+		if proj.Type != NodeProject || len(proj.Children) != 1 {
+			return n
+		}
+		groupBy := make([]string, 0, len(proj.Projections))
+		groupByExprs := make([]plansql.Node, 0, len(proj.Projections))
+		seen := make(map[string]bool, len(proj.Projections))
+		for _, p := range proj.Projections {
+			key, ast, ok := projectionGroupKey(p)
+			if !ok {
+				return n
+			}
+			if !seen[key] {
+				seen[key] = true
+				groupBy = append(groupBy, key)
+				groupByExprs = append(groupByExprs, ast)
+			}
+		}
+		if len(groupBy) == 0 {
+			return n
+		}
+		agg := NewAggregate(proj.Children[0], groupBy, nil)
+		agg.GroupByExprs = groupByExprs
+		proj.Children = []*Node{agg}
+		// The Distinct may be the plan root, which carries the CTE
+		// definitions the physical planner resolves against.
+		proj.CTEs = n.CTEs
+		return proj
+	}
+	return n
+}
+
+// subqueryRe conservatively detects a subquery inside an expression. False
+// positives only cost the sharded path (the query falls back to coordinator
+// dedup); false negatives would group by an unevaluable expression.
+var subqueryRe = regexp.MustCompile(`(?i)\bselect\b`)
+
+// projectionGroupKey returns the GROUP BY key string and AST for a
+// projection, and whether the projection can serve as a group key.
+func projectionGroupKey(p Projection) (string, plansql.Node, bool) {
+	if p.IsAgg {
+		return "", nil, false
+	}
+	if p.Expr == "" || subqueryRe.MatchString(p.Expr) {
+		return "", nil, false
+	}
+	ast := p.ASTExpr
+	if ast == nil {
+		parsed, err := plansql.ParseExpression(p.Expr)
+		if err != nil {
+			return "", nil, false
+		}
+		ast = parsed
+	}
+	if _, isSub := ast.(*plansql.SubqueryNode); isSub {
+		return "", nil, false
+	}
+	// Bare column references group by the column name; expressions group
+	// by their raw text — the same strings BuildFromSelect records for an
+	// explicit GROUP BY, which the worker-side derived-group-by projection
+	// (buildAggInputProjection) evaluates before the partial aggregate.
+	if ref, ok := ast.(*plansql.ColRef); ok {
+		return ref.String(), ast, true
+	}
+	return p.Expr, ast, true
+}

--- a/internal/planner/logical/distinct_rewrite_test.go
+++ b/internal/planner/logical/distinct_rewrite_test.go
@@ -1,0 +1,137 @@
+package logical
+
+import (
+	"testing"
+
+	plansql "github.com/citc-tech/wadjet/internal/planner/sql"
+)
+
+func buildPlan(t *testing.T, sql string) *Node {
+	t.Helper()
+	parsed, err := plansql.Parse(sql)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	info, err := plansql.ExtractSelect(parsed)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	plan, err := BuildFromSelect(info)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	return plan
+}
+
+func hasNodeType(n *Node, nt NodeType) bool {
+	if n == nil {
+		return false
+	}
+	if n.Type == nt {
+		return true
+	}
+	for _, c := range n.Children {
+		if hasNodeType(c, nt) {
+			return true
+		}
+	}
+	return false
+}
+
+func findFirst(n *Node, nt NodeType) *Node {
+	if n == nil {
+		return nil
+	}
+	if n.Type == nt {
+		return n
+	}
+	for _, c := range n.Children {
+		if f := findFirst(c, nt); f != nil {
+			return f
+		}
+	}
+	return nil
+}
+
+func TestRewriteDistinctAsGroupBy(t *testing.T) {
+	cases := []struct {
+		name      string
+		sql       string
+		rewritten bool
+		groupBy   []string
+	}{
+		{"single column", "SELECT DISTINCT a FROM t", true, []string{"a"}},
+		{"two columns", "SELECT DISTINCT a, b FROM t", true, []string{"a", "b"}},
+		{"aliased column", "SELECT DISTINCT a AS x FROM t", true, []string{"a"}},
+		{"order by", "SELECT DISTINCT a FROM t ORDER BY a", true, []string{"a"}},
+		{"order by limit", "SELECT DISTINCT a FROM t ORDER BY a LIMIT 5", true, []string{"a"}},
+		{"duplicate column deduped", "SELECT DISTINCT a, a FROM t", true, []string{"a"}},
+		{"expression", "SELECT DISTINCT a, b + c FROM t", true, []string{"a", "b + c"}},
+		{"function expression", "SELECT DISTINCT lower(a) AS x FROM t", true, []string{"lower(a)"}},
+		{"star falls back", "SELECT DISTINCT * FROM t", false, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := rewriteDistinctAsGroupBy(buildPlan(t, tc.sql))
+			if hasNodeType(plan, NodeDistinct) == tc.rewritten {
+				t.Fatalf("distinct present=%v, want rewritten=%v\n%s",
+					!tc.rewritten, tc.rewritten, plan.PrettyPrint(0))
+			}
+			if !tc.rewritten {
+				return
+			}
+			agg := findFirst(plan, NodeAggregate)
+			if agg == nil {
+				t.Fatalf("no aggregate node after rewrite\n%s", plan.PrettyPrint(0))
+			}
+			if len(agg.AggExprs) != 0 {
+				t.Fatalf("expected aggregate-free GROUP BY, got %d agg exprs", len(agg.AggExprs))
+			}
+			if len(agg.GroupBy) != len(tc.groupBy) {
+				t.Fatalf("group by = %v, want %v", agg.GroupBy, tc.groupBy)
+			}
+			for i := range tc.groupBy {
+				if agg.GroupBy[i] != tc.groupBy[i] {
+					t.Fatalf("group by = %v, want %v", agg.GroupBy, tc.groupBy)
+				}
+			}
+			// The Project must sit ABOVE the aggregate so output naming
+			// (aliases) resolves against the aggregate's group columns.
+			proj := findFirst(plan, NodeProject)
+			if proj == nil || findFirst(proj, NodeAggregate) == nil {
+				t.Fatalf("project must be an ancestor of the aggregate\n%s", plan.PrettyPrint(0))
+			}
+		})
+	}
+}
+
+// Semi/anti build-side dedup Distincts sit under joins — the rewrite must
+// not touch them (they are not on the root path).
+func TestRewriteDistinctAsGroupBy_LeavesSemiAntiDedupAlone(t *testing.T) {
+	child := NewScan("s", "")
+	proj := NewProject(child, []Projection{{Expr: "k", Column: "k"}})
+	dedup := NewDistinct(proj)
+	join := &Node{Type: NodeJoin, JoinType: "semi", Children: []*Node{NewScan("t", ""), dedup}}
+	root := NewProject(join, []Projection{{Expr: "a", Column: "a"}})
+
+	out := rewriteDistinctAsGroupBy(root)
+	if !hasNodeType(out, NodeDistinct) {
+		t.Fatalf("semi/anti build-side Distinct was rewritten\n%s", out.PrettyPrint(0))
+	}
+}
+
+// The Distinct node can be the plan root and carry CTE definitions; the
+// rewrite must transfer them to the new root.
+func TestRewriteDistinctAsGroupBy_PreservesCTEs(t *testing.T) {
+	plan := buildPlan(t, "WITH c AS (SELECT a FROM t) SELECT DISTINCT a FROM c")
+	if plan.CTEs == nil {
+		t.Skip("builder did not attach CTEs at root for this shape")
+	}
+	out := rewriteDistinctAsGroupBy(plan)
+	if out.CTEs == nil {
+		t.Fatal("CTEs lost in rewrite")
+	}
+	if hasNodeType(out, NodeDistinct) {
+		t.Fatalf("distinct not rewritten\n%s", out.PrettyPrint(0))
+	}
+}

--- a/internal/planner/logical/optimizer.go
+++ b/internal/planner/logical/optimizer.go
@@ -33,6 +33,7 @@ func Optimize(plan *Node, annotators ...func(*Node)) *Node {
 	plan = pushdownPredicates(plan)
 	plan = dedupSemiAntiBuildSide(plan)
 	plan = reorderJoins(plan)
+	plan = rewriteDistinctAsGroupBy(plan)
 	plan = extractPartitionFilters(plan)
 	plan = pruneProjections(plan)
 	computeRequiredColumns(plan)


### PR DESCRIPTION
## Summary

Two changes that together complete the sharded distributed-DISTINCT workstream (follow-up to #163/#165):

1. **`fix(coordinator)` — closes #166.** The gate routing a fused leaf scan into `dispatchScanAggregateStage` required `FusedAggSpecs` non-empty, so a bare `GROUP BY` (group cols, zero aggregate functions) dispatched as a plain scan: no partial dedup, no hash-partition exchange, and the N final tasks read overlapping raw-row slices (3 groups × 3 workers = 9 rows). The planner already emitted the correct sharded shape; only the dispatch gate was wrong.

2. **`perf(planner)` — sharded DISTINCT.** Top-level `SELECT DISTINCT` is rewritten at logical-optimize time into the aggregate-free GROUP BY tree (`Project → Aggregate{GroupBy: select list} → child`), so it rides the now-correct sharded path: partial dedup fused into the scan → hash-partition exchange on the distinct keys → per-partition final tasks → gather concatenates. The coordinator-side dedup funnel (#165's first cut) no longer runs for these shapes (`MergeInfo.HasDistinct` is false post-rewrite).

The rewrite covers bare columns, aliases, and scalar expressions (derived group-bys evaluate worker-side via `buildAggInputProjection`). **It also fixes distributed DISTINCT-over-expression, which was returning every input row even with the #165 fallback** — the gather can't project expressions, so coordinator dedup ran over raw upstream columns. Semi/anti build-side dedup Distincts are untouched (root-path-only rewrite; planner snapshots and Q20 dynamic-filter eligibility unchanged). `SELECT DISTINCT *`, aggregate projections, and subquery expressions still take the coordinator fallback.

## Stage shape (3 workers)

```
SELECT DISTINCT l_returnflag, l_linestatus FROM lineitem
  scan (fused partial dedup, Exchange{keys=[l_returnflag l_linestatus], count=3})
  → final_aggregate (HashPartitioned count=3 → 3 disjoint tasks)
  → exchange-gather (concatenate, no re-dedup)
```

## Validation

- `TestDistributedDistinctDedup` multi-worker e2e extended to 9 shapes: DISTINCT 1/2-col, DISTINCT+ORDER BY, aliased, expression, bare GROUP BY 1/2-col, expression GROUP BY control, COUNT control — all row-correct against ground truth
- New unit tests for the rewrite rule (scope gating, CTE transfer, semi/anti non-interference)
- Full `./internal/...` suite, TPC-H SF0.01 correctness, `wadjet/` public API: green
- `tpch-harness --mode=local`: **PASS** (multi-worker distributed gate)
- No TPC-H query contains a top-level DISTINCT, so SF1/SF100 A/B would show nothing; the win is structural (dedup memory/work now shards across workers instead of funneling to the coordinator)

Internals doc (`docs/internals/native-dag-execution.md`) updated: Known Issues resolved, dedup-placement table rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U7JZMFJ97Qi8E8njxmGZL