### PR TITLE
build(bench): wire streaming exchange into the benchmark deploy harness

### DIFF
--- a/cmd/tpch-bench/main.go
+++ b/cmd/tpch-bench/main.go
@@ -338,6 +338,11 @@ func setupDistributed(ctx context.Context, logger *slog.Logger, endpoint, region
 		NATSUrl:        embeddedNATS.ClientURL(),
 		ResultBucket:   bucket,
 		DynamicFilters: os.Getenv("WADJET_DYNAMIC_FILTERS") == "1" || strings.EqualFold(os.Getenv("WADJET_DYNAMIC_FILTERS"), "true"),
+		// Streaming exchange (docs/design/streaming-exchange.md): annotate
+		// tasks with peer-location hints + fetch tokens and run stage
+		// uploads async. Workers must run with --streaming-exchange too
+		// (terraform var streaming_exchange wires both sides).
+		StreamingExchange: os.Getenv("TPCH_STREAMING_EXCHANGE") == "1" || strings.EqualFold(os.Getenv("TPCH_STREAMING_EXCHANGE"), "true"),
 	}, cat, nc, js, logger)
 	coord.Workers().StartReaper(ctx)
 	coord.Workers().StartSubStatsLogger(ctx)

--- a/deploy/benchmark/terraform/main.tf
+++ b/deploy/benchmark/terraform/main.tf
@@ -148,6 +148,17 @@ resource "aws_security_group" "bench" {
     self      = true
   }
 
+  # Peer exchange (worker ↔ worker FetchShuffle, streaming exchange).
+  # A small range: each worker PROCESS on a host binds base+idx
+  # (workers_per_node processes per host). Idle unless streaming_exchange
+  # is set; harmless to keep open intra-SG.
+  ingress {
+    from_port = var.peer_exchange_port
+    to_port   = var.peer_exchange_port + 15
+    protocol  = "tcp"
+    self      = true
+  }
+
   # pgwire
   ingress {
     from_port = 5433
@@ -368,6 +379,10 @@ locals {
     # ${var.data_plane_port}.
     export TPCH_DATA_PLANE="${var.data_plane}"
     export TPCH_DATA_PLANE_ADDR=":${var.data_plane_port}"
+    # Streaming exchange (peer shuffle reads + async upload). Coordinator
+    # side of the flag; the worker cloud-init adds --streaming-exchange
+    # from the same terraform var.
+    export TPCH_STREAMING_EXCHANGE="${var.streaming_exchange ? "1" : "0"}"
     # Catalog snapshot/restore prefix (PR #115). Non-empty = restore the
     # post-discovery catalog from s3://<bucket>/<prefix> instead of paying
     # ~15 min of discovery+ANALYZE per deploy; first boot writes it.
@@ -625,6 +640,10 @@ resource "aws_instance" "worker" {
             %{if var.data_plane == "grpc"~}
             --data-plane=grpc \
             --coord-data-plane="$COORD_IP:${var.data_plane_port}" \
+            %{endif~}
+            %{if var.streaming_exchange~}
+            --streaming-exchange \
+            --peer-exchange-addr=":$((${var.peer_exchange_port} + idx))" \
             %{endif~}
             --mmap-relief=${var.mmap_relief} \
             --mmap-relief-threshold-mb=${var.mmap_relief_threshold_mb} \

--- a/deploy/benchmark/terraform/variables.tf
+++ b/deploy/benchmark/terraform/variables.tf
@@ -216,6 +216,18 @@ variable "data_plane" {
   default     = ""
 }
 
+variable "streaming_exchange" {
+  description = "Streaming exchange (docs/design/streaming-exchange.md): consumers fetch stage outputs from producing workers' local disk over gRPC (peer-exchange port below) with async S3 upload; every failure falls through to the S3 path. Wires the coordinator (TPCH_STREAMING_EXCHANGE) and worker --streaming-exchange flags together. Default false = today's synchronous S3 shuffle."
+  type        = bool
+  default     = false
+}
+
+variable "peer_exchange_port" {
+  description = "Worker↔worker peer-exchange (FetchShuffle) port; SG opens it intra-cluster whenever streaming_exchange is set."
+  type        = number
+  default     = 9095
+}
+
 variable "data_plane_port" {
   description = "TCP port for the gRPC data-plane listener on the coordinator. Workers dial coord on this port. Only used when data_plane=grpc."
   type        = number


### PR DESCRIPTION
Deploy-harness knob for the SF10 A/B of #174/#175: `-var=streaming_exchange=true` enables the flag on both the tpch-bench-embedded coordinator (via `TPCH_STREAMING_EXCHANGE`, same pattern as `WADJET_DYNAMIC_FILTERS`) and every worker process (`--streaming-exchange --peer-exchange-addr=:9095+idx`), plus the intra-SG peer-exchange port range. Default false = no change to existing deploys. `tofu validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)