### PR TITLE
docs: runbook — run scenarios, flag surface, runtime-switch feasibility

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,203 @@
+# Wadjet Runbook — run scenarios and the flag surface
+
+How to run the engine in each deployment shape, which knobs matter for
+which scenario, and what is (and is not) changeable at runtime. Grounded
+against `cmd/wadjet/main.go` as of 2026-07-04 (post morsel-v2 merge).
+Companion docs: `operations.md` (metrics, troubleshooting),
+`configuration.md` (YAML config file), `distributed.md` (cluster
+concepts), `security.md` (authn/z), `tuning.md`.
+
+> **Freshness note:** `configuration.md`/`tuning.md`/`operations.md`
+> predate the March→July flag additions. This file is the authoritative
+> flag list until they are refreshed; where they conflict, trust this one.
+
+## 1. Run scenarios
+
+### 1.1 Embedded (library, no server)
+
+```go
+db, err := wadjet.Open(...)   // public API in wadjet/
+```
+
+No flags, no NATS, no server processes. The embedded pipeline runs
+parallel by default (`exec.Pipeline` with Workers=NumCPU). Use
+`objstore.NewMemStore()`/`FileStore` for tests and local tools.
+
+### 1.2 Standalone dev server (local files)
+
+```bash
+wadjet serve --mode=standalone --storage-type=file --data-dir=./data --pg-addr=:5432
+psql -h localhost -p 5432 -U wadjet -d wadjet
+```
+
+Everything in one process: embedded NATS (`--nats-port`, default 4222),
+pgwire, HTTP (`:8080`), gRPC (`:9090`), Prometheus (`--metrics-addr`,
+default `:9100`).
+
+### 1.3 Standalone against S3-compatible storage
+
+```bash
+wadjet serve --mode=standalone \
+  --storage-type=s3 --endpoint=minio:9000 --bucket=wadjet \
+  --access-key=... --secret-key=... [--ssl --region=us-east-2]
+```
+
+Credentials empty = auto-detect from env/IAM. Works with MinIO, AWS S3,
+R2.
+
+### 1.4 Production distributed cluster
+
+```bash
+# Coordinator
+wadjet serve --mode=coordinator \
+  --pg-addr=:5432 --nats-url=nats://nats:4222 \
+  --storage-type=s3 --endpoint=s3.us-east-2.amazonaws.com --ssl \
+  --bucket=<data-bucket> --region=us-east-2 \
+  --data-plane=grpc --data-plane-addr=:9091 \
+  --catalog-snapshot-s3-prefix=s3://<bucket>/catalog/
+
+# Each worker
+wadjet serve --mode=worker \
+  --nats-url=nats://nats:4222 \
+  --storage-type=s3 --endpoint=... --bucket=... --region=... --ssl \
+  --data-plane=grpc --coord-data-plane=<coord-host>:9091 \
+  --spill-dir=/mnt/nvme/spill \
+  --max-concurrent=4
+```
+
+Key facts for sizing and reliability:
+
+- **NATS is the control plane** (heartbeats, cancellation, catalog/UDF
+  KV, DLQ); **gRPC is the data plane** (`--data-plane=grpc`: task
+  dispatch, results, gather, TaskProgress over one multiplexed
+  bidi stream per worker, plaintext intra-cluster). `nats` remains the
+  data-plane default for small/legacy setups; use `grpc` in production.
+- **Memory envelope:** `--memory-budget` (per-task) and
+  `--shared-pool-budget` (worker-wide pool) auto-detect from the cgroup
+  when 0. The validated SF100 shape on 32 GB workers:
+  `--memory-budget=5015936171 --shared-pool-budget=20063744686
+  --cache-bytes=2229304965 --max-concurrent=4`.
+- **Spill wants real disk.** Put `--spill-dir` on NVMe. tmpfs-backed
+  `/tmp` turns spills into RAM and ENOSPCs under load (SF10 Q18,
+  2026-05-03).
+- **`--max-concurrent` is a memory knob, not a CPU knob.** It bounds
+  memory-owning task pipelines per worker; 4 is validated at SF100 on
+  32 GB. Intra-task CPU parallelism is `--morsel-workers` (§2).
+- **Catalog snapshots** (`--catalog-snapshot-s3-prefix`, 5m interval
+  default) make a rebooted cluster discover its catalog in seconds
+  instead of re-scanning the bucket. `--force-restore-catalog=latest`
+  recovers from a lost NATS KV.
+- **Fast boot + result delivery:** `--result-store` (default 512 MB)
+  keeps small results in memory instead of S3 round trips.
+
+### 1.5 Memory-tight / edge envelopes
+
+Defaults are already the validated memory-tight profile:
+`--mmap-relief=true` (RSS ceiling auto = 85% of the detected limit) and
+`--bounded-dirty-writes=true`. Two standing rules from the SF100 record:
+
+- **Never enable `--spill-floating-budget`.** Convicted of a 2× Q18
+  regression (bisect 2026-06-10); the static 40%/90% thresholds stay.
+- Don't re-tune `--mmap-relief-threshold-mb` reflexively — thresholds
+  proved insensitive; 0 (auto) is right unless the cgroup limit is
+  invisible to the process.
+
+### 1.6 Query-routing and execution-shape knobs
+
+- `--local-fastpath-bytes` (default 64 MiB): queries whose post-pruning
+  scan bytes fit under it run in-process on the coordinator, skipping
+  the stage DAG entirely (measured 2-12× on small/top-N queries). 0
+  disables. Failures fall back to the DAG.
+- `--streaming-exchange` (default **true**): consumers fetch stage
+  outputs from producer workers' local disk over gRPC with async S3
+  upload; any failure falls back to the durable S3 path. Validated
+  SF10 −10% / SF100 −23% suite wall. `--peer-exchange-addr` (default
+  `:0`) / `--peer-exchange-advertise` control the FetchShuffle listener
+  when firewalls need a pinned port.
+- `--morsel-workers` (default **1 = serial**): intra-fragment parallel
+  consumers per task. `0` = auto (width adapts to fragment size and
+  idle CPU tokens) — validated SF100-safe 2026-07-04 (22/22, zero
+  reaps, wins on scan-agg shapes) but not yet the default; the flip
+  awaits a same-window SF100 serial-vs-auto pair. `N>1` = fixed width
+  (benchmark/testing knob, bypasses the size gate).
+
+### 1.7 Edge federation
+
+Edge clusters connect to central via NATS leaf nodes:
+`--leaf-remote=nats://central:7422` (repeatable), `--cluster-id=<name>`,
+mTLS via `--nats-tls-cert/-key/-ca`. See `distributed.md`.
+
+### 1.8 Benchmarks
+
+Use `deploy/benchmark/` (OpenTofu + `run-benchmark.sh`); see its
+README. Local gate first: `cmd/tpch-harness --mode=local` (~11s)
+catches distributed regressions before any EC2 spend. Disable
+`--background-compaction=false` for comparable timings.
+
+## 2. Flag reference (serve-relevant, as of 2026-07-04)
+
+"Runtime?" = can this become a live switch without a restart, given how
+the value is consumed today. **Today every flag is process-start only**
+— there is no dynamic-config subsystem (see §3). The column records
+what a SET-style facility could expose cheaply vs never.
+
+| Flag | Default | What it does | Runtime? |
+|---|---|---|---|
+| `--mode` | standalone | standalone / coordinator / worker | boot-only (structural) |
+| `--storage-type`, `--endpoint`, `--bucket`, `--region`, `--ssl`, `--access-key`, `--secret-key` | s3 / localhost:9000 / wadjet | object-store binding | boot-only (clients built at start) |
+| `--data-dir` | — | FileStore root (`--storage-type=file`) | boot-only |
+| `--pg-addr`, `--http-addr`, `--grpc-addr`, `--metrics-addr`, `--data-plane-addr`, `--peer-exchange-addr` | :5433 / :8080 / :9090 / :9100 / :9091 / :0 | listeners | boot-only (bound at start) |
+| `--pg-tls-*`, `--nats-tls-*` | — | TLS material | boot-only (cert reload would be its own feature) |
+| `--nats-url`, `--nats-port`, `--nats-store-dir` | — / 4222 | control plane | boot-only |
+| `--data-plane`, `--coord-data-plane` | nats | task/result transport | boot-only (streams established at start) |
+| `--cluster-id`, `--leaf-remote` | local | federation topology | boot-only |
+| `--memory-budget` | 0 = auto | per-task budget; also drives GOMEMLIMIT derivation | boot-only today (tracker budgets + GOMEMLIMIT cached at start) |
+| `--shared-pool-budget` | 0 = auto | worker-wide reservation pool | boot-only today (same) |
+| `--cache-bytes` | 0 = auto (20% mem) | LRU file cache size | boot-only (sized at start) |
+| `--spill-dir` | OS temp | spill volume | boot-only |
+| `--max-concurrent` | 4 | task slots per worker (memory-owner count) | feasible-with-work (semaphore is sized at Start; needs a resizable gate) |
+| `--max-concurrent-queries` | 0 | coordinator query gate | **feasible** (admission check) |
+| `--query-timeout` | 0 | default per-query timeout | **feasible** (read per query) |
+| `--morsel-workers` | 1 | intra-task parallel width policy | **feasible** (policy read per fragment via `Executor.SetMorselWorkers`; needs atomic field + propagation) |
+| `--local-fastpath-bytes` | 64 MiB | in-process routing threshold | **feasible** (read per query on the coordinator) |
+| `--streaming-exchange` | true | peer-fetch shuffle vs S3-only | **feasible** (per-stage decision; falls back safely by design) |
+| `--mmap-relief`, `--mmap-relief-threshold-mb` | true / 0 = auto | RSS-ceiling MADV relief | **feasible** (periodic sweep reads config) |
+| `--bounded-dirty-writes` | true | windowed sync_file_range on spill/stage writes | **feasible** (applies to newly opened writers) |
+| `--spill-floating-budget` | false | floating spill threshold | feasible but **do not enable** (see §1.5) |
+| `--background-compaction` | true | 5m small-file compaction sweep | **feasible** (ticker gate) |
+| `--enable-alerts` | false | CREATE ALERT DDL + scheduler | **feasible** (scheduler gate) |
+| `--catalog-snapshot-s3-prefix`, `--catalog-snapshot-interval`, `--force-restore-catalog` | — / 5m / — | catalog snapshot/restore | interval feasible; prefix/restore boot-only |
+| `--result-store` | 512 MB | in-memory result store cap | feasible-with-work (store sized at start) |
+| `--log-level` | info | slog level | **feasible** (slog LevelVar pattern) |
+| `--otel-endpoint`, `--otel-insecure` | — | tracing exporter | boot-only |
+| `--geoip-city`, `--geoip-asn` | — | GeoIP databases | feasible-with-work (reload) |
+| `--config` | — | YAML file mirroring these flags | n/a |
+
+## 3. Runtime switches: current state and the path there
+
+**Today: none.** Every knob above is a process-start flag; changing any
+of them means restarting the process (workers restart cheaply — tasks
+are re-dispatched by the retry machinery, and catalog snapshots make
+coordinator restarts fast — but it is still a restart).
+
+The engine already has both halves of a natural dynamic-config design:
+
+1. **A SQL surface on the coordinator** (pgwire): `SET wadjet.<knob> =
+   <value>` session-scoped, `ALTER SYSTEM SET wadjet.<knob>` (or
+   similar) cluster-scoped — the Postgres-idiomatic shape, usable from
+   psql/JDBC/Superset.
+2. **NATS KV with watchers** for propagation: the catalog and UDF
+   registries already use exactly this pattern (KV bucket + revision
+   CAS + worker-side watch). A `config` KV bucket that workers watch
+   and apply to the **feasible** subset in §2 is a small, well-trodden
+   extension.
+
+The feasible subset is exactly the flags whose values are read
+per-query, per-fragment, or per-sweep from a field (marked **feasible**
+above): morsel width, fastpath threshold, streaming exchange, relief
+ceiling, dirty-write bounding, compaction/alert/ snapshot cadence,
+query gates, log level. The structural set (addresses, transports,
+storage bindings, memory envelope) should stay boot-only — pretending
+those are live switches invites half-reconfigured processes.
+
+Not built yet; scoped as a small standalone workstream if wanted.


### PR DESCRIPTION
Scenario-oriented operations runbook (embedded / standalone / distributed / memory-tight / federation), the complete current serve-flag reference with defaults, and a per-flag runtime-switchability classification. Existing ops docs are from 2026-03-17 and miss everything since; this is the authoritative reference until they're refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)