### PR TITLE
feat: streaming exchange Phase B — async upload with deferred durability

### DIFF
--- a/docs/design/streaming-exchange.md
+++ b/docs/design/streaming-exchange.md
@@ -1,7 +1,6 @@
 # Streaming Exchange — Design Memo
 
-> **Status:** Phase A implemented (this branch); Phase B (async upload)
-> not started. **Date:** 2026-07-02.
+> **Status:** Phases A and B implemented. **Date:** 2026-07-02.
 > **Verified against:** main @ 9402cbc (post-#173). All `file:line` anchors
 > checked against that commit; they drift — confirm before relying on them.
 >
@@ -14,6 +13,24 @@
 > stage boundaries (previously never matched in distributed mode), and
 > worker-side `CleanupQuery` (broadcast with the root ID, which never
 > matched stage-scoped cache entries — a spill-dir leak until process exit).
+>
+> **Implementation notes (Phase B):** `Task.AsyncUpload` is set only for
+> native-DAG task types (stage/shuffle) — pipeline/gather outputs feed
+> coordinator-side reads. The one coordinator-side stage-output read
+> (scalar-subquery extraction) got its own durability-aware bounded wait
+> (`fetchStageOutputData`); the small-payload NATS KV tier is written
+> synchronously from local bytes, so it stays hot with no S3 dependency.
+> Consumers re-poll S3 (bounded, 15 s) for any missing streaming-query key
+> — triggered by hint OR token, covering producers reaped before the
+> consumer dispatched — then fail with a structural `MissingInputKey`. The
+> retrier consults `classifyFatalResult` before retrying (dead producer +
+> non-durable key skips straight to terminal, tagged `inputLostMarker`);
+> `ExecuteSQL` re-executes once with the query pinned into the
+> streaming-disabled set via a ctx flag that caps depth at one. Known
+> residual: a query that is terminal before its uploads finish cancels
+> them (the S3-PUT saving), and one in-flight PUT per worker can land
+> after the coordinator's scratch purge — reclaimed by the periodic
+> `CleanStale` GC.
 
 ## 1. Goal
 

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -178,6 +178,15 @@ type Coordinator struct {
 	// unless Config.StreamingExchange). Fed by noteTaskResult; drained by
 	// the scheduler's task annotator and cleanupQuery.
 	peerFiles *peerFileRegistry
+	// uploadCompleteSub feeds peerFiles durability bits (Phase B).
+	uploadCompleteSub *nats.Subscription
+	// streamingDisabled holds root query IDs running the one-shot
+	// ErrInputLost re-execution (pure S3 semantics: no hints, no async).
+	streamingDisabled sync.Map
+	// streamingReruns counts ErrInputLost re-executions (observability —
+	// a non-zero rate is the signal to revisit single-level producer
+	// re-run per the design memo).
+	streamingReruns atomic.Int64
 }
 
 // New creates a new Coordinator.
@@ -209,10 +218,30 @@ func New(cfg Config, cat *catalog.Catalog, nc *nats.Conn, js jetstream.JetStream
 
 	// Streaming exchange (Phase A): annotate every dispatched task — initial
 	// and retried alike, since retries re-enter PublishTasks — with peer
-	// location hints and the query's fetch token.
+	// location hints and the query's fetch token. Phase B: track upload
+	// durability from worker UploadComplete notifications.
 	if cfg.StreamingExchange {
 		c.peerFiles = newPeerFileRegistry()
 		c.scheduler.SetTaskAnnotator(c.annotateTaskPeerLocations)
+		if nc != nil {
+			sub, subErr := nc.Subscribe(distributed.SubjectUploadComplete, func(msg *nats.Msg) {
+				var uc distributed.UploadComplete
+				if err := distributed.Unmarshal(msg.Data, &uc); err != nil {
+					return
+				}
+				if uc.Failed {
+					c.logger.Warn("worker abandoned background uploads; keys stay non-durable",
+						"root", uc.RootQueryID, "task_id", uc.TaskID, "worker", uc.WorkerID, "keys", len(uc.Keys))
+					return
+				}
+				c.peerFiles.MarkDurable(uc.Keys)
+			})
+			if subErr != nil {
+				logger.Warn("upload-complete subscription failed; durability bits stay conservative", "error", subErr)
+			} else {
+				c.uploadCompleteSub = sub
+			}
+		}
 	}
 
 	// NATS KV result cache: coordinator writes inline results here instead of S3.
@@ -701,10 +730,31 @@ func (c *Coordinator) ExecuteSQL(ctx context.Context, sql string) (*SQLResult, e
 		return nil, fmt.Errorf("physical plan: %w", err)
 	}
 
+	// Streaming-disabled re-execution (Phase B): a ctx flagged by the
+	// ErrInputLost rerun below pins this query ID into the disabled set so
+	// the task annotator emits no hints/tokens and no AsyncUpload — pure
+	// synchronous-S3 semantics for the whole run.
+	if streamingExchangeDisabled(ctx) {
+		c.streamingDisabled.Store(queryID, struct{}{})
+		defer c.streamingDisabled.Delete(queryID)
+	}
+
 	c.logger.Info("routing to native DAG executor",
 		"query", queryID, "stages", len(physStages))
 	gr, gerr := c.executeStageDAG(ctx, queryID, sql, physStages, c.workers.Count())
 	if gerr != nil {
+		// ErrInputLost: a producer died before its background upload landed
+		// and its output is unrecoverable by task retry. Reads are
+		// idempotent and nothing has reached the client (ExecuteSQL returns
+		// once), so re-execute the whole query ONCE with streaming exchange
+		// disabled — the fast-path bail-out pattern one level up. The ctx
+		// flag caps the depth at one.
+		if IsInputLostErr(gerr) && c.peerFiles != nil && !streamingExchangeDisabled(ctx) {
+			c.streamingReruns.Add(1)
+			c.logger.Warn("streaming-exchange input lost; re-executing query with streaming disabled",
+				"query", queryID, "error", gerr)
+			return c.ExecuteSQL(withStreamingExchangeDisabled(ctx), sql)
+		}
 		return &SQLResult{
 			QueryID: queryID,
 			Error:   gerr.Error(),

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -994,7 +994,7 @@ func (c *Coordinator) materializeReplicate(
 			c.logger.Error("materialize task retry publish failed",
 				"stage_id", stage.ID, "task_id", t.ID, "error", pubErr)
 		}
-	}, c.logger, stage.ID)
+	}, c.logger, stage.ID, c.classifyFatalResult)
 	defer c.watchStuckTasks(ctx, retrier)()
 	sub, err := c.subscribeTaskResults(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
@@ -1410,7 +1410,7 @@ func (c *Coordinator) dispatchScanAggregateStage(
 			c.logger.Error("scan-agg task retry publish failed",
 				"stage_id", stage.ID, "task_id", t.ID, "error", pubErr)
 		}
-	}, c.logger, stage.ID)
+	}, c.logger, stage.ID, c.classifyFatalResult)
 	defer c.watchStuckTasks(ctx, retrier)()
 	sub, err := c.subscribeTaskResults(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
@@ -1680,7 +1680,7 @@ func (c *Coordinator) dispatchScanFilterStage(
 			c.logger.Error("scan-filter task retry publish failed",
 				"stage_id", stage.ID, "task_id", t.ID, "error", pubErr)
 		}
-	}, c.logger, stage.ID)
+	}, c.logger, stage.ID, c.classifyFatalResult)
 	defer c.watchStuckTasks(ctx, retrier)()
 	sub, err := c.subscribeTaskResults(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
@@ -2146,7 +2146,7 @@ func (c *Coordinator) dispatchComputeStage(
 			c.logger.Error("task retry publish failed",
 				"stage_id", stage.ID, "task_id", t.ID, "error", pubErr)
 		}
-	}, c.logger, stage.ID)
+	}, c.logger, stage.ID, c.classifyFatalResult)
 	defer c.watchStuckTasks(ctx, retrier)()
 	sub, err := c.subscribeTaskResults(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
@@ -2878,7 +2878,7 @@ func (c *Coordinator) runStageTasks(
 			c.logger.Error("task retry publish failed",
 				"stage_id", stageLabel, "task_id", t.ID, "error", pubErr)
 		}
-	}, c.logger, stageLabel)
+	}, c.logger, stageLabel, c.classifyFatalResult)
 	defer c.watchStuckTasks(ctx, retrier)()
 	sub, err := c.subscribeTaskResults(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification

--- a/internal/coordinator/orchestrate_repartition.go
+++ b/internal/coordinator/orchestrate_repartition.go
@@ -244,7 +244,7 @@ func (c *Coordinator) runShuffleSide(
 			c.logger.Error("shuffle task retry publish failed",
 				"side", sideName, "task_id", t.ID, "error", pubErr)
 		}
-	}, c.logger, stageID)
+	}, c.logger, stageID, c.classifyFatalResult)
 	defer c.watchStuckTasks(ctx, retrier)()
 
 	sub, err := c.subscribeTaskResults(subject, func(msg *nats.Msg) {

--- a/internal/coordinator/peer_locations.go
+++ b/internal/coordinator/peer_locations.go
@@ -1,8 +1,10 @@
 package coordinator
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"sync"
 	"time"
 
@@ -40,6 +42,7 @@ type peerFileRegistry struct {
 
 type peerFileGroup struct {
 	keys      []string
+	durable   map[string]bool // key → background upload landed (Phase B); absent = not durable
 	createdAt time.Time
 }
 
@@ -90,6 +93,46 @@ func (r *peerFileRegistry) Lookup(key string) string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.files[key]
+}
+
+// MarkDurable flips the durability bit for keys whose background upload
+// landed (worker UploadComplete). Unknown keys are recorded durable-only —
+// message ordering vs the result notification is not guaranteed.
+func (r *peerFileRegistry) MarkDurable(keys []string) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, k := range keys {
+		qid := QueryIDFromPath(k)
+		if qid == "" {
+			continue
+		}
+		g := r.groups[qid]
+		if g == nil {
+			g = &peerFileGroup{createdAt: time.Now()}
+			r.groups[qid] = g
+		}
+		if g.durable == nil {
+			g.durable = make(map[string]bool)
+		}
+		g.durable[k] = true
+	}
+}
+
+// IsDurable reports whether the key's durable copy is known to exist.
+// Conservative: false for unknown keys and for keys produced by
+// synchronous-upload tasks that never send UploadComplete — callers treat
+// "not durable" as "don't conclude anything", never as "safe to fail".
+func (r *peerFileRegistry) IsDurable(key string) bool {
+	if r == nil {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	g := r.groups[QueryIDFromPath(key)]
+	return g != nil && g.durable[key]
 }
 
 // TokenFor returns the fetch token for a query ID, minting one on first
@@ -152,7 +195,18 @@ func (c *Coordinator) annotateTaskPeerLocations(t *distributed.Task) {
 	if root == "" {
 		return
 	}
+	if c.streamingDisabledFor(root) {
+		return // ErrInputLost re-execution: pure Phase-A-less S3 semantics
+	}
 	t.FetchToken = c.peerFiles.TokenFor(root)
+	// Phase B: native-DAG stage/shuffle outputs are consumed by workers
+	// (peer tier + bounded S3 re-poll), so their uploads can run in the
+	// background. Pipeline/gather tasks stay synchronous — their outputs
+	// feed coordinator-side reads (legacy result retrieval) or stream
+	// directly.
+	if t.Type == distributed.TaskTypeStage || t.Type == distributed.TaskTypeShuffle {
+		t.AsyncUpload = true
+	}
 	var locs map[string]string
 	addAll := func(files []string) {
 		for _, f := range files {
@@ -186,6 +240,85 @@ func (c *Coordinator) annotateTaskPeerLocations(t *distributed.Task) {
 		addAll(t.FusedJoins[i].BuildFiles)
 	}
 	t.InputLocations = locs
+}
+
+// classifyFatalResult is the taskRetrier's fatal hook (nil-safe when
+// streaming exchange is off): a missing-input failure is unrecoverable by
+// task retry exactly when the producing worker is dead AND the key's
+// durable copy never landed (Phase-B async upload died with the worker).
+// Everything else returns false — retries either hit the peer again
+// (transient fetch failure) or S3 once the in-flight upload lands.
+func (c *Coordinator) classifyFatalResult(r distributed.ResultNotification) bool {
+	if r.MissingInputKey == "" || c.peerFiles == nil {
+		return false
+	}
+	if c.peerFiles.IsDurable(r.MissingInputKey) {
+		return false // durable copy exists now; a retry will read it
+	}
+	producer := c.peerFiles.Lookup(r.MissingInputKey)
+	if producer == "" {
+		return false // unknown producer — can't conclude, let retries run
+	}
+	if c.workers.IsAlive(producer) {
+		return false // producer alive: its upload will land or peer serves
+	}
+	c.logger.Error("streaming-exchange input lost: producer dead before upload landed",
+		"key", r.MissingInputKey, "producer", producer, "task_id", r.TaskID)
+	return true
+}
+
+// fetchStageOutputData reads one stage-output object for coordinator-side
+// consumption (scalar-subquery extraction). With streaming exchange off it
+// is a plain fetchResultData. With it on, a miss may just mean the
+// producer's Phase-B background upload hasn't landed — bounded re-poll,
+// with a fast input-lost exit when the producer is dead and the key never
+// went durable (the coordinator has no peer tier; S3 is its only read
+// path).
+func (c *Coordinator) fetchStageOutputData(ctx context.Context, path string) ([]byte, error) {
+	data, err := c.fetchResultData(ctx, "", path)
+	if err == nil || c.peerFiles == nil {
+		return data, err
+	}
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		if !c.peerFiles.IsDurable(path) {
+			if producer := c.peerFiles.Lookup(path); producer != "" && !c.workers.IsAlive(producer) {
+				return nil, fmt.Errorf("%s (%s): producer dead before upload landed", inputLostMarker, path)
+			}
+		}
+		if time.Now().After(deadline) {
+			return nil, err
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+		if data, err = c.fetchResultData(ctx, "", path); err == nil {
+			return data, nil
+		}
+	}
+}
+
+// streamingDisabledFor reports whether the root query runs with streaming
+// exchange disabled (the one-shot ErrInputLost re-execution).
+func (c *Coordinator) streamingDisabledFor(root string) bool {
+	_, disabled := c.streamingDisabled.Load(root)
+	return disabled
+}
+
+// streamingDisabledCtxKey marks a context as belonging to a
+// streaming-disabled re-execution; ExecuteSQL propagates it onto the fresh
+// query ID before dispatch and uses it to cap re-execution depth at one.
+type streamingDisabledCtxKey struct{}
+
+func withStreamingExchangeDisabled(ctx context.Context) context.Context {
+	return context.WithValue(ctx, streamingDisabledCtxKey{}, true)
+}
+
+func streamingExchangeDisabled(ctx context.Context) bool {
+	v, _ := ctx.Value(streamingDisabledCtxKey{}).(bool)
+	return v
 }
 
 // sweepLocked drops groups and tokens past peerRegistryTTL, at most once

--- a/internal/coordinator/peer_locations_test.go
+++ b/internal/coordinator/peer_locations_test.go
@@ -1,0 +1,168 @@
+package coordinator
+
+import (
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+)
+
+func testCoordinatorForPeers(staleTTL time.Duration) *Coordinator {
+	return &Coordinator{
+		config:    Config{StreamingExchange: true},
+		peerFiles: newPeerFileRegistry(),
+		workers: &WorkerRegistry{
+			workers: make(map[string]*WorkerInfo),
+			stale:   staleTTL,
+			logger:  slog.Default(),
+		},
+		logger: slog.Default(),
+	}
+}
+
+func TestClassifyFatalResult(t *testing.T) {
+	const key = "queries/q1/stage-2/partition=0001/t7.wshf"
+	fail := distributed.ResultNotification{TaskID: "t9", MissingInputKey: key}
+
+	t.Run("no missing key", func(t *testing.T) {
+		c := testCoordinatorForPeers(time.Minute)
+		if c.classifyFatalResult(distributed.ResultNotification{TaskID: "t9"}) {
+			t.Fatal("classified fatal without a missing key")
+		}
+	})
+	t.Run("unknown producer", func(t *testing.T) {
+		c := testCoordinatorForPeers(time.Minute)
+		if c.classifyFatalResult(fail) {
+			t.Fatal("classified fatal with unknown producer")
+		}
+	})
+	t.Run("producer alive", func(t *testing.T) {
+		c := testCoordinatorForPeers(time.Minute)
+		c.peerFiles.Record([]string{key}, "w1")
+		c.workers.record(distributed.WorkerHeartbeat{WorkerID: "w1"})
+		if c.classifyFatalResult(fail) {
+			t.Fatal("classified fatal with live producer (upload may still land)")
+		}
+	})
+	t.Run("durable key", func(t *testing.T) {
+		c := testCoordinatorForPeers(time.Millisecond)
+		c.peerFiles.Record([]string{key}, "w1")
+		c.peerFiles.MarkDurable([]string{key})
+		// Producer dead, but the copy landed — retry reads S3.
+		time.Sleep(5 * time.Millisecond)
+		if c.classifyFatalResult(fail) {
+			t.Fatal("classified fatal despite durable copy")
+		}
+	})
+	t.Run("producer dead, not durable = input lost", func(t *testing.T) {
+		c := testCoordinatorForPeers(time.Millisecond)
+		c.peerFiles.Record([]string{key}, "w1")
+		c.workers.record(distributed.WorkerHeartbeat{WorkerID: "w1"})
+		time.Sleep(5 * time.Millisecond) // heartbeat goes stale
+		if !c.classifyFatalResult(fail) {
+			t.Fatal("dead producer + non-durable key must classify as input lost")
+		}
+	})
+}
+
+func TestRetrierFatalSkipsRetries(t *testing.T) {
+	tasks := []distributed.Task{{ID: "t1"}}
+	republished := 0
+	fatal := func(r distributed.ResultNotification) bool { return r.MissingInputKey != "" }
+	tr := newTaskRetrier(tasks, true, func(distributed.Task) { republished++ }, slog.Default(), "s", fatal)
+
+	done := tr.Observe(distributed.ResultNotification{
+		TaskID: "t1", Success: false,
+		Error:           "input queries/q1/s/x.wshf unavailable",
+		MissingInputKey: "queries/q1/s/x.wshf",
+	})
+	if !done {
+		t.Fatal("fatal failure must be terminal immediately")
+	}
+	if republished != 0 {
+		t.Fatalf("fatal failure was republished %d times", republished)
+	}
+	_, errMsg, failed := tr.FirstError()
+	if !failed || !strings.Contains(errMsg, inputLostMarker) {
+		t.Fatalf("terminal error %q missing input-lost marker", errMsg)
+	}
+	if !IsInputLostErr(errors.New("native DAG: stage s: " + errMsg)) {
+		t.Fatal("wrapped error not recognized by IsInputLostErr")
+	}
+}
+
+func TestRetrierExhaustedMissingInputCarriesMarker(t *testing.T) {
+	// Producer ALIVE (fatal=false) but the upload never lands: attempts
+	// exhaust and the terminal error must still carry the marker so
+	// ExecuteSQL reruns streaming-disabled.
+	tasks := []distributed.Task{{ID: "t1"}}
+	tr := newTaskRetrier(tasks, true, func(distributed.Task) {}, slog.Default(), "s",
+		func(distributed.ResultNotification) bool { return false })
+	fail := distributed.ResultNotification{
+		TaskID: "t1", Success: false,
+		Error: "input unavailable", MissingInputKey: "queries/q1/s/x.wshf",
+	}
+	for i := 0; i < maxTaskAttempts; i++ {
+		tr.Observe(fail)
+	}
+	_, errMsg, failed := tr.FirstError()
+	if !failed || !strings.Contains(errMsg, inputLostMarker) {
+		t.Fatalf("exhausted-attempts error %q missing marker", errMsg)
+	}
+}
+
+func TestAnnotatorAsyncUploadAndDisable(t *testing.T) {
+	c := testCoordinatorForPeers(time.Minute)
+	c.peerFiles.Record([]string{"queries/qr/stage-1/a.wshf"}, "w1")
+	c.workers.record(distributed.WorkerHeartbeat{WorkerID: "w1", PeerAddr: "10.0.0.1:9095"})
+
+	stageTask := distributed.Task{
+		ID: "t1", QueryID: "st-join-2-qr", Type: distributed.TaskTypeStage,
+		ResultPrefix: "queries/qr/stage-2/",
+		InputFiles:   []string{"queries/qr/stage-1/a.wshf"},
+	}
+	c.annotateTaskPeerLocations(&stageTask)
+	if !stageTask.AsyncUpload {
+		t.Fatal("stage task not marked AsyncUpload")
+	}
+	if stageTask.FetchToken == "" {
+		t.Fatal("stage task got no fetch token")
+	}
+	if stageTask.InputLocations["queries/qr/stage-1/a.wshf"] != "10.0.0.1:9095" {
+		t.Fatalf("hints = %v", stageTask.InputLocations)
+	}
+
+	pipelineTask := distributed.Task{
+		ID: "t2", QueryID: "qr", Type: distributed.TaskTypePipeline,
+		ResultPrefix: "queries/qr/",
+	}
+	c.annotateTaskPeerLocations(&pipelineTask)
+	if pipelineTask.AsyncUpload {
+		t.Fatal("pipeline task must stay on synchronous upload (coordinator-side reads)")
+	}
+
+	// Streaming-disabled root: no hints, no token, no async — pure S3.
+	c.streamingDisabled.Store("qr", struct{}{})
+	disabledTask := stageTask
+	disabledTask.AsyncUpload = false
+	disabledTask.FetchToken = ""
+	disabledTask.InputLocations = nil
+	c.annotateTaskPeerLocations(&disabledTask)
+	if disabledTask.AsyncUpload || disabledTask.FetchToken != "" || disabledTask.InputLocations != nil {
+		t.Fatalf("disabled query still annotated: async=%v token=%q hints=%v",
+			disabledTask.AsyncUpload, disabledTask.FetchToken, disabledTask.InputLocations)
+	}
+}
+
+func TestStreamingDisabledCtxDepthCap(t *testing.T) {
+	ctx := withStreamingExchangeDisabled(t.Context())
+	if !streamingExchangeDisabled(ctx) {
+		t.Fatal("ctx flag not readable")
+	}
+	if streamingExchangeDisabled(t.Context()) {
+		t.Fatal("flag leaked into a fresh ctx")
+	}
+}

--- a/internal/coordinator/scalar_extract.go
+++ b/internal/coordinator/scalar_extract.go
@@ -38,7 +38,7 @@ func (c *Coordinator) readScalarFromStageOutput(ctx context.Context, out StageOu
 	// files surfaced (e.g. a zero-row shard plus a one-row shard), scan
 	// until we find the first non-empty row.
 	for _, path := range files {
-		data, err := c.fetchResultData(ctx, "", path)
+		data, err := c.fetchStageOutputData(ctx, path)
 		if err != nil {
 			return "", fmt.Errorf("fetch %s: %w", path, err)
 		}

--- a/internal/coordinator/scheduler_binpack_test.go
+++ b/internal/coordinator/scheduler_binpack_test.go
@@ -79,7 +79,7 @@ func TestTaskRetrier_GrowEstimateOnRetry(t *testing.T) {
 	tasks := retryTestTasks(2)
 	tasks[0].EstimatedBytes = 100
 	// tasks[1] stays 0.
-	tr := newTaskRetrier(tasks, true, rep.republish, slog.Default(), "s")
+	tr := newTaskRetrier(tasks, true, rep.republish, slog.Default(), "s", nil)
 
 	if tr.Observe(failResult("a", "boom")) {
 		t.Fatal("terminal too early")
@@ -108,7 +108,7 @@ func TestTaskRetrier_GrowEstimateOnRetry(t *testing.T) {
 // TestTaskRetrier_TotalBytes: worker-reported SizeBytes sums across
 // successful tasks; duplicates don't double-count; failures contribute 0.
 func TestTaskRetrier_TotalBytes(t *testing.T) {
-	tr := newTaskRetrier(retryTestTasks(3), false, nil, slog.Default(), "s")
+	tr := newTaskRetrier(retryTestTasks(3), false, nil, slog.Default(), "s", nil)
 	rA := okResult("a", "f-a")
 	rA.SizeBytes = 100
 	rB := okResult("b", "f-b")

--- a/internal/coordinator/streaming_exchange_test.go
+++ b/internal/coordinator/streaming_exchange_test.go
@@ -176,14 +176,28 @@ func TestStreamingExchangeShuffleCorrectness(t *testing.T) {
 		})
 	}
 
-	var hits, falls int64
+	var hits, falls, uploaded, cancelled, failed int64
 	for _, w := range workers {
 		h, f := w.PeerFetchStats()
 		hits += h
 		falls += f
+		up, ca, fa := w.UploadStats()
+		uploaded += up
+		cancelled += ca
+		failed += fa
 	}
-	t.Logf("peer tier: %d hits, %d fallthroughs", hits, falls)
+	t.Logf("peer tier: %d hits, %d fallthroughs; async uploads: %d landed, %d cancelled, %d failed",
+		hits, falls, uploaded, cancelled, failed)
 	if hits == 0 {
 		t.Error("peer tier never served a read — the accelerator is dead and row parity above is vacuous")
+	}
+	// Phase B: stage/shuffle outputs upload in the background. Zero total
+	// means AsyncUpload never reached the workers — the deferred-durability
+	// path is dead and the row parity above proved only Phase A.
+	if uploaded+cancelled == 0 {
+		t.Error("no background uploads ran — Phase-B async path is dead")
+	}
+	if failed != 0 {
+		t.Errorf("%d background uploads abandoned", failed)
 	}
 }

--- a/internal/coordinator/task_retry.go
+++ b/internal/coordinator/task_retry.go
@@ -3,6 +3,7 @@ package coordinator
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -41,6 +42,26 @@ type taskRetrier struct {
 	republish    func(distributed.Task)
 	logger       *slog.Logger
 	stageID      string
+
+	// fatal, when non-nil, is consulted on every failure BEFORE the retry
+	// decision: returning true marks the task terminally failed without
+	// burning the remaining attempts. Streaming exchange uses it for
+	// missing-input failures whose producer is dead with no durable copy
+	// (ErrInputLost) — a state no re-dispatch can fix.
+	fatal func(distributed.ResultNotification) bool
+}
+
+// inputLostMarker tags terminal failures caused by an unresolvable
+// streaming-exchange input (ResultNotification.MissingInputKey). ExecuteSQL
+// matches it (via IsInputLostErr) to trigger the one-shot re-execution with
+// streaming exchange disabled. A string marker because the retrier's error
+// state crosses dispatcher boundaries as text.
+const inputLostMarker = "streaming-exchange input lost"
+
+// IsInputLostErr reports whether err (anywhere in its message chain) is a
+// streaming-exchange input-lost failure.
+func IsInputLostErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), inputLostMarker)
 }
 
 type taskAttemptState struct {
@@ -54,8 +75,10 @@ type taskAttemptState struct {
 
 // newTaskRetrier registers the dispatched tasks. republish re-dispatches a
 // single task; it is invoked on the caller-provided function asynchronously
-// (from the NATS subscription goroutine) and must not block long.
-func newTaskRetrier(tasks []distributed.Task, retryEnabled bool, republish func(distributed.Task), logger *slog.Logger, stageID string) *taskRetrier {
+// (from the NATS subscription goroutine) and must not block long. fatal
+// (optional) short-circuits retries for failures no re-dispatch can fix —
+// see taskRetrier.fatal.
+func newTaskRetrier(tasks []distributed.Task, retryEnabled bool, republish func(distributed.Task), logger *slog.Logger, stageID string, fatal func(distributed.ResultNotification) bool) *taskRetrier {
 	tr := &taskRetrier{
 		states:       make(map[string]*taskAttemptState, len(tasks)),
 		tasks:        make(map[string]distributed.Task, len(tasks)),
@@ -64,6 +87,7 @@ func newTaskRetrier(tasks []distributed.Task, retryEnabled bool, republish func(
 		republish:    republish,
 		logger:       logger,
 		stageID:      stageID,
+		fatal:        fatal,
 	}
 	for _, t := range tasks {
 		tr.states[t.ID] = &taskAttemptState{attempts: 1}
@@ -95,8 +119,11 @@ func (tr *taskRetrier) Observe(r distributed.ResultNotification) (allDone bool) 
 		tr.mu.Unlock()
 		return done
 	}
-	// Failure: retry if attempts remain, else terminal failure.
-	if tr.retryEnabled && st.attempts < maxTaskAttempts {
+	// Failure: retry if attempts remain, else terminal failure. A
+	// fatal-classified failure (input lost) skips straight to terminal —
+	// re-dispatching cannot recreate a dead producer's un-uploaded output.
+	fatalNow := tr.fatal != nil && tr.fatal(r)
+	if !fatalNow && tr.retryEnabled && st.attempts < maxTaskAttempts {
 		st.attempts++
 		task := tr.growEstimateLocked(r.TaskID)
 		task.Attempt = st.attempts
@@ -113,6 +140,12 @@ func (tr *taskRetrier) Observe(r distributed.ResultNotification) (allDone bool) 
 		return false
 	}
 	st.errMsg = r.Error
+	if r.MissingInputKey != "" {
+		// Tag both the fatal-classified case and attempts-exhausted-on-
+		// missing-input so ExecuteSQL's streaming-disabled re-execution
+		// triggers on either.
+		st.errMsg = inputLostMarker + " (" + r.MissingInputKey + "): " + r.Error
+	}
 	st.terminal = true
 	tr.terminal++
 	done := tr.terminal >= len(tr.order)
@@ -120,7 +153,7 @@ func (tr *taskRetrier) Observe(r distributed.ResultNotification) (allDone bool) 
 	if tr.logger != nil {
 		tr.logger.Error("task failed terminally",
 			"stage_id", tr.stageID, "task_id", r.TaskID,
-			"attempts", st.attempts, "error", r.Error)
+			"attempts", st.attempts, "fatal_classified", fatalNow, "error", r.Error)
 	}
 	return done
 }

--- a/internal/coordinator/task_retry_test.go
+++ b/internal/coordinator/task_retry_test.go
@@ -64,7 +64,7 @@ func waitRepublished(t *testing.T, c *collectingRepublisher, n int) []distribute
 
 func TestTaskRetrier_AllSucceedFirstTry(t *testing.T) {
 	rep := &collectingRepublisher{}
-	tr := newTaskRetrier(retryTestTasks(3), true, rep.republish, slog.Default(), "s")
+	tr := newTaskRetrier(retryTestTasks(3), true, rep.republish, slog.Default(), "s", nil)
 	if tr.Observe(okResult("a", "f-a")) {
 		t.Fatal("done after 1/3")
 	}
@@ -91,7 +91,7 @@ func TestTaskRetrier_AllSucceedFirstTry(t *testing.T) {
 
 func TestTaskRetrier_FailThenRetrySucceeds(t *testing.T) {
 	rep := &collectingRepublisher{}
-	tr := newTaskRetrier(retryTestTasks(2), true, rep.republish, slog.Default(), "s")
+	tr := newTaskRetrier(retryTestTasks(2), true, rep.republish, slog.Default(), "s", nil)
 	if tr.Observe(failResult("a", "worker died")) {
 		t.Fatal("failure with retries left must not be terminal")
 	}
@@ -116,7 +116,7 @@ func TestTaskRetrier_FailThenRetrySucceeds(t *testing.T) {
 
 func TestTaskRetrier_ExhaustsAttempts(t *testing.T) {
 	rep := &collectingRepublisher{}
-	tr := newTaskRetrier(retryTestTasks(1), true, rep.republish, slog.Default(), "s")
+	tr := newTaskRetrier(retryTestTasks(1), true, rep.republish, slog.Default(), "s", nil)
 	// Attempt 1 fails → retry (attempt 2). Attempt 2 fails → retry (attempt 3).
 	// Attempt 3 fails → terminal.
 	if tr.Observe(failResult("a", "boom-1")) {
@@ -144,7 +144,7 @@ func TestTaskRetrier_ExhaustsAttempts(t *testing.T) {
 
 func TestTaskRetrier_RetryDisabled(t *testing.T) {
 	rep := &collectingRepublisher{}
-	tr := newTaskRetrier(retryTestTasks(1), false, rep.republish, slog.Default(), "s")
+	tr := newTaskRetrier(retryTestTasks(1), false, rep.republish, slog.Default(), "s", nil)
 	if !tr.Observe(failResult("a", "boom")) {
 		t.Fatal("with retry disabled, first failure must be terminal")
 	}
@@ -162,7 +162,7 @@ func TestTaskRetrier_RetryDisabled(t *testing.T) {
 // a task still outstanding.
 func TestTaskRetrier_DuplicateDeliveryIgnored(t *testing.T) {
 	rep := &collectingRepublisher{}
-	tr := newTaskRetrier(retryTestTasks(2), true, rep.republish, slog.Default(), "s")
+	tr := newTaskRetrier(retryTestTasks(2), true, rep.republish, slog.Default(), "s", nil)
 	if tr.Observe(okResult("a", "f-a")) {
 		t.Fatal("done after 1/2")
 	}
@@ -179,7 +179,7 @@ func TestTaskRetrier_DuplicateDeliveryIgnored(t *testing.T) {
 }
 
 func TestTaskRetrier_UnknownTaskIgnored(t *testing.T) {
-	tr := newTaskRetrier(retryTestTasks(1), true, nil, slog.Default(), "s")
+	tr := newTaskRetrier(retryTestTasks(1), true, nil, slog.Default(), "s", nil)
 	if tr.Observe(okResult("zzz", "f")) {
 		t.Fatal("unknown task must not complete the stage")
 	}
@@ -195,7 +195,7 @@ func TestTaskRetrier_UnknownTaskIgnored(t *testing.T) {
 // the eventual success must still win.
 func TestTaskRetrier_LateDuplicateAfterRetry(t *testing.T) {
 	rep := &collectingRepublisher{}
-	tr := newTaskRetrier(retryTestTasks(1), true, rep.republish, slog.Default(), "s")
+	tr := newTaskRetrier(retryTestTasks(1), true, rep.republish, slog.Default(), "s", nil)
 	if tr.Observe(failResult("a", "boom")) {
 		t.Fatal("terminal too early")
 	}
@@ -217,7 +217,7 @@ func TestTaskRetrier_LateDuplicateAfterRetry(t *testing.T) {
 // attempt's notification are captured per task and flattened in dispatch
 // order; duplicates must not double-collect.
 func TestTaskRetrier_DynamicFilterPartials(t *testing.T) {
-	tr := newTaskRetrier(retryTestTasks(2), true, nil, slog.Default(), "s")
+	tr := newTaskRetrier(retryTestTasks(2), true, nil, slog.Default(), "s", nil)
 	rA := okResult("a", "f-a")
 	rA.DynamicFilterPartials = []distributed.DynamicFilterPartialRef{
 		{FilterID: "df1", Bucket: "b", Key: "a-df1"},
@@ -244,7 +244,7 @@ func TestTaskRetrier_DynamicFilterPartials(t *testing.T) {
 // reported back for liveness cleanup.
 func TestTaskRetrier_RetryStuck_Redispatches(t *testing.T) {
 	rep := &collectingRepublisher{}
-	tr := newTaskRetrier(retryTestTasks(2), true, rep.republish, slog.Default(), "s")
+	tr := newTaskRetrier(retryTestTasks(2), true, rep.republish, slog.Default(), "s", nil)
 	tr.Observe(okResult("b", "f-b")) // b terminal
 
 	re, term := tr.RetryStuck([]string{"a", "b", "zzz"})
@@ -272,7 +272,7 @@ func TestTaskRetrier_RetryStuck_Redispatches(t *testing.T) {
 // reported failure; the stage idle timeout is the backstop.
 func TestTaskRetrier_RetryStuck_CapDoesNotFail(t *testing.T) {
 	rep := &collectingRepublisher{}
-	tr := newTaskRetrier(retryTestTasks(1), true, rep.republish, slog.Default(), "s")
+	tr := newTaskRetrier(retryTestTasks(1), true, rep.republish, slog.Default(), "s", nil)
 	re, _ := tr.RetryStuck([]string{"a"}) // attempt 2
 	if len(re) != 1 {
 		t.Fatalf("first stuck sweep redispatched %v, want [a]", re)
@@ -301,7 +301,7 @@ func TestTaskRetrier_RetryStuck_CapDoesNotFail(t *testing.T) {
 // re-dispatch, even for stuck tasks (a retry would duplicate streamed rows).
 func TestTaskRetrier_RetryStuck_RetryDisabled(t *testing.T) {
 	rep := &collectingRepublisher{}
-	tr := newTaskRetrier(retryTestTasks(1), false, rep.republish, slog.Default(), "s")
+	tr := newTaskRetrier(retryTestTasks(1), false, rep.republish, slog.Default(), "s", nil)
 	re, _ := tr.RetryStuck([]string{"a"})
 	if len(re) != 0 {
 		t.Fatalf("redispatched %v with retry disabled", re)
@@ -316,7 +316,7 @@ func TestTaskRetrier_RetryStuck_RetryDisabled(t *testing.T) {
 // other stages' entries alone.
 func TestReapStuckOnce(t *testing.T) {
 	rep := &collectingRepublisher{}
-	tr := newTaskRetrier(retryTestTasks(2), true, rep.republish, slog.Default(), "s")
+	tr := newTaskRetrier(retryTestTasks(2), true, rep.republish, slog.Default(), "s", nil)
 	tr.Observe(okResult("b", "f-b")) // b terminal
 
 	liveness := NewTaskLiveness()

--- a/internal/coordinator/workers.go
+++ b/internal/coordinator/workers.go
@@ -307,6 +307,16 @@ func (wr *WorkerRegistry) PeerAddr(workerID string) string {
 	return w.PeerAddr
 }
 
+// IsAlive reports whether the worker has been seen within the stale TTL
+// (draining still counts as alive — a draining worker serves peer fetches
+// and finishes uploads).
+func (wr *WorkerRegistry) IsAlive(workerID string) bool {
+	wr.mu.RLock()
+	defer wr.mu.RUnlock()
+	w, ok := wr.workers[workerID]
+	return ok && w.LastSeen.After(time.Now().Add(-wr.stale))
+}
+
 // Count returns the number of active workers.
 func (wr *WorkerRegistry) Count() int {
 	return len(wr.ActiveWorkers())

--- a/internal/distributed/messages.go
+++ b/internal/distributed/messages.go
@@ -189,6 +189,16 @@ type Task struct {
 	// coordinator; empty when streaming exchange is disabled.
 	FetchToken string `json:"fetch_token,omitempty"`
 
+	// AsyncUpload (streaming exchange Phase B) tells the worker to report
+	// task completion once stage-output files are finalized on local disk
+	// (and adopted into the LocalStageCache for peer serving), continuing
+	// the S3 upload in the background. The worker publishes UploadComplete
+	// when the task's uploads land; until then the S3 copy may not exist
+	// and consumers rely on the peer tier (with a bounded S3 re-poll).
+	// Only set by the coordinator for native-DAG task types whose outputs
+	// are consumed by workers; false = today's synchronous upload.
+	AsyncUpload bool `json:"async_upload,omitempty"`
+
 	// Output is the S3 prefix where this task's output is materialized.
 	// Shuffle/pipeline-intermediate: worker writes "<Output>partition=NNNN/<taskID>.wshf".
 	// Pipeline-final (before Gather): single-partition output at "<Output><taskID>.wshf".
@@ -454,6 +464,30 @@ type ResultNotification struct {
 	// build-scan with DynamicFilterEmit set. One ref per emit. Coordinator
 	// fetches+unions before dispatching the downstream probe-scan stage.
 	DynamicFilterPartials []DynamicFilterPartialRef `json:"dynamic_filter_partials,omitempty"`
+
+	// MissingInputKey (streaming exchange Phase B), set on failure when the
+	// task could not resolve an input file that carried a peer-location
+	// hint: peer fetch failed AND the durable copy was absent past the
+	// bounded re-poll. The coordinator classifies it against the producing
+	// worker's liveness and the key's durability bit — producer dead with
+	// the key not durable is ErrInputLost (unrecoverable by task retry).
+	MissingInputKey string `json:"missing_input_key,omitempty"`
+}
+
+// UploadComplete (streaming exchange Phase B) is published by a worker when
+// an async-upload task's background S3 uploads have all landed. The
+// coordinator flips the per-key durability bits it uses to classify
+// missing-input failures and to gate its own direct reads of stage output
+// (scalar-subquery extraction).
+type UploadComplete struct {
+	RootQueryID string   `json:"root_query_id"`
+	TaskID      string   `json:"task_id"`
+	WorkerID    string   `json:"worker_id"`
+	Keys        []string `json:"keys"`
+	// Failed marks uploads abandoned after retries (S3 outage) or
+	// cancelled (query terminal). Keys stay non-durable; ErrInputLost
+	// remains the backstop if the producer also dies.
+	Failed bool `json:"failed,omitempty"`
 }
 
 // TaskStats captures per-task execution metrics for debugging.

--- a/internal/distributed/subjects.go
+++ b/internal/distributed/subjects.go
@@ -28,6 +28,13 @@ const (
 	SubjectTaskProgress    = "wadjet.task.progress"
 	SubjectTaskProgressAll = "wadjet.task.progress.>"
 
+	// Async-upload completion (streaming exchange Phase B) — Core NATS.
+	// Published by workers when a task's background stage-output uploads
+	// land; coordinator flips per-key durability bits. Best-effort: a
+	// lost message leaves keys non-durable, which only means the
+	// coordinator stays conservative about them.
+	SubjectUploadComplete = "wadjet.uploads.complete"
+
 	// Query cancellation — Core NATS
 	SubjectCancel = "wadjet.cancel"
 

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -87,11 +88,15 @@ type Executor struct {
 	// specs, and the outbound PeerClient (nil client = peer reads disabled).
 	// Always non-nil; dormant without --streaming-exchange.
 	peers *peerExchange
+
+	// uploads runs Phase-B background S3 uploads for AsyncUpload tasks.
+	// Always non-nil; dormant unless tasks arrive with the flag set.
+	uploads *uploadManager
 }
 
 // NewExecutor creates a new task executor.
 func NewExecutor(store objstore.Store, cache *LRUCache, js jetstream.JetStream) *Executor {
-	return &Executor{
+	e := &Executor{
 		store:          store,
 		js:             js,
 		cache:          cache,
@@ -99,6 +104,8 @@ func NewExecutor(store objstore.Store, cache *LRUCache, js jetstream.JetStream) 
 		broadcastCache: newBroadcastJoinCache(),
 		peers:          newPeerExchange(),
 	}
+	e.uploads = newUploadManager(store, nil, e.logger)
+	return e
 }
 
 // SetMemoryBudget configures the per-task memory budget and the spill
@@ -215,9 +222,13 @@ func (e *Executor) SetLocalStageCache(c *LocalStageCache) {
 }
 
 // SetNATSConn attaches a NATS connection used by Gather tasks to stream
-// batches back to the coordinator's reply subject.
+// batches back to the coordinator's reply subject (and by the async upload
+// manager for UploadComplete notifications).
 func (e *Executor) SetNATSConn(nc *nats.Conn) {
 	e.nc = nc
+	if e.uploads != nil {
+		e.uploads.nc = nc
+	}
 }
 
 // SetDataPlaneClient enables gRPC result streaming for gather sinks
@@ -243,6 +254,9 @@ func (e *Executor) SetMetrics(m *metrics.Metrics) {
 // SetLogger sets the executor's logger.
 func (e *Executor) SetLogger(l *slog.Logger) {
 	e.logger = l
+	if e.uploads != nil {
+		e.uploads.logger = l
+	}
 }
 
 // newSpillManager creates a Tracker + SpillManager for a task.
@@ -366,6 +380,13 @@ func (e *Executor) Execute(ctx context.Context, task distributed.Task, workerID 
 	if err != nil {
 		result.Success = false
 		result.Error = err.Error()
+		// Streaming exchange Phase B: surface unresolvable hinted inputs
+		// structurally so the coordinator can classify against producer
+		// liveness + durability instead of parsing error text.
+		var miss *missingInputError
+		if errors.As(err, &miss) {
+			result.MissingInputKey = miss.key
+		}
 	} else {
 		result.Success = true
 	}
@@ -953,6 +974,49 @@ func (e *Executor) executeShuffle(ctx context.Context, task distributed.Task, re
 		return fmt.Errorf("shuffle task %s: finalizing sink: %w", task.ID, err)
 	}
 	tFinalizeEnd = time.Now()
+
+	// Phase-B async upload: report completion now — every partition file is
+	// finalized on local disk — adopt each into the LocalStageCache (peers
+	// and the background upload read the adopted copy), and hand the S3
+	// PUTs to the upload manager. Consumers overwhelmingly peer-fetch; the
+	// durable copy lands in the background and UploadComplete flips the
+	// coordinator's per-key durability bits.
+	if root, asyncOK := e.asyncUploadEligible(&task); asyncOK {
+		var jobs []uploadJob
+		for p, localPath := range sink.PartitionFiles() {
+			if localPath == "" {
+				continue // empty partition
+			}
+			key := fmt.Sprintf("%spartition=%04d/%s.wshf", task.ResultPrefix, p, task.ID)
+			fi, statErr := os.Stat(localPath)
+			if statErr != nil {
+				return fmt.Errorf("shuffle task %s: stat partition %d: %w", task.ID, p, statErr)
+			}
+			if job, ok := e.finishStageOutputAsync(ctx, &task, key, localPath, fi.Size(), true, result); ok {
+				jobs = append(jobs, job)
+				continue
+			}
+			// Adoption failed (cross-device rename etc.) — this partition
+			// must upload synchronously: its local file dies with the task
+			// spill dir and nothing else could produce the durable copy.
+			if upErr := e.uploads.uploadOnce(ctx, uploadJob{
+				bucket: task.ResultBucket, key: key, srcPath: localPath,
+				compress: true, tmpDir: e.spillDir,
+			}); upErr != nil {
+				return fmt.Errorf("shuffle task %s: partition %d sync-fallback upload: %w", task.ID, p, upErr)
+			}
+			result.ResultFiles = append(result.ResultFiles, key)
+			result.SizeBytes += fi.Size()
+		}
+		e.uploads.StartTask(root, task.ID, result.WorkerID, jobs)
+		result.NumRows = totalRows
+		e.logger.Info("shuffle task completed (async upload pending)",
+			"task_id", task.ID, "rows", totalRows,
+			"partitions", len(result.ResultFiles), "background_uploads", len(jobs),
+			"stream_ms", tStreamEnd.Sub(tStart).Milliseconds(),
+			"finalize_ms", tFinalizeEnd.Sub(tStreamEnd).Milliseconds())
+		return nil
+	}
 
 	// Upload partition files in parallel. Q18 SF1 shuffle-17 produces 8 × 100MB
 	// partitions; serial uploads take ~4.4s on FileStore, parallel ~1.4s. The

--- a/internal/worker/executor_async_upload.go
+++ b/internal/worker/executor_async_upload.go
@@ -1,0 +1,57 @@
+package worker
+
+import (
+	"context"
+	"os"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+)
+
+// asyncUploadEligible reports whether this task's stage outputs may be
+// reported complete before their S3 upload lands (streaming exchange
+// Phase B). Requires the LocalStageCache (the retained local file is what
+// peers fetch and what the background upload reads) and a derivable root
+// query ID (upload cancellation is root-scoped).
+func (e *Executor) asyncUploadEligible(task *distributed.Task) (root string, ok bool) {
+	if !task.AsyncUpload || e.uploads == nil || e.localCache == nil || e.spillDir == "" {
+		return "", false
+	}
+	root = distributed.TaskRootQueryID(task)
+	return root, root != ""
+}
+
+// finishStageOutputAsync completes one finalized local stage-output file
+// the Phase-B way: adopt it into the LocalStageCache (peers and the
+// background upload read the adopted copy), record it on the result, and
+// write the small-payload KV tier from local bytes. Returns the background
+// upload job. ok=false when adoption fails (cross-device rename etc.) —
+// the caller must upload synchronously instead, because the local file
+// dies with the task spill dir and nothing else could ever produce the
+// durable copy.
+func (e *Executor) finishStageOutputAsync(ctx context.Context, task *distributed.Task, key, localPath string, size int64, compress bool, result *distributed.ResultNotification) (uploadJob, bool) {
+	adopted := e.localCache.Adopt(task.QueryID, key, localPath)
+	if adopted == "" {
+		return uploadJob{}, false
+	}
+	result.ResultFiles = append(result.ResultFiles, key)
+	result.SizeBytes += size
+
+	// KV fast-read tier for small payloads, written from the local copy —
+	// no S3 dependency, so the tier stays as hot as on the sync path.
+	if e.resultKV != nil && size <= natsKVResultThreshold {
+		if payload, readErr := os.ReadFile(adopted); readErr == nil {
+			if _, putErr := e.resultKV.Put(ctx, natsKVKey(key), payload); putErr != nil {
+				e.logger.Debug("KV cache write failed (upload pending, peers cover reads)",
+					"task_id", task.ID, "key", key, "err", putErr)
+			}
+		}
+	}
+
+	return uploadJob{
+		bucket:   task.ResultBucket,
+		key:      key,
+		srcPath:  adopted,
+		compress: compress,
+		tmpDir:   e.spillDir,
+	}, true
+}

--- a/internal/worker/executor_stage.go
+++ b/internal/worker/executor_stage.go
@@ -41,6 +41,15 @@ func (e *Executor) uploadUnpartitionedSpill(ctx context.Context, task distribute
 	}
 	size := stat.Size()
 
+	// Phase-B async upload: adopt + record + KV now, PUT in the background.
+	// Adoption failure falls through to the synchronous body below.
+	if root, asyncOK := e.asyncUploadEligible(&task); asyncOK {
+		if job, ok := e.finishStageOutputAsync(ctx, &task, key, srcPath, size, false, result); ok {
+			e.uploads.StartTask(root, task.ID, result.WorkerID, []uploadJob{job})
+			return nil
+		}
+	}
+
 	f, err := os.Open(srcPath)
 	if err != nil {
 		return fmt.Errorf("scan task %s: open spill file: %w", task.ID, err)
@@ -309,9 +318,29 @@ func (e *Executor) writePartitionedShuffle(ctx context.Context, task distributed
 // between the legacy collect-then-partition path (writePartitionedShuffle) and
 // the streaming-partition path (runStageScanPartitionedStreaming).
 func (e *Executor) uploadPartitionedShuffleFiles(ctx context.Context, task distributed.Task, sink *partitionedShuffleSink, result *distributed.ResultNotification) error {
+	root, asyncOK := e.asyncUploadEligible(&task)
+	var jobs []uploadJob
+	defer func() {
+		if len(jobs) > 0 {
+			e.uploads.StartTask(root, task.ID, result.WorkerID, jobs)
+		}
+	}()
 	for p, localPath := range sink.PartitionFiles() {
 		if localPath == "" {
 			continue
+		}
+		// Phase-B async upload: adopt + record + KV, PUT in the background.
+		// Adoption failure falls through to the synchronous body below.
+		if asyncOK {
+			fi, statErr := os.Stat(localPath)
+			if statErr != nil {
+				return fmt.Errorf("stage task %s: stat partition %d: %w", task.ID, p, statErr)
+			}
+			key := fmt.Sprintf("%spartition=%04d/%s.wshf", task.ResultPrefix, p, task.ID)
+			if job, ok := e.finishStageOutputAsync(ctx, &task, key, localPath, fi.Size(), false, result); ok {
+				jobs = append(jobs, job)
+				continue
+			}
 		}
 		f, err := os.Open(localPath)
 		if err != nil {
@@ -395,6 +424,27 @@ func (e *Executor) writeUnpartitionedWSHF(ctx context.Context, task distributed.
 
 	key := fmt.Sprintf("%s%s.wshf", task.ResultPrefix, task.ID)
 
+	// Phase-B async upload: stage the payload as a cache-adopted local file
+	// (peers + background upload read it), record + KV now, PUT in the
+	// background. Adoption failure falls through to the synchronous path.
+	if root, asyncOK := e.asyncUploadEligible(&task); asyncOK {
+		if adopted := e.cacheUnpartitionedLocal(task.QueryID, key, payload); adopted != "" {
+			result.ResultFiles = append(result.ResultFiles, key)
+			result.SizeBytes += int64(len(payload))
+			if e.resultKV != nil && len(payload) <= natsKVResultThreshold {
+				if _, kvErr := e.resultKV.Put(ctx, natsKVKey(key), payload); kvErr != nil {
+					e.logger.Debug("KV cache write failed (upload pending, peers cover reads)",
+						"task_id", task.ID, "key", key, "err", kvErr)
+				}
+			}
+			e.uploads.StartTask(root, task.ID, result.WorkerID, []uploadJob{{
+				bucket: task.ResultBucket, key: key, srcPath: adopted,
+				compress: false, tmpDir: e.spillDir,
+			}})
+			return nil
+		}
+	}
+
 	// S3 is the durable store. NATS KV has a 5-minute TTL (coordinator.go
 	// jetstream.KeyValueConfig) and a 1 GB bucket cap — entries can expire or
 	// be evicted before downstream stages read them. Q02 SF10 2026-04-28 hit
@@ -428,31 +478,35 @@ func (e *Executor) writeUnpartitionedWSHF(ctx context.Context, task distributed.
 }
 
 // cacheUnpartitionedLocal writes payload to a temp file under the worker's
-// spill directory and adopts it into the LocalStageCache. Best-effort — any
-// I/O failure leaves the cache empty for this entry, and the consumer falls
-// through to S3 as before. Caller must have already written payload durably
-// to S3 (or KV) before invoking this.
-func (e *Executor) cacheUnpartitionedLocal(queryID, key string, payload []byte) {
+// spill directory and adopts it into the LocalStageCache, returning the
+// adopted path ("" on any failure). Best-effort for synchronous callers —
+// an empty return leaves the cache cold and consumers fall through to S3.
+// The Phase-B async path REQUIRES a non-empty return before skipping the
+// synchronous upload (the adopted file is what the background upload
+// reads).
+func (e *Executor) cacheUnpartitionedLocal(queryID, key string, payload []byte) string {
 	if e.localCache == nil || e.spillDir == "" {
-		return
+		return ""
 	}
 	tmp, err := os.CreateTemp(e.spillDir, "stage-unpart-*.wshf")
 	if err != nil {
-		return
+		return ""
 	}
 	tmpPath := tmp.Name()
 	if _, err := tmp.Write(payload); err != nil {
 		tmp.Close()
 		_ = os.Remove(tmpPath)
-		return
+		return ""
 	}
 	if err := tmp.Close(); err != nil {
 		_ = os.Remove(tmpPath)
-		return
+		return ""
 	}
-	if adopted := e.localCache.Adopt(queryID, key, tmpPath); adopted == "" {
+	adopted := e.localCache.Adopt(queryID, key, tmpPath)
+	if adopted == "" {
 		_ = os.Remove(tmpPath)
 	}
+	return adopted
 }
 
 // mapJoinTypeString converts the canonical join-type string carried on

--- a/internal/worker/peer_exchange.go
+++ b/internal/worker/peer_exchange.go
@@ -2,13 +2,16 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/citc-tech/wadjet/internal/dataplane"
 	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
 )
 
 // peerExchange holds the worker's streaming-exchange state (Phase A,
@@ -158,6 +161,61 @@ func (s *cachedFileStreamSource) openShuffleFromPeer(ctx context.Context, key, a
 		return fmt.Errorf("peer %s returned non-shuffle payload for %s (magic %q)", addr, key, magic[:])
 	}
 	return s.openShuffleFile(ctx, key, magic[:], rc, wshc)
+}
+
+// durableWaitTotal bounds how long a consumer re-polls S3 for a
+// streaming-query key whose peer fetch failed (or had no hint) while the
+// durable copy hasn't landed yet (Phase-B async upload in flight).
+// Failure-recovery path, not a hot loop — past the bound the task fails
+// with MissingInputKey and the coordinator classifies. var so tests can
+// shrink the window.
+var durableWaitTotal = 15 * time.Second
+
+// durableWaitPoll is the S3 re-poll cadence within durableWaitTotal.
+var durableWaitPoll = 500 * time.Millisecond
+
+// missingInputError marks a task failure caused by an unresolvable hinted
+// input: the peer fetch failed and the durable copy stayed absent past the
+// bounded wait. Surfaces as ResultNotification.MissingInputKey so the
+// coordinator can distinguish "producer died before its upload landed"
+// (ErrInputLost, unrecoverable by task retry) from ordinary failures.
+type missingInputError struct {
+	key   string
+	cause error
+}
+
+func (e *missingInputError) Error() string {
+	return fmt.Sprintf("input %s unavailable: peer fetch failed and no durable copy after %s: %v", e.key, durableWaitTotal, e.cause)
+}
+
+func (e *missingInputError) Unwrap() error { return e.cause }
+
+// awaitDurableObject re-polls the store for a hinted key whose first read
+// missed — the producing worker reported the file, so either its background
+// upload is in flight (it will land) or the producer died with it (it
+// won't). Returns the opened reader on success.
+func (s *cachedFileStreamSource) awaitDurableObject(ctx context.Context, key string) (io.ReadCloser, error) {
+	deadline := time.Now().Add(durableWaitTotal)
+	var lastErr error
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return nil, lastErr
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(min(durableWaitPoll, remaining)):
+		}
+		rc, _, err := s.executor.store.Get(ctx, s.bucket, key)
+		if err == nil {
+			return rc, nil
+		}
+		lastErr = err
+		if !errors.Is(err, objstore.ErrNotFound) {
+			return nil, err // real store error — don't spin on it
+		}
+	}
 }
 
 // PeerFetchHits returns how many input files were served via peer fetch.

--- a/internal/worker/peer_exchange_test.go
+++ b/internal/worker/peer_exchange_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/citc-tech/wadjet/internal/dataplane"
 	"github.com/citc-tech/wadjet/internal/distributed"
@@ -174,6 +176,79 @@ func TestPeerTierBadTokenFallsThrough(t *testing.T) {
 	if consumer.PeerFetchFallthroughs() != 1 {
 		t.Fatalf("fallthroughs = %d, want 1", consumer.PeerFetchFallthroughs())
 	}
+}
+
+// TestMissingInputSurfacesStructurally drives the Phase-B failure contract:
+// dead peer + no durable copy past the bounded wait → a typed
+// missingInputError that survives wrapping (so Execute can populate
+// ResultNotification.MissingInputKey for the coordinator's classifier).
+// Also covers the hint-less case: a producer reaped before this consumer
+// dispatched leaves only the fetch token behind.
+func TestMissingInputSurfacesStructurally(t *testing.T) {
+	origTotal, origPoll := durableWaitTotal, durableWaitPoll
+	durableWaitTotal, durableWaitPoll = 200*time.Millisecond, 20*time.Millisecond
+	t.Cleanup(func() { durableWaitTotal, durableWaitPoll = origTotal, origPoll })
+
+	const (
+		queryID = "q-lost"
+		key     = "queries/q-lost/stage-1/partition=0001/task-9.wshf"
+		bucket  = "scratch"
+	)
+	for name, hints := range map[string]map[string]string{
+		"dead peer hint": {key: "127.0.0.1:1"},
+		"no hint":        nil,
+	} {
+		t.Run(name, func(t *testing.T) {
+			consumer, _ := newConsumer(t, bucket) // no object in the store
+			consumer.peers.registerTask(&distributed.Task{
+				QueryID:        "st-join-2-" + queryID,
+				ResultPrefix:   "queries/" + queryID + "/stage-2/",
+				FetchToken:     "tok",
+				InputLocations: hints,
+			})
+			src := newCachedFileStreamSource(consumer, "st-join-2-"+queryID, bucket, []string{key})
+			defer src.Close()
+			_, err := src.Next(context.Background())
+			if err == nil {
+				t.Fatal("expected missing-input failure")
+			}
+			wrapped := fmt.Errorf("stage task t9: source next: %w", err)
+			var miss *missingInputError
+			if !errors.As(wrapped, &miss) || miss.key != key {
+				t.Fatalf("error not a missingInputError for %s: %v", key, wrapped)
+			}
+		})
+	}
+
+	// Untokened query (streaming off): plain error, no missingInputError.
+	t.Run("no token no hint", func(t *testing.T) {
+		consumer, _ := newConsumer(t, bucket)
+		src := newCachedFileStreamSource(consumer, queryID, bucket, []string{key})
+		defer src.Close()
+		_, err := src.Next(context.Background())
+		var miss *missingInputError
+		if err == nil || errors.As(err, &miss) {
+			t.Fatalf("non-streaming miss must stay a plain error, got %v", err)
+		}
+	})
+
+	// Upload lands DURING the bounded wait → read succeeds.
+	t.Run("upload lands mid-wait", func(t *testing.T) {
+		consumer, store := newConsumer(t, bucket)
+		consumer.peers.registerTask(&distributed.Task{
+			QueryID:      "st-join-2-" + queryID,
+			ResultPrefix: "queries/" + queryID + "/stage-2/",
+			FetchToken:   "tok",
+		})
+		go func() {
+			time.Sleep(60 * time.Millisecond)
+			putObject(t, store, bucket, key, makeWshfBytes(t, []int64{42}))
+		}()
+		src := newCachedFileStreamSource(consumer, "st-join-2-"+queryID, bucket, []string{key})
+		if got := drainRows(t, src); got != 1 {
+			t.Fatalf("rows = %d, want 1", got)
+		}
+	})
 }
 
 func TestPeerExchangeRegistryLifecycle(t *testing.T) {

--- a/internal/worker/stream_source.go
+++ b/internal/worker/stream_source.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -15,6 +16,7 @@ import (
 	"github.com/citc-tech/wadjet/internal/engine/diskio"
 	"github.com/citc-tech/wadjet/internal/engine/exec"
 	"github.com/citc-tech/wadjet/internal/engine/scan"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
 )
 
@@ -356,6 +358,25 @@ func (s *cachedFileStreamSource) openNextFile(ctx context.Context) error {
 	// at the magic bytes, and decide whether this is a WSHF (or compressed
 	// WSHC) shuffle file or some legacy Parquet payload.
 	rc, _, err := s.executor.store.Get(ctx, s.bucket, filePath)
+	if err != nil {
+		// Streaming-query key with no durable copy: the producer reported
+		// this file, so its Phase-B background upload is either in flight
+		// (bounded re-poll below catches it landing) or died with the
+		// producer (missingInputError → coordinator classifies via liveness
+		// + durability bits). Trigger on a hint OR on the query's fetch
+		// token alone — a producer reaped before this task was dispatched
+		// leaves no hint, but the key can still be upload-pending.
+		if peers := s.executor.peers; peers != nil && errors.Is(err, objstore.ErrNotFound) {
+			if addr, token := peers.hintFor(filePath); addr != "" || token != "" {
+				waited, waitErr := s.awaitDurableObject(ctx, filePath)
+				if waitErr != nil {
+					return &missingInputError{key: filePath, cause: waitErr}
+				}
+				rc = waited
+				err = nil
+			}
+		}
+	}
 	if err != nil {
 		// Both KV and store missed. Annotate so the diagnostic gap from
 		// 2026-04-25 (object not found cascade in pgwire→coord routing)

--- a/internal/worker/upload_manager.go
+++ b/internal/worker/upload_manager.go
@@ -1,0 +1,282 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+)
+
+// uploadRetryAttempts bounds background upload retries per file. Failures
+// past the cap mark the task's UploadComplete as Failed — the keys stay
+// non-durable and the coordinator's ErrInputLost classification is the
+// backstop if the producer also dies.
+const uploadRetryAttempts = 3
+
+// uploadRetryBackoff is the base delay between background upload retries
+// (doubled per attempt). Background work — latency here is invisible to
+// the query unless a consumer's S3 fallthrough is waiting on it.
+const uploadRetryBackoff = 500 * time.Millisecond
+
+// uploadManager runs the Phase-B background S3 uploads of stage-output
+// files that were already finalized locally and adopted into the
+// LocalStageCache (docs/design/streaming-exchange.md §5). One per Executor,
+// dormant unless tasks arrive with AsyncUpload set.
+//
+// Cancellation: uploads are grouped per ROOT query ID; the worker's
+// query-complete/cancel broadcast handlers call CancelQuery, aborting
+// pending uploads for terminal queries — files a finished query never
+// fetched from S3 never reach S3 at all. Residual race (a PUT landing
+// after the coordinator's scratch purge) is bounded by one in-flight file
+// per worker and reclaimed by the coordinator's periodic CleanStale GC.
+type uploadManager struct {
+	store  objstore.Store
+	nc     *nats.Conn
+	logger *slog.Logger
+
+	sem chan struct{} // global upload concurrency (matches the sync path's 8)
+
+	mu      sync.Mutex
+	queries map[string]*queryUploadState
+
+	// Observability counters.
+	completed      atomic.Int64 // files uploaded in the background
+	cancelledFiles atomic.Int64 // uploads aborted by query completion
+	failedFiles    atomic.Int64 // uploads abandoned after retries
+}
+
+type queryUploadState struct {
+	ctx      context.Context
+	cancel   context.CancelFunc
+	inflight sync.WaitGroup
+}
+
+func newUploadManager(store objstore.Store, nc *nats.Conn, logger *slog.Logger) *uploadManager {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &uploadManager{
+		store:   store,
+		nc:      nc,
+		logger:  logger,
+		sem:     make(chan struct{}, 8),
+		queries: make(map[string]*queryUploadState),
+	}
+}
+
+// uploadJob is one file to land in S3: srcPath is a LocalStageCache-owned
+// local file (the manager never deletes it — the cache does, on query
+// cleanup), key/bucket the durable destination. compress applies the same
+// ≥10% s2 heuristic as the synchronous path, staging the compressed
+// artifact as a temp file next to tmpDir.
+type uploadJob struct {
+	bucket   string
+	key      string
+	srcPath  string
+	compress bool
+	tmpDir   string // where compressed temps go; must outlive the upload (NOT the task spill dir)
+}
+
+// taskUploads tracks one task's background uploads and publishes
+// UploadComplete when the last one settles.
+type taskUploads struct {
+	m           *uploadManager
+	root        string
+	taskID      string
+	workerID    string
+	keys        []string
+	remaining   atomic.Int64
+	anyFailed   atomic.Bool
+	anyCanceled atomic.Bool
+}
+
+// queryState returns (creating if needed) the cancel scope for a root query.
+func (m *uploadManager) queryState(root string) *queryUploadState {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	qs := m.queries[root]
+	if qs == nil {
+		ctx, cancel := context.WithCancel(context.Background())
+		qs = &queryUploadState{ctx: ctx, cancel: cancel}
+		m.queries[root] = qs
+	}
+	return qs
+}
+
+// CancelQuery aborts pending uploads for a terminal query and drops its
+// scope. Safe for unknown roots, repeated calls, and nil receivers.
+func (m *uploadManager) CancelQuery(root string) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	qs := m.queries[root]
+	delete(m.queries, root)
+	m.mu.Unlock()
+	if qs != nil {
+		qs.cancel()
+	}
+}
+
+// Drain cancels everything (worker shutdown).
+func (m *uploadManager) Drain() {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	states := make([]*queryUploadState, 0, len(m.queries))
+	for root, qs := range m.queries {
+		states = append(states, qs)
+		delete(m.queries, root)
+	}
+	m.mu.Unlock()
+	for _, qs := range states {
+		qs.cancel()
+	}
+}
+
+// StartTask begins tracking a task's background uploads and enqueues each
+// job. Call after every job's srcPath is stable (adopted into the cache).
+func (m *uploadManager) StartTask(root, taskID, workerID string, jobs []uploadJob) {
+	if m == nil || len(jobs) == 0 {
+		return
+	}
+	tu := &taskUploads{m: m, root: root, taskID: taskID, workerID: workerID}
+	for _, j := range jobs {
+		tu.keys = append(tu.keys, j.key)
+	}
+	tu.remaining.Store(int64(len(jobs)))
+	qs := m.queryState(root)
+	for _, j := range jobs {
+		qs.inflight.Add(1)
+		go func(j uploadJob) {
+			defer qs.inflight.Done()
+			m.runJob(qs.ctx, tu, j)
+		}(j)
+	}
+}
+
+func (m *uploadManager) runJob(ctx context.Context, tu *taskUploads, j uploadJob) {
+	defer tu.jobDone()
+	select {
+	case m.sem <- struct{}{}:
+		defer func() { <-m.sem }()
+	case <-ctx.Done():
+		tu.anyCanceled.Store(true)
+		m.cancelledFiles.Add(1)
+		return
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= uploadRetryAttempts; attempt++ {
+		if ctx.Err() != nil {
+			tu.anyCanceled.Store(true)
+			m.cancelledFiles.Add(1)
+			return
+		}
+		lastErr = m.uploadOnce(ctx, j)
+		if lastErr == nil {
+			m.completed.Add(1)
+			return
+		}
+		if ctx.Err() != nil {
+			tu.anyCanceled.Store(true)
+			m.cancelledFiles.Add(1)
+			return
+		}
+		backoff := uploadRetryBackoff << (attempt - 1)
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			tu.anyCanceled.Store(true)
+			m.cancelledFiles.Add(1)
+			return
+		}
+	}
+	tu.anyFailed.Store(true)
+	m.failedFiles.Add(1)
+	m.logger.Error("background stage-output upload abandoned; key stays non-durable",
+		"key", j.key, "task_id", tu.taskID, "attempts", uploadRetryAttempts, "error", lastErr)
+}
+
+// uploadOnce mirrors the synchronous path: optional s2 compression (≥10%
+// savings heuristic) staged as a temp file, then a streaming Put. The
+// source file is cache-owned and never deleted here.
+func (m *uploadManager) uploadOnce(ctx context.Context, j uploadJob) error {
+	uploadPath := j.srcPath
+	var tmpCompressed string
+	if j.compress {
+		tmp, err := os.CreateTemp(j.tmpDir, "async-upload-*.s2")
+		if err == nil {
+			tmpPath := tmp.Name()
+			tmp.Close()
+			_, useCompressed, compErr := CompressShuffleFile(j.srcPath, tmpPath)
+			if compErr != nil || !useCompressed {
+				_ = os.Remove(tmpPath)
+			} else {
+				uploadPath = tmpPath
+				tmpCompressed = tmpPath
+			}
+		}
+		// Temp-file failure → upload raw; compression is an optimization.
+	}
+	if tmpCompressed != "" {
+		defer os.Remove(tmpCompressed)
+	}
+
+	f, err := os.Open(uploadPath)
+	if err != nil {
+		return fmt.Errorf("opening %s: %w", uploadPath, err)
+	}
+	defer f.Close()
+	fi, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", uploadPath, err)
+	}
+	if _, err := m.store.Put(ctx, j.bucket, j.key, f, fi.Size(), "application/octet-stream"); err != nil {
+		return fmt.Errorf("put %s: %w", j.key, err)
+	}
+	return nil
+}
+
+// jobDone publishes UploadComplete when the task's last upload settles.
+func (tu *taskUploads) jobDone() {
+	if tu.remaining.Add(-1) != 0 {
+		return
+	}
+	if tu.anyCanceled.Load() {
+		// Query is terminal — nobody consumes the durability bit anymore.
+		return
+	}
+	msg := distributed.UploadComplete{
+		RootQueryID: tu.root,
+		TaskID:      tu.taskID,
+		WorkerID:    tu.workerID,
+		Keys:        tu.keys,
+		Failed:      tu.anyFailed.Load(),
+	}
+	data, err := distributed.Marshal(msg)
+	if err != nil {
+		return
+	}
+	if tu.m.nc != nil {
+		if err := tu.m.nc.Publish(distributed.SubjectUploadComplete, data); err != nil {
+			tu.m.logger.Debug("UploadComplete publish failed (keys stay non-durable)",
+				"task_id", tu.taskID, "error", err)
+		}
+	}
+}
+
+// UploadStats returns (completed, cancelled, failed) background upload
+// file counts. Observability/test helper.
+func (m *uploadManager) UploadStats() (completed, cancelled, failed int64) {
+	return m.completed.Load(), m.cancelledFiles.Load(), m.failedFiles.Load()
+}

--- a/internal/worker/upload_manager_test.go
+++ b/internal/worker/upload_manager_test.go
@@ -1,0 +1,165 @@
+package worker
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+)
+
+// gatedStore blocks Put until the gate closes — deterministic control over
+// the async-upload in-flight window.
+type gatedStore struct {
+	*objstore.MemStore
+	gate chan struct{}
+}
+
+func (g *gatedStore) Put(ctx context.Context, bucket, key string, r io.Reader, size int64, contentType string) (string, error) {
+	select {
+	case <-g.gate:
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+	return g.MemStore.Put(ctx, bucket, key, r, size, contentType)
+}
+
+func writeTempFile(t *testing.T, data []byte) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "part.wshf")
+	if err := os.WriteFile(p, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for !cond() {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", what)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestUploadManagerLandsFiles(t *testing.T) {
+	store := newTestStore(t, "b")
+	m := newUploadManager(store, nil, nil)
+	payload := makeWshfBytes(t, []int64{1, 2, 3})
+	m.StartTask("q1", "t1", "w1", []uploadJob{
+		{bucket: "b", key: "queries/q1/s/a.wshf", srcPath: writeTempFile(t, payload), tmpDir: t.TempDir()},
+		{bucket: "b", key: "queries/q1/s/c.wshf", srcPath: writeTempFile(t, payload), compress: true, tmpDir: t.TempDir()},
+	})
+	waitFor(t, "uploads to land", func() bool {
+		c, _, _ := m.UploadStats()
+		return c == 2
+	})
+	for _, key := range []string{"queries/q1/s/a.wshf", "queries/q1/s/c.wshf"} {
+		rc, _, err := store.Get(context.Background(), "b", key)
+		if err != nil {
+			t.Fatalf("uploaded object %s missing: %v", key, err)
+		}
+		got, _ := io.ReadAll(rc)
+		rc.Close()
+		// The compressed variant may be WSHC; either way it must round-trip
+		// through the standard reader path — just check non-empty here (the
+		// consumer-path tests cover decoding).
+		if len(got) == 0 {
+			t.Fatalf("uploaded object %s empty", key)
+		}
+	}
+	// Source files are cache-owned: the manager must not delete them.
+	if _, _, failed := m.UploadStats(); failed != 0 {
+		t.Fatalf("unexpected failed uploads")
+	}
+}
+
+func TestUploadManagerCancelQuery(t *testing.T) {
+	mem := objstore.NewMemStore()
+	if err := mem.MakeBucket(context.Background(), "b"); err != nil {
+		t.Fatal(err)
+	}
+	gs := &gatedStore{MemStore: mem, gate: make(chan struct{})}
+	m := newUploadManager(gs, nil, nil)
+	m.StartTask("q1", "t1", "w1", []uploadJob{
+		{bucket: "b", key: "queries/q1/s/a.wshf", srcPath: writeTempFile(t, []byte("WSHFxxxx")), tmpDir: t.TempDir()},
+	})
+	// The job is blocked inside Put; cancelling the query must abort it
+	// without the gate ever opening.
+	time.Sleep(50 * time.Millisecond)
+	m.CancelQuery("q1")
+	waitFor(t, "upload cancellation", func() bool {
+		_, cancelled, _ := m.UploadStats()
+		return cancelled == 1
+	})
+	if _, _, err := mem.Get(context.Background(), "b", "queries/q1/s/a.wshf"); err == nil {
+		t.Fatal("cancelled upload landed anyway")
+	}
+}
+
+// TestAsyncUnpartitionedWrite drives the Phase-B producer path end to end
+// at the executor level: completion is immediate (cache adopted, KV+peers
+// servable), the durable copy lands in the background.
+func TestAsyncUnpartitionedWrite(t *testing.T) {
+	store := newTestStore(t, "b")
+	e := NewExecutor(store, NewLRUCache(1<<20), nil)
+	e.SetMemoryBudget(0, t.TempDir())
+	e.SetLocalStageCache(NewLocalStageCache(filepath.Join(t.TempDir(), "sc")))
+
+	task := distributed.Task{
+		ID: "t1", QueryID: "st-agg-1-qz", Type: distributed.TaskTypeStage,
+		ResultBucket: "b", ResultPrefix: "queries/qz/stage-1/",
+		AsyncUpload: true, FetchToken: "tok",
+	}
+	payload := makeWshfBytes(t, []int64{5, 6})
+	var result distributed.ResultNotification
+	result.WorkerID = "w1"
+	batches, err := readShuffleBatchesForTest(payload)
+	if err != nil {
+		t.Fatalf("decoding test payload: %v", err)
+	}
+	schema := batches[0].Schema
+	if err := e.writeUnpartitionedWSHF(context.Background(), task, batches, schema, &result); err != nil {
+		t.Fatalf("writeUnpartitionedWSHF: %v", err)
+	}
+	key := "queries/qz/stage-1/t1.wshf"
+	if len(result.ResultFiles) != 1 || result.ResultFiles[0] != key {
+		t.Fatalf("result files = %v", result.ResultFiles)
+	}
+	// Peer-servable immediately: the cache holds the file under the root.
+	if e.localCache.Get("anything", key) == "" {
+		t.Fatal("output not in LocalStageCache at completion time")
+	}
+	// Durable copy lands in the background.
+	waitFor(t, "background upload", func() bool {
+		_, _, err := store.Get(context.Background(), "b", key)
+		return err == nil
+	})
+}
+
+// readShuffleBatchesForTest decodes a WSHF payload via the production
+// chunk reader.
+func readShuffleBatchesForTest(payload []byte) ([]*batch.RecordBatch, error) {
+	r, err := newShuffleChunkReader(payload)
+	if err != nil {
+		return nil, err
+	}
+	var out []*batch.RecordBatch
+	for {
+		b, err := r.Next()
+		if err != nil {
+			return nil, err
+		}
+		if b == nil {
+			return out, nil
+		}
+		out = append(out, b)
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -372,6 +372,9 @@ func (w *Worker) Start(ctx context.Context) error {
 			w.executor.broadcastCache.CleanupQuery(queryID)
 		}
 		w.executor.peers.CleanupQuery(queryID)
+		// Abort pending background uploads — a terminal query's scratch is
+		// about to be purged; landing more of it is waste (and re-leaks).
+		w.executor.uploads.CancelQuery(queryID)
 		w.logger.Debug("query cancelled", "query_id", queryID)
 	})
 	if err != nil {
@@ -409,6 +412,7 @@ func (w *Worker) Start(ctx context.Context) error {
 			w.executor.resultStore.CleanupQuery(queryID)
 		}
 		w.executor.peers.CleanupQuery(queryID)
+		w.executor.uploads.CancelQuery(queryID)
 	})
 	if err != nil {
 		return fmt.Errorf("subscribing to completions: %w", err)
@@ -669,6 +673,7 @@ func (w *Worker) Stop() {
 	if w.peerClient != nil {
 		w.peerClient.Close()
 	}
+	w.executor.uploads.Drain()
 
 	w.logger.Info("worker stopped", "worker_id", w.config.WorkerID)
 }
@@ -1502,6 +1507,12 @@ func (w *Worker) PeerExchangeAddr() string {
 // served via peer fetch, and hinted fetches that fell through to S3.
 func (w *Worker) PeerFetchStats() (hits, fallthroughs int64) {
 	return w.executor.PeerFetchHits(), w.executor.PeerFetchFallthroughs()
+}
+
+// UploadStats returns the Phase-B background-upload counters: files landed,
+// files cancelled by query completion, files abandoned after retries.
+func (w *Worker) UploadStats() (completed, cancelled, failed int64) {
+	return w.executor.uploads.UploadStats()
 }
 
 // reapCancelled removes cancellation entries older than maxAge.


### PR DESCRIPTION
## Summary

Phase B of the streaming-exchange workstream (design memo §5; Phase A was #174). With `--streaming-exchange`, native-DAG stage/shuffle tasks now **report completion once their outputs are finalized on local disk** — S2-compress + S3 PUT leave the producer critical path entirely and run in a background upload manager. Combined with Phase A's peer reads, the full per-stage-boundary S3 round-trip (PUT + GET) is off the critical path; S3 remains the durability substrate for retry.

## What's in it

- **Background upload manager** (`worker/upload_manager.go`): bounded concurrency (8, matching the sync path), 3 retries with backoff, grouped per root query. **Uploads for a terminal query are cancelled** — the complete/cancel broadcasts abort pending PUTs, so short queries whose consumers only ever peer-fetched never pay the S3 writes at all (direct scratch-cost reduction). Workers publish `UploadComplete` (new NATS subject) when a task's uploads land.
- **Coordinator durability bits**: `peerFiles` tracks per-key durable state from `UploadComplete`; the task annotator sets `Task.AsyncUpload` for stage/shuffle types only — pipeline/gather outputs feed coordinator-side result retrieval and stay synchronous.
- **Failure semantics, exactly per the memo**:
  - Consumers re-poll S3 (bounded, 15 s) for a missing streaming-query key — triggered by location hint **or** fetch token, so a producer reaped before the consumer dispatched is still covered — then fail with a structural `ResultNotification.MissingInputKey` (typed error, no string parsing).
  - The task retrier consults a **fatal classifier** before burning attempts: producer dead + key non-durable is unrecoverable by re-dispatch → terminal immediately, tagged with an input-lost marker (attempts-exhausted missing-input failures carry it too).
  - `ExecuteSQL` **re-executes the query once with streaming exchange fully disabled** (no hints/tokens/async — pure synchronous-S3 semantics). Safe because reads are idempotent and nothing reaches the client until ExecuteSQL returns; a ctx flag caps depth at one. `streamingReruns` counter makes the rate visible — non-zero rates are the memo's signal to revisit single-level producer re-run.
  - The one coordinator-side stage-output read (scalar-subquery extraction) gets a durability-aware bounded wait with a fast input-lost exit.
- KV small-payload tier written synchronously from local bytes (stays hot, no S3 dependency). Known residual: one in-flight PUT per worker can land after the scratch purge; the periodic `CleanStale` GC reclaims it.

## Validation

- Unit: upload landing + compression, **deterministic cancellation** (gated-store Put blocked until cancel), async producer path (peer-servable at completion, durable copy lands in background), missing-input surfacing (dead-peer hint, hint-less, non-streaming stays plain, upload-lands-mid-wait succeeds), classifier truth table (alive / durable / dead+non-durable), retrier fatal skip + exhausted-attempts marker, ctx depth cap.
- 3-worker e2e: shuffle-heavy TPC-H subset row-identical with **51 peer hits, 90 background uploads, 0 failed** — the async path is asserted live, not assumed.
- Full coordinator + worker suites, TPC-H SF0.01 22/22, `tpch-harness --mode=local` row-identical both flag states, `-race` clean on the new paths.

## Next

SF10 A/B on EC2 (`--streaming-exchange` off vs on) to measure the boundary-cost win at real S3 latency — will follow the standard deploy preflight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)