### PR TITLE
feat(worker): morsel-driven execution Phase 1 — parallel linear fragments behind --morsel-workers

### DIFF
--- a/cmd/wadjet/main.go
+++ b/cmd/wadjet/main.go
@@ -80,6 +80,7 @@ var (
 	useSSL                bool
 	s3Region              string
 	maxConcurrent         int
+	morselWorkers         int
 	cacheBytes            int64
 	logLevel              string
 	natsTLSCert           string
@@ -145,6 +146,7 @@ func main() {
 	rootCmd.PersistentFlags().IntVar(&maxConcurrentQry, "max-concurrent-queries", 0, "Maximum concurrent queries (0=unlimited)")
 	rootCmd.PersistentFlags().StringVar(&metricsAddr, "metrics-addr", ":9100", "Prometheus metrics listen address (worker mode)")
 	rootCmd.PersistentFlags().IntVar(&maxConcurrent, "max-concurrent", 4, "Maximum concurrent tasks per worker")
+	rootCmd.PersistentFlags().IntVar(&morselWorkers, "morsel-workers", 1, "Intra-fragment parallel pipeline consumers per task (morsel-driven execution, docs/design/morsel-execution.md). 1 = serial (default; kill switch), 0 = auto (width adapts to fragment input size and idle CPU tokens), N>1 = fixed width of N (bypasses the size gate; testing/benchmark knob).")
 	rootCmd.PersistentFlags().StringVar(&dataPlane, "data-plane", "nats", "Worker↔coord data-plane transport: nats (default) or grpc. See project_split_plane_design_2026-05-20.")
 	rootCmd.PersistentFlags().StringVar(&dataPlaneAddr, "data-plane-addr", ":9091", "Data-plane gRPC listen address (coord/standalone)")
 	rootCmd.PersistentFlags().StringVar(&coordDataPlane, "coord-data-plane", "", "Coord's data-plane host:port (worker only; defaults to coord-host + 9091)")
@@ -846,6 +848,7 @@ func runStandalone(ctx context.Context, store objstore.Store, logger *slog.Logge
 		NATSUrl:               embeddedNATS.ClientURL(),
 		ClusterID:             clusterID,
 		MaxConcurrent:         maxConcurrent,
+		MorselWorkers:         morselWorkersConfig(morselWorkers),
 		CacheBytes:            cacheBytes,
 		MemoryBudget:          memoryBudget,
 		SharedPoolBudget:      sharedPoolBudget,
@@ -1398,6 +1401,7 @@ func runWorker(ctx context.Context, store objstore.Store, logger *slog.Logger) e
 		NATSUrl:               natsAddr,
 		ClusterID:             clusterID,
 		MaxConcurrent:         maxConcurrent,
+		MorselWorkers:         morselWorkersConfig(morselWorkers),
 		CacheBytes:            cacheBytes,
 		MemoryBudget:          memoryBudget,
 		SharedPoolBudget:      sharedPoolBudget,
@@ -2056,6 +2060,16 @@ func peerListenAddr() string {
 		return ""
 	}
 	return peerExchangeAddr
+}
+
+// morselWorkersConfig maps the --morsel-workers flag to worker.Config
+// semantics: flag 0 (auto) becomes Config -1, because the Config zero value
+// must stay serial/dormant for programmatic callers that never set it.
+func morselWorkersConfig(flagVal int) int {
+	if flagVal == 0 {
+		return -1
+	}
+	return flagVal
 }
 
 func deriveDataPlaneAddr(natsAddr, portFromFlag string) string {

--- a/docs/design/morsel-execution.md
+++ b/docs/design/morsel-execution.md
@@ -1,0 +1,305 @@
+# Morsel-Driven Execution — Design Memo
+
+> **Status:** proposed (v1 scoped, not started). **Date:** 2026-07-02.
+> **Verified against:** main @ 0cc5419 (post-#177). `file:line` anchors
+> drift — confirm before relying on them.
+
+## 1. Goal
+
+Decouple a worker's CPU parallelism from its memory-owner count. Today both
+are the same knob: `max_concurrent` task slots, each driving one pipeline
+with (essentially) one compute goroutine. The SF100 history is unambiguous
+that this knob is **pinned by memory, not CPU** — mc=4 on 16-vCPU workers
+survived only after the HashJoin partition-on-arrival fix, and every prior
+attempt to raise it died on cumulative live heap, never on cores
+(`sf100-distributed.tfvars:17-33`). Steady state leaves ~12 of 16 vCPUs
+idle whenever tasks aren't inside one of the existing bursty parallel
+sections. Morsel-driven execution (HyPer, Leis et al.) runs **few pipeline
+(memory) instances with many worker threads pulling small work units**, so
+CPU utilization scales to cores while the number of concurrent
+accumulating operators — the thing that OOMs — stays where admission put it.
+
+This is the last Tier-1 keystone on the Trino-gap roadmap; it also unblocks
+the streaming-exchange follow-up ("eager consumer dispatch"), which needs
+intra-task consumption that can absorb producer-task files as they appear.
+
+## 2. Current state (verified 2026-07-02)
+
+The exploration found that **most of the morsel machinery already exists**
+— built for the single-process engine — and the production distributed path
+is the one place it is never engaged.
+
+**The production fragment path is serial.** `executeFragment`
+(`worker/executor_fragment.go:169`) drives linear fragments with a
+2-goroutine producer/consumer split (`runFragmentLinear:326`, source decode
+overlapped with the op chain, channel cap 2) and breaker fragments with
+fully serial phases (`runFragmentWithBreakers:493` → `exec.Pipeline` built
+**without `Workers`** → `runSerial`). Intra-task parallelism today is
+step-local and bursty: per-column parquet decode
+(`scan/columnar_native.go:134`), per-partition shuffle writes
+(`partitioned_shuffle_sink.go:174`), overlapped builds of *distinct* joins
+(`executor_fragment.go:851`), async uploads. The operator chain and every
+breaker consume/drain phase are one goroutine.
+
+**A morsel engine already exists and runs in production — elsewhere.**
+`exec.Pipeline.runParallel` (`engine/exec/pipeline.go:175`): N workers
+share one source (a buffered channel *is* the morsel queue; `Next()` is
+the pull), each runs a **cloned** op chain (`Cloneable`,
+`operators.go:42` — "each clone gets its own scratch buffers"), each feeds
+a per-worker **`MergeableSink`** clone, partials merge after the join
+barrier. The planner enables it with `Workers = runtime.NumCPU()` whenever
+the source is channel-based (`planner/physical/plan.go:1573`), so the
+embedded `wadjet.DB`, the coordinator local fast path, and the HTTP server
+already execute this way. The distributed fragment runner is the only
+`pipeline.Run` caller that bypasses it.
+
+**Operator taxonomy (who can already do this):**
+
+| Operator | Parallel story today |
+|---|---|
+| Filter/Project/expr ops | `Cloneable` — fresh scratch per clone; trivially morsel-safe |
+| HashJoin probe | **Concurrency-safe by design**, proven in production: `broadcastJoinCache` shares one built join across concurrent probe *tasks* with zero probe-path synchronization (`worker/broadcast_join_cache.go:20-25`); per-probe scratch via `h.Probe()`, atomic lazy key resolution. Exception: RIGHT/FULL OUTER mark matched build rows under `h.mu` (`join.go:1834,1938`) — correct but serializing |
+| HashAggregate | `MergeableSink`: spill-less per-worker partials with SoA fast merges (`aggregate.go:2728,2743,2859`); merge itself single-threaded |
+| Sort | `MergeableSink`: per-worker batch lists, concat merge, single sort at Finalize (`sort.go:312,323`) |
+| Limit | Shares itself — atomic counters + `DoneSignaler` (`limit.go:97-103`) |
+| **Window** | **NOT mergeable** — no CloneSink; N workers would serialize on its mutex (`window.go:123`). The serial funnel of the operator set |
+| Scan sources | Channel-based planner sources support concurrent `Next` (the allowlist at `plan.go:1573`); the fragment source (`cachedFileStreamSource`) is a single-threaded state machine; `RowGroupIter` walks row groups sequentially with unguarded cursors, though `ReadRowGroupNative` itself is safe per-row-group against the immutable `FileReader` |
+
+**Memory machinery is already morsel-ready.** Accounting is a worker-wide
+shared pool with per-task child trackers, all atomic/lock-free
+(`memory/tracker.go:53-98`; `executor.go:265-277`) — the Trino
+MemoryPool shape. `SpillManager` is thread-safe and its relief path
+already calls into accumulators from another thread (mutex +
+`accState` atomics). `TaskProgress` is atomic. Per-task `EstimatedBytes`
+admission (`worker.go:610`) is a per-task-total and is indifferent to
+thread count. **More threads per task does not create more memory
+owners** — this is the load-bearing fact.
+
+**Known ceilings to design against** (documented in-repo):
+- `runParallel`'s single shared source serializes workers per batch —
+  5-15% loss on I/O-bound parallel pipelines
+  (`docs/performance-bottlenecks.md:234`).
+- Parallelism pays only above a size threshold: the parallel join build is
+  gated because per-worker insert cost ate the win on small builds
+  (`join.go:653-702`). Granularity/worker-count must be adaptive.
+- Oversubscription is a real pathology: GOMAXPROCS is unpinned (=16), and
+  the existing bursty sections already reach for it; heartbeat starvation
+  under heavy mixed goroutine load is a tested failure mode
+  (`heartbeat_starvation_test.go:17`).
+- Selection-vector scratch aliasing: retaining sinks must snapshot `b.Sel`
+  (`pipeline.go:530-542`); a batch belongs to exactly one worker at a time.
+- Clone-lifecycle hygiene: transient operator instances must
+  `UnpublishOwned` at close or the ledger drifts (`tracker.go:172`, the
+  −146 GB incident).
+
+## 3. Design space
+
+### A. Engage the existing parallel model on the fragment path (per-task morsels)
+
+Make `executeFragment` drive its pipelines the way the single-process
+engine already does: a concurrent morsel-dispensing source + `Workers = k`
+cloned op chains + mergeable breaker sinks. No new scheduler; the bounded
+channel is the work queue and idle workers pulling from it is the load
+balancing (fixed-worker data parallelism, not stealing — sufficient when
+morsels are uniform-ish batches).
+
+### B. Worker-global morsel scheduler with work stealing
+
+A single pool of ~GOMAXPROCS threads owned by the worker process; every
+active task contributes pipeline jobs; threads steal morsels across tasks.
+The full HyPer shape. Strictly more powerful: global CPU governance falls
+out for free, skew between tasks self-balances, `max_concurrent` becomes a
+pure memory-admission knob.
+
+### C. Just raise `max_concurrent`
+
+Rejected outright: it multiplies memory owners — the exact thing the SF100
+history shows OOMs. It also multiplies broadcast build decodes
+(`broadcast_join_cache.go:22`: builds decoded once per concurrent probe
+task). Never-OOM says no.
+
+### Decision
+
+**V1 = A, with B's CPU governance extracted as a small shared primitive;
+full work-stealing deferred.** Rationale:
+
+1. A reuses interfaces that are **already proven in production** on three
+   entry paths; the delta is confined to the fragment runner and the
+   fragment sources. B requires a new scheduler, a per-pipeline state
+   machine, and rewiring task lifecycle (progress, cancel, admission) —
+   and its marginal win over A is cross-task stealing, which matters most
+   when tasks are skewed *and* scarce; at mc=4 with fan-out task counts ≥
+   capacity, per-task parallelism recovers most of the idle CPU.
+2. The one piece of B that v1 cannot skip is **global CPU budgeting**: k
+   morsel workers × mc tasks + the existing bursty sections must not
+   oversubscribe GOMAXPROCS (the starvation pathology). A tiny process-wide
+   semaphore ("CPU tokens", capacity ≈ GOMAXPROCS) acquired by morsel
+   workers and the existing errgroup sections gives A the governance
+   without B's scheduler. This primitive *is* B's kernel; if stealing is
+   ever needed, it grows from here.
+3. Sequencing with streaming exchange: eager consumer dispatch wants
+   "pipeline consumes inputs as they appear" — A's dispenser source is
+   exactly that seam.
+
+## 4. Mechanism (v1)
+
+### 4.1 The morsel dispenser (fragment source concurrency)
+
+Replace the fragment's single-threaded source pull with a **dispenser**: 
+one producer goroutine per input *file* stage feeding a bounded channel of
+`*batch.RecordBatch` (the morsel = one batch, 2048 rows), consumed by k
+pipeline workers via concurrent `Next()`. This is the same shape the
+planner sources already have, applied to `cachedFileStreamSource`:
+
+- **Granularity:** the dispenser decodes at existing boundaries — WSHF
+  chunk / parquet row group — inside the producer; consumers never touch
+  decode state. Row-group-parallel *decode* (multiple producer goroutines
+  over one file's row groups, which `ReadRowGroupNative`'s immutability
+  makes legal) is a v1.5 upgrade behind the same interface; v1 keeps one
+  producer per source and gets consumer-side parallelism only. This
+  sidesteps the unguarded `RowGroupIter` cursors rather than retrofitting
+  atomics into them.
+- The bounded channel (small, ~2×k) preserves the never-OOM property:
+  decode cannot run ahead of consumption by more than the channel depth,
+  same as today's `batchChanCap = 2` split.
+- No shared source mutex — the channel replaces it, addressing the
+  documented 5-15% `sourceMu` ceiling.
+
+### 4.2 Worker count policy (adaptive, threshold-gated)
+
+`k = 1` (today's behavior) unless the fragment's input estimate clears a
+bytes threshold, then `k = min(cpuTokensAvailable, fragmentParallelismCap)`.
+Sizing inputs already exist: `task.EstimatedBytes`, per-file sizes, and the
+join-build size-gate precedent. Small fragments must not pay clone/merge
+overhead — this is the `join.go` lesson institutionalized. The CPU-token
+semaphore (capacity `GOMAXPROCS`, minus a reserve for the runtime/heartbeat
+goroutines) bounds Σ(k) across concurrent tasks *and* is taken by the
+existing errgroup bursts, so the process never schedules more compute
+goroutines than cores.
+
+### 4.3 Pipeline breakers
+
+- **HashAggregate / Sort:** per-worker `CloneSink` partials merged at the
+  barrier — existing, tested machinery. Two rules make it never-OOM-safe
+  (the one real memory tension in this design):
+  1. **Clones reserve.** Spill-less partials are fine for low-cardinality
+     scan-side aggregation, but a high-NDV aggregate's per-worker partial
+     state is k× the serial footprint. Clone accumulation must be
+     accounted against the task's child tracker, and
+  2. **Pressure collapses k.** When `ShouldSpillFor` trips during
+     parallel consume, workers drain-and-merge into the spill-armed
+     primary and the fragment continues serial (k=1) with today's
+     partial-drain spill machinery. Parallelism is a fair-weather
+     optimization; the memory story under pressure is exactly the current,
+     SF100-validated one. No new spill format, no spilling clones.
+- **Window:** stays serial in v1 (no `CloneSink`; the shared-mutex funnel
+  is correctness-safe, just not parallel). A partition-key-sharded Window
+  is a self-contained follow-up.
+- **RIGHT/FULL OUTER probes:** stay under the existing `h.mu` match-marking
+  — correct, serializing only the marking. INNER/LEFT/SEMI/ANTI probe
+  fully parallel (production-proven).
+- **Merge phase:** single-threaded as today; a tree merge is a follow-up
+  only if profiles show the barrier merge on the critical path.
+- **End-state note (so collapse is not mistaken for the architecture):**
+  the long-term form of parallel aggregation is **partition-owned
+  partials** — workers own disjoint group-key partitions, so no group is
+  duplicated across partials (no k× state multiplication), and merge and
+  spill parallelize per partition. HashAggregate's existing
+  `fibHash & (drainK-1)` drain-partition scheme is already the right
+  sharding; the upgrade is routing clone partials onto it. Pressure-
+  collapse is the never-OOM guard until that lands, not the destination.
+
+### 4.4 What carries over unchanged
+
+Per-task admission (`EstimatedBytes`, `waitForPoolHeadroom`), the
+`max_concurrent` semaphore semantics (now purely a memory-owner/admission
+knob), coordinator task-count policy (§7), TaskProgress (atomic — safe
+from k workers; the "idle task" wedge detector gets coarser and that is
+acceptable: the per-task deadline and stage-idle backstops remain), task
+context cancellation (`runParallel` already fans cancel out via its
+worker ctx), batch single-owner discipline and `Sel` snapshot rules.
+
+## 5. Never-OOM analysis
+
+The design adds exactly one new memory consumer: k−1 extra clone partials
+per breaker fragment. Bounded by (a) clone reservations hitting the same
+shared pool that admission and spill already govern, (b) the
+pressure-collapse rule (§4.3) converting parallel consume back to the
+validated serial spill path, and (c) the bytes threshold keeping k=1 for
+small fragments. Scan-side fused partial aggregates (the common case) have
+group counts bounded by the fusion design and were the original
+justification for spill-less clones. The dispenser channel bounds decode
+run-ahead. No operator gains an unaccounted buffer; no sleep-based
+backpressure anywhere (channel + semaphore only).
+
+## 6. Blast radius
+
+Changes live in: `worker/executor_fragment.go` (engage Workers + dispenser
++ pressure-collapse), fragment source wrappers around
+`cachedFileStreamSource`/`partition_shard_source`, a new `cpuTokens`
+primitive (worker-scoped), and small additions in `exec` (formalize the
+`Source.Next` concurrency contract that today is an ad-hoc type allowlist
+at `plan.go:1573`; pressure-collapse hook on the parallel run). The
+embedded DB / fast path / HTTP paths are untouched (already parallel);
+`exec.Pipeline.runParallel` gains the collapse hook and token awareness,
+which those paths inherit.
+
+## 7. Coordinator interaction
+
+V1 leaves task granularity alone: task counts keyed to
+`ClusterCapacity = Σ MaxConcurrent` still bound per-task memory, and
+`splitFilesEvenly`/`ScanShardCount` still spread bytes. Morsels change how
+fast a slot drains, not what a slot holds. Two follow-ups become available
+later, deliberately out of v1: raising per-task file counts (fewer, larger
+tasks now that a task can eat them in parallel — fewer stage-boundary
+files also compounds with streaming exchange), and reporting a CPU
+dimension in heartbeats for bin-packing. Don't touch either until v1's
+utilization data says where the next bottleneck is.
+
+## 8. Rollout and gates
+
+- Flag-gated: `--morsel-workers` (serve flag; 0/absent = auto policy from
+  §4.2, 1 = today's serial behavior as the kill switch). Config zero value
+  = serial, dormant-safe.
+- Gates in order: unit (dispenser contract, clone/merge parity per
+  operator, pressure-collapse mid-consume, CPU-token accounting,
+  Sel-snapshot under reorder), `-race` on all of it (this feature is
+  *made* of data races waiting to happen), multi-worker e2e row parity
+  serial vs parallel, `tpch-harness --mode=local` both flag states, SF10
+  A/B, then SF100 with the standard preflight — SF100 is the real gate:
+  it is where mc-vs-memory history lives, so watch Q17/Q18/Q21 heap/spill
+  behavior, worker RSS, and reap counts, not just wall.
+- Instrumentation from day one: per-fragment k chosen, CPU-token
+  utilization, pressure-collapse count, clone partial peak bytes, merge
+  barrier time.
+
+## 9. Rejected / deferred
+
+- **Raise max_concurrent** — multiplies memory owners; the SF100 record is
+  the refutation (§3C).
+- **Full work-stealing scheduler now** — B's kernel (CPU tokens) ships in
+  v1; the stealing layer waits until per-task parallelism's utilization
+  data shows cross-task skew actually matters at mc=4.
+- **Retrofit atomics into `RowGroupIter` for consumer-side decode** —
+  producer-side decode behind the dispenser achieves the same overlap
+  without making a hot cursor loop atomic; revisit only if single-producer
+  decode is the measured ceiling (then add producers per file, §4.1).
+- **Spilling clone partials** — collapse-to-serial reuses the validated
+  spill path instead of inventing a concurrent one.
+- **NUMA awareness** — single-socket cloud VMs; not applicable.
+
+## 10. Kickoff open questions — answers
+
+1. **Morsel granularity:** one `RecordBatch` via a bounded-channel
+   dispenser; decode stays producer-side at row-group/WSHF-chunk
+   boundaries (§4.1).
+2. **Shared vs partitioned breaker state:** per-worker clone partials +
+   merge (existing `MergeableSink`), with reservation + pressure-collapse
+   rules; probes share the immutable build (production-proven); Window
+   serial in v1 (§4.3).
+3. **Scheduler shape:** per-task fixed-worker pull from the dispenser +
+   process-wide CPU-token semaphore; no global queue yet (§3, §4.2).
+4. **Memory ledger:** unchanged shared pool + child trackers (already
+   thread-safe); clones reserve; admission untouched (§5).
+5. **Progress/cancel:** atomic progress is k-safe; cancel fans out via the
+   parallel run's worker ctx; wedge detection backstops unchanged (§4.4).

--- a/internal/engine/exec/join_spill.go
+++ b/internal/engine/exec/join_spill.go
@@ -213,7 +213,13 @@ func (s *spillState) closeProbeWriters() error {
 	return nil
 }
 
-// cleanup removes all spill files.
+// cleanup removes all spill files and clears the partition bookkeeping.
+// Clearing matters under morsel-parallel fragments: cloned HashJoinProbes
+// share this spillState with per-probe drain cursors, and the fragment
+// runner drains every clone's chain. The first drain processes all spilled
+// partitions and lands here; without the clears, the next clone's
+// HasPendingFlush would see stale spilledParts entries and re-open files
+// this call just deleted.
 func (s *spillState) cleanup() {
 	for _, files := range s.partBuildFiles {
 		for _, f := range files {
@@ -225,6 +231,9 @@ func (s *spillState) cleanup() {
 			os.Remove(f)
 		}
 	}
+	clear(s.spilledParts)
+	clear(s.partBuildFiles)
+	clear(s.partProbeFiles)
 }
 
 // ---- Columnar Batch Spill I/O ----

--- a/internal/worker/cpu_tokens.go
+++ b/internal/worker/cpu_tokens.go
@@ -1,0 +1,88 @@
+package worker
+
+import (
+	"runtime"
+	"sync/atomic"
+)
+
+// cpuTokens is a worker-wide counting semaphore over EXTRA compute
+// goroutines (morsel-driven execution, docs/design/morsel-execution.md §4.2).
+// Every task's first pipeline goroutine is free — the serial baseline is
+// always allowed — and only additional parallel consumers take tokens, so
+// Σ(extra widths) across concurrent tasks never schedules more compute
+// goroutines than the reserved core budget.
+//
+// Acquisition is non-blocking BY DESIGN: a fragment that cannot get tokens
+// degrades to a narrower width (ultimately serial) instead of waiting.
+// Blocking here would recreate the parked-waiter admission shape rejected in
+// project_admission_control_rejected_2026-05-18 — a goroutine holding
+// upstream resources while gated on capacity that only its own progress
+// would release.
+type cpuTokens struct {
+	capacity int64
+	used     atomic.Int64
+}
+
+// newCPUTokens creates a token pool of the given capacity. Capacity 0 (or
+// negative) is legal and means "no extra parallelism ever" — every
+// TryAcquire returns 0 and fragments run serial.
+func newCPUTokens(capacity int) *cpuTokens {
+	if capacity < 0 {
+		capacity = 0
+	}
+	return &cpuTokens{capacity: int64(capacity)}
+}
+
+// defaultCPUTokenCapacity reserves two cores of headroom for the process's
+// fixed goroutine load — GC workers, NATS/gRPC I/O, and the heartbeat loop.
+// Heartbeat starvation under compute oversubscription is a tested failure
+// mode (heartbeat_starvation_test.go), so the reserve is not optional.
+func defaultCPUTokenCapacity() int {
+	return runtime.GOMAXPROCS(0) - 2
+}
+
+// TryAcquire claims up to n tokens without blocking and returns how many it
+// got (0..n). Callers must Release exactly that many when done.
+func (t *cpuTokens) TryAcquire(n int) int {
+	if t == nil || n <= 0 {
+		return 0
+	}
+	for {
+		cur := t.used.Load()
+		avail := t.capacity - cur
+		if avail <= 0 {
+			return 0
+		}
+		take := int64(n)
+		if take > avail {
+			take = avail
+		}
+		if t.used.CompareAndSwap(cur, cur+take) {
+			return int(take)
+		}
+	}
+}
+
+// Release returns n previously acquired tokens to the pool.
+func (t *cpuTokens) Release(n int) {
+	if t == nil || n <= 0 {
+		return
+	}
+	t.used.Add(-int64(n))
+}
+
+// InUse reports the number of tokens currently held (instrumentation).
+func (t *cpuTokens) InUse() int64 {
+	if t == nil {
+		return 0
+	}
+	return t.used.Load()
+}
+
+// Capacity reports the pool size (instrumentation).
+func (t *cpuTokens) Capacity() int64 {
+	if t == nil {
+		return 0
+	}
+	return t.capacity
+}

--- a/internal/worker/cpu_tokens_test.go
+++ b/internal/worker/cpu_tokens_test.go
@@ -1,0 +1,82 @@
+package worker
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestCPUTokens_TryAcquireSemantics(t *testing.T) {
+	tok := newCPUTokens(4)
+
+	if got := tok.TryAcquire(0); got != 0 {
+		t.Errorf("TryAcquire(0) = %d, want 0", got)
+	}
+	if got := tok.TryAcquire(-1); got != 0 {
+		t.Errorf("TryAcquire(-1) = %d, want 0", got)
+	}
+	// Partial grant when the ask exceeds what's left.
+	if got := tok.TryAcquire(3); got != 3 {
+		t.Fatalf("TryAcquire(3) = %d, want 3", got)
+	}
+	if got := tok.TryAcquire(3); got != 1 {
+		t.Fatalf("TryAcquire(3) after 3 held = %d, want 1 (partial)", got)
+	}
+	// Exhausted: non-blocking zero, not a wait.
+	if got := tok.TryAcquire(1); got != 0 {
+		t.Fatalf("TryAcquire(1) at capacity = %d, want 0", got)
+	}
+	tok.Release(4)
+	if got := tok.InUse(); got != 0 {
+		t.Fatalf("InUse after full release = %d, want 0", got)
+	}
+	if got := tok.TryAcquire(10); got != 4 {
+		t.Fatalf("TryAcquire(10) on empty pool = %d, want capacity 4", got)
+	}
+}
+
+func TestCPUTokens_ZeroCapacityAndNil(t *testing.T) {
+	tok := newCPUTokens(0)
+	if got := tok.TryAcquire(5); got != 0 {
+		t.Errorf("zero-capacity TryAcquire = %d, want 0", got)
+	}
+	neg := newCPUTokens(-3)
+	if got := neg.TryAcquire(1); got != 0 {
+		t.Errorf("negative-capacity TryAcquire = %d, want 0", got)
+	}
+	var nilTok *cpuTokens
+	if got := nilTok.TryAcquire(1); got != 0 {
+		t.Errorf("nil TryAcquire = %d, want 0", got)
+	}
+	nilTok.Release(1) // must not panic
+	if nilTok.InUse() != 0 || nilTok.Capacity() != 0 {
+		t.Error("nil accessors should report 0")
+	}
+}
+
+// TestCPUTokens_ConcurrentNeverExceedsCapacity hammers the pool from many
+// goroutines and asserts the invariant the whole design leans on: the sum of
+// outstanding grants never exceeds capacity, and everything returns to zero.
+// Run under -race.
+func TestCPUTokens_ConcurrentNeverExceedsCapacity(t *testing.T) {
+	const capacity = 6
+	tok := newCPUTokens(capacity)
+
+	var wg sync.WaitGroup
+	for g := 0; g < 16; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 1000; i++ {
+				got := tok.TryAcquire(3)
+				if used := tok.InUse(); used > capacity {
+					t.Errorf("InUse %d exceeds capacity %d", used, capacity)
+				}
+				tok.Release(got)
+			}
+		}()
+	}
+	wg.Wait()
+	if got := tok.InUse(); got != 0 {
+		t.Fatalf("InUse after all released = %d, want 0", got)
+	}
+}

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -92,6 +92,14 @@ type Executor struct {
 	// uploads runs Phase-B background S3 uploads for AsyncUpload tasks.
 	// Always non-nil; dormant unless tasks arrive with the flag set.
 	uploads *uploadManager
+
+	// Morsel-driven intra-fragment parallelism (SetMorselWorkers,
+	// docs/design/morsel-execution.md). morselWorkers: 0/1 = serial (zero
+	// value is dormant-safe), -1 = auto, N>1 = fixed width. cpuTokens bounds
+	// the EXTRA compute goroutines across all concurrent tasks; nil when
+	// morsels are disabled.
+	morselWorkers int
+	cpuTokens     *cpuTokens
 }
 
 // NewExecutor creates a new task executor.
@@ -256,6 +264,20 @@ func (e *Executor) SetLogger(l *slog.Logger) {
 	e.logger = l
 	if e.uploads != nil {
 		e.uploads.logger = l
+	}
+}
+
+// SetMorselWorkers configures intra-fragment parallel pipeline consumers
+// (morsel-driven execution, docs/design/morsel-execution.md). 0 and 1 =
+// serial (today's behavior); -1 = auto (width adapts to fragment input size
+// and idle CPU tokens); N>1 = fixed width of N. Must be called before the
+// worker starts executing tasks.
+func (e *Executor) SetMorselWorkers(n int) {
+	e.morselWorkers = n
+	if n == -1 || n > 1 {
+		e.cpuTokens = newCPUTokens(defaultCPUTokenCapacity())
+	} else {
+		e.cpuTokens = nil
 	}
 }
 

--- a/internal/worker/executor_fragment.go
+++ b/internal/worker/executor_fragment.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -39,6 +41,9 @@ const fragmentProgressInterval = 30 * time.Second
 // worker logs (the SF100 Q17 hang investigation needed this signal because
 // the coord saw silence between dispatch and reap with no worker-side
 // evidence of forward progress).
+// All counters are atomic and the log timestamps are mutex-guarded: under
+// morsel-parallel fragments (runFragmentLinearParallel) addRows and
+// applyBackpressure are called concurrently from k consumer goroutines.
 type fragmentProgress struct {
 	logger    *slog.Logger
 	taskID    string
@@ -46,15 +51,17 @@ type fragmentProgress struct {
 	stageType string
 	exec      *Executor // for SharedPoolStats(); nil-safe in tests
 	started   time.Time
-	lastLog   time.Time
-	rows      int64
+	rows      atomic.Int64
 
 	// Heap-backpressure tracking. The fragment runner calls applyBackpressure
 	// between batches; when HeapBackpressureActive() fires it sleeps briefly
 	// to let GC catch up. We summarize how often and how long that fired so
 	// worker logs make slow-task root cause obvious without per-pause spam.
-	backpressureCount   int64
-	backpressurePauseMS int64
+	backpressureCount   atomic.Int64
+	backpressurePauseMS atomic.Int64
+
+	mu                  sync.Mutex // guards the two log timestamps below
+	lastLog             time.Time
 	lastBackpressureLog time.Time
 }
 
@@ -72,17 +79,21 @@ func newFragmentProgress(logger *slog.Logger, task distributed.Task, e *Executor
 }
 
 func (p *fragmentProgress) addRows(n int64) {
-	p.rows += n
+	total := p.rows.Add(n)
+	p.mu.Lock()
 	if time.Since(p.lastLog) < fragmentProgressInterval {
+		p.mu.Unlock()
 		return
 	}
+	p.lastLog = time.Now()
+	p.mu.Unlock()
 	elapsed := time.Since(p.started)
 	attrs := []any{
 		"task_id", p.taskID,
 		"stage_id", p.stageID,
 		"stage_type", p.stageType,
 		"elapsed", elapsed.Round(time.Second),
-		"rows", p.rows,
+		"rows", total,
 	}
 	if p.exec != nil {
 		used, budget := p.exec.SharedPoolStats()
@@ -93,13 +104,12 @@ func (p *fragmentProgress) addRows(n int64) {
 				"pool_pct", used*100/budget)
 		}
 	}
-	if p.backpressureCount > 0 {
+	if bp := p.backpressureCount.Load(); bp > 0 {
 		attrs = append(attrs,
-			"bp_count", p.backpressureCount,
-			"bp_paused_ms", p.backpressurePauseMS)
+			"bp_count", bp,
+			"bp_paused_ms", p.backpressurePauseMS.Load())
 	}
 	p.logger.Info("fragment task progress", attrs...)
-	p.lastLog = time.Now()
 }
 
 // applyBackpressure pauses the consume loop briefly when the process heap
@@ -121,23 +131,29 @@ func (p *fragmentProgress) applyBackpressure(ctx context.Context) error {
 	if !memory.HeapBackpressureActive() {
 		return nil
 	}
-	p.backpressureCount++
+	p.backpressureCount.Add(1)
 	started := time.Now()
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-time.After(fragmentBackpressurePauseMS * time.Millisecond):
 	}
-	p.backpressurePauseMS += time.Since(started).Milliseconds()
+	p.backpressurePauseMS.Add(time.Since(started).Milliseconds())
 	// Log on the first hit and at most every 30 s thereafter so sustained
 	// backpressure shows up in logs without flooding them.
-	if p.lastBackpressureLog.IsZero() || time.Since(p.lastBackpressureLog) > 30*time.Second {
+	p.mu.Lock()
+	shouldLog := p.lastBackpressureLog.IsZero() || time.Since(p.lastBackpressureLog) > 30*time.Second
+	if shouldLog {
+		p.lastBackpressureLog = time.Now()
+	}
+	p.mu.Unlock()
+	if shouldLog {
 		attrs := []any{
 			"task_id", p.taskID,
 			"stage_id", p.stageID,
 			"stage_type", p.stageType,
-			"count", p.backpressureCount,
-			"total_paused_ms", p.backpressurePauseMS,
+			"count", p.backpressureCount.Load(),
+			"total_paused_ms", p.backpressurePauseMS.Load(),
 		}
 		if p.exec != nil {
 			used, budget := p.exec.SharedPoolStats()
@@ -148,7 +164,6 @@ func (p *fragmentProgress) applyBackpressure(ctx context.Context) error {
 			}
 		}
 		p.logger.Info("fragment task heap backpressure", attrs...)
-		p.lastBackpressureLog = time.Now()
 	}
 	return nil
 }
@@ -324,6 +339,21 @@ func buildDynamicFilterEmitOps(specs []distributed.DynamicFilterEmit) ([]*exec.D
 // goroutine to avoid races on its counters; applyBackpressure (heap-pressure
 // pause) lives in the consumer so the pause reflects the full pipeline state.
 func (e *Executor) runFragmentLinear(ctx context.Context, task distributed.Task, src exec.Source, ops []exec.UnaryOperator, sink fragmentSink, result *distributed.ResultNotification) error {
+	// Morsel-driven parallel path (docs/design/morsel-execution.md §4). k > 1
+	// only when the flag allows it, every op is Cloneable, the fragment
+	// clears the size gate, and CPU tokens are available. Tokens are held for
+	// the duration of the fragment.
+	if k, release := e.morselFragmentWorkers(task, ops); k > 1 {
+		defer release()
+		e.logger.Debug("morsel parallel fragment",
+			"task_id", task.ID,
+			"stage_id", task.StageID,
+			"k", k,
+			"estimated_bytes", task.EstimatedBytes,
+			"cpu_tokens_in_use", e.cpuTokens.InUse(),
+			"cpu_tokens_cap", e.cpuTokens.Capacity())
+		return e.runFragmentLinearParallel(ctx, task, src, ops, sink, result, k)
+	}
 	progress := exec.ProgressReporterFromContext(ctx)
 	fp := newFragmentProgress(e.logger, task, e)
 	var totalRows int64
@@ -402,6 +432,222 @@ func (e *Executor) runFragmentLinear(ctx context.Context, task distributed.Task,
 		return fmt.Errorf("fragment task %s: flush spilled ops: %w", task.ID, err)
 	}
 	result.NumRows = totalRows
+	if err := sink.finalize(ctx, task, result); err != nil {
+		return fmt.Errorf("fragment task %s: sink finalize: %w", task.ID, err)
+	}
+	return nil
+}
+
+// morselMinFragmentBytes is the auto-mode size gate: fragments whose
+// EstimatedBytes fall below it stay serial. Parallelism pays only above a
+// size threshold — the parallel join build learned this the hard way
+// (join.go, size-gated for the same reason). Package-level var so tests can
+// lower it.
+var morselMinFragmentBytes int64 = 64 << 20
+
+// morselFragmentParallelismCap bounds per-fragment width regardless of
+// policy: past ~8 consumers the single producer (source decode) is the
+// bottleneck and extra clones only add merge/scratch overhead.
+const morselFragmentParallelismCap = 8
+
+// morselFragmentWorkers decides the parallel width for a linear fragment and
+// acquires CPU tokens for the extra consumers. Returns k and a release
+// function (call exactly once, after the fragment finishes). k == 1 means
+// serial — the returned release is a no-op.
+//
+// The first consumer is free (the serial baseline is always allowed); each
+// extra consumer takes one token. Acquisition is non-blocking: under token
+// exhaustion the fragment degrades toward serial rather than queueing.
+func (e *Executor) morselFragmentWorkers(task distributed.Task, ops []exec.UnaryOperator) (int, func()) {
+	noop := func() {}
+	policy := e.morselWorkers
+	if policy == 0 || policy == 1 || e.cpuTokens == nil {
+		return 1, noop
+	}
+	// Every op must be Cloneable — non-cloneable ops (e.g. the
+	// DynamicFilterEmitOp accumulator) keep the fragment serial.
+	for _, op := range ops {
+		if _, ok := op.(exec.Cloneable); !ok {
+			return 1, noop
+		}
+	}
+	target := policy
+	if policy < 0 { // auto: size-gated, width up to core count
+		if task.EstimatedBytes < morselMinFragmentBytes {
+			return 1, noop
+		}
+		target = runtime.GOMAXPROCS(0)
+	}
+	if target > morselFragmentParallelismCap {
+		target = morselFragmentParallelismCap
+	}
+	if target <= 1 {
+		return 1, noop
+	}
+	got := e.cpuTokens.TryAcquire(target - 1)
+	if got == 0 {
+		return 1, noop
+	}
+	return 1 + got, func() { e.cpuTokens.Release(got) }
+}
+
+// runFragmentLinearParallel is the morsel-driven variant of
+// runFragmentLinear: the same single producer feeds a bounded channel (the
+// morsel dispenser — cap 2·k preserves the decode-can't-run-ahead property
+// of the serial split), consumed by k goroutines that each run a private
+// Clone()d copy of the op chain. The fragment sink is shared behind a mutex:
+// every fragment sink consumes each batch synchronously (partitioned shuffle
+// write, WSHF append, gather publish) and retains no reference afterward, so
+// serializing consume is sufficient — no Sel snapshot needed.
+//
+// One batch is pushed through the ORIGINAL ops before cloning ("warmup",
+// same pattern as exec.Pipeline.runParallel): operator scratch is per-clone,
+// but predicate/expression closures are SHARED across clones and resolve
+// column indices lazily on first use (exec.ColumnCompare's cachedIdx,
+// expr.ColRef's sync.Once). The warmup batch completes those writes while
+// the chain is still single-threaded; clones then only read the resolved
+// caches.
+func (e *Executor) runFragmentLinearParallel(ctx context.Context, task distributed.Task, src exec.Source, ops []exec.UnaryOperator, sink fragmentSink, result *distributed.ResultNotification, k int) error {
+	progress := exec.ProgressReporterFromContext(ctx)
+	fp := newFragmentProgress(e.logger, task, e)
+	var totalRows atomic.Int64
+	var sinkMu sync.Mutex
+	consume := func(ctx context.Context, b *batch.RecordBatch) error {
+		sinkMu.Lock()
+		err := sink.consume(ctx, b)
+		sinkMu.Unlock()
+		if err != nil {
+			return err
+		}
+		n := int64(b.ActiveLen())
+		totalRows.Add(n)
+		if progress != nil {
+			progress.AddRows(n)
+		}
+		fp.addRows(n)
+		return nil
+	}
+
+	// Warmup: one batch through the original chain before any clone exists.
+	warmup, err := src.Next(ctx)
+	if err != nil {
+		return fmt.Errorf("fragment task %s: source next: %w", task.ID, err)
+	}
+	chains := make([][]exec.UnaryOperator, 1, k)
+	chains[0] = ops
+	if warmup != nil {
+		cur := warmup
+		for _, op := range ops {
+			cur, err = op.Execute(ctx, cur)
+			if err != nil {
+				return fmt.Errorf("fragment task %s: unary exec: %w", task.ID, err)
+			}
+			if cur == nil {
+				break
+			}
+		}
+		if cur != nil && cur.ActiveLen() > 0 {
+			if err := consume(ctx, cur); err != nil {
+				return fmt.Errorf("fragment task %s: sink consume: %w", task.ID, err)
+			}
+		}
+
+		// Build the k−1 cloned chains. Clones that return the original
+		// instance (Limit-style shared state) are neither re-Init'd nor
+		// closed — the original's owner handles both.
+		defer func() {
+			for _, chain := range chains[1:] {
+				for j, op := range chain {
+					if op == ops[j] {
+						continue
+					}
+					op.Close()
+				}
+			}
+		}()
+		for i := 1; i < k; i++ {
+			chain := make([]exec.UnaryOperator, len(ops))
+			for j, op := range ops {
+				chain[j] = op.(exec.Cloneable).Clone()
+			}
+			chains = append(chains, chain)
+			for j, cop := range chain {
+				if cop == ops[j] {
+					continue
+				}
+				if err := cop.Init(ctx); err != nil {
+					return fmt.Errorf("fragment task %s: cloned op init: %w", task.ID, err)
+				}
+			}
+		}
+
+		ch := make(chan *batch.RecordBatch, 2*k)
+		g, gctx := errgroup.WithContext(ctx)
+		// Producer: source.Next → channel. Closes ch on EOF or error. Decode
+		// stays single-threaded inside the source (WSHF chunk / parquet
+		// row-group state machines keep their unguarded cursors).
+		g.Go(func() error {
+			defer close(ch)
+			for {
+				b, err := src.Next(gctx)
+				if err != nil {
+					return fmt.Errorf("source next: %w", err)
+				}
+				if b == nil {
+					return nil
+				}
+				select {
+				case <-gctx.Done():
+					return gctx.Err()
+				case ch <- b:
+				}
+			}
+		})
+		for i := 0; i < k; i++ {
+			chain := chains[i]
+			g.Go(func() error {
+				for b := range ch {
+					if err := fp.applyBackpressure(gctx); err != nil {
+						return err
+					}
+					cur := b
+					var err error
+					for _, op := range chain {
+						cur, err = op.Execute(gctx, cur)
+						if err != nil {
+							return fmt.Errorf("unary exec: %w", err)
+						}
+						if cur == nil {
+							break
+						}
+					}
+					if cur == nil || cur.ActiveLen() == 0 {
+						continue
+					}
+					if err := consume(gctx, cur); err != nil {
+						return fmt.Errorf("sink consume: %w", err)
+					}
+				}
+				return nil
+			})
+		}
+		if err := g.Wait(); err != nil {
+			return fmt.Errorf("fragment task %s: %w", task.ID, err)
+		}
+	}
+
+	// Spilled-partition flush, over EVERY chain. Clone probes share the
+	// underlying join's spillState, so the first chain's drain processes all
+	// spilled partitions (including rows routed there by other clones) and
+	// its terminal cleanup() clears the partition maps — later chains see
+	// nothing pending and no-op. Iterating all chains keeps this correct if
+	// a future FlushableOperator holds per-instance flush state.
+	for _, chain := range chains {
+		if err := drainFlushableOps(ctx, chain, false, consume); err != nil {
+			return fmt.Errorf("fragment task %s: flush spilled ops: %w", task.ID, err)
+		}
+	}
+	result.NumRows = totalRows.Load()
 	if err := sink.finalize(ctx, task, result); err != nil {
 		return fmt.Errorf("fragment task %s: sink finalize: %w", task.ID, err)
 	}

--- a/internal/worker/morsel_fragment_test.go
+++ b/internal/worker/morsel_fragment_test.go
@@ -1,0 +1,385 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"runtime"
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/engine/exec"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+)
+
+// nonCloneableOp is a UnaryOperator that deliberately does NOT implement
+// exec.Cloneable — fragments containing one must stay serial.
+type nonCloneableOp struct{}
+
+func (nonCloneableOp) Init(context.Context) error { return nil }
+func (nonCloneableOp) Execute(_ context.Context, b *batch.RecordBatch) (*batch.RecordBatch, error) {
+	return b, nil
+}
+func (nonCloneableOp) Close() error { return nil }
+
+func TestMorselFragmentWorkers_Gates(t *testing.T) {
+	newExec := func(policy, tokens int) *Executor {
+		e := NewExecutor(objstore.NewMemStore(), NewLRUCache(1024*1024), nil)
+		e.SetMorselWorkers(policy)
+		if e.cpuTokens != nil {
+			e.cpuTokens = newCPUTokens(tokens)
+		}
+		return e
+	}
+	cloneable := []exec.UnaryOperator{exec.NewFilter(func(*batch.RecordBatch, int) bool { return true })}
+	bigTask := distributed.Task{EstimatedBytes: morselMinFragmentBytes}
+	smallTask := distributed.Task{EstimatedBytes: morselMinFragmentBytes - 1}
+
+	t.Run("zero value stays serial", func(t *testing.T) {
+		e := NewExecutor(objstore.NewMemStore(), NewLRUCache(1024*1024), nil)
+		if k, _ := e.morselFragmentWorkers(bigTask, cloneable); k != 1 {
+			t.Fatalf("k = %d, want 1", k)
+		}
+	})
+	t.Run("explicit 1 stays serial", func(t *testing.T) {
+		e := newExec(1, 8)
+		if k, _ := e.morselFragmentWorkers(bigTask, cloneable); k != 1 {
+			t.Fatalf("k = %d, want 1", k)
+		}
+	})
+	t.Run("fixed width acquires extras and releases", func(t *testing.T) {
+		e := newExec(4, 8)
+		k, release := e.morselFragmentWorkers(smallTask, cloneable) // fixed bypasses size gate
+		if k != 4 {
+			t.Fatalf("k = %d, want 4", k)
+		}
+		if got := e.cpuTokens.InUse(); got != 3 {
+			t.Fatalf("tokens in use = %d, want 3 (first consumer is free)", got)
+		}
+		release()
+		if got := e.cpuTokens.InUse(); got != 0 {
+			t.Fatalf("tokens in use after release = %d, want 0", got)
+		}
+	})
+	t.Run("token scarcity narrows width", func(t *testing.T) {
+		e := newExec(4, 1)
+		k, release := e.morselFragmentWorkers(bigTask, cloneable)
+		if k != 2 {
+			t.Fatalf("k = %d, want 2 (1 free + 1 token)", k)
+		}
+		release()
+	})
+	t.Run("token exhaustion degrades to serial", func(t *testing.T) {
+		e := newExec(4, 0)
+		k, release := e.morselFragmentWorkers(bigTask, cloneable)
+		if k != 1 {
+			t.Fatalf("k = %d, want 1", k)
+		}
+		release()
+		if got := e.cpuTokens.InUse(); got != 0 {
+			t.Fatalf("tokens leaked: %d", got)
+		}
+	})
+	t.Run("non-cloneable op stays serial without taking tokens", func(t *testing.T) {
+		e := newExec(4, 8)
+		ops := append([]exec.UnaryOperator{nonCloneableOp{}}, cloneable...)
+		k, _ := e.morselFragmentWorkers(bigTask, ops)
+		if k != 1 {
+			t.Fatalf("k = %d, want 1", k)
+		}
+		if got := e.cpuTokens.InUse(); got != 0 {
+			t.Fatalf("tokens in use = %d, want 0", got)
+		}
+	})
+	t.Run("auto respects size gate", func(t *testing.T) {
+		e := newExec(-1, 8)
+		if k, _ := e.morselFragmentWorkers(smallTask, cloneable); k != 1 {
+			t.Fatalf("small fragment k = %d, want 1", k)
+		}
+		k, release := e.morselFragmentWorkers(bigTask, cloneable)
+		want := runtime.GOMAXPROCS(0)
+		if want > morselFragmentParallelismCap {
+			want = morselFragmentParallelismCap
+		}
+		if want > 9 { // tokens(8) + 1 free
+			want = 9
+		}
+		if k != want {
+			t.Fatalf("big fragment k = %d, want %d", k, want)
+		}
+		release()
+	})
+	t.Run("fixed width capped", func(t *testing.T) {
+		e := newExec(64, 64)
+		k, release := e.morselFragmentWorkers(bigTask, cloneable)
+		if k != morselFragmentParallelismCap {
+			t.Fatalf("k = %d, want cap %d", k, morselFragmentParallelismCap)
+		}
+		release()
+	})
+}
+
+// TestExecuteFragment_MorselParallel_FilterParity runs the same
+// scan→filter→unpartitioned-sink fragment serial and morsel-parallel and
+// asserts the outputs are row-identical (as sets — parallel consumers
+// reorder). Multi-file input so the producer emits many batches; the filter
+// predicates are compiled closures with lazily-resolved column caches, so
+// running this under -race also exercises the warmup-before-clone rule.
+func TestExecuteFragment_MorselParallel_FilterParity(t *testing.T) {
+	ctx := context.Background()
+	const numFiles = 8
+	const rowsPerFile = 1000
+
+	run := func(t *testing.T, bucket string, morselWorkers int) (int64, []int64) {
+		store := objstore.NewMemStore()
+		if err := store.MakeBucket(ctx, bucket); err != nil {
+			t.Fatalf("MakeBucket: %v", err)
+		}
+		keys := make([]string, numFiles)
+		for f := 0; f < numFiles; f++ {
+			rows := make([][2]int64, rowsPerFile)
+			for i := range rows {
+				id := int64(f*rowsPerFile + i)
+				rows[i] = [2]int64{id, id * 10}
+			}
+			data := makeScanWshf(t, rows)
+			key := "in/scan/t" + strconv.Itoa(f) + ".wshf"
+			if _, err := store.Put(ctx, bucket, key, bytes.NewReader(data), int64(len(data)), "application/octet-stream"); err != nil {
+				t.Fatalf("Put: %v", err)
+			}
+			keys[f] = key
+		}
+
+		executor := NewExecutor(store, NewLRUCache(4*1024*1024), nil)
+		executor.SetMorselWorkers(morselWorkers)
+		if executor.cpuTokens != nil {
+			executor.cpuTokens = newCPUTokens(8) // deterministic width on small CI boxes
+		}
+
+		task := distributed.Task{
+			ID:           "frag-morsel-parity",
+			QueryID:      "q-morsel-parity",
+			StageID:      "scan-1",
+			Type:         distributed.TaskTypeStage,
+			DataBucket:   bucket,
+			ResultBucket: bucket,
+			ResultPrefix: "out/scan-1/",
+			Operators: []distributed.OpSpec{
+				{
+					Type:        distributed.OpScan,
+					InputAlias:  "t",
+					InputFiles:  keys,
+					InputBucket: bucket,
+					Columns:     []string{"id", "val"},
+				},
+				{
+					Type:       distributed.OpFilter,
+					Predicates: []string{"id > 500", "val < 60000"},
+				},
+				{
+					Type: distributed.OpUnpartitionedSink,
+				},
+			},
+		}
+		result := &distributed.ResultNotification{TaskID: task.ID}
+		if err := executor.executeStage(ctx, task, result); err != nil {
+			t.Fatalf("executeStage (morsel=%d): %v", morselWorkers, err)
+		}
+		if executor.cpuTokens != nil {
+			if held := executor.cpuTokens.InUse(); held != 0 {
+				t.Fatalf("cpu tokens leaked after fragment: %d", held)
+			}
+		}
+		if len(result.ResultFiles) != 1 {
+			t.Fatalf("expected 1 output file, got %d", len(result.ResultFiles))
+		}
+		ids := readMemStoreInts(t, store, bucket, result.ResultFiles[0], "id")
+		sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+		return result.NumRows, ids
+	}
+
+	serialRows, serialIDs := run(t, "morsel-parity-serial", 1)
+	parallelRows, parallelIDs := run(t, "morsel-parity-parallel", 4)
+
+	// ids 501..5999 pass both predicates (val = id*10 < 60000).
+	const wantRows = 5499
+	if serialRows != wantRows {
+		t.Fatalf("serial NumRows = %d, want %d", serialRows, wantRows)
+	}
+	if parallelRows != serialRows {
+		t.Fatalf("parallel NumRows = %d, serial = %d", parallelRows, serialRows)
+	}
+	if len(parallelIDs) != len(serialIDs) {
+		t.Fatalf("parallel output rows = %d, serial = %d", len(parallelIDs), len(serialIDs))
+	}
+	for i := range serialIDs {
+		if serialIDs[i] != parallelIDs[i] {
+			t.Fatalf("row %d: parallel id %d != serial id %d", i, parallelIDs[i], serialIDs[i])
+		}
+	}
+}
+
+// TestExecuteFragment_MorselParallel_JoinSpillFlush is the morsel-parallel
+// variant of TestExecuteFragment_HashJoinProbe_FlushesSpilledPartitions:
+// cloned probes share the grace join's spillState, all clones route
+// spilled-partition probe rows to the shared (mutex'd) writers, and the
+// post-Wait drain must produce each spilled match EXACTLY once — fewer means
+// a clone's routed rows were dropped, more means the per-clone drain
+// double-processed the shared partitions.
+func TestExecuteFragment_MorselParallel_JoinSpillFlush(t *testing.T) {
+	ctx := context.Background()
+	const bucket = "test-morsel-hj-flush"
+
+	const numBuildFiles = 4
+	const rowsPerFile = 2048
+	const buildN = numBuildFiles * rowsPerFile
+
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(ctx, bucket); err != nil {
+		t.Fatalf("MakeBucket: %v", err)
+	}
+	buildKeys := make([]string, numBuildFiles)
+	for f := 0; f < numBuildFiles; f++ {
+		rows := make([][2]int64, rowsPerFile)
+		for i := range rows {
+			id := int64(f*rowsPerFile + i)
+			rows[i] = [2]int64{id, id * 10}
+		}
+		data := makeBuildWshf(t, rows)
+		key := "in/hj/build-" + strconv.Itoa(f) + ".wshf"
+		if _, err := store.Put(ctx, bucket, key, bytes.NewReader(data), int64(len(data)), "application/octet-stream"); err != nil {
+			t.Fatal(err)
+		}
+		buildKeys[f] = key
+	}
+	// Probe side spans multiple files so the parallel consumers actually see
+	// concurrent batches.
+	const numProbeFiles = 4
+	const probePerFile = 2048
+	const probeN = numProbeFiles * probePerFile
+	probeKeys := make([]string, numProbeFiles)
+	for f := 0; f < numProbeFiles; f++ {
+		probeRows := make([]struct {
+			ID   int64
+			Name string
+		}, probePerFile)
+		for i := range probeRows {
+			n := f*probePerFile + i
+			probeRows[i] = struct {
+				ID   int64
+				Name string
+			}{ID: int64(n % buildN), Name: "row-" + strconv.Itoa(n)}
+		}
+		data := makeProbeWshf(t, probeRows)
+		key := "in/hj/probe-" + strconv.Itoa(f) + ".wshf"
+		if _, err := store.Put(ctx, bucket, key, bytes.NewReader(data), int64(len(data)), "application/octet-stream"); err != nil {
+			t.Fatal(err)
+		}
+		probeKeys[f] = key
+	}
+
+	executor := NewExecutor(store, NewLRUCache(4*1024*1024), nil)
+	// Tight shared budget forces the build to spill a partition; probe rows
+	// hashing there route to disk and re-enter via the flush drain.
+	executor.SetSharedPoolBudget(500 * 1024)
+	executor.SetMorselWorkers(4)
+	executor.cpuTokens = newCPUTokens(8)
+
+	task := distributed.Task{
+		ID:           "frag-morsel-hj-flush",
+		QueryID:      "q-morsel-hj-flush",
+		StageID:      "join-0",
+		Type:         distributed.TaskTypeStage,
+		DataBucket:   bucket,
+		ResultBucket: bucket,
+		ResultPrefix: "out/join-0/",
+		Operators: []distributed.OpSpec{
+			{
+				Type:        distributed.OpShuffleSource,
+				InputAlias:  "probe",
+				InputFiles:  probeKeys,
+				InputBucket: bucket,
+			},
+			{
+				Type:        distributed.OpBroadcastProbe,
+				JoinType:    "inner",
+				LeftKeys:    []string{"id"},
+				RightKeys:   []string{"id"},
+				BuildAlias:  "build",
+				BuildFiles:  buildKeys,
+				BuildBucket: bucket,
+			},
+			{
+				Type: distributed.OpUnpartitionedSink,
+			},
+		},
+	}
+
+	result := &distributed.ResultNotification{TaskID: task.ID}
+	if err := executor.executeStage(ctx, task, result); err != nil {
+		t.Fatalf("executeStage: %v", err)
+	}
+	if result.NumRows != int64(probeN) {
+		t.Fatalf("NumRows = %d, want exactly %d (fewer = spilled probe rows dropped; more = per-clone drain double-processed shared partitions)",
+			result.NumRows, probeN)
+	}
+	if held := executor.cpuTokens.InUse(); held != 0 {
+		t.Fatalf("cpu tokens leaked after fragment: %d", held)
+	}
+}
+
+// TestExecuteFragment_MorselParallel_EmptyInput covers the warmup-nil path:
+// input files exist but decode to zero batches. The parallel runner must
+// still run the flush drain and finalize the sink with NumRows 0.
+func TestExecuteFragment_MorselParallel_EmptyInput(t *testing.T) {
+	ctx := context.Background()
+	const bucket = "test-morsel-empty"
+
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(ctx, bucket); err != nil {
+		t.Fatalf("MakeBucket: %v", err)
+	}
+	data := makeScanWshf(t, nil)
+	key := "in/scan/empty.wshf"
+	if _, err := store.Put(ctx, bucket, key, bytes.NewReader(data), int64(len(data)), "application/octet-stream"); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	executor := NewExecutor(store, NewLRUCache(1024*1024), nil)
+	executor.SetMorselWorkers(4)
+	executor.cpuTokens = newCPUTokens(8)
+
+	task := distributed.Task{
+		ID:           "frag-morsel-empty",
+		QueryID:      "q-morsel-empty",
+		StageID:      "scan-1",
+		Type:         distributed.TaskTypeStage,
+		DataBucket:   bucket,
+		ResultBucket: bucket,
+		ResultPrefix: "out/scan-1/",
+		Operators: []distributed.OpSpec{
+			{
+				Type:        distributed.OpScan,
+				InputAlias:  "t",
+				InputFiles:  []string{key},
+				InputBucket: bucket,
+				Columns:     []string{"id", "val"},
+			},
+			{
+				Type: distributed.OpUnpartitionedSink,
+			},
+		},
+	}
+	result := &distributed.ResultNotification{TaskID: task.ID}
+	if err := executor.executeStage(ctx, task, result); err != nil {
+		t.Fatalf("executeStage: %v", err)
+	}
+	if result.NumRows != 0 {
+		t.Fatalf("NumRows = %d, want 0", result.NumRows)
+	}
+	if held := executor.cpuTokens.InUse(); held != 0 {
+		t.Fatalf("cpu tokens leaked: %d", held)
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -89,6 +89,15 @@ type Config struct {
 	// Empty = derived from the bound listener (specific IP, else the first
 	// non-loopback unicast IPv4).
 	PeerAdvertiseAddr string
+
+	// MorselWorkers controls intra-fragment parallel pipeline consumers per
+	// task (morsel-driven execution, docs/design/morsel-execution.md). 0
+	// (zero value) and 1 = serial, today's behavior — dormant-safe. -1 =
+	// auto: width adapts to fragment input size and idle CPU tokens. N>1 =
+	// fixed width of N (bypasses the size gate; testing/benchmark knob).
+	// Extra consumers are bounded worker-wide by a CPU-token pool sized
+	// GOMAXPROCS−2 so concurrent tasks cannot oversubscribe cores.
+	MorselWorkers int
 }
 
 // DefaultConfig returns default worker configuration.
@@ -202,6 +211,7 @@ func New(cfg Config, store objstore.Store, nc *nats.Conn, js jetstream.JetStream
 	}
 	executor.SetLogger(logger)
 	executor.SetNATSConn(nc)
+	executor.SetMorselWorkers(cfg.MorselWorkers)
 	// Phase 3: wire the system-reservoir registry for ACCOUNTING (Available()/
 	// drift) — this does NOT activate the floating spill threshold; that stays
 	// gated on FloatingBudgetActive (default false → tuned static 40%/90% path).


### PR DESCRIPTION
## Summary

Phase 1 of the morsel-driven execution workstream ([design memo](docs/design/morsel-execution.md), included on this branch). Engages intra-fragment CPU parallelism on the production fragment path — the one pipeline runner that never used the engine's existing parallel model — while leaving the number of concurrent memory owners exactly where admission put it.

- **`cpuTokens`** (`internal/worker/cpu_tokens.go`): worker-wide non-blocking semaphore over *extra* compute goroutines, capacity `GOMAXPROCS−2`. Every task's first consumer is free (the serial baseline is always allowed); extras take tokens and degrade toward serial under scarcity rather than queueing — blocking here would recreate the rejected parked-waiter admission shape.
- **`runFragmentLinearParallel`**: the existing single producer feeds a bounded channel (cap 2·k — the morsel dispenser; decode can't run ahead of consumption), consumed by k goroutines each running a private `Clone()`d op chain. One warmup batch goes through the **original** chain before cloning so shared predicate/expression closures (`ColumnCompare` cachedIdx, `expr.ColRef` sync.Once) resolve single-threaded. The fragment sink is mutex'd — all three fragment sinks consume synchronously and retain nothing, so no Sel snapshot is needed. Progress + backpressure counters are now atomic.
- **Spilled-partition flush** drains every chain post-join; `spillState.cleanup()` now clears its partition maps so drains after the first no-op instead of re-opening deleted files (clone probes share the join's `spillState`; probe-side routing was already mutex'd for exactly this).
- **Flag**: `--morsel-workers` — default `1` = serial kill switch (today's behavior, dormant Config zero value); `0` = auto (size-gated at 64 MiB `EstimatedBytes`, width up to cores, capped at 8); `N>1` = fixed width bypassing the size gate (testing knob). **Default stays serial until the SF10/SF100 A/Bs.**

Out of scope (Phase 2, separate PR): breaker (HashAggregate/Sort) clone partials with reservation + pressure-collapse to the serial spill path; errgroup burst-section token adoption.

## Gates

| Gate | Result |
|---|---|
| `go test -race ./internal/worker ./internal/engine/exec` | pass |
| Full `./internal/...` unit suite | pass |
| TPC-H SF0.01 correctness | 22/22 |
| `tpch-harness --mode=local` (default, serial) | PASS |
| `tpch-harness --mode=local --serve-args=--morsel-workers=4` | PASS — 22/22 row- **and checksum**-identical vs serial (two micro checksum diffs are pre-existing no-ORDER-BY gather nondeterminism, reproduced serial-vs-serial) |
| `-race`-built wadjet through the forced-parallel harness | PASS, **0** detector reports across coord + both worker logs |
| Engagement proof | 140 parallel fragments at k=4 in the forced run (`morsel parallel fragment` debug lines; token accounting in_use=3/cap=22) |

New unit coverage: token semantics + concurrent-never-exceeds-capacity stress, width-policy gates (size gate, cloneability gate, token scarcity/exhaustion, cap, release accounting), serial-vs-parallel row parity on multi-file scan→filter fragments, the grace-join spilled-partition flush under parallel clones (asserts *exactly* probeN rows — catches both dropped flushes and double-drains), and the empty-input warmup path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)