### PR TITLE
feat: heuristic query routing — small-query local fast path vs distributed DAG

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ Network-native types (IPv4, IPv6, CIDR, MAC, Port, Protocol) are first-class wit
 ### Distribution
 
 - **Modes**: `standalone` (all-in-one), `coordinator` (plan+dispatch), `worker` (execute)
+- **Small-query fast path**: the coordinator routes queries whose post-pruning catalog scan bytes stay under `--local-fastpath-bytes` (default 64 MiB; 0 disables) onto an in-process single-process pipeline, skipping the DAG's per-stage dispatch + S3 materialization. Both paths consume the identical optimized logical plan; local failures fall back to the DAG. See `docs/internals/native-dag-execution.md` §Small-query local fast path.
 - **Stage-DAG execution**: Distributed queries run as a multi-stage DAG. Every stage's output **materializes to S3** (`queries/<id>/...`) and is read back by the next stage — structurally like Trino's fault-tolerant execution with exchange spooling, not like its streaming mode. `exchange-repartition` stages hash-partition `.wshf` shuffle files; large-build joins (> `shuffleBuildThreshold`) take this path by default.
 - **Broadcast + probe-split**: Builds under `BroadcastBytesThreshold` replicate to all workers; the probe side's files are split across workers, each runs the full join, coordinator merges partial results (re-aggregation, sort, dedup).
 - **NATS JetStream**: Task queues with request/reply result delivery, metadata KV

--- a/cmd/wadjet/main.go
+++ b/cmd/wadjet/main.go
@@ -93,6 +93,7 @@ var (
 	dataPlane             string
 	dataPlaneAddr         string
 	coordDataPlane        string
+	localFastPathBytes    int64
 )
 
 func main() {
@@ -144,6 +145,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&dataPlane, "data-plane", "nats", "Worker↔coord data-plane transport: nats (default) or grpc. See project_split_plane_design_2026-05-20.")
 	rootCmd.PersistentFlags().StringVar(&dataPlaneAddr, "data-plane-addr", ":9091", "Data-plane gRPC listen address (coord/standalone)")
 	rootCmd.PersistentFlags().StringVar(&coordDataPlane, "coord-data-plane", "", "Coord's data-plane host:port (worker only; defaults to coord-host + 9091)")
