### PR TITLE
build(bench): wire --morsel-workers into the SF10/SF100 deploy harness

### DIFF
--- a/deploy/benchmark/terraform/main.tf
+++ b/deploy/benchmark/terraform/main.tf
@@ -648,6 +648,7 @@ resource "aws_instance" "worker" {
             --mmap-relief=${var.mmap_relief} \
             --mmap-relief-threshold-mb=${var.mmap_relief_threshold_mb} \
             --bounded-dirty-writes=${var.bounded_dirty_writes} \
+            --morsel-workers=${var.morsel_workers} \
             %{if var.spill_floating_budget~}
             --spill-floating-budget \
             %{endif~}

--- a/deploy/benchmark/terraform/variables.tf
+++ b/deploy/benchmark/terraform/variables.tf
@@ -116,6 +116,12 @@ variable "max_concurrent" {
   default     = 4
 }
 
+variable "morsel_workers" {
+  description = "Worker --morsel-workers: intra-fragment parallel pipeline consumers per task (docs/design/morsel-execution.md). 1 = serial (matches the binary default; use for baselines), 0 = auto (width adapts to fragment size + idle CPU tokens — the A/B treatment), N>1 = fixed width."
+  type        = number
+  default     = 1
+}
+
 variable "mmap_relief" {
   description = "Worker --mmap-relief: MADV_DONTNEED relief of cold mmap'd cache files when RSS exceeds the ceiling. Default true (matches the binary default; validated at SF100 + edge 2026-06-11). Set false for flags-off A/B baselines."
   type        = bool


### PR DESCRIPTION
morsel_workers TF variable (default 1 = serial, matching the binary
default) passed to every worker process. Set -var=morsel_workers=0 for
the auto-width A/B treatment arm.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
