### PR TITLE
feat(worker): morsel-driven execution Phase 2 — parallel breaker consume, reserving clones, pressure-collapse

### DIFF
--- a/internal/engine/exec/aggregate.go
+++ b/internal/engine/exec/aggregate.go
@@ -2157,8 +2157,64 @@ func (h *HashAggregate) Finalize(_ context.Context) error {
 		h.unregisterAccounted = nil
 	}
 
+	// Legacy raw-row spill re-aggregation. This MUST run before the
+	// partial-merge dispatch below: an aggregate that changes group-key
+	// paths mid-stream AFTER partial-state runs already exist (post-spill
+	// MergeSink migration to the generic map, null-group-key demotion)
+	// loses canUseExternalMerge, so later pressure consumes buffer raw rows
+	// into spillFiles/spillBuffer while partialSpillFiles still holds the
+	// earlier runs. Re-consuming the raw rows into the in-memory table here
+	// folds them into the remainder that finalizeViaPartialMerge merges.
+	// The previous ordering returned early on partialSpillFiles and
+	// silently orphaned the legacy files (rows dropped from the output).
+	if len(h.spillFiles) > 0 || len(h.spillBuffer) > 0 {
+		// Re-process spilled input rows through the same aggregate logic.
+		// This is correct for all aggregate functions because we're
+		// processing raw input, not merging partial results.
+		for _, f := range h.spillFiles {
+			rows, err := memory.ReadSpilledRows(f)
+			if err != nil {
+				return err
+			}
+			if len(rows) == 0 {
+				continue
+			}
+			b := batch.FromRows(h.inputSchema, rows)
+			// Resolve indices only if not already resolved. Do NOT force
+			// re-resolution (h.resolved = false) — after a parallel merge
+			// (MergeSink), the aggregate has been migrated from compact/int
+			// key mode to generic string mode. Re-resolving would switch
+			// back to compact mode with a fresh intGroupStates, losing all
+			// merged groups and causing index-out-of-bounds in Next().
+			// The spilled batch uses h.inputSchema (same column order as
+			// the original), so re-resolution is unnecessary.
+			if !h.resolved {
+				h.resolveIndices(b)
+			}
+			h.consumeBatch(b)
+		}
+		h.spillFiles = nil
+
+		// Drain any rows that were buffered but never crossed the flush
+		// threshold — they're still in memory and can be consumed directly
+		// without a round-trip through disk.
+		if len(h.spillBuffer) > 0 {
+			b := batch.FromRows(h.inputSchema, h.spillBuffer)
+			if !h.resolved {
+				h.resolveIndices(b)
+			}
+			h.consumeBatch(b)
+			if h.Spill != nil {
+				h.Spill.ReleaseTracking(h.spillBufferBytes)
+			}
+			h.spillBuffer = nil
+			h.spillBufferBytes = 0
+		}
+	}
+
 	// External-merge path: when partial-state files exist, k-way merge them
-	// (plus any in-memory remainder) instead of re-aggregating raw rows. This
+	// (plus any in-memory remainder, which now includes any re-aggregated
+	// legacy spill from above) instead of re-aggregating raw rows. This
 	// is the SF100+ unblock: the legacy raw-row Finalize re-reads ALL spilled
 	// input back into the hash table and re-runs Consume on it, blowing the
 	// budget when input >> output. Partial-state merge processes each group
@@ -2166,54 +2222,6 @@ func (h *HashAggregate) Finalize(_ context.Context) error {
 	if len(h.partialSpillFiles) > 0 {
 		return h.finalizeViaPartialMerge()
 	}
-
-	if len(h.spillFiles) == 0 && len(h.spillBuffer) == 0 {
-		return nil
-	}
-
-	// Re-process spilled input rows through the same aggregate logic.
-	// This is correct for all aggregate functions because we're processing
-	// raw input, not merging partial results.
-	for _, f := range h.spillFiles {
-		rows, err := memory.ReadSpilledRows(f)
-		if err != nil {
-			return err
-		}
-		if len(rows) == 0 {
-			continue
-		}
-		b := batch.FromRows(h.inputSchema, rows)
-		// Resolve indices only if not already resolved. Do NOT force
-		// re-resolution (h.resolved = false) — after a parallel merge
-		// (MergeSink), the aggregate has been migrated from compact/int
-		// key mode to generic string mode. Re-resolving would switch
-		// back to compact mode with a fresh intGroupStates, losing all
-		// merged groups and causing index-out-of-bounds in Next().
-		// The spilled batch uses h.inputSchema (same column order as
-		// the original), so re-resolution is unnecessary.
-		if !h.resolved {
-			h.resolveIndices(b)
-		}
-		h.consumeBatch(b)
-	}
-	h.spillFiles = nil
-
-	// Drain any rows that were buffered but never crossed the flush
-	// threshold — they're still in memory and can be consumed directly
-	// without a round-trip through disk.
-	if len(h.spillBuffer) > 0 {
-		b := batch.FromRows(h.inputSchema, h.spillBuffer)
-		if !h.resolved {
-			h.resolveIndices(b)
-		}
-		h.consumeBatch(b)
-		if h.Spill != nil {
-			h.Spill.ReleaseTracking(h.spillBufferBytes)
-		}
-		h.spillBuffer = nil
-		h.spillBufferBytes = 0
-	}
-
 	return nil
 }
 
