### PR TITLE
feat: adaptive bail-out for the local fast path

### DIFF
--- a/docs/internals/native-dag-execution.md
+++ b/docs/internals/native-dag-execution.md
@@ -48,6 +48,12 @@ Facts that matter when touching this:
 - Unestimable plans (unknown table = table functions, residual subquery
   expressions in Raw predicate/projection text) route to the DAG.
 - Concurrency-capped (`localSem`); overflow routes to the DAG, never queues.
+- **Adaptive bail-out:** scan input is bounded by the estimate but join
+  output is not — the collect sink carries a result budget (8× the routing
+  threshold; `CollectSink.MaxBytes` → `exec.ErrCollectBudget`), and an
+  over-budget local run aborts and re-dispatches as a DAG query (reads are
+  idempotent; the DAG gather spills oversized results to scratch). This
+  makes the threshold a latency knob, not a correctness-of-judgment knob.
 - `Config.LocalFastPathBytes <= 0` = disabled (the zero value, so library
   and test usage is DAG-pure by default); `wadjet serve` enables it by
   default via `--local-fastpath-bytes` (64 MiB).

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -122,6 +122,10 @@ type Coordinator struct {
 	querySem   chan struct{}                           // limits concurrent inflight queries
 	localSem   chan struct{}                           // limits concurrent local fast-path executions
 	localHits  atomic.Int64                            // queries served by the local fast path
+	localBails atomic.Int64                            // local runs aborted over result budget, re-dispatched as DAG
+	// localResultBudgetOverride replaces localResultBudget's derivation in
+	// tests (0 = derive from the routing threshold).
+	localResultBudgetOverride int64
 
 	// Alert scheduler fields (see alerts.go for lifecycle methods).
 	alertScheduler       *alerts.Scheduler

--- a/internal/coordinator/local_fastpath.go
+++ b/internal/coordinator/local_fastpath.go
@@ -2,6 +2,7 @@ package coordinator
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/citc-tech/wadjet/internal/engine/exec"
@@ -34,6 +35,26 @@ func (c *Coordinator) localFastPathBytes() int64 {
 // path. Exposed for tests and observability.
 func (c *Coordinator) LocalFastPathHits() int64 {
 	return c.localHits.Load()
+}
+
+// LocalFastPathBails reports how many local executions bailed out over the
+// result budget and re-dispatched as DAG queries.
+func (c *Coordinator) LocalFastPathBails() int64 {
+	return c.localBails.Load()
+}
+
+// localResultBudget bounds the materialized result of a local fast-path
+// execution. Scan input is bounded by the routing threshold, but join
+// output is not — a misrouted blow-up (e.g. a many-to-many self join) would
+// otherwise grow coordinator heap without limit. Past the budget the local
+// run aborts and the query re-dispatches as a DAG, whose gather spills
+// oversized results to scratch. 8× the routing threshold: proportional to
+// what routing declared "small", far above any well-routed result.
+func (c *Coordinator) localResultBudget(threshold int64) int64 {
+	if c.localResultBudgetOverride > 0 {
+		return c.localResultBudgetOverride
+	}
+	return 8 * threshold
 }
 
 // tryLocalFastPath routes a small query onto the coordinator-local
@@ -93,10 +114,21 @@ func (c *Coordinator) tryLocalFastPath(ctx context.Context, queryID string, logi
 	// arena), so they safely outlive pipeline.Close and stream to the wire
 	// one batch at a time like the gather path's result.
 	sink.SkipFinalizeToRows = true
+	// Adaptive bail-out: the scan input is bounded by the estimate, the
+	// RESULT is not (join blow-up). Past the budget the run aborts here
+	// and the caller re-dispatches as a DAG query — reads are idempotent,
+	// and the DAG gather spills oversized results to scratch.
+	sink.MaxBytes = c.localResultBudget(threshold)
 	if err := pipeline.Run(ctx); err != nil {
 		pipeline.Close()
-		c.logger.Warn("local fast path execution failed, routing to DAG",
-			"query", queryID, "error", err)
+		if errors.Is(err, exec.ErrCollectBudget) {
+			c.localBails.Add(1)
+			c.logger.Info("local fast path result over budget, re-dispatching as DAG",
+				"query", queryID, "budget_bytes", sink.MaxBytes)
+		} else {
+			c.logger.Warn("local fast path execution failed, routing to DAG",
+				"query", queryID, "error", err)
+		}
 		return nil, false
 	}
 	defer pipeline.Close()

--- a/internal/coordinator/local_fastpath_test.go
+++ b/internal/coordinator/local_fastpath_test.go
@@ -247,4 +247,39 @@ func TestLocalFastPathDifferential(t *testing.T) {
 			t.Fatalf("expression row %d: got %s want %s", i, got[i], want[i])
 		}
 	}
+
+	// Adaptive bail-out: a routed query whose RESULT blows past the local
+	// budget must abort mid-run and re-dispatch as a DAG query, still
+	// returning the complete correct result. The 1-byte override trips on
+	// the first collected batch.
+	bail := New(Config{NATSUrl: embeddedNATS.ClientURL(), ResultBucket: "test",
+		LocalFastPathBytes: DefaultLocalFastPathBytes}, cat, nc, js, logger)
+	bail.localResultBudgetOverride = 1
+	for i := 0; i < 3; i++ {
+		bail.workers.record(distributed.WorkerHeartbeat{WorkerID: fmt.Sprintf("fake-%d", i), Timestamp: time.Now()})
+	}
+	bailRes, err := bail.ExecuteSQL(ctx, "SELECT l_orderkey, l_extendedprice FROM lineitem WHERE l_orderkey < 100")
+	if err != nil || bailRes.Error != "" {
+		t.Fatalf("bail-out query: %v %s", err, bailRes.Error)
+	}
+	if bail.LocalFastPathBails() != 1 {
+		t.Errorf("expected 1 bail-out, got %d", bail.LocalFastPathBails())
+	}
+	if bail.LocalFastPathHits() != 0 {
+		t.Errorf("bailed query still counted as a fast-path hit")
+	}
+	dagRef, err := dag.ExecuteSQL(ctx, "SELECT l_orderkey, l_extendedprice FROM lineitem WHERE l_orderkey < 100")
+	if err != nil || dagRef.Error != "" {
+		t.Fatalf("bail-out reference: %v %s", err, dagRef.Error)
+	}
+	br := canon(mustRows(t, bailRes), []string{"l_orderkey", "l_extendedprice"}, false)
+	dr := canon(mustRows(t, dagRef), []string{"l_orderkey", "l_extendedprice"}, false)
+	if len(br) != len(dr) {
+		t.Fatalf("bail-out: got %d rows, want %d", len(br), len(dr))
+	}
+	for i := range br {
+		if br[i] != dr[i] {
+			t.Fatalf("bail-out row %d: got %s want %s", i, br[i], dr[i])
+		}
+	}
 }

--- a/internal/engine/exec/collect_sink_test.go
+++ b/internal/engine/exec/collect_sink_test.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/citc-tech/wadjet/internal/engine/batch"
@@ -84,5 +85,35 @@ func TestCollectSink_SkipFinalizeToRows(t *testing.T) {
 	}
 	if got := sink.Batches(); len(got) != 1 {
 		t.Fatalf("Batches() = %d, want 1", len(got))
+	}
+}
+
+// MaxBytes bounds the collected result: Consume must return
+// ErrCollectBudget once accumulated batch bytes exceed it, so callers with
+// a cheaper home for oversized results (the coordinator's local fast path
+// re-dispatches to the DAG) can bail out instead of growing the heap.
+func TestCollectSink_MaxBytes(t *testing.T) {
+	schema := []parquet.Column{{Name: "n", Type: parquet.TypeInt64}}
+	mk := func() *batch.RecordBatch {
+		return batch.FromRows(schema, []map[string]any{{"n": int64(1)}, {"n": int64(2)}})
+	}
+	sink := &CollectSink{MaxBytes: 1}
+	ctx := context.Background()
+	if err := sink.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	err := sink.Consume(ctx, mk())
+	if !errors.Is(err, ErrCollectBudget) {
+		t.Fatalf("expected ErrCollectBudget, got %v", err)
+	}
+
+	unbounded := &CollectSink{}
+	if err := unbounded.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 100; i++ {
+		if err := unbounded.Consume(ctx, mk()); err != nil {
+			t.Fatalf("unbounded sink errored: %v", err)
+		}
 	}
 }

