### PR TITLE
fix: compute SELECT-list expressions in the scan fragment (#169)

### DIFF
--- a/docs/internals/native-dag-execution.md
+++ b/docs/internals/native-dag-execution.md
@@ -114,16 +114,6 @@ requires `len(GroupByCols)>0 || len(Aggregates)>0` and has **no `GroupByAll`**
 
 ## Known Issues
 
-### scan→gather never computes SELECT-list expressions (#169)
-
-A bare expression SELECT over a scan (`SELECT lower(x) AS m FROM t WHERE …`)
-returns raw scan columns distributed — no compute stage exists and the
-gather's `applyOutputRenames` can rename/drop but not evaluate. Expression
-SELECTs above aggregates/joins are unaffected (the compute fragment
-projects). The local fast path computes this shape correctly, so only
-over-threshold bare-expression scans hit it. Found by the fast-path
-differential test.
-
 ### DISTINCT over a non-decorrelatable scalar-subquery projection (fallback, distributed)
 
 The coordinator-dedup fallback dedups the *gather output*, and the gather
@@ -133,6 +123,15 @@ whose subquery survives decorrelation dedups over raw upstream columns
 sharded rewrite, so this is a narrow residual shape.
 
 ### History
+
+**Fixed 2026-07 (#169):** a bare expression SELECT over a scan returned raw
+scan columns distributed — no compute stage existed and the gather can only
+rename/drop. Now `attachScanSelectProjections` (plan.go) sets
+`Stage.ProjectExprs` on a leaf scan feeding the gather directly, the scan
+dispatches through the fragment path, and an `OpProject` op computes the
+SELECT list worker-side (plan-time type inference via `inferProjectionType`
+rides along — the output column doesn't exist in the input schema, so the
+worker can't resolve its type). Found by the fast-path differential test.
 
 **Fixed 2026-07:** distributed `SELECT DISTINCT` and aggregate-free `GROUP BY`
 returned every input row (no cross-task dedup) — #163 (first-cut coordinator

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -1102,7 +1102,13 @@ func (c *Coordinator) dispatchPipelineStage(
 		// many results. Dispatch a filter-scan task that reads the
 		// parquet files, applies FilterExprs, and writes a WSHF output
 		// the rest of the native-DAG pipeline can consume.
-		if len(stage.FilterExprs) > 0 {
+		//
+		// ProjectExprs likewise forces the fragment path (#169): the
+		// SELECT list carries expressions that must be COMPUTED before
+		// the gather — raw-parquet passthrough would hand the gather
+		// un-projected scan columns, and applyOutputRenames can only
+		// rename/drop.
+		if len(stage.FilterExprs) > 0 || len(stage.ProjectExprs) > 0 {
 			return c.dispatchScanFilterStage(ctx, queryID, stage, inputs, workerCount)
 		}
 		// No filter: by default pass raw parquet files through (saves the
@@ -1603,6 +1609,16 @@ func (c *Coordinator) dispatchScanFilterStage(
 			t.Operators = append(t.Operators, distributed.OpSpec{
 				Type:       distributed.OpFilter,
 				Predicates: append([]string(nil), stage.FilterExprs...),
+			})
+		}
+		if len(stage.ProjectExprs) > 0 {
+			projections := make([]distributed.ProjectSpec, len(stage.ProjectExprs))
+			for i, p := range stage.ProjectExprs {
+				projections[i] = distributed.ProjectSpec{Expr: p.Expr, Name: p.Name, Type: int(p.Type)}
+			}
+			t.Operators = append(t.Operators, distributed.OpSpec{
+				Type:        distributed.OpProject,
+				Projections: projections,
 			})
 		}
 		if fuseShuffle {

--- a/internal/coordinator/local_fastpath_test.go
+++ b/internal/coordinator/local_fastpath_test.go
@@ -130,12 +130,18 @@ func TestLocalFastPathDifferential(t *testing.T) {
 		{"SELECT DISTINCT l_returnflag, l_linestatus FROM lineitem",
 			[]string{"l_returnflag", "l_linestatus"}, false},
 		// Expression above a GROUP BY: the aggregate fragment computes the
-		// derived columns, so both paths project. (A bare expression SELECT
-		// over a scan is NOT here — the DAG path has a pre-existing bug
-		// where scan→gather never computes SELECT-list expressions; the
-		// ground-truth check at the end of this test covers that shape.)
+		// derived columns, so both paths project.
 		{"SELECT lower(l_shipmode) AS m, COUNT(*) AS c FROM lineitem GROUP BY lower(l_shipmode)",
 			[]string{"m", "c"}, false},
+		// Bare expression SELECT over a scan — #169's shape: the scan
+		// fragment computes the SELECT list (Stage.ProjectExprs → OpProject).
+		// Also checked against ground truth at the end of this test.
+		{"SELECT lower(l_shipmode) AS m, l_quantity * 2 AS q2 FROM lineitem WHERE l_orderkey < 10",
+			[]string{"m", "q2"}, false},
+		// Same shape without a WHERE: forces the raw-parquet-passthrough
+		// scan into the fragment path purely for the projection.
+		{"SELECT upper(l_returnflag) AS r FROM lineitem",
+			[]string{"r"}, false},
 		{"SELECT a.l_orderkey, a.l_linenumber, b.l_extendedprice FROM lineitem a JOIN lineitem b ON a.l_orderkey = b.l_orderkey WHERE a.l_orderkey < 50",
 			[]string{"a.l_orderkey", "a.l_linenumber", "b.l_extendedprice"}, false},
 	}
@@ -217,10 +223,8 @@ func TestLocalFastPathDifferential(t *testing.T) {
 	}
 
 	// Bare expression SELECT over a scan, checked against ground truth
-	// computed from the source rows. This shape is differential-excluded:
-	// the DAG's scan→gather path never computes SELECT-list expressions
-	// (pre-existing bug, same family as the #163 gather-projection gap) —
-	// the fast path is the one that gets it right.
+	// computed from the source rows (both paths compute it since the #169
+	// fix; this pins the actual values, not just path agreement).
 	fastRes, err := fast.ExecuteSQL(ctx, "SELECT lower(l_shipmode) AS m, l_quantity * 2 AS q2 FROM lineitem WHERE l_orderkey < 10")
 	if err != nil || fastRes.Error != "" {
 		t.Fatalf("expression fast: %v %s", err, fastRes.Error)

--- a/internal/distributed/messages.go
+++ b/internal/distributed/messages.go
@@ -251,6 +251,8 @@ const (
 	OpExchangeSender    OpType = "exchange_sender"    // partitionedShuffleSink: hash-partition into N output files
 	OpUnpartitionedSink OpType = "unpartitioned_sink" // unpartitionedStageSink: single .wshf output
 	OpGatherSink        OpType = "gather_sink"        // gatherReplySink: stream batches to ReplySubject
+
+	OpProject OpType = "project" // compute SELECT-list expressions (exec.Project); output = exactly Projections
 )
 
 // OpSpec describes one operator within a fragment pipeline. Fields are
@@ -270,6 +272,9 @@ type OpSpec struct {
 
 	// OpFilter.
 	Predicates []string `json:"predicates,omitempty"`
+
+	// OpProject.
+	Projections []ProjectSpec `json:"projections,omitempty"`
 
 	// OpHashJoinProbe / OpBroadcastProbe.
 	JoinType            string   `json:"join_type,omitempty"`  // inner, left, semi, anti, …
@@ -329,6 +334,18 @@ type PreComputedAggregate struct {
 	GroupByCols []string  `json:"group_by_cols"`
 	AggSpecs    []AggSpec `json:"agg_specs"`
 	CacheFiles  []string  `json:"cache_files"`
+}
+
+// ProjectSpec is one output column of an OpProject: Name is the emitted
+// column, Expr the SQL expression the worker compiles (bare column
+// references become passthrough copies). Type is the plan-time inferred
+// parquet.TypeID for computed expressions (0 = resolve from the source
+// column) — the worker can't infer it from the input schema because the
+// output column doesn't exist there.
+type ProjectSpec struct {
+	Expr string `json:"expr"`
+	Name string `json:"name"`
+	Type int    `json:"type,omitempty"`
 }
 
 // AggSpec defines an aggregation in a task.

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -152,6 +152,17 @@ type Stage struct {
 	// ("supp_nation", "l_year"). Only populated on the Gather stage.
 	OutputRenames []OutputRename
 
+	// ProjectExprs, set on a leaf scan stage whose output feeds the gather
+	// directly, makes the scan fragment compute the SELECT list (worker-side
+	// exec.Project after scan+filter). Without it a bare expression SELECT
+	// over a scan reaches the gather as raw scan columns — the gather's
+	// applyOutputRenames can rename/drop but not evaluate (#169). Expression
+	// entries are named by the lowercased expression text, matching the
+	// convention extractOutputRenames already expects for worker-computed
+	// expressions; bare columns are passthrough entries so the fragment
+	// output is exactly the SELECT-list inputs.
+	ProjectExprs []ProjectExprSpec
+
 	// Dynamic filter (Trino-style semi-join pushdown) annotations.
 	// EmitDynamicFilters is set on a build-side leaf scan stage; each task
 	// computes a partial KeyRange+Bloom and uploads as a sideband artifact.
@@ -189,6 +200,18 @@ type OutputRename struct {
 	From string
 	To   string
 	Expr plansql.Node
+}
+
+// ProjectExprSpec is one SELECT-list item a scan fragment must emit: Name is
+// the output column, Expr the SQL text the worker compiles and evaluates
+// (bare column references become passthrough copies). Type is the plan-time
+// inferred output type for computed expressions (inferProjectionType) — the
+// worker cannot resolve it from the input schema because the output column
+// doesn't exist there; zero means "resolve from source column" (bare refs).
+type ProjectExprSpec struct {
+	Expr string
+	Name string
+	Type parquet.TypeID
 }
 
 // WindowColSpec defines a window function column in a stage.
@@ -1690,7 +1713,77 @@ func (p *Planner) PlanDistributed(ctx context.Context, node *logical.Node) ([]St
 			}
 		}
 	}
+	// #169: when the SELECT list carries scalar expressions and the gather
+	// reads a bare leaf scan, the expressions would never be computed —
+	// applyOutputRenames can rename/drop but not evaluate. Attach the
+	// SELECT list to the scan so its fragment projects it worker-side.
+	attachScanSelectProjections(node, stages)
 	return stages, nil
+}
+
+// attachScanSelectProjections sets ProjectExprs on a leaf scan stage when
+// (a) the terminal gather's sole dependency is that scan (nothing computes
+// between scan and gather) and (b) the outermost SELECT list contains at
+// least one scalar expression (non-column, non-aggregate, not a wrapped
+// synthetic aggregate). Expression outputs are named by their lowercased
+// text — exactly the source name extractOutputRenames maps to the user's
+// alias — and bare columns become passthrough entries so the fragment emits
+// the full SELECT-list input set.
+func attachScanSelectProjections(root *logical.Node, stages []Stage) {
+	proj := findOutputProjectionsForRename(root)
+	if len(proj) == 0 {
+		return
+	}
+	hasExpr := false
+	specs := make([]ProjectExprSpec, 0, len(proj))
+	for _, p := range proj {
+		if p.IsAgg {
+			return // aggregates compute in their own fragments
+		}
+		expr := p.Expr
+		if expr == "" {
+			expr = p.Column
+		}
+		if expr == "" {
+			return
+		}
+		name := strings.ToLower(expr)
+		var typ parquet.TypeID
+		if p.ASTExpr != nil && !isSimpleColRefForRename(p.ASTExpr) {
+			if referencesSyntheticAgg(p.ASTExpr) {
+				return // wrapped aggregate — evaluated at the gather
+			}
+			hasExpr = true
+			typ = inferProjectionType(p.ASTExpr, parquet.TypeString)
+		}
+		specs = append(specs, ProjectExprSpec{Expr: expr, Name: name, Type: typ})
+	}
+	if !hasExpr {
+		return
+	}
+	var gather *Stage
+	for i := range stages {
+		if stages[i].Type == StageExchangeGather {
+			gather = &stages[i]
+			break
+		}
+	}
+	if gather == nil || len(gather.Dependencies) != 1 {
+		return
+	}
+	for i := range stages {
+		s := &stages[i]
+		if s.ID != gather.Dependencies[0] {
+			continue
+		}
+		// Plain leaf scans only: fused scan-aggregates project via their
+		// aggregate machinery, and non-scan stages mean something else
+		// computes between scan and gather.
+		if s.Type == StageScan && len(s.FusedAggGroupBy) == 0 && len(s.FusedAggSpecs) == 0 {
+			s.ProjectExprs = specs
+		}
+		return
+	}
 }
 
 // extractOutputRenames inspects the logical plan tree's outermost projection

--- a/internal/worker/executor_fragment.go
+++ b/internal/worker/executor_fragment.go
@@ -962,6 +962,13 @@ func (e *Executor) buildFragmentUnary(ctx context.Context, task distributed.Task
 	case distributed.OpHashJoinProbe, distributed.OpBroadcastProbe:
 		return e.buildFragmentJoinProbe(ctx, task, spec)
 
+	case distributed.OpProject:
+		proj, err := buildSelectProjection(spec.Projections)
+		if err != nil {
+			return nil, nil, err
+		}
+		return []exec.UnaryOperator{proj}, nil, nil
+
 	default:
 		return nil, nil, fmt.Errorf("unsupported unary op %q", spec.Type)
 	}
@@ -1217,4 +1224,3 @@ func (s *fragmentGatherSink) finalize(ctx context.Context, _ distributed.Task, _
 }
 
 func (s *fragmentGatherSink) close() {}
-

--- a/internal/worker/filter_compile.go
+++ b/internal/worker/filter_compile.go
@@ -274,3 +274,52 @@ func collectFilterColumns(n plansql.Node, out map[string]struct{}) {
 		}
 	}
 }
+
+// buildSelectProjection compiles an OpProject spec into an exec.Project.
+// Bare column references become passthrough copies (DirectCopy with a
+// ColumnRef fallback); everything else compiles through the expression
+// engine and evaluates per row. Output columns appear in spec order and are
+// exactly the fragment's output schema — anything not listed is dropped,
+// which is the point: the fragment emits the SELECT list, not the scan's
+// input columns (#169).
+func buildSelectProjection(specs []distributed.ProjectSpec) (*exec.Project, error) {
+	if len(specs) == 0 {
+		return nil, fmt.Errorf("project: at least one projection required")
+	}
+	projCols := make([]exec.ProjectColumn, 0, len(specs))
+	for _, p := range specs {
+		node, err := plansql.ParseExpression(p.Expr)
+		if err != nil {
+			return nil, fmt.Errorf("parse projection %q: %w", p.Expr, err)
+		}
+		if ref, ok := node.(*plansql.ColRef); ok {
+			src := ref.String()
+			projCols = append(projCols, exec.ProjectColumn{
+				Name:       p.Name,
+				DirectCopy: src,
+				SourceCol:  src,
+				Expr:       exec.ColumnRef(src),
+			})
+			continue
+		}
+		compiled, err := expr.Compile(node)
+		if err != nil {
+			return nil, fmt.Errorf("compile projection %q: %w", p.Expr, err)
+		}
+		typ := parquet.TypeID(p.Type)
+		if p.Type == 0 {
+			typ = parquet.TypeString
+		}
+		e := compiled
+		projCols = append(projCols, exec.ProjectColumn{
+			Name: p.Name,
+			// Plan-time inferred type: the output column doesn't exist in
+			// the input schema, so exec.Project cannot resolve it there.
+			Type: typ,
+			Expr: func(b *batch.RecordBatch, row int) any {
+				return e.Eval(b, row)
+			},
+		})
+	}
+	return exec.NewProject(projCols), nil
+}


### PR DESCRIPTION
## Summary

Fixes #169: a bare expression SELECT over a scan (`SELECT lower(x) AS m FROM t WHERE …`) returned **raw scan columns** in distributed mode — the plan is `scan → gather` with no compute stage, and the gather's `applyOutputRenames` can rename/drop but not evaluate. Found by the fast-path differential test in #170.

## Fix (worker-side — compute where the data is)

- **Planner**: `attachScanSelectProjections` sets `Stage.ProjectExprs` on a leaf scan whose output feeds the gather directly when the SELECT list carries scalar expressions. Expression outputs are named by lowercased expression text (the exact source name `extractOutputRenames` already maps to the user's alias), with plan-time output types from `inferProjectionType` — the worker can't resolve them because the output column doesn't exist in the input schema.
- **Wire + worker**: new `OpProject` fragment operator; `buildSelectProjection` compiles the SELECT list into an `exec.Project` (bare column refs become passthrough copies).
- **Dispatcher**: projection-carrying scans route through the scan-filter fragment path (previously raw-parquet passthrough) with the `OpProject` appended after the filter.

Scope: only fires when the gather's sole dependency is a plain leaf scan; aggregate/wrapped-aggregate SELECT lists return early (their fragments already project), fused scan-aggregates untouched.

## Validation

- Both bare-expression shapes (with and without a pushed WHERE) promoted into the fast-path **differential set** — DAG and local paths now row-identical — plus a ground-truth check pinning actual values
- Full `./internal/...`, TPC-H SF0.01 correctness, `tpch-harness --mode=local`: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U7JZMFJ97Qi8E8njxmGZL