@@ -2740,8 +2748,19 @@ func (h *HashAggregate) CloneSink() SinkSource {
 
 // MergeSink merges another HashAggregate's partial state into this one.
 // Called after all parallel workers finish to combine partial aggregates.
+//
+// After the state merge, h's group footprint has grown by the clone's
+// state; reconcileGroupMemory recharges h so the shared-tracker reservation
+// follows the state (morsel-parallel clones charge a tracking-only
+// SpillManager view; their own charge is released at clone Close, AFTER
+// this recharge, so the tracker never under-reports in between). No-op when
+// h.Spill is nil — the single-process planner path.
 func (h *HashAggregate) MergeSink(other SinkSource) {
-	o := other.(*HashAggregate)
+	h.mergeSinkState(other.(*HashAggregate))
+	h.reconcileGroupMemory()
+}
+
+func (h *HashAggregate) mergeSinkState(o *HashAggregate) {
 
 	// When the parent (h) was never fed a batch — runParallel's warmup batch
 	// gets consumed when present, but if the warmup row group is fully

--- a/internal/engine/exec/merge_accounting_test.go
+++ b/internal/engine/exec/merge_accounting_test.go
@@ -1,0 +1,290 @@
+package exec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/engine/memory"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// TestSortMergeSink_TransfersAccounting verifies the morsel-clone rule:
+// when a clone Sort tracked its buffered batches (tracking-only SpillManager
+// view against a shared tracker), MergeSink moves the reservation to the
+// primary along with the batches — charge-primary-first, release-clone — so
+// tracker.Used never dips and the merged bytes stay visible to the
+// primary's spill trigger until Finalize/Close.
+func TestSortMergeSink_TransfersAccounting(t *testing.T) {
+	tracker := memory.NewTracker("test", 1<<30)
+	real, err := memory.NewSpillManager(t.TempDir(), tracker)
+	if err != nil {
+		t.Fatalf("NewSpillManager: %v", err)
+	}
+	view := real.TrackingOnlyView()
+
+	schema := []parquet.Column{
+		{Name: "k", Type: parquet.TypeInt64},
+		{Name: "v", Type: parquet.TypeFloat64},
+	}
+	mkBatch := func(base int) *batch.RecordBatch {
+		rows := make([]map[string]any, 100)
+		for i := range rows {
+			rows[i] = map[string]any{"k": int64(base + i), "v": float64(i)}
+		}
+		return batch.FromRows(schema, rows)
+	}
+
+	primary := &Sort{Keys: []SortKey{{Column: "k"}}, Spill: real}
+	clone := primary.CloneSink().(*Sort)
+	clone.Spill = view
+
+	ctx := context.Background()
+	if err := primary.Consume(ctx, mkBatch(0)); err != nil {
+		t.Fatal(err)
+	}
+	if err := clone.Consume(ctx, mkBatch(100)); err != nil {
+		t.Fatal(err)
+	}
+	preMerge := tracker.Used()
+	if preMerge <= 0 {
+		t.Fatalf("expected both sides to have charged the shared tracker, Used = %d", preMerge)
+	}
+
+	primary.MergeSink(clone)
+	if got := tracker.Used(); got != preMerge {
+		t.Fatalf("tracker.Used changed across MergeSink: %d -> %d (transfer must be net-zero)", preMerge, got)
+	}
+	// The clone must hold nothing after merge: its Close releases nothing.
+	if err := clone.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := tracker.Used(); got != preMerge {
+		t.Fatalf("clone.Close released tracked bytes it no longer owns: %d -> %d", preMerge, got)
+	}
+	// The primary owns everything: its Close returns the tracker to zero.
+	if err := primary.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := tracker.Used(); got != 0 {
+		t.Fatalf("tracker.Used after primary.Close = %d, want 0", got)
+	}
+}
+
+// TestHashAggregateFinalize_MixedSpillFormats is the regression test for
+// the orphaned-legacy-spill bug: an aggregate that (1) partial-drains
+// int-keyed runs under pressure, then (2) migrates to the generic map
+// (here via MergeSink into the post-spill reset state; a mid-stream null
+// group key triggers the same demotion), then (3) buffers more input on
+// the legacy raw-row spill path (canUseExternalMerge is false after the
+// migration) must fold BOTH spill formats into Finalize. The old Finalize
+// returned early on partialSpillFiles and silently dropped the legacy
+// rows.
+func TestHashAggregateFinalize_MixedSpillFormats(t *testing.T) {
+	// Budget 1 with tracked state > 0 keeps ShouldSpillFor(SpillCheap)
+	// permanently true — every Consume takes the pressure branch.
+	tracker := memory.NewTracker("test", 1)
+	spill, err := memory.NewSpillManager(t.TempDir(), tracker)
+	if err != nil {
+		t.Fatalf("NewSpillManager: %v", err)
+	}
+
+	schema := []parquet.Column{
+		{Name: "g", Type: parquet.TypeInt64},
+		{Name: "v", Type: parquet.TypeFloat64},
+	}
+	mkBatch := func(base, n int) *batch.RecordBatch {
+		rows := make([]map[string]any, n)
+		for i := range rows {
+			rows[i] = map[string]any{"g": int64(base + i), "v": float64(base + i)}
+		}
+		return batch.FromRows(schema, rows)
+	}
+
+	agg := &HashAggregate{
+		GroupByCols: []string{"g"},
+		Aggs:        []AggColumn{{Func: AggSum, InputCol: "v", OutputCol: "total", OutputType: parquet.TypeFloat64}},
+		Spill:       spill,
+	}
+	ctx := context.Background()
+	if err := agg.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// (1) Int-keyed consume under pressure → partial-state run + reset.
+	// The first Consume tracks state (Used goes 0→positive); the second
+	// sees ShouldSpillFor true and partial-drains.
+	if err := agg.Consume(ctx, mkBatch(0, 256)); err != nil {
+		t.Fatal(err)
+	}
+	if err := agg.Consume(ctx, mkBatch(256, 256)); err != nil {
+		t.Fatal(err)
+	}
+	if len(agg.partialSpillFiles) == 0 {
+		t.Fatal("test setup: expected a partial-state spill run after the second pressured consume")
+	}
+	// (2) Merge an int-keyed clone into the reset (empty, flat-accs-nil)
+	// primary → mergeSinkState migrates both to the generic map.
+	clone := agg.CloneSink().(*HashAggregate)
+	if err := clone.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := clone.Consume(ctx, mkBatch(1000, 512)); err != nil {
+		t.Fatal(err)
+	}
+	agg.MergeSink(clone)
+	if err := clone.Close(); err != nil {
+		t.Fatal(err)
+	}
+	// (3) More input under pressure on the now-generic aggregate → legacy
+	// raw-row spill path.
+	if err := agg.Consume(ctx, mkBatch(2000, 512)); err != nil {
+		t.Fatal(err)
+	}
+	if len(agg.spillBuffer) == 0 && len(agg.spillFiles) == 0 {
+		t.Fatal("test setup: expected legacy raw-row spill after the post-migration pressured consume")
+	}
+
+	if err := agg.Finalize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	seen := map[int64]float64{}
+	for {
+		b, err := agg.Next(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if b == nil {
+			break
+		}
+		gIdx, tIdx := -1, -1
+		for i, c := range b.Schema {
+			switch c.Name {
+			case "g":
+				gIdx = i
+			case "total":
+				tIdx = i
+			}
+		}
+		for i := 0; i < b.ActiveLen(); i++ {
+			row := i
+			if b.Sel != nil {
+				row = int(b.Sel[i])
+			}
+			var g int64
+			switch b.Columns[gIdx].Type {
+			case batch.TypeInt64:
+				g = b.Columns[gIdx].Int64Data[row]
+			default:
+				t.Fatalf("unexpected group key type %v", b.Columns[gIdx].Type)
+			}
+			seen[g] += b.Columns[tIdx].Float64Data[row]
+		}
+	}
+	if len(seen) != 1536 {
+		t.Fatalf("groups = %d, want 1536 (512 spilled-run + 512 merged + 512 legacy-spilled)", len(seen))
+	}
+	for _, base := range []int{0, 1000, 2000} {
+		for i := 0; i < 512; i += 511 { // spot-check ends of each range
+			g := int64(base + i)
+			if seen[g] != float64(g) {
+				t.Fatalf("group %d: sum %v, want %v", g, seen[g], float64(g))
+			}
+		}
+	}
+	if err := agg.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestHashAggregateMergeSink_RechargesPrimary verifies that merging a
+// clone's group state into a spill-armed primary recharges the primary's
+// tracked footprint (reconcileGroupMemory runs inside MergeSink) and that
+// the clone's release at Close leaves the shared tracker consistent —
+// ending at exactly the primary's tracked group memory.
+func TestHashAggregateMergeSink_RechargesPrimary(t *testing.T) {
+	tracker := memory.NewTracker("test", 1<<30)
+	real, err := memory.NewSpillManager(t.TempDir(), tracker)
+	if err != nil {
+		t.Fatalf("NewSpillManager: %v", err)
+	}
+	view := real.TrackingOnlyView()
+
+	schema := []parquet.Column{
+		{Name: "g", Type: parquet.TypeInt64},
+		{Name: "v", Type: parquet.TypeFloat64},
+	}
+	mkBatch := func(base int) *batch.RecordBatch {
+		rows := make([]map[string]any, 512)
+		for i := range rows {
+			rows[i] = map[string]any{"g": int64(base + i), "v": float64(i)}
+		}
+		return batch.FromRows(schema, rows)
+	}
+
+	primary := &HashAggregate{
+		GroupByCols: []string{"g"},
+		Aggs:        []AggColumn{{Func: AggSum, InputCol: "v", OutputCol: "s", OutputType: parquet.TypeFloat64}},
+		Spill:       real,
+	}
+	ctx := context.Background()
+	if err := primary.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	clone := primary.CloneSink().(*HashAggregate)
+	clone.Spill = view
+	if err := clone.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := primary.Consume(ctx, mkBatch(0)); err != nil {
+		t.Fatal(err)
+	}
+	if err := clone.Consume(ctx, mkBatch(10000)); err != nil {
+		t.Fatal(err)
+	}
+	if tracker.Used() <= 0 {
+		t.Fatalf("expected group state charges on the shared tracker, Used = %d", tracker.Used())
+	}
+
+	primary.MergeSink(clone)
+	afterMerge := tracker.Used()
+	if err := clone.Close(); err != nil {
+		t.Fatal(err)
+	}
+	afterClose := tracker.Used()
+	if afterClose >= afterMerge {
+		t.Fatalf("clone.Close must release the clone's charge: %d -> %d", afterMerge, afterClose)
+	}
+	if afterClose != primary.trackedGroupMem {
+		t.Fatalf("tracker.Used (%d) != primary.trackedGroupMem (%d) after merge+clone-close — merged state under- or over-accounted",
+			afterClose, primary.trackedGroupMem)
+	}
+	// The merged footprint must cover both sides' groups (1024 distinct).
+	if primary.trackedGroupMem <= 0 {
+		t.Fatal("primary tracked footprint is zero after absorbing clone state")
+	}
+	if err := primary.Finalize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	total := 0
+	for {
+		b, err := primary.Next(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if b == nil {
+			break
+		}
+		total += b.ActiveLen()
+	}
+	if total != 1024 {
+		t.Fatalf("merged aggregate produced %d groups, want 1024", total)
+	}
+	if err := primary.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := tracker.Used(); got != 0 {
+		t.Fatalf("tracker.Used after primary.Close = %d, want 0", got)
+	}
+}

--- a/internal/engine/exec/sort.go
+++ b/internal/engine/exec/sort.go
@@ -320,11 +320,33 @@ func (s *Sort) CloneSink() SinkSource {
 // MergeSink merges another Sort's accumulated batches into this one.
 // Called after all parallel workers finish to combine partial batch lists
 // before the single-threaded Finalize sort.
+//
+// Memory accounting transfers with the batches: when the clone tracked its
+// buffered rows (morsel-parallel clones charge a tracking-only SpillManager
+// view against the shared pool), the reservation must follow the state or
+// the merged bytes become invisible to the primary's spill trigger. Charge
+// the primary FIRST, then release the clone, so the shared tracker never
+// under-reports in between. No-op when neither side tracks (the
+// single-process planner path).
 func (s *Sort) MergeSink(other SinkSource) {
 	o := other.(*Sort)
 	s.batches = append(s.batches, o.batches...)
 	s.totalRows += o.totalRows
 	o.batches = nil
+	if o.trackedMem > 0 {
+		if s.Spill != nil {
+			s.Spill.TrackBatch(o.trackedMem)
+			s.trackedMem += o.trackedMem
+			if s.accInstanceID != 0 {
+				s.Spill.Tracker().PublishOwned(s.accInstanceID, s.trackedMem)
+			}
+		}
+		o.Spill.ReleaseTracking(o.trackedMem)
+		o.trackedMem = 0
+		if o.accInstanceID != 0 {
+			o.Spill.Tracker().PublishOwned(o.accInstanceID, 0)
+		}
+	}
 }
 
 // Close releases any tracker reservation Sort still holds for buffered rows

--- a/internal/engine/memory/spill.go
+++ b/internal/engine/memory/spill.go
@@ -79,6 +79,11 @@ type SpillManager struct {
 	reliefMu       sync.Mutex
 	lastReliefAt   map[uint64]time.Time
 	rotationCursor int
+
+	// trackingOnly makes ShouldSpillFor/ShouldSpill answer false
+	// unconditionally while TrackBatch/ReleaseTracking still charge the
+	// shared tracker. See TrackingOnlyView.
+	trackingOnly bool
 }
 
 // defaultSpillCheapFraction is the fraction of the floating operator budget at
@@ -122,6 +127,32 @@ func (sm *SpillManager) SetFloatingBudgetActive(active bool) { sm.floatingBudget
 func (sm *SpillManager) SetCheapFraction(f float64) {
 	if f > 0 && f < 1 {
 		sm.cheapFrac = f
+	}
+}
+
+// TrackingOnlyView returns a SpillManager that charges the SAME tracker as
+// sm (TrackBatch/ReleaseTracking/PublishOwned all flow to the shared pool)
+// but never asks its operators to spill: ShouldSpillFor and ShouldSpill
+// answer false unconditionally, including the heap-pressure backstop.
+//
+// Built for morsel-parallel clone partials (morsel-execution.md §4.3):
+// clone accumulation must be visible to admission and to the PRIMARY
+// operator's spill trigger — clone reservations push tracker.Used up, so
+// the primary trips at the same cumulative point the serial pipeline would
+// — but clones themselves never spill. There is no concurrent spill format;
+// under pressure the fragment runner collapses parallelism and merges
+// clones into the spill-armed primary instead. Operators registered on the
+// view (RegisterAccounted) are invisible to the real manager's relief
+// targeting, which walks only its own registry — by design, since a clone
+// cannot honor SpillSome.
+func (sm *SpillManager) TrackingOnlyView() *SpillManager {
+	return &SpillManager{
+		dir:           sm.dir,
+		tracker:       sm.tracker,
+		cheapFrac:     sm.cheapFrac,
+		accountedPeak: make(map[uint64]int64),
+		lastReliefAt:  make(map[uint64]time.Time),
+		trackingOnly:  true,
 	}
 }
 
@@ -207,6 +238,9 @@ const (
 // free on local NVMe. Spill bytes 67-80 MB across the sweep (lower
 // threshold → more bytes spilled, as expected).
 func (sm *SpillManager) ShouldSpillFor(urgency SpillUrgency) bool {
+	if sm.trackingOnly {
+		return false
+	}
 	// Floating-budget path: the threshold is a fraction of the LIVE available
 	// operator budget (GOMEMLIMIT − Σreservoir actual − GC headroom) rather than
 	// the static pool budget. cheapFrac (default 0.90) gates SpillCheap;
@@ -268,6 +302,9 @@ func (sm *SpillManager) ShouldSpillFor(urgency SpillUrgency) bool {
 // runtime.ReadMemStats is moderately expensive (sub-millisecond), so the
 // reading is rate-limited to once per 100 ms across all callers.
 func (sm *SpillManager) ShouldSpill() bool {
+	if sm.trackingOnly {
+		return false
+	}
 	if sm.tracker != nil && sm.tracker.Budget() > 0 &&
 		sm.tracker.Used() > sm.tracker.Budget()*60/100 {
 		return true

--- a/internal/engine/memory/tracking_only_test.go
+++ b/internal/engine/memory/tracking_only_test.go
@@ -1,0 +1,41 @@
+package memory
+
+import (
+	"testing"
+)
+
+// TestSpillManager_TrackingOnlyView verifies the morsel-clone accounting
+// contract: the view charges the SAME tracker as the real manager but never
+// asks its operators to spill, regardless of tracker pressure or the
+// heap-pressure backstop.
+func TestSpillManager_TrackingOnlyView(t *testing.T) {
+	tracker := NewTracker("test", 1000)
+	sm, err := NewSpillManager(t.TempDir(), tracker)
+	if err != nil {
+		t.Fatalf("NewSpillManager: %v", err)
+	}
+	view := sm.TrackingOnlyView()
+
+	// Charges through the view are visible to the real manager's tracker.
+	view.TrackBatch(900)
+	if got := tracker.Used(); got != 900 {
+		t.Fatalf("tracker.Used = %d, want 900 (view charge must hit the shared tracker)", got)
+	}
+
+	// 900/1000 is past every static threshold: the REAL manager wants spill,
+	// the view never does.
+	if !sm.ShouldSpillFor(SpillCheap) {
+		t.Error("real manager at 90%% of budget should want SpillCheap")
+	}
+	if view.ShouldSpillFor(SpillCheap) || view.ShouldSpillFor(SpillExpensive) {
+		t.Error("tracking-only view must never request spill")
+	}
+	if view.ShouldSpill() {
+		t.Error("tracking-only view ShouldSpill must be false")
+	}
+
+	view.ReleaseTracking(900)
+	if got := tracker.Used(); got != 0 {
+		t.Fatalf("tracker.Used after release = %d, want 0", got)
+	}
+}

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/citc-tech/wadjet/internal/auth"
@@ -97,9 +98,11 @@ type Executor struct {
 	// docs/design/morsel-execution.md). morselWorkers: 0/1 = serial (zero
 	// value is dormant-safe), -1 = auto, N>1 = fixed width. cpuTokens bounds
 	// the EXTRA compute goroutines across all concurrent tasks; nil when
-	// morsels are disabled.
-	morselWorkers int
-	cpuTokens     *cpuTokens
+	// morsels are disabled. morselCollapses counts pressure-collapse events
+	// (parallel breaker consume reverting to the serial spill path).
+	morselWorkers   int
+	cpuTokens       *cpuTokens
+	morselCollapses atomic.Int64
 }
 
 // NewExecutor creates a new task executor.

--- a/internal/worker/executor_fragment.go
+++ b/internal/worker/executor_fragment.go
@@ -654,6 +654,248 @@ func (e *Executor) runFragmentLinearParallel(ctx context.Context, task distribut
 	return nil
 }
 
+// runBreakerConsumeParallel is the morsel-parallel variant of the breaker
+// consume phase (source → first breaker): the single producer feeds a
+// bounded channel consumed by k goroutines, each running a Clone()d op
+// chain into its own CloneSink partial; partials merge into the primary at
+// the barrier (the exec.Pipeline.runParallel shape, with two additions the
+// never-OOM rules require — memo §4.3):
+//
+//  1. Clones RESERVE. Each clone sink charges its accumulated state to a
+//     tracking-only view of the shared SpillManager, so admission and the
+//     primary's spill trigger see the k× partial footprint. Clones never
+//     spill — there is no concurrent spill format.
+//  2. Pressure COLLAPSES k. When the real SpillManager's ShouldSpillFor
+//     trips during parallel consume, the consumers stop, partials merge
+//     into the spill-armed primary (the merge transfers the memory
+//     accounting), and the remaining input drains serially through the
+//     ORIGINAL chain into the primary — whose own partial-drain spill
+//     machinery is exactly today's SF100-validated path. Parallelism is a
+//     fair-weather optimization; the pressure story is unchanged serial.
+//
+// Sel is snapshotted before every breaker Consume: breakers retain batches
+// (Sort stores them) while upstream Filters reuse per-instance Sel scratch —
+// same rule as drainThroughBreaker. Finalize on the primary is called here,
+// matching the serial Pipeline.Run contract for the j==0 phase.
+func (e *Executor) runBreakerConsumeParallel(ctx context.Context, task distributed.Task, src exec.Source, ops []exec.UnaryOperator, sink exec.MergeableSink, k int) error {
+	fp := newFragmentProgress(e.logger, task, e)
+
+	consumeInto := func(ctx context.Context, dst exec.Sink, b *batch.RecordBatch) error {
+		if b.Sel != nil {
+			selCopy := make([]uint32, len(b.Sel))
+			copy(selCopy, b.Sel)
+			b.Sel = selCopy
+		}
+		return dst.Consume(ctx, b)
+	}
+	runChain := func(ctx context.Context, chain []exec.UnaryOperator, b *batch.RecordBatch) (*batch.RecordBatch, error) {
+		cur := b
+		var err error
+		for _, op := range chain {
+			cur, err = op.Execute(ctx, cur)
+			if err != nil {
+				return nil, fmt.Errorf("unary exec: %w", err)
+			}
+			if cur == nil {
+				return nil, nil
+			}
+		}
+		return cur, nil
+	}
+	flushAll := func(chains [][]exec.UnaryOperator) error {
+		for _, chain := range chains {
+			if err := drainFlushableOps(ctx, chain, true, func(c context.Context, b *batch.RecordBatch) error {
+				return sink.Consume(c, b)
+			}); err != nil {
+				return fmt.Errorf("flush spilled ops: %w", err)
+			}
+		}
+		return nil
+	}
+
+	// Warmup through the ORIGINAL chain into the primary — resolves the
+	// lazily-cached column indices in shared predicate/expression closures
+	// before any clone exists, and gives the primary sink its schema (the
+	// MergeSink schema-inherit path covers the fully-filtered-warmup case).
+	warmup, err := src.Next(ctx)
+	if err != nil {
+		return fmt.Errorf("source next: %w", err)
+	}
+	if warmup == nil {
+		if err := flushAll([][]exec.UnaryOperator{ops}); err != nil {
+			return err
+		}
+		return sink.Finalize(ctx)
+	}
+	if cur, err := runChain(ctx, ops, warmup); err != nil {
+		return err
+	} else if cur != nil && cur.ActiveLen() > 0 {
+		if err := consumeInto(ctx, sink, cur); err != nil {
+			return fmt.Errorf("sink consume: %w", err)
+		}
+	}
+
+	// Cloned chains + clone sinks. Worker 0 keeps the originals and the
+	// primary. Clone sinks charge a tracking-only SpillManager view; the
+	// deferred Closes release whatever charge a clone still holds (Close is
+	// idempotent about it — post-merge the clone's charge is zero for Sort
+	// and released-once for HashAggregate).
+	var trackingSpill *memory.SpillManager
+	if e.sharedSpill != nil {
+		trackingSpill = e.sharedSpill.TrackingOnlyView()
+	}
+	chains := make([][]exec.UnaryOperator, 1, k)
+	chains[0] = ops
+	sinks := make([]exec.Sink, 1, k)
+	sinks[0] = sink
+	defer func() {
+		for _, chain := range chains[1:] {
+			for j, op := range chain {
+				if op == ops[j] {
+					continue
+				}
+				op.Close()
+			}
+		}
+		for _, ws := range sinks[1:] {
+			ws.Close()
+		}
+	}()
+	for i := 1; i < k; i++ {
+		chain := make([]exec.UnaryOperator, len(ops))
+		for j, op := range ops {
+			chain[j] = op.(exec.Cloneable).Clone()
+		}
+		chains = append(chains, chain)
+		for j, cop := range chain {
+			if cop == ops[j] {
+				continue
+			}
+			if err := cop.Init(ctx); err != nil {
+				return fmt.Errorf("cloned op init: %w", err)
+			}
+		}
+		cloned := sink.CloneSink()
+		switch cs := cloned.(type) {
+		case *exec.HashAggregate:
+			cs.Spill = trackingSpill
+		case *exec.Sort:
+			cs.Spill = trackingSpill
+		}
+		if err := cloned.Init(ctx); err != nil {
+			cloned.Close()
+			return fmt.Errorf("cloned sink init: %w", err)
+		}
+		sinks = append(sinks, cloned)
+	}
+
+	// Producer: source.Next → channel. Runs until EOF or cancel; it keeps
+	// feeding the serial continuation after a collapse, so its lifetime is
+	// the whole function, not the parallel section.
+	prodCtx, prodCancel := context.WithCancel(ctx)
+	defer prodCancel()
+	ch := make(chan *batch.RecordBatch, 2*k)
+	prodErr := make(chan error, 1)
+	go func() {
+		defer close(ch)
+		for {
+			b, err := src.Next(prodCtx)
+			if err != nil {
+				prodErr <- fmt.Errorf("source next: %w", err)
+				return
+			}
+			if b == nil {
+				prodErr <- nil
+				return
+			}
+			select {
+			case <-prodCtx.Done():
+				prodErr <- prodCtx.Err()
+				return
+			case ch <- b:
+			}
+		}
+	}()
+
+	var collapsed atomic.Bool
+	g, gctx := errgroup.WithContext(ctx)
+	for i := 0; i < k; i++ {
+		chain, wsink := chains[i], sinks[i]
+		g.Go(func() error {
+			for b := range ch {
+				if err := fp.applyBackpressure(gctx); err != nil {
+					return err
+				}
+				cur, err := runChain(gctx, chain, b)
+				if err != nil {
+					return err
+				}
+				if cur != nil && cur.ActiveLen() > 0 {
+					if err := consumeInto(gctx, wsink, cur); err != nil {
+						return fmt.Errorf("sink consume: %w", err)
+					}
+				}
+				if collapsed.Load() {
+					return nil
+				}
+				if e.sharedSpill != nil && e.sharedSpill.ShouldSpillFor(memory.SpillCheap) {
+					collapsed.Store(true)
+					return nil
+				}
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	// Barrier: merge clone partials into the spill-armed primary. MergeSink
+	// transfers the memory accounting with the state, so the primary's next
+	// ShouldSpillFor sees the full merged footprint.
+	for i := 1; i < k; i++ {
+		sink.MergeSink(sinks[i].(exec.SinkSource))
+	}
+	if collapsed.Load() {
+		e.morselCollapses.Add(1)
+		e.logger.Info("morsel pressure collapse: breaker consume continuing serial",
+			"task_id", task.ID,
+			"stage_id", task.StageID,
+			"k", k)
+	}
+
+	// Serial continuation. After a normal completion the channel is closed
+	// and empty — zero iterations. After a collapse this drains the rest of
+	// the input through the ORIGINAL chain into the primary, whose own
+	// spill machinery now governs memory exactly like the serial path.
+	for b := range ch {
+		if err := fp.applyBackpressure(ctx); err != nil {
+			return err
+		}
+		cur, err := runChain(ctx, ops, b)
+		if err != nil {
+			return err
+		}
+		if cur == nil || cur.ActiveLen() == 0 {
+			continue
+		}
+		if err := consumeInto(ctx, sink, cur); err != nil {
+			return fmt.Errorf("sink consume: %w", err)
+		}
+	}
+	if err := <-prodErr; err != nil {
+		return err
+	}
+
+	// Spilled-partition flush over every chain (shared spillState; the first
+	// drain clears it, later chains no-op — same rule as the linear path),
+	// then finalize the primary, matching the serial Pipeline.Run contract.
+	if err := flushAll(chains); err != nil {
+		return err
+	}
+	return sink.Finalize(ctx)
+}
+
 // drainFlushableOps drains any FlushableOperators (Grace Hash Join probes that
 // spilled partitions to disk) through the remaining unary chain into consume.
 // Mirrors exec.Pipeline.flushSpilledOps.
@@ -777,9 +1019,39 @@ func (e *Executor) runFragmentWithBreakers(ctx context.Context, task distributed
 		phaseOps = append(phaseOps, breakers[j].PrependOps...)
 
 		if j == 0 {
-			pipe := &exec.Pipeline{Source: currentSrc, Ops: phaseOps, Sink: breakers[j].Op}
-			if err := pipe.Run(ctx); err != nil {
-				return fmt.Errorf("fragment task %s: %s consume: %w", task.ID, breakers[j].Label, err)
+			// Morsel-parallel breaker consume (docs/design/morsel-execution.md
+			// §4.3): when the width gate passes and the breaker supports
+			// per-worker partials, run the source→first-breaker phase with k
+			// cloned chains + CloneSink partials, collapsing back to the
+			// serial spill path under memory pressure. Otherwise today's
+			// serial Pipeline.
+			mergeable, isMergeable := breakers[j].Op.(exec.MergeableSink)
+			k, release := 1, func() {}
+			if isMergeable {
+				k, release = e.morselFragmentWorkers(task, phaseOps)
+			}
+			if k > 1 {
+				err = func() error {
+					defer release()
+					e.logger.Debug("morsel parallel breaker consume",
+						"task_id", task.ID,
+						"stage_id", task.StageID,
+						"breaker", breakers[j].Label,
+						"k", k,
+						"estimated_bytes", task.EstimatedBytes,
+						"cpu_tokens_in_use", e.cpuTokens.InUse(),
+						"cpu_tokens_cap", e.cpuTokens.Capacity())
+					return e.runBreakerConsumeParallel(ctx, task, currentSrc, phaseOps, mergeable, k)
+				}()
+				if err != nil {
+					return fmt.Errorf("fragment task %s: %s consume: %w", task.ID, breakers[j].Label, err)
+				}
+			} else {
+				release()
+				pipe := &exec.Pipeline{Source: currentSrc, Ops: phaseOps, Sink: breakers[j].Op}
+				if err := pipe.Run(ctx); err != nil {
+					return fmt.Errorf("fragment task %s: %s consume: %w", task.ID, breakers[j].Label, err)
+				}
 			}
 		} else {
 			if err := drainThroughBreaker(ctx, currentSrc, breakers[j-1].DrainXform, phaseOps, breakers[j].Op); err != nil {
@@ -1095,7 +1367,22 @@ func (e *Executor) buildUnaryChain(ctx context.Context, task distributed.Task, s
 		results[0] = built{ops: opChain, cleanup: opCleanup}
 	default:
 		g, gctx := errgroup.WithContext(ctx)
-		if limit := runtime.GOMAXPROCS(0); limit < len(specs) {
+		if e.cpuTokens != nil {
+			// Burst-section token adoption (morsel-execution.md §4.2): this
+			// concurrent op-build burst (broadcast build decode + hash-index
+			// construction is CPU-heavy) draws from the same worker-wide
+			// token pool as the morsel consumers, so Σ(compute goroutines)
+			// across concurrent tasks stays within the core budget. The
+			// first build slot is free, mirroring the consumer rule; token
+			// scarcity narrows the burst, never blocks it.
+			want := len(specs)
+			if m := runtime.GOMAXPROCS(0); m < want {
+				want = m
+			}
+			extra := e.cpuTokens.TryAcquire(want - 1)
+			defer e.cpuTokens.Release(extra)
+			g.SetLimit(1 + extra)
+		} else if limit := runtime.GOMAXPROCS(0); limit < len(specs) {
 			g.SetLimit(limit)
 		}
 		for i := range specs {

--- a/internal/worker/morsel_breaker_test.go
+++ b/internal/worker/morsel_breaker_test.go
@@ -1,0 +1,403 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strconv"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+)
+
+// readGroupTotals decodes an unpartitioned agg output (g, total) into a map.
+func readGroupTotals(t *testing.T, store *objstore.MemStore, bucket, key string) map[int64]float64 {
+	t.Helper()
+	rc, _, err := store.Get(context.Background(), bucket, key)
+	if err != nil {
+		t.Fatalf("get output: %v", err)
+	}
+	defer rc.Close()
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	r, err := newShuffleChunkReader(data)
+	if err != nil {
+		t.Fatalf("parse output: %v", err)
+	}
+	got := map[int64]float64{}
+	for {
+		b, err := r.Next()
+		if err != nil {
+			t.Fatalf("chunk next: %v", err)
+		}
+		if b == nil {
+			return got
+		}
+		gIdx, totalIdx := -1, -1
+		for i, c := range b.Schema {
+			switch c.Name {
+			case "g":
+				gIdx = i
+			case "total":
+				totalIdx = i
+			}
+		}
+		if gIdx < 0 || totalIdx < 0 {
+			t.Fatalf("output schema missing g/total: %+v", b.Schema)
+		}
+		for i := 0; i < b.ActiveLen(); i++ {
+			row := i
+			if b.Sel != nil {
+				row = int(b.Sel[i])
+			}
+			got[b.Columns[gIdx].Int64Data[row]] += b.Columns[totalIdx].Float64Data[row]
+		}
+	}
+}
+
+// putGroupedFiles writes numFiles wshf inputs with (g, v) rows where
+// g = id % groups and v = id, and returns the keys plus the expected
+// per-group sums for rows passing `v >= minV`.
+func putGroupedFiles(t *testing.T, store *objstore.MemStore, bucket string, numFiles, rowsPerFile, groups int, minV int64) ([]string, map[int64]float64) {
+	t.Helper()
+	ctx := context.Background()
+	keys := make([]string, numFiles)
+	want := map[int64]float64{}
+	for f := 0; f < numFiles; f++ {
+		rows := make([][2]int64, rowsPerFile)
+		for i := range rows {
+			id := int64(f*rowsPerFile + i)
+			g := id % int64(groups)
+			rows[i] = [2]int64{g, id}
+			if id >= minV {
+				want[g] += float64(id)
+			}
+		}
+		data := makeGroupedWshf(t, rows)
+		key := "in/agg/t" + strconv.Itoa(f) + ".wshf"
+		if _, err := store.Put(ctx, bucket, key, bytes.NewReader(data), int64(len(data)), "application/octet-stream"); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+		keys[f] = key
+	}
+	return keys, want
+}
+
+func aggFragmentTask(bucket string, keys []string, minV int64) distributed.Task {
+	return distributed.Task{
+		ID:           "frag-morsel-agg",
+		QueryID:      "q-morsel-agg",
+		StageID:      "agg-0",
+		Type:         distributed.TaskTypeStage,
+		DataBucket:   bucket,
+		ResultBucket: bucket,
+		ResultPrefix: "out/agg-0/",
+		Operators: []distributed.OpSpec{
+			{
+				Type:        distributed.OpScan,
+				InputAlias:  "src",
+				InputFiles:  keys,
+				InputBucket: bucket,
+				Columns:     []string{"g", "v"},
+			},
+			{
+				Type:       distributed.OpFilter,
+				Predicates: []string{"v >= " + strconv.FormatInt(minV, 10)},
+			},
+			{
+				Type:        distributed.OpHashAggregate,
+				GroupByCols: []string{"g"},
+				Aggregates: []distributed.AggSpec{
+					{Func: "sum", InputCol: "v", OutputCol: "total"},
+				},
+				MergeMode:    false,
+				BuildProject: true,
+			},
+			{
+				Type: distributed.OpUnpartitionedSink,
+			},
+		},
+	}
+}
+
+// TestExecuteFragment_MorselParallel_AggParity runs the same
+// scan→filter→aggregate→sink breaker fragment serial and morsel-parallel
+// (CloneSink partials + barrier merge) and asserts identical group sums.
+func TestExecuteFragment_MorselParallel_AggParity(t *testing.T) {
+	const numFiles = 8
+	const rowsPerFile = 1000
+	const groups = 50
+	const minV = 1000
+
+	run := func(t *testing.T, bucket string, morselWorkers int) map[int64]float64 {
+		store := objstore.NewMemStore()
+		if err := store.MakeBucket(context.Background(), bucket); err != nil {
+			t.Fatalf("MakeBucket: %v", err)
+		}
+		keys, _ := putGroupedFiles(t, store, bucket, numFiles, rowsPerFile, groups, minV)
+
+		executor := NewExecutor(store, NewLRUCache(4*1024*1024), nil)
+		executor.SetMorselWorkers(morselWorkers)
+		if executor.cpuTokens != nil {
+			executor.cpuTokens = newCPUTokens(8)
+		}
+		task := aggFragmentTask(bucket, keys, minV)
+		result := &distributed.ResultNotification{TaskID: task.ID}
+		if err := executor.executeStage(context.Background(), task, result); err != nil {
+			t.Fatalf("executeStage (morsel=%d): %v", morselWorkers, err)
+		}
+		if executor.cpuTokens != nil {
+			if held := executor.cpuTokens.InUse(); held != 0 {
+				t.Fatalf("cpu tokens leaked: %d", held)
+			}
+		}
+		if len(result.ResultFiles) != 1 {
+			t.Fatalf("expected 1 output file, got %d", len(result.ResultFiles))
+		}
+		return readGroupTotals(t, store, bucket, result.ResultFiles[0])
+	}
+
+	serial := run(t, "morsel-agg-serial", 1)
+	parallel := run(t, "morsel-agg-parallel", 4)
+
+	if len(serial) != groups {
+		t.Fatalf("serial groups = %d, want %d", len(serial), groups)
+	}
+	if len(parallel) != len(serial) {
+		t.Fatalf("parallel groups = %d, serial = %d", len(parallel), len(serial))
+	}
+	for g, s := range serial {
+		if parallel[g] != s {
+			t.Errorf("group %d: parallel total %v != serial %v", g, parallel[g], s)
+		}
+	}
+}
+
+// TestExecuteFragment_MorselParallel_AggFloatDrift documents and bounds the
+// one acceptable serial-vs-parallel divergence: float SUM order. Clone
+// partials sum disjoint row subsets and merge, so non-associative float64
+// addition can drift in the last ulps (this is why the harness row
+// CHECKSUMS differ on float-aggregate TPC-H queries while row counts and
+// values match). Anything beyond relative 1e-9 is a real bug, not drift.
+func TestExecuteFragment_MorselParallel_AggFloatDrift(t *testing.T) {
+	const numFiles = 8
+	const rowsPerFile = 1000
+	const groups = 10
+
+	run := func(t *testing.T, bucket string, morselWorkers int) map[int64]float64 {
+		store := objstore.NewMemStore()
+		if err := store.MakeBucket(context.Background(), bucket); err != nil {
+			t.Fatalf("MakeBucket: %v", err)
+		}
+		keys := make([]string, numFiles)
+		for f := 0; f < numFiles; f++ {
+			rows := make([][2]int64, rowsPerFile)
+			for i := range rows {
+				id := int64(f*rowsPerFile + i)
+				rows[i] = [2]int64{id % groups, id*7919 + 13} // large odd values → inexact float sums
+			}
+			data := makeGroupedWshf(t, rows)
+			key := "in/agg/t" + strconv.Itoa(f) + ".wshf"
+			if _, err := store.Put(context.Background(), bucket, key, bytes.NewReader(data), int64(len(data)), "application/octet-stream"); err != nil {
+				t.Fatalf("Put: %v", err)
+			}
+			keys[f] = key
+		}
+		executor := NewExecutor(store, NewLRUCache(4*1024*1024), nil)
+		executor.SetMorselWorkers(morselWorkers)
+		if executor.cpuTokens != nil {
+			executor.cpuTokens = newCPUTokens(8)
+		}
+		task := aggFragmentTask(bucket, keys, 0)
+		result := &distributed.ResultNotification{TaskID: task.ID}
+		if err := executor.executeStage(context.Background(), task, result); err != nil {
+			t.Fatalf("executeStage: %v", err)
+		}
+		return readGroupTotals(t, store, bucket, result.ResultFiles[0])
+	}
+
+	serial := run(t, "morsel-drift-serial", 1)
+	parallel := run(t, "morsel-drift-parallel", 4)
+	if len(serial) != groups || len(parallel) != groups {
+		t.Fatalf("groups: serial %d, parallel %d, want %d", len(serial), len(parallel), groups)
+	}
+	for g, s := range serial {
+		p := parallel[g]
+		diff := s - p
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff > 1e-9*s {
+			t.Errorf("group %d: parallel %v vs serial %v — beyond float-order drift", g, p, s)
+		}
+	}
+}
+
+// TestExecuteFragment_MorselParallel_SortParity: order-sensitive breaker.
+// The parallel consume feeds per-worker Sort partials in nondeterministic
+// interleave; the Finalize sort must still produce the exact serial output
+// sequence.
+func TestExecuteFragment_MorselParallel_SortParity(t *testing.T) {
+	const numFiles = 8
+	const rowsPerFile = 1000
+
+	run := func(t *testing.T, bucket string, morselWorkers int) []int64 {
+		store := objstore.NewMemStore()
+		if err := store.MakeBucket(context.Background(), bucket); err != nil {
+			t.Fatalf("MakeBucket: %v", err)
+		}
+		keys := make([]string, numFiles)
+		for f := 0; f < numFiles; f++ {
+			rows := make([][2]int64, rowsPerFile)
+			for i := range rows {
+				id := int64(f*rowsPerFile + i)
+				rows[i] = [2]int64{id, id * 7 % 9973} // shuffled-ish values, unique ids
+			}
+			data := makeScanWshf(t, rows)
+			key := "in/sort/t" + strconv.Itoa(f) + ".wshf"
+			if _, err := store.Put(context.Background(), bucket, key, bytes.NewReader(data), int64(len(data)), "application/octet-stream"); err != nil {
+				t.Fatalf("Put: %v", err)
+			}
+			keys[f] = key
+		}
+
+		executor := NewExecutor(store, NewLRUCache(4*1024*1024), nil)
+		executor.SetMorselWorkers(morselWorkers)
+		if executor.cpuTokens != nil {
+			executor.cpuTokens = newCPUTokens(8)
+		}
+		task := distributed.Task{
+			ID:           "frag-morsel-sort",
+			QueryID:      "q-morsel-sort",
+			StageID:      "sort-0",
+			Type:         distributed.TaskTypeStage,
+			DataBucket:   bucket,
+			ResultBucket: bucket,
+			ResultPrefix: "out/sort-0/",
+			Operators: []distributed.OpSpec{
+				{
+					Type:        distributed.OpScan,
+					InputAlias:  "t",
+					InputFiles:  keys,
+					InputBucket: bucket,
+					Columns:     []string{"id", "val"},
+				},
+				{
+					Type: distributed.OpSort,
+					SortKeySpecs: []distributed.SortKeySpec{
+						{Column: "val", Desc: true},
+						{Column: "id", Desc: false},
+					},
+				},
+				{
+					Type: distributed.OpUnpartitionedSink,
+				},
+			},
+		}
+		result := &distributed.ResultNotification{TaskID: task.ID}
+		if err := executor.executeStage(context.Background(), task, result); err != nil {
+			t.Fatalf("executeStage (morsel=%d): %v", morselWorkers, err)
+		}
+		if result.NumRows != int64(numFiles*rowsPerFile) {
+			t.Fatalf("NumRows = %d, want %d", result.NumRows, numFiles*rowsPerFile)
+		}
+		return readMemStoreInts(t, store, bucket, result.ResultFiles[0], "id")
+	}
+
+	serial := run(t, "morsel-sort-serial", 1)
+	parallel := run(t, "morsel-sort-parallel", 4)
+	if len(serial) != len(parallel) {
+		t.Fatalf("row counts differ: serial %d, parallel %d", len(serial), len(parallel))
+	}
+	for i := range serial {
+		if serial[i] != parallel[i] {
+			t.Fatalf("row %d: parallel id %d != serial id %d (sorted output must be identical)", i, parallel[i], serial[i])
+		}
+	}
+}
+
+// TestExecuteFragment_MorselParallel_AggPressureCollapse forces the shared
+// pool over the SpillCheap threshold mid-consume (high-cardinality groups,
+// tiny budget). The parallel consume must collapse to the serial spill path
+// — observable via the executor's collapse counter — and still produce
+// exactly one output row per distinct group with correct sums.
+func TestExecuteFragment_MorselParallel_AggPressureCollapse(t *testing.T) {
+	const numFiles = 16
+	const rowsPerFile = 2048
+	const totalRows = numFiles * rowsPerFile
+
+	bucket := "morsel-agg-collapse"
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(context.Background(), bucket); err != nil {
+		t.Fatalf("MakeBucket: %v", err)
+	}
+	// groups == totalRows → every row is its own group; group state grows
+	// linearly with input and blows through the tiny budget fast.
+	keys, want := putGroupedFiles(t, store, bucket, numFiles, rowsPerFile, totalRows, 0)
+
+	executor := NewExecutor(store, NewLRUCache(4*1024*1024), nil)
+	// 40% SpillCheap threshold of 256 KB = ~100 KB — the warmup batch's
+	// group state alone approaches it, so collapse fires within the first
+	// few parallel batches.
+	executor.SetSharedPoolBudget(256 * 1024)
+	executor.SetMorselWorkers(4)
+	executor.cpuTokens = newCPUTokens(8)
+
+	task := aggFragmentTask(bucket, keys, 0)
+	result := &distributed.ResultNotification{TaskID: task.ID}
+	if err := executor.executeStage(context.Background(), task, result); err != nil {
+		t.Fatalf("executeStage: %v", err)
+	}
+	if got := executor.morselCollapses.Load(); got < 1 {
+		t.Fatalf("expected at least one pressure collapse, counter = %d", got)
+	}
+	if held := executor.cpuTokens.InUse(); held != 0 {
+		t.Fatalf("cpu tokens leaked after collapse: %d", held)
+	}
+	if result.NumRows != int64(totalRows) {
+		t.Fatalf("NumRows = %d, want %d distinct groups", result.NumRows, totalRows)
+	}
+	got := readGroupTotals(t, store, bucket, result.ResultFiles[0])
+	if len(got) != totalRows {
+		t.Fatalf("output groups = %d, want %d", len(got), totalRows)
+	}
+	for g, s := range want {
+		if got[g] != s {
+			t.Fatalf("group %d: total %v, want %v (state lost across collapse/merge)", g, got[g], s)
+		}
+	}
+}
+
+// TestExecuteFragment_MorselParallel_AggEmptyInput covers the breaker
+// warmup-nil path: zero input batches must still finalize the aggregate
+// (empty output) without engaging clones.
+func TestExecuteFragment_MorselParallel_AggEmptyInput(t *testing.T) {
+	bucket := "morsel-agg-empty"
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(context.Background(), bucket); err != nil {
+		t.Fatalf("MakeBucket: %v", err)
+	}
+	data := makeGroupedWshf(t, nil)
+	key := "in/agg/empty.wshf"
+	if _, err := store.Put(context.Background(), bucket, key, bytes.NewReader(data), int64(len(data)), "application/octet-stream"); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	executor := NewExecutor(store, NewLRUCache(1024*1024), nil)
+	executor.SetMorselWorkers(4)
+	executor.cpuTokens = newCPUTokens(8)
+
+	task := aggFragmentTask(bucket, []string{key}, 0)
+	result := &distributed.ResultNotification{TaskID: task.ID}
+	if err := executor.executeStage(context.Background(), task, result); err != nil {
+		t.Fatalf("executeStage: %v", err)
+	}
+	if result.NumRows != 0 {
+		t.Fatalf("NumRows = %d, want 0", result.NumRows)
+	}
+	if held := executor.cpuTokens.InUse(); held != 0 {
+		t.Fatalf("cpu tokens leaked: %d", held)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 2 of morsel-driven execution ([memo §4.3](docs/design/morsel-execution.md)), on top of #178. The source→first-breaker consume phase of fragment execution (HashAggregate / Sort) now runs morsel-parallel under the same gates as Phase 1 (`--morsel-workers`, all-Cloneable, size gate, CPU tokens): k cloned chains feed per-worker `CloneSink` partials that merge into the primary at the barrier — with the two additions the never-OOM rules require:

- **Clones reserve.** New `SpillManager.TrackingOnlyView()`: charges the SAME shared tracker (so admission and the primary's spill trigger see the k× partial footprint) but never requests spill — there is no concurrent spill format. `MergeSink` now transfers accounting with the state: Sort moves the reservation charge-primary-first/release-clone-second; HashAggregate recharges via `reconcileGroupMemory`. The shared tracker never under-reports in between.
- **Pressure collapses k.** When the *real* manager's `ShouldSpillFor` trips mid-consume, consumers stop within a batch, partials merge into the spill-armed primary, and the remaining input drains serially through the original chain — exactly today's SF100-validated partial-drain spill path. Collapse events are counted (`morselCollapses`) and logged.
- **Burst token adoption**: `buildUnaryChain`'s concurrent op-build burst (broadcast build decode + hash-index construction) draws from the same worker-wide token pool, so build bursts and morsel consumers share one core budget.

## Pre-existing correctness bug found and fixed

The pressure-collapse test (`-race`, 20×) exposed an **orphaned-spill hole in `HashAggregate.Finalize`** that predates morsels: an aggregate that changes group-key paths mid-stream *after* partial-state runs exist (post-spill `MergeSink` migration to the generic map — or the pre-existing **null-group-key demotion**) loses `canUseExternalMerge`, so later pressure input lands on the legacy raw-row spill path; Finalize's early-return on `partialSpillFiles` then silently dropped those rows. Legacy re-aggregation now runs before the partial-merge dispatch so it folds into the in-memory remainder. `TestHashAggregateFinalize_MixedSpillFormats` is deterministic (no timing), self-checking (asserts both spill formats actually coexist), and was verified failing pre-fix (1024/1536 groups).

## Known, bounded divergence

Parallel float SUM order differs from serial (clone partials sum disjoint subsets → non-associative float64 addition drifts in the last ulps), so harness row **checksums** differ on float-aggregate queries (q07/q08/q09/q22) while row counts and values match. `TestExecuteFragment_MorselParallel_AggFloatDrift` bounds it at relative 1e-9. Relevant later: golden-baseline checksum comparisons at SF10/SF100 will need value-tolerance for parallel runs.

## Gates

| Gate | Result |
|---|---|
| New unit tests (`-race`): tracking-only view, MergeSink accounting transfer (Sort + HashAggregate, tracker returns to 0), mixed-spill regression, agg/sort parity, collapse ×20, float-drift bound, empty-input, token release | pass |
| `go test -race ./internal/worker ./internal/engine/exec ./internal/engine/memory` | pass |
| Full `./internal/...` suite | pass |
| TPC-H SF0.01 correctness | 22/22 |
| `tpch-harness --mode=local` serial (default) | PASS |
| `tpch-harness --mode=local --serve-args=--morsel-workers=4` | PASS — row counts identical; **51 parallel breaker engagements** at k=4 (scan-side partials + final aggregates) |
| `-race`-built wadjet through the forced-parallel harness | PASS, **0** detector reports across coord + both workers |

Default remains serial (`--morsel-workers=1`); SF10/SF100 A/Bs follow now that both phases are in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)