--- a/internal/engine/exec/pipeline.go
+++ b/internal/engine/exec/pipeline.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -495,6 +496,11 @@ func (s *SliceSource) Next(_ context.Context) (*batch.RecordBatch, error) {
 
 func (s *SliceSource) Close() error { return nil }
 
+// ErrCollectBudget is returned by CollectSink.Consume when the accumulated
+// result exceeds CollectSink.MaxBytes. Callers match with errors.Is to
+// distinguish "result too big for this execution path" from real failures.
+var ErrCollectBudget = errors.New("collect sink result budget exceeded")
+
 // CollectSink collects all consumed batches. Data is stored columnar internally.
 // Rows are converted lazily on first access to ToRows(), not during Finalize.
 // Use Batches() for zero-copy columnar access.
@@ -550,10 +556,17 @@ func (s *BatchSink) Batches() []*batch.RecordBatch {
 }
 
 type CollectSink struct {
-	Rows     []map[string]any     // populated lazily on first access
-	batches  []*batch.RecordBatch // columnar storage; released by ToRows
-	schema   []parquet.Column     // captured from the first batch; survives ToRows
-	rowsDone bool
+	Rows       []map[string]any     // populated lazily on first access
+	batches    []*batch.RecordBatch // columnar storage; released by ToRows
+	schema     []parquet.Column     // captured from the first batch; survives ToRows
+	rowsDone   bool
+	accumBytes int64 // running MemBytes of collected batches
+	// MaxBytes, when >0, bounds the collected result: Consume returns
+	// ErrCollectBudget once accumulated batch bytes exceed it. Callers that
+	// have a cheaper place to put oversized results (the coordinator's
+	// local fast path re-dispatches to the DAG, whose gather spills to
+	// scratch) set this to bail out instead of growing the heap unboundedly.
+	MaxBytes int64
 	mu       sync.Mutex
 	// SkipFinalizeToRows, when true, makes Finalize a no-op instead of
 	// eagerly materializing ToRows. Callers that consume Batches() directly
@@ -588,7 +601,12 @@ func (s *CollectSink) Consume(_ context.Context, b *batch.RecordBatch) error {
 		b.Sel = selCopy
 	}
 	s.batches = append(s.batches, b)
+	s.accumBytes += b.MemBytes()
+	over := s.MaxBytes > 0 && s.accumBytes > s.MaxBytes
 	s.mu.Unlock()
+	if over {
+		return fmt.Errorf("collect sink at %d bytes: %w", s.accumBytes, ErrCollectBudget)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Completes the fast-path routing design (#170 follow-up): a misrouted query can no longer hurt the coordinator. Routing bounds a query's **scan input** via the catalog estimate, but nothing bounded its **result** — a many-to-many join under the byte threshold could blow up the collect sink's heap.

- `exec.CollectSink` gains `MaxBytes`: `Consume` returns `exec.ErrCollectBudget` once accumulated batch bytes exceed it (0 = unbounded, all existing users unchanged).
- The fast path sets it to 8× the routing threshold. On breach, the local run aborts and the query **re-dispatches as a DAG query** through the existing fallback — reads are idempotent, and the DAG gather spills oversized results to scratch.

Result: the routing threshold is a pure latency knob. A wrong routing decision costs one aborted local attempt, never memory or correctness.

## Validation

- e2e (`TestLocalFastPathDifferential`): a routed query with a 1-byte budget override aborts mid-run, re-dispatches, and returns the complete result identical to a DAG-only coordinator; `LocalFastPathBails`/`Hits` counters assert the path taken.
- Unit test for `CollectSink.MaxBytes` (budget trips, unbounded default unaffected).
- Full `./internal/...` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U7JZMFJ97Qi8E8njxmGZL