+	rootCmd.PersistentFlags().Int64Var(&localFastPathBytes, "local-fastpath-bytes", coordinator.DefaultLocalFastPathBytes, "Queries whose post-pruning catalog scan bytes stay under this threshold execute in-process on the coordinator (skipping the distributed stage DAG and its per-stage object-store round trips). 0 = disabled.")
 	rootCmd.PersistentFlags().StringVar(&geoipCityDB, "geoip-city", "", "Path to MaxMind GeoIP City database (GeoLite2-City.mmdb)")
 	rootCmd.PersistentFlags().StringVar(&geoipASNDB, "geoip-asn", "", "Path to MaxMind GeoIP ASN database (GeoLite2-ASN.mmdb)")
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Log level: debug, info, warn, error")
@@ -857,9 +859,10 @@ func runStandalone(ctx context.Context, store objstore.Store, logger *slog.Logge
 
 	// Start coordinator
 	coord := coordinator.New(coordinator.Config{
-		NATSUrl:        embeddedNATS.ClientURL(),
-		ResultBucket:   bucket,
-		DynamicFilters: dynamicFiltersFromEnv(),
+		NATSUrl:            embeddedNATS.ClientURL(),
+		ResultBucket:       bucket,
+		DynamicFilters:     dynamicFiltersFromEnv(),
+		LocalFastPathBytes: localFastPathBytes,
 	}, cat, nc, js, logger)
 
 	// Phase A: same-process data-plane server + client when enabled.
@@ -1143,9 +1146,10 @@ func runCoordinator(ctx context.Context, store objstore.Store, logger *slog.Logg
 	wireUDFPersistence(cat, logger)
 
 	coord := coordinator.New(coordinator.Config{
-		NATSUrl:        embeddedNATS.ClientURL(),
-		ResultBucket:   bucket,
-		DynamicFilters: dynamicFiltersFromEnv(),
+		NATSUrl:            embeddedNATS.ClientURL(),
+		ResultBucket:       bucket,
+		DynamicFilters:     dynamicFiltersFromEnv(),
+		LocalFastPathBytes: localFastPathBytes,
 	}, cat, nc, js, logger)
 
 	// Phase A: start data-plane gRPC server alongside coord when enabled.

--- a/docs/internals/native-dag-execution.md
+++ b/docs/internals/native-dag-execution.md
@@ -26,6 +26,38 @@ There are **two coordinator entry paths** — know which one you're in:
 ⚠️ **These paths handle DISTINCT differently.** The probe-split path dedups via
 `MergeInfo.HasDistinct`; the native-DAG path does **not** (see Known Issues).
 
+## Small-query local fast path (routing ahead of the DAG)
+
+Before planning a DAG, `ExecuteSQL` routes small queries onto a
+**coordinator-local single-process pipeline** (`coordinator/local_fastpath.go`
+`tryLocalFastPath`): when `EstimatePlanScanBytes`
+(`planner/physical/scan_estimate.go` — catalog bytes after partition-filter
+pruning, summed over every scan in the optimized logical plan) stays under
+`Config.LocalFastPathBytes`, the query executes in-process via
+`physical.Planner.Plan` (the `wadjet.DB` engine) and streams columnar batches
+straight into `SQLResult`. No task dispatch, no per-stage object-store
+materialization — the DAG's fixed costs are O(stages) and independent of data
+size, so small queries pay a latency floor the local pipeline doesn't have
+(measured: DAG 2–12× slower at zero store latency, top-N worst; the full
+tiny-scale TPC-H suite runs row-identical through either path).
+
+Facts that matter when touching this:
+- Both paths consume the **identical optimized logical plan** (post
+  RLS-injection, post `logical.Optimize`) — result and policy parity is by
+  construction. Any local plan/execute error falls back to the DAG.
+- Unestimable plans (unknown table = table functions, residual subquery
+  expressions in Raw predicate/projection text) route to the DAG.
+- Concurrency-capped (`localSem`); overflow routes to the DAG, never queues.
+- `Config.LocalFastPathBytes <= 0` = disabled (the zero value, so library
+  and test usage is DAG-pure by default); `wadjet serve` enables it by
+  default via `--local-fastpath-bytes` (64 MiB).
+- The tpch-harness spawns coordinators with `--local-fastpath-bytes=0` so
+  the DAG gate keeps meaning; re-enable via
+  `--serve-args=--local-fastpath-bytes=N` (later flag wins) to run the same
+  suite through the fast path.
+- Differential gate: `coordinator/local_fastpath_test.go` runs every shape
+  through both paths and diffs rows. **It found #169 on its first run.**
+
 ## Planning pipeline (logical → stages)
 
 `PlanDistributed` (`planner/physical/plan.go:1579`):
@@ -81,6 +113,16 @@ requires `len(GroupByCols)>0 || len(Aggregates)>0` and has **no `GroupByAll`**
 - **DISTINCT fallback shapes** (`SELECT DISTINCT *`, DISTINCT with aggregate projections, subquery expressions): not rewritten; `ExecuteSQL` applies `dedupGatherResult` over the projected gather output (`MergeInfo.HasDistinct`). Correct but single-node at the coordinator.
 
 ## Known Issues
+
+### scan→gather never computes SELECT-list expressions (#169)
+
+A bare expression SELECT over a scan (`SELECT lower(x) AS m FROM t WHERE …`)
+returns raw scan columns distributed — no compute stage exists and the
+gather's `applyOutputRenames` can rename/drop but not evaluate. Expression
+SELECTs above aggregates/joins are unaffected (the compute fragment
+projects). The local fast path computes this shape correctly, so only
+over-threshold bare-expression scans hit it. Found by the fast-path
+differential test.
 
 ### DISTINCT over a non-decorrelatable scalar-subquery projection (fallback, distributed)
 

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -55,6 +55,14 @@ type Config struct {
 	// a scratch-write failure fails the query (cleanly — the coordinator
 	// process never OOMs for one query's result size).
 	GatherResultBudget int64
+	// LocalFastPathBytes routes queries whose total post-pruning catalog
+	// scan bytes stay under this threshold onto the coordinator-local
+	// single-process pipeline, skipping task dispatch and per-stage
+	// object-store materialization. <=0 = disabled (every query runs the
+	// distributed DAG — the zero value keeps library/test semantics
+	// unchanged). `wadjet serve` enables it by default via its flag
+	// (DefaultLocalFastPathBytes).
+	LocalFastPathBytes int64
 }
 
 // gatherResultBudget resolves Config.GatherResultBudget: explicit value,
@@ -112,6 +120,8 @@ type Coordinator struct {
 	resultSubs map[string]context.CancelFunc          // queryID -> cancel
 	queryMetas map[string]*queryMeta                  // queryID -> metadata for result retrieval
 	querySem   chan struct{}                           // limits concurrent inflight queries
+	localSem   chan struct{}                           // limits concurrent local fast-path executions
+	localHits  atomic.Int64                            // queries served by the local fast path
 
 	// Alert scheduler fields (see alerts.go for lifecycle methods).
 	alertScheduler       *alerts.Scheduler
@@ -151,6 +161,7 @@ func New(cfg Config, cat *catalog.Catalog, nc *nats.Conn, js jetstream.JetStream
 		resultSubs: make(map[string]context.CancelFunc),
 		queryMetas: make(map[string]*queryMeta),
 		querySem:   make(chan struct{}, maxInflight),
+		localSem:   make(chan struct{}, defaultLocalFastPathConcurrency),
 	}
 	// Memory-aware gRPC placement: the scheduler bin-packs estimated task
 	// footprints against heartbeat pool stats. No-op on the NATS path.
@@ -600,6 +611,18 @@ func (c *Coordinator) ExecuteSQL(ctx context.Context, sql string) (*SQLResult, e
 	scanAnnotator(logicalPlan)
 	logicalPlan = logical.Optimize(logicalPlan, scanAnnotator)
 	planStr := logicalPlan.PrettyPrint(0)
+
+	// Small-query fast path: when the plan's total post-pruning scan bytes
+	// stay under the routing threshold, execute in-process on the
+	// coordinator instead of dispatching a stage DAG. The DAG's fixed
+	// costs (task dispatch, object-store materialization per stage
+	// boundary) dominate small queries; the local pipeline answers in
+	// milliseconds. Both paths consume the identical optimized logical
+	// plan, so results and policy enforcement match by construction. Any
+	// local failure falls through to the DAG.
+	if res, handled := c.tryLocalFastPath(ctx, queryID, logicalPlan, planStr, start); handled {
+		return res, nil
+	}
 
 	planner := physical.NewPlanner(c.catalog)
 	planner.WorkerCount = c.workers.Count()

--- a/internal/coordinator/local_fastpath.go
+++ b/internal/coordinator/local_fastpath.go
@@ -1,0 +1,125 @@
+package coordinator
+
+import (
+	"context"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/engine/exec"
+	"github.com/citc-tech/wadjet/internal/planner/logical"
+	"github.com/citc-tech/wadjet/internal/planner/physical"
+)
+
+// DefaultLocalFastPathBytes is the default routing threshold: a query whose
+// total post-pruning catalog scan bytes stay under this executes in-process
+// on the coordinator instead of as a distributed stage DAG. The DAG's fixed
+// costs (task dispatch + object-store materialization per stage boundary)
+// are independent of data size, so small queries pay a latency floor the
+// local pipeline doesn't have.
+const DefaultLocalFastPathBytes = 64 << 20
+
+// defaultLocalFastPathConcurrency bounds simultaneous local executions so a
+// burst of interactive queries cannot monopolize coordinator CPU/memory.
+// Overflow routes to the DAG — degraded latency, never a queue.
+const defaultLocalFastPathConcurrency = 4
+
+// localFastPathBytes resolves Config.LocalFastPathBytes: <=0 = disabled.
+func (c *Coordinator) localFastPathBytes() int64 {
+	if v := c.config.LocalFastPathBytes; v > 0 {
+		return v
+	}
+	return 0
+}
+
+// LocalFastPathHits reports how many queries executed on the local fast
+// path. Exposed for tests and observability.
+func (c *Coordinator) LocalFastPathHits() int64 {
+	return c.localHits.Load()
+}
+
+// tryLocalFastPath routes a small query onto the coordinator-local
+// single-process pipeline. Returns (result, true) when the query was
+// executed locally; (nil, false) when the caller should proceed with the
+// distributed DAG — because the fast path is disabled, the concurrency cap
+// is saturated, the plan's input size is unestimable or over threshold, or
+// local planning/execution failed (any local error falls back to the DAG,
+// which is the reliability path).
+//
+// The logical plan passed here is the final optimized plan — identical to
+// what PlanDistributed would consume — so both paths see the same RLS row
+// filters and rewrites, and answer identically by construction.
+func (c *Coordinator) tryLocalFastPath(ctx context.Context, queryID string, logicalPlan *logical.Node, planStr string, start time.Time) (*SQLResult, bool) {
+	threshold := c.localFastPathBytes()
+	if threshold <= 0 {
+		return nil, false
+	}
+	select {
+	case c.localSem <- struct{}{}:
+		defer func() { <-c.localSem }()
+	default:
+		c.logger.Debug("local fast path saturated, routing to DAG", "query", queryID)
+		return nil, false
+	}
+
+	planner := physical.NewPlanner(c.catalog)
+	estBytes, ok := planner.EstimatePlanScanBytes(ctx, logicalPlan)
+	if !ok || estBytes > threshold {
+		return nil, false
+	}
+
+	// Pipeline breakers spill past the budget; the budget only bounds
+	// resident operator state, so a misestimate degrades to disk instead
+	// of coordinator OOM.
+	planner.MemoryBudget = 8 * threshold
+	physPlan, err := planner.Plan(ctx, logicalPlan)
+	if err != nil {
+		c.logger.Warn("local fast path plan failed, routing to DAG",
+			"query", queryID, "error", err)
+		return nil, false
+	}
+	if physPlan.Cleanup != nil {
+		defer physPlan.Cleanup()
+	}
+	pipeline := physPlan.Pipeline
+	sink, ok := pipeline.Sink.(*exec.CollectSink)
+	if !ok {
+		pipeline.Close()
+		c.logger.Warn("local fast path: unexpected sink type, routing to DAG",
+			"query", queryID)
+		return nil, false
+	}
+	// Keep the result columnar: Finalize would otherwise box every row into
+	// map[string]any and release the batches. The collected batches are
+	// self-contained (Consume Detach()es them and BytesColumn owns its
+	// arena), so they safely outlive pipeline.Close and stream to the wire
+	// one batch at a time like the gather path's result.
+	sink.SkipFinalizeToRows = true
+	if err := pipeline.Run(ctx); err != nil {
+		pipeline.Close()
+		c.logger.Warn("local fast path execution failed, routing to DAG",
+			"query", queryID, "error", err)
+		return nil, false
+	}
+	defer pipeline.Close()
+	batches := sink.Batches()
+	var totalRows int64
+	for _, b := range batches {
+		totalRows += int64(b.ActiveLen())
+	}
+	columns := make([]string, 0, len(sink.Schema()))
+	for _, col := range sink.Schema() {
+		columns = append(columns, col.Name)
+	}
+
+	c.localHits.Add(1)
+	c.logger.Info("query executed on local fast path",
+		"query", queryID, "est_scan_bytes", estBytes,
+		"rows", totalRows, "elapsed", time.Since(start))
+	return &SQLResult{
+		QueryID:   queryID,
+		Columns:   columns,
+		Batches:   batches,
+		TotalRows: totalRows,
+		Elapsed:   time.Since(start),
+		Plan:      planStr,
+	}, true
+}

--- a/internal/coordinator/local_fastpath_test.go
+++ b/internal/coordinator/local_fastpath_test.go
@@ -1,0 +1,235 @@
+package coordinator
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/benchmarks/tpch"
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/storage/catalog"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+	"github.com/citc-tech/wadjet/internal/worker"
+)
+
+// TestLocalFastPathDifferential is the correctness gate for the small-query
+// fast path: every query runs through BOTH a fast-path-enabled coordinator
+// (executes in-process) and a DAG-only coordinator (distributed stage DAG)
+// against the same catalog and data, and the results must match. The two
+// paths consume the identical optimized logical plan, so any divergence is
+// a routing or execution bug.
+func TestLocalFastPathDifferential(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	t.Cleanup(cancel)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	natsCfg := distributed.DefaultNATSConfig()
+	natsCfg.Port = -1
+	natsCfg.StoreDir = t.TempDir()
+	embeddedNATS, err := distributed.NewEmbeddedNATS(natsCfg, logger)
+	if err != nil {
+		t.Fatalf("nats: %v", err)
+	}
+	t.Cleanup(embeddedNATS.Shutdown)
+	nc, err := distributed.ConnectInProcess(embeddedNATS.Server())
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { nc.Close() })
+	js, err := distributed.NewJetStream(nc)
+	if err != nil {
+		t.Fatalf("js: %v", err)
+	}
+	if err := distributed.SetupStreams(ctx, js); err != nil {
+		t.Fatalf("streams: %v", err)
+	}
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(ctx, "test"); err != nil {
+		t.Fatal(err)
+	}
+	kv, err := catalog.NewNATSKV(js)
+	if err != nil {
+		t.Fatalf("kv: %v", err)
+	}
+	cat := catalog.New(kv, store, "test")
+	if err := cat.Init(ctx); err != nil {
+		t.Fatalf("cat init: %v", err)
+	}
+
+	data := tpch.Generate(tpch.SF001)
+	schema := tpch.AllTables["lineitem"]
+	rows := data["lineitem"]
+	if err := cat.CreateTable(ctx, "lineitem", schema, nil); err != nil {
+		t.Fatal(err)
+	}
+	const chunks = 3
+	per := (len(rows) + chunks - 1) / chunks
+	for c := 0; c < chunks; c++ {
+		lo, hi := c*per, c*per+per
+		if hi > len(rows) {
+			hi = len(rows)
+		}
+		if lo >= hi {
+			break
+		}
+		var buf bytes.Buffer
+		pw, _ := parquet.NewWriter(&buf, schema, parquet.DefaultWriterConfig())
+		if err := pw.WriteRows(rows[lo:hi]); err != nil {
+			t.Fatal(err)
+		}
+		pw.Close()
+		fp := fmt.Sprintf("tables/lineitem/chunk_%04d.parquet", c)
+		pd := buf.Bytes()
+		store.Put(ctx, "test", fp, bytes.NewReader(pd), int64(len(pd)), "application/octet-stream")
+		cat.AddFiles(ctx, "lineitem", map[string]string{}, "tables/lineitem/", []catalog.FileEntry{{
+			Path: fp, SizeBytes: int64(len(pd)), NumRows: int64(hi - lo), CreatedAt: time.Now(),
+		}})
+	}
+
+	for i := 0; i < 3; i++ {
+		w := worker.New(worker.Config{NATSUrl: embeddedNATS.ClientURL(), MaxConcurrent: 4, CacheBytes: 64 << 20}, store, nc, js, logger)
+		wctx, wcancel := context.WithCancel(context.Background())
+		t.Cleanup(wcancel)
+		if err := w.Start(wctx); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(w.Stop)
+	}
+
+	fast := New(Config{NATSUrl: embeddedNATS.ClientURL(), ResultBucket: "test",
+		LocalFastPathBytes: DefaultLocalFastPathBytes}, cat, nc, js, logger)
+	dag := New(Config{NATSUrl: embeddedNATS.ClientURL(), ResultBucket: "test"}, cat, nc, js, logger)
+	tiny := New(Config{NATSUrl: embeddedNATS.ClientURL(), ResultBucket: "test",
+		LocalFastPathBytes: 1}, cat, nc, js, logger)
+	for _, c := range []*Coordinator{fast, dag, tiny} {
+		for i := 0; i < 3; i++ {
+			c.workers.record(distributed.WorkerHeartbeat{WorkerID: fmt.Sprintf("fake-%d", i), Timestamp: time.Now()})
+		}
+	}
+
+	queries := []struct {
+		sql     string
+		cols    []string
+		ordered bool
+	}{
+		{"SELECT l_orderkey, l_extendedprice FROM lineitem WHERE l_orderkey = 1",
+			[]string{"l_orderkey", "l_extendedprice"}, false},
+		{"SELECT COUNT(*) AS c FROM lineitem WHERE l_quantity > 45",
+			[]string{"c"}, false},
+		{"SELECT l_returnflag, COUNT(*) AS c, SUM(l_extendedprice) AS s FROM lineitem GROUP BY l_returnflag",
+			[]string{"l_returnflag", "c", "s"}, false},
+		{"SELECT l_orderkey, l_extendedprice FROM lineitem ORDER BY l_extendedprice DESC LIMIT 10",
+			[]string{"l_orderkey", "l_extendedprice"}, true},
+		{"SELECT DISTINCT l_returnflag, l_linestatus FROM lineitem",
+			[]string{"l_returnflag", "l_linestatus"}, false},
+		// Expression above a GROUP BY: the aggregate fragment computes the
+		// derived columns, so both paths project. (A bare expression SELECT
+		// over a scan is NOT here — the DAG path has a pre-existing bug
+		// where scan→gather never computes SELECT-list expressions; the
+		// ground-truth check at the end of this test covers that shape.)
+		{"SELECT lower(l_shipmode) AS m, COUNT(*) AS c FROM lineitem GROUP BY lower(l_shipmode)",
+			[]string{"m", "c"}, false},
+		{"SELECT a.l_orderkey, a.l_linenumber, b.l_extendedprice FROM lineitem a JOIN lineitem b ON a.l_orderkey = b.l_orderkey WHERE a.l_orderkey < 50",
+			[]string{"a.l_orderkey", "a.l_linenumber", "b.l_extendedprice"}, false},
+	}
+
+	// canon renders each row as the requested output columns, positionally.
+	// Lookup tries the qualified name first, then the unqualified suffix —
+	// the two paths qualify join output columns differently, and the DAG
+	// gather can carry extra upstream columns; value parity on the
+	// requested columns is the correctness contract here (column-set/name
+	// parity is tracked as a separate polish issue).
+	canon := func(rows []map[string]any, cols []string, ordered bool) []string {
+		out := make([]string, len(rows))
+		for i, r := range rows {
+			var sb strings.Builder
+			for _, col := range cols {
+				v, ok := r[col]
+				if !ok {
+					if dot := strings.LastIndexByte(col, '.'); dot >= 0 {
+						v = r[col[dot+1:]]
+					}
+				}
+				fmt.Fprintf(&sb, "%v|", v)
+			}
+			out[i] = sb.String()
+		}
+		if !ordered {
+			sort.Strings(out)
+		}
+		return out
+	}
+
+	for i, q := range queries {
+		fastRes, err := fast.ExecuteSQL(ctx, q.sql)
+		if err != nil || fastRes.Error != "" {
+			t.Fatalf("fast %s: %v %s", q.sql, err, fastRes.Error)
+		}
+		if got := fast.LocalFastPathHits(); got != int64(i+1) {
+			t.Fatalf("%s: expected fast path hit %d, counter=%d (routed to DAG?)", q.sql, i+1, got)
+		}
+		dagRes, err := dag.ExecuteSQL(ctx, q.sql)
+		if err != nil || dagRes.Error != "" {
+			t.Fatalf("dag %s: %v %s", q.sql, err, dagRes.Error)
+		}
+		fr, dr := canon(mustRows(t, fastRes), q.cols, q.ordered), canon(mustRows(t, dagRes), q.cols, q.ordered)
+		if len(fr) != len(dr) {
+			t.Errorf("%s: row count fast=%d dag=%d", q.sql, len(fr), len(dr))
+			continue
+		}
+		for j := range fr {
+			if fr[j] != dr[j] {
+				t.Errorf("%s: row %d differs\n fast: %s\n dag:  %s", q.sql, j, fr[j], dr[j])
+				break
+			}
+		}
+	}
+	if dag.LocalFastPathHits() != 0 {
+		t.Errorf("DAG-only coordinator took the fast path %d times", dag.LocalFastPathHits())
+	}
+
+	// A threshold smaller than the table forces the DAG even with the fast
+	// path enabled.
+	res, err := tiny.ExecuteSQL(ctx, "SELECT COUNT(*) AS c FROM lineitem")
+	if err != nil || res.Error != "" {
+		t.Fatalf("tiny threshold: %v %s", err, res.Error)
+	}
+	if tiny.LocalFastPathHits() != 0 {
+		t.Errorf("over-threshold query took the fast path")
+	}
+
+	// Bare expression SELECT over a scan, checked against ground truth
+	// computed from the source rows. This shape is differential-excluded:
+	// the DAG's scan→gather path never computes SELECT-list expressions
+	// (pre-existing bug, same family as the #163 gather-projection gap) —
+	// the fast path is the one that gets it right.
+	fastRes, err := fast.ExecuteSQL(ctx, "SELECT lower(l_shipmode) AS m, l_quantity * 2 AS q2 FROM lineitem WHERE l_orderkey < 10")
+	if err != nil || fastRes.Error != "" {
+		t.Fatalf("expression fast: %v %s", err, fastRes.Error)
+	}
+	var want []string
+	for _, r := range rows {
+		if r["l_orderkey"].(int32) < 10 {
+			want = append(want, fmt.Sprintf("%v|%v|",
+				strings.ToLower(r["l_shipmode"].(string)),
+				r["l_quantity"].(float64)*2))
+		}
+	}
+	sort.Strings(want)
+	got := canon(mustRows(t, fastRes), []string{"m", "q2"}, false)
+	if len(got) != len(want) {
+		t.Fatalf("expression: got %d rows, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expression row %d: got %s want %s", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/coordinator/local_fastpath_test.go
+++ b/internal/coordinator/local_fastpath_test.go
@@ -145,7 +145,11 @@ func TestLocalFastPathDifferential(t *testing.T) {
 	// the two paths qualify join output columns differently, and the DAG
 	// gather can carry extra upstream columns; value parity on the
 	// requested columns is the correctness contract here (column-set/name
-	// parity is tracked as a separate polish issue).
+	// parity is tracked as a separate polish issue). Floats render at 12
+	// significant digits: the single-process pipeline sums sequentially
+	// while the DAG merges partial sums, so float aggregates legitimately
+	// drift by a few ULP between the paths (same non-associativity as the
+	// Q15 CTE float drift).
 	canon := func(rows []map[string]any, cols []string, ordered bool) []string {
 		out := make([]string, len(rows))
 		for i, r := range rows {
@@ -157,7 +161,14 @@ func TestLocalFastPathDifferential(t *testing.T) {
 						v = r[col[dot+1:]]
 					}
 				}
-				fmt.Fprintf(&sb, "%v|", v)
+				switch f := v.(type) {
+				case float64:
+					fmt.Fprintf(&sb, "%.12g|", f)
+				case float32:
+					fmt.Fprintf(&sb, "%.6g|", f)
+				default:
+					fmt.Fprintf(&sb, "%v|", v)
+				}
 			}
 			out[i] = sb.String()
 		}
@@ -217,7 +228,7 @@ func TestLocalFastPathDifferential(t *testing.T) {
 	var want []string
 	for _, r := range rows {
 		if r["l_orderkey"].(int32) < 10 {
-			want = append(want, fmt.Sprintf("%v|%v|",
+			want = append(want, fmt.Sprintf("%v|%.12g|",
 				strings.ToLower(r["l_shipmode"].(string)),
 				r["l_quantity"].(float64)*2))
 		}

--- a/internal/harness/cluster.go
+++ b/internal/harness/cluster.go
@@ -162,6 +162,12 @@ func (c *Cluster) StartCoordinator(ctx context.Context) error {
 		"--grpc-addr=:" + strconv.Itoa(c.grpcPort),
 		"--spill-dir=" + filepath.Join(c.cfg.RunDir, "spill", "coord"),
 		"--nats-store-dir=" + filepath.Join(c.cfg.RunDir, "nats"),
+		// The harness exists to catch DISTRIBUTED regressions; its data is
+		// small enough that the coordinator-local fast path would route
+		// every query in-process and silently stop exercising the DAG.
+		// Disable it. Callers can re-enable via ExtraServeArgs (later
+		// flags win) to run the same suite through the fast path.
+		"--local-fastpath-bytes=0",
 	}
 	if c.cfg.DataPlane == "grpc" {
 		c.dataPlanePort = freePort()

--- a/internal/planner/physical/scan_estimate.go
+++ b/internal/planner/physical/scan_estimate.go
@@ -1,0 +1,61 @@
+package physical
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/citc-tech/wadjet/internal/planner/logical"
+)
+
+// planSubqueryRe conservatively detects a residual (non-decorrelated)
+// subquery inside a node's raw expressions. Estimation cannot see inside
+// such subqueries, so a match makes the plan unestimable. False positives
+// only cost the local fast path (the query runs distributed).
+var planSubqueryRe = regexp.MustCompile(`(?i)\bselect\b`)
+
+// EstimatePlanScanBytes walks a logical plan and sums the catalog bytes
+// (compressed parquet, after partition-filter pruning) of every scan.
+// Returns ok=false when the plan's input size cannot be resolved from the
+// catalog — unknown table (table functions, virtual sources) or a residual
+// subquery expression whose scans are not visible in the tree. Callers use
+// this to route small queries onto the coordinator-local fast path; the
+// only safe failure mode is over-estimation, so every unknown is "too big".
+func (p *Planner) EstimatePlanScanBytes(ctx context.Context, n *logical.Node) (int64, bool) {
+	if n == nil {
+		return 0, true
+	}
+	var total int64
+	if n.Type == logical.NodeScan {
+		meta, err := p.catalog.GetManifest(ctx, n.TableName)
+		if err != nil {
+			return 0, false
+		}
+		for _, part := range meta.Partitions {
+			if len(n.PartitionFilter) > 0 && len(part.Values) > 0 &&
+				!matchesPartitionFilter(part.Values, n.PartitionFilter) {
+				continue
+			}
+			for _, f := range part.Files {
+				total += f.SizeBytes
+			}
+		}
+	}
+	for _, pred := range n.Predicates {
+		if pred.Raw != "" && planSubqueryRe.MatchString(pred.Raw) {
+			return 0, false
+		}
+	}
+	for _, proj := range n.Projections {
+		if proj.Expr != "" && planSubqueryRe.MatchString(proj.Expr) {
+			return 0, false
+		}
+	}
+	for _, child := range n.Children {
+		b, ok := p.EstimatePlanScanBytes(ctx, child)
+		if !ok {
+			return 0, false
+		}
+		total += b
+	}
+	return total, true
+}

--- a/internal/planner/physical/scan_estimate_test.go
+++ b/internal/planner/physical/scan_estimate_test.go
@@ -1,0 +1,73 @@
+package physical
+
+import (
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/planner/logical"
+	plansql "github.com/citc-tech/wadjet/internal/planner/sql"
+)
+
+// setupTPCHCatalog registers every file as 10 MiB (plan_tpch_test.go), so
+// expected estimates are fileCount × 10 MiB.
+func TestEstimatePlanScanBytes(t *testing.T) {
+	cat, ctx := setupTPCHCatalog(t)
+	const mb10 = 10 * 1024 * 1024
+
+	buildOptimized := func(sql string) *logical.Node {
+		t.Helper()
+		parsed, err := plansql.Parse(sql)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		info, err := plansql.ExtractSelect(parsed)
+		if err != nil {
+			t.Fatalf("extract: %v", err)
+		}
+		plan, err := logical.BuildFromSelect(info)
+		if err != nil {
+			t.Fatalf("build: %v", err)
+		}
+		annotate := func(p *logical.Node) { NewPlanner(cat).AnnotateScanColumns(ctx, p) }
+		annotate(plan)
+		return logical.Optimize(plan, annotate)
+	}
+
+	cases := []struct {
+		name  string
+		sql   string
+		bytes int64
+		ok    bool
+	}{
+		{"single small table", "SELECT n_name FROM nation", 1 * mb10, true},
+		{"large table", "SELECT l_orderkey FROM lineitem WHERE l_orderkey = 1", 600 * mb10, true},
+		{"join sums all scans", "SELECT n_name, r_name FROM nation JOIN region ON n_regionkey = r_regionkey", 2 * mb10, true},
+		{"aggregate", "SELECT COUNT(*) AS c FROM supplier", 1 * mb10, true},
+		{"no table", "SELECT 1 AS x", 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := buildOptimized(tc.sql)
+			got, ok := NewPlanner(cat).EstimatePlanScanBytes(ctx, plan)
+			if ok != tc.ok {
+				t.Fatalf("ok=%v want %v", ok, tc.ok)
+			}
+			if got != tc.bytes {
+				t.Fatalf("bytes=%d want %d", got, tc.bytes)
+			}
+		})
+	}
+
+	// Unknown table (table functions, virtual sources) is unestimable.
+	unknown := &logical.Node{Type: logical.NodeScan, TableName: "no_such_table"}
+	if _, ok := NewPlanner(cat).EstimatePlanScanBytes(ctx, unknown); ok {
+		t.Fatal("unknown table should be unestimable")
+	}
+
+	// A residual subquery expression hides scans from the walk.
+	sub := &logical.Node{Type: logical.NodeFilter,
+		Predicates: []logical.Predicate{{Raw: "l_quantity > (SELECT avg(l_quantity) FROM lineitem)"}},
+		Children:   []*logical.Node{{Type: logical.NodeScan, TableName: "nation"}}}
+	if _, ok := NewPlanner(cat).EstimatePlanScanBytes(ctx, sub); ok {
+		t.Fatal("residual subquery predicate should be unestimable")
+	}
+}


### PR DESCRIPTION
## Summary

Implements complexity-weighted query routing: `ExecuteSQL` now estimates a query's total post-partition-pruning catalog scan bytes (`physical.EstimatePlanScanBytes`) and, under a threshold, executes it **in-process on the coordinator** via the single-process pipeline (the `wadjet.DB` engine) — no task dispatch, no per-stage object-store materialization. Everything else takes the distributed stage DAG exactly as before.

## Why

The DAG's fixed costs are O(stages) and independent of data size — a latency floor no data-side optimization can reach. Measured on identical data (in-memory store, in-process NATS — the DAG's best case):

| query shape | DAG | local | ratio |
|---|---|---|---|
| point select | 6.1 ms | 2.8 ms | 2.2× |
| small group-by | 11.5 ms | 5.5 ms | 2.1× |
| top-N (sort→merge stages) | 71.3 ms | 5.8 ms | 12.3× |

With 10 ms simulated S3 RTT per store op, the routed fast path answers in ~24 ms across shapes where the DAG takes 38–99 ms; real S3 widens this further. Harness tiny-scale TPC-H: q18 223 ms → 26 ms, q20 303 ms → 12 ms. This is the dominant lever for interactive/dashboard workloads (many small per-tenant queries) and also isolates them from big scans' task queues.

## Design

- **Router** (`coordinator/local_fastpath.go`): branch point is *after* the final optimized logical plan (post RLS injection) — both paths consume the identical plan, so results and policy enforcement match by construction.
- **Estimator** (`planner/physical/scan_estimate.go`): sums catalog file bytes per scan after partition-filter pruning (same resolution walkStages uses). Unknown tables (table functions) and residual subquery expressions are unestimable → DAG.
- **Fallback-on-anything**: local plan error, execution error, unexpected sink, concurrency-cap saturation → DAG. The DAG remains the reliability path.
- **Memory**: local pipeline runs with a budget (8× threshold); pipeline breakers spill as everywhere else.
- **Config**: `Config.LocalFastPathBytes` zero value = **disabled** (library/tests keep DAG-pure semantics); `wadjet serve --local-fastpath-bytes` defaults to 64 MiB, `0` disables.
- **Harness**: spawned coordinators get `--local-fastpath-bytes=0` so the distributed gate keeps meaning; `--serve-args=--local-fastpath-bytes=N` re-enables (later flag wins).

## Differential testing — and a bug it found immediately

`TestLocalFastPathDifferential` runs every query shape through a fast-path coordinator AND a DAG-only coordinator on the same catalog/data and diffs rows (filter, agg, group-by, order-by+limit, DISTINCT, expression-over-group-by, self-join). On its **first run** it exposed a pre-existing distributed bug: **scan→gather never computes bare SELECT-list expressions** (filed as #169 — `SELECT lower(x) AS m FROM t WHERE …` returns raw scan columns distributed). The fast path computes that shape correctly; it's covered by a ground-truth check until #169 is fixed, then it should be promoted into the differential set.

## Validation

- Differential e2e (7 shapes × both paths, multi-worker embedded-NATS cluster) + threshold gating + expression ground truth
- Estimator unit tests (single/join/aggregate/dual/unknown-table/subquery)
- Full `./internal/...`, TPC-H SF0.01, `wadjet/` suites: green
- `tpch-harness --mode=local`: **PASS both ways** — DAG gate (fast path disabled) and the full suite forced through the fast path (row-identical to golden)

Follow-ups (documented in `docs/internals/native-dag-execution.md`): v2 adaptive bail-out (cancel over-budget local queries and re-dispatch as DAG), selectivity-aware estimates from CBO stats, column-name parity polish between paths, #169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U7JZMFJ97Qi8E8njxmGZL