### PR TITLE
feat(worker): graceful drain for Kubernetes — SIGTERM drains, upload flush, probes, /drain

### DIFF
--- a/cmd/wadjet/main.go
+++ b/cmd/wadjet/main.go
@@ -92,6 +92,7 @@ var (
 	enableAlerts          bool
 	backgroundCompaction  bool
 	dataPlane             string
+	drainTimeout          time.Duration
 	dataPlaneAddr         string
 	coordDataPlane        string
 	localFastPathBytes    int64
@@ -147,6 +148,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&metricsAddr, "metrics-addr", ":9100", "Prometheus metrics listen address (worker mode)")
 	rootCmd.PersistentFlags().IntVar(&maxConcurrent, "max-concurrent", 4, "Maximum concurrent tasks per worker")
 	rootCmd.PersistentFlags().IntVar(&morselWorkers, "morsel-workers", 1, "Intra-fragment parallel pipeline consumers per task (morsel-driven execution, docs/design/morsel-execution.md). 1 = serial (default; kill switch), 0 = auto (width adapts to fragment input size and idle CPU tokens), N>1 = fixed width of N (bypasses the size gate; testing/benchmark knob).")
+	rootCmd.PersistentFlags().DurationVar(&drainTimeout, "drain-timeout", 0, "Bound on graceful worker drain (SIGTERM): time allowed for in-flight tasks to finish and pending stage-output uploads to flush before escalating to a hard stop. 0 = unbounded (the platform kill timeout, e.g. the Kubernetes termination grace period, is the backstop).")
 	rootCmd.PersistentFlags().StringVar(&dataPlane, "data-plane", "nats", "Worker↔coord data-plane transport: nats (default) or grpc. See project_split_plane_design_2026-05-20.")
 	rootCmd.PersistentFlags().StringVar(&dataPlaneAddr, "data-plane-addr", ":9091", "Data-plane gRPC listen address (coord/standalone)")
 	rootCmd.PersistentFlags().StringVar(&coordDataPlane, "coord-data-plane", "", "Coord's data-plane host:port (worker only; defaults to coord-host + 9091)")
@@ -849,6 +851,7 @@ func runStandalone(ctx context.Context, store objstore.Store, logger *slog.Logge
 		ClusterID:             clusterID,
 		MaxConcurrent:         maxConcurrent,
 		MorselWorkers:         morselWorkersConfig(morselWorkers),
+		DrainTimeout:          drainTimeout,
 		CacheBytes:            cacheBytes,
 		MemoryBudget:          memoryBudget,
 		SharedPoolBudget:      sharedPoolBudget,
@@ -1402,6 +1405,7 @@ func runWorker(ctx context.Context, store objstore.Store, logger *slog.Logger) e
 		ClusterID:             clusterID,
 		MaxConcurrent:         maxConcurrent,
 		MorselWorkers:         morselWorkersConfig(morselWorkers),
+		DrainTimeout:          drainTimeout,
 		CacheBytes:            cacheBytes,
 		MemoryBudget:          memoryBudget,
 		SharedPoolBudget:      sharedPoolBudget,
@@ -1446,8 +1450,33 @@ func runWorker(ctx context.Context, store objstore.Store, logger *slog.Logger) e
 	m := metrics.New()
 	w.SetMetrics(m)
 
-	// Start /metrics HTTP endpoint for Prometheus scraping
+	// Start /metrics HTTP endpoint for Prometheus scraping, plus the
+	// Kubernetes lifecycle surface: liveness, readiness (false once
+	// draining, so the pod drops out of any Service while it finishes),
+	// and a POST /drain admin hook (preStop-hook alternative to SIGTERM).
 	metricsMux := http.NewServeMux()
+	metricsMux.HandleFunc("/healthz", func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+		rw.Write([]byte("ok"))
+	})
+	metricsMux.HandleFunc("/readyz", func(rw http.ResponseWriter, _ *http.Request) {
+		if w.Draining() {
+			rw.WriteHeader(http.StatusServiceUnavailable)
+			rw.Write([]byte("draining"))
+			return
+		}
+		rw.WriteHeader(http.StatusOK)
+		rw.Write([]byte("ok"))
+	})
+	metricsMux.HandleFunc("/drain", func(rw http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			rw.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.BeginDrain()
+		rw.WriteHeader(http.StatusAccepted)
+		rw.Write([]byte("draining"))
+	})
 	metricsMux.Handle("/metrics", m.Handler())
 	metricsMux.HandleFunc("/debug/pprof/", nethttppprof.Index)
 	metricsMux.HandleFunc("/debug/pprof/cmdline", nethttppprof.Cmdline)
@@ -1477,16 +1506,32 @@ func runWorker(ctx context.Context, store objstore.Store, logger *slog.Logger) e
 		return fmt.Errorf("starting worker: %w", err)
 	}
 
-	// SIGQUIT triggers graceful drain: stop accepting new tasks, finish
-	// in-flight work, then exit. SIGINT/SIGTERM still do a hard stop.
-	drainCh := make(chan os.Signal, 1)
-	signal.Notify(drainCh, syscall.SIGQUIT)
+	// Signal contract for workers (Kubernetes-compatible):
+	//   SIGTERM, SIGQUIT  -> graceful drain: stop taking tasks, finish
+	//                        in-flight work, flush stage-output uploads,
+	//                        exit. K8s sends SIGTERM on pod termination;
+	//                        --drain-timeout (or the pod's grace period)
+	//                        bounds it.
+	//   SIGINT            -> hard stop (interactive Ctrl-C).
+	// The serve command's NotifyContext claimed SIGINT+SIGTERM for a hard
+	// cancel before we got here; detach both so SIGTERM cannot race into
+	// the hard path and cancel in-flight task contexts mid-drain.
+	signal.Reset(syscall.SIGINT, syscall.SIGTERM)
+	hardCh := make(chan os.Signal, 1)
+	signal.Notify(hardCh, syscall.SIGINT)
+	drainSigCh := make(chan os.Signal, 1)
+	signal.Notify(drainSigCh, syscall.SIGTERM, syscall.SIGQUIT)
 
 	select {
-	case <-ctx.Done():
+	case <-hardCh:
+		logger.Info("SIGINT received, stopping worker...")
 		w.Stop()
-	case <-drainCh:
-		logger.Info("SIGQUIT received, draining worker...")
+	case sig := <-drainSigCh:
+		logger.Info("drain signal received, draining worker...", "signal", sig.String())
+		w.Drain()
+	case <-w.DrainRequested():
+		// NATS drain subject (coordinator reap) or POST /drain.
+		logger.Info("drain requested via control plane, draining worker...")
 		w.Drain()
 	}
 	return nil

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,203 @@
+# Wadjet Runbook — run scenarios and the flag surface
+
+How to run the engine in each deployment shape, which knobs matter for
+which scenario, and what is (and is not) changeable at runtime. Grounded
+against `cmd/wadjet/main.go` as of 2026-07-04 (post morsel-v2 merge).
+Companion docs: `operations.md` (metrics, troubleshooting),
+`configuration.md` (YAML config file), `distributed.md` (cluster
+concepts), `security.md` (authn/z), `tuning.md`.
+
+> **Freshness note:** `configuration.md`/`tuning.md`/`operations.md`
+> predate the March→July flag additions. This file is the authoritative
+> flag list until they are refreshed; where they conflict, trust this one.
+
+## 1. Run scenarios
+
+### 1.1 Embedded (library, no server)
+
+```go
+db, err := wadjet.Open(...)   // public API in wadjet/
+```
+
+No flags, no NATS, no server processes. The embedded pipeline runs
+parallel by default (`exec.Pipeline` with Workers=NumCPU). Use
+`objstore.NewMemStore()`/`FileStore` for tests and local tools.
+
+### 1.2 Standalone dev server (local files)
+
+```bash
+wadjet serve --mode=standalone --storage-type=file --data-dir=./data --pg-addr=:5432
+psql -h localhost -p 5432 -U wadjet -d wadjet
+```
+
+Everything in one process: embedded NATS (`--nats-port`, default 4222),
+pgwire, HTTP (`:8080`), gRPC (`:9090`), Prometheus (`--metrics-addr`,
+default `:9100`).
+
+### 1.3 Standalone against S3-compatible storage
+
+```bash
+wadjet serve --mode=standalone \
+  --storage-type=s3 --endpoint=minio:9000 --bucket=wadjet \
+  --access-key=... --secret-key=... [--ssl --region=us-east-2]
+```
+
+Credentials empty = auto-detect from env/IAM. Works with MinIO, AWS S3,
+R2.
+
+### 1.4 Production distributed cluster
+
+```bash
+# Coordinator
+wadjet serve --mode=coordinator \
+  --pg-addr=:5432 --nats-url=nats://nats:4222 \
+  --storage-type=s3 --endpoint=s3.us-east-2.amazonaws.com --ssl \
+  --bucket=<data-bucket> --region=us-east-2 \
+  --data-plane=grpc --data-plane-addr=:9091 \
+  --catalog-snapshot-s3-prefix=s3://<bucket>/catalog/
+
+# Each worker
+wadjet serve --mode=worker \
+  --nats-url=nats://nats:4222 \
+  --storage-type=s3 --endpoint=... --bucket=... --region=... --ssl \
+  --data-plane=grpc --coord-data-plane=<coord-host>:9091 \
+  --spill-dir=/mnt/nvme/spill \
+  --max-concurrent=4
+```
+
+Key facts for sizing and reliability:
+
+- **NATS is the control plane** (heartbeats, cancellation, catalog/UDF
+  KV, DLQ); **gRPC is the data plane** (`--data-plane=grpc`: task
+  dispatch, results, gather, TaskProgress over one multiplexed
+  bidi stream per worker, plaintext intra-cluster). `nats` remains the
+  data-plane default for small/legacy setups; use `grpc` in production.
+- **Memory envelope:** `--memory-budget` (per-task) and
+  `--shared-pool-budget` (worker-wide pool) auto-detect from the cgroup
+  when 0. The validated SF100 shape on 32 GB workers:
+  `--memory-budget=5015936171 --shared-pool-budget=20063744686
+  --cache-bytes=2229304965 --max-concurrent=4`.
+- **Spill wants real disk.** Put `--spill-dir` on NVMe. tmpfs-backed
+  `/tmp` turns spills into RAM and ENOSPCs under load (SF10 Q18,
+  2026-05-03).
+- **`--max-concurrent` is a memory knob, not a CPU knob.** It bounds
+  memory-owning task pipelines per worker; 4 is validated at SF100 on
+  32 GB. Intra-task CPU parallelism is `--morsel-workers` (§2).
+- **Catalog snapshots** (`--catalog-snapshot-s3-prefix`, 5m interval
+  default) make a rebooted cluster discover its catalog in seconds
+  instead of re-scanning the bucket. `--force-restore-catalog=latest`
+  recovers from a lost NATS KV.
+- **Fast boot + result delivery:** `--result-store` (default 512 MB)
+  keeps small results in memory instead of S3 round trips.
+
+### 1.5 Memory-tight / edge envelopes
+
+Defaults are already the validated memory-tight profile:
+`--mmap-relief=true` (RSS ceiling auto = 85% of the detected limit) and
+`--bounded-dirty-writes=true`. Two standing rules from the SF100 record:
+
+- **Never enable `--spill-floating-budget`.** Convicted of a 2× Q18
+  regression (bisect 2026-06-10); the static 40%/90% thresholds stay.
+- Don't re-tune `--mmap-relief-threshold-mb` reflexively — thresholds
+  proved insensitive; 0 (auto) is right unless the cgroup limit is
+  invisible to the process.
+
+### 1.6 Query-routing and execution-shape knobs
+
+- `--local-fastpath-bytes` (default 64 MiB): queries whose post-pruning
+  scan bytes fit under it run in-process on the coordinator, skipping
+  the stage DAG entirely (measured 2-12× on small/top-N queries). 0
+  disables. Failures fall back to the DAG.
+- `--streaming-exchange` (default **true**): consumers fetch stage
+  outputs from producer workers' local disk over gRPC with async S3
+  upload; any failure falls back to the durable S3 path. Validated
+  SF10 −10% / SF100 −23% suite wall. `--peer-exchange-addr` (default
+  `:0`) / `--peer-exchange-advertise` control the FetchShuffle listener
+  when firewalls need a pinned port.
+- `--morsel-workers` (default **1 = serial**): intra-fragment parallel
+  consumers per task. `0` = auto (width adapts to fragment size and
+  idle CPU tokens) — validated SF100-safe 2026-07-04 (22/22, zero
+  reaps, wins on scan-agg shapes) but not yet the default; the flip
+  awaits a same-window SF100 serial-vs-auto pair. `N>1` = fixed width
+  (benchmark/testing knob, bypasses the size gate).
+
+### 1.7 Edge federation
+
+Edge clusters connect to central via NATS leaf nodes:
+`--leaf-remote=nats://central:7422` (repeatable), `--cluster-id=<name>`,
+mTLS via `--nats-tls-cert/-key/-ca`. See `distributed.md`.
+
+### 1.8 Benchmarks
+
+Use `deploy/benchmark/` (OpenTofu + `run-benchmark.sh`); see its
+README. Local gate first: `cmd/tpch-harness --mode=local` (~11s)
+catches distributed regressions before any EC2 spend. Disable
+`--background-compaction=false` for comparable timings.
+
+## 2. Flag reference (serve-relevant, as of 2026-07-04)
+
+"Runtime?" = can this become a live switch without a restart, given how
+the value is consumed today. **Today every flag is process-start only**
+— there is no dynamic-config subsystem (see §3). The column records
+what a SET-style facility could expose cheaply vs never.
+
+| Flag | Default | What it does | Runtime? |
+|---|---|---|---|
+| `--mode` | standalone | standalone / coordinator / worker | boot-only (structural) |
+| `--storage-type`, `--endpoint`, `--bucket`, `--region`, `--ssl`, `--access-key`, `--secret-key` | s3 / localhost:9000 / wadjet | object-store binding | boot-only (clients built at start) |
+| `--data-dir` | — | FileStore root (`--storage-type=file`) | boot-only |
+| `--pg-addr`, `--http-addr`, `--grpc-addr`, `--metrics-addr`, `--data-plane-addr`, `--peer-exchange-addr` | :5433 / :8080 / :9090 / :9100 / :9091 / :0 | listeners | boot-only (bound at start) |
+| `--pg-tls-*`, `--nats-tls-*` | — | TLS material | boot-only (cert reload would be its own feature) |
+| `--nats-url`, `--nats-port`, `--nats-store-dir` | — / 4222 | control plane | boot-only |
+| `--data-plane`, `--coord-data-plane` | nats | task/result transport | boot-only (streams established at start) |
+| `--cluster-id`, `--leaf-remote` | local | federation topology | boot-only |
+| `--memory-budget` | 0 = auto | per-task budget; also drives GOMEMLIMIT derivation | boot-only today (tracker budgets + GOMEMLIMIT cached at start) |
+| `--shared-pool-budget` | 0 = auto | worker-wide reservation pool | boot-only today (same) |
+| `--cache-bytes` | 0 = auto (20% mem) | LRU file cache size | boot-only (sized at start) |
+| `--spill-dir` | OS temp | spill volume | boot-only |
+| `--max-concurrent` | 4 | task slots per worker (memory-owner count) | feasible-with-work (semaphore is sized at Start; needs a resizable gate) |
+| `--max-concurrent-queries` | 0 | coordinator query gate | **feasible** (admission check) |
+| `--query-timeout` | 0 | default per-query timeout | **feasible** (read per query) |
+| `--morsel-workers` | 1 | intra-task parallel width policy | **feasible** (policy read per fragment via `Executor.SetMorselWorkers`; needs atomic field + propagation) |
+| `--local-fastpath-bytes` | 64 MiB | in-process routing threshold | **feasible** (read per query on the coordinator) |
+| `--streaming-exchange` | true | peer-fetch shuffle vs S3-only | **feasible** (per-stage decision; falls back safely by design) |
+| `--mmap-relief`, `--mmap-relief-threshold-mb` | true / 0 = auto | RSS-ceiling MADV relief | **feasible** (periodic sweep reads config) |
+| `--bounded-dirty-writes` | true | windowed sync_file_range on spill/stage writes | **feasible** (applies to newly opened writers) |
+| `--spill-floating-budget` | false | floating spill threshold | feasible but **do not enable** (see §1.5) |
+| `--background-compaction` | true | 5m small-file compaction sweep | **feasible** (ticker gate) |
+| `--enable-alerts` | false | CREATE ALERT DDL + scheduler | **feasible** (scheduler gate) |
+| `--catalog-snapshot-s3-prefix`, `--catalog-snapshot-interval`, `--force-restore-catalog` | — / 5m / — | catalog snapshot/restore | interval feasible; prefix/restore boot-only |
+| `--result-store` | 512 MB | in-memory result store cap | feasible-with-work (store sized at start) |
+| `--log-level` | info | slog level | **feasible** (slog LevelVar pattern) |
+| `--otel-endpoint`, `--otel-insecure` | — | tracing exporter | boot-only |
+| `--geoip-city`, `--geoip-asn` | — | GeoIP databases | feasible-with-work (reload) |
+| `--config` | — | YAML file mirroring these flags | n/a |
+
+## 3. Runtime switches: current state and the path there
+
+**Today: none.** Every knob above is a process-start flag; changing any
+of them means restarting the process (workers restart cheaply — tasks
+are re-dispatched by the retry machinery, and catalog snapshots make
+coordinator restarts fast — but it is still a restart).
+
+The engine already has both halves of a natural dynamic-config design:
+
+1. **A SQL surface on the coordinator** (pgwire): `SET wadjet.<knob> =
+   <value>` session-scoped, `ALTER SYSTEM SET wadjet.<knob>` (or
+   similar) cluster-scoped — the Postgres-idiomatic shape, usable from
+   psql/JDBC/Superset.
+2. **NATS KV with watchers** for propagation: the catalog and UDF
+   registries already use exactly this pattern (KV bucket + revision
+   CAS + worker-side watch). A `config` KV bucket that workers watch
+   and apply to the **feasible** subset in §2 is a small, well-trodden
+   extension.
+
+The feasible subset is exactly the flags whose values are read
+per-query, per-fragment, or per-sweep from a field (marked **feasible**
+above): morsel width, fastpath threshold, streaming exchange, relief
+ceiling, dirty-write bounding, compaction/alert/ snapshot cadence,
+query gates, log level. The structural set (addresses, transports,
+storage bindings, memory envelope) should stay boot-only — pretending
+those are live switches invites half-reconfigured processes.
+
+Not built yet; scoped as a small standalone workstream if wanted.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -121,13 +121,49 @@ Defaults are already the validated memory-tight profile:
   awaits a same-window SF100 serial-vs-auto pair. `N>1` = fixed width
   (benchmark/testing knob, bypasses the size gate).
 
-### 1.7 Edge federation
+### 1.7 Worker lifecycle on Kubernetes (graceful drain)
+
+Workers support graceful drain: stop taking new tasks, finish in-flight
+work, flush pending stage-output uploads to the object store (so
+consumers keep their durable fallback once the peer-exchange server goes
+away), then exit.
+
+Signal contract (worker mode):
+
+| Trigger | Behavior |
+|---|---|
+| `SIGTERM`, `SIGQUIT` | graceful drain, then exit |
+| `SIGINT` | hard stop (in-flight tasks abort; the coordinator's retry machinery re-dispatches them) |
+| `POST /drain` on the metrics port | same as SIGTERM (returns 202 immediately; drain proceeds) |
+| NATS `wadjet.worker.<id>.drain` | same (the coordinator sends this when it reaps a stale worker) |
+
+During drain the worker keeps heartbeating with `Draining=true`, which
+excludes it from dispatch targeting without tripping the reaper, and it
+keeps serving peer-exchange fetches until uploads are flushed.
+`--drain-timeout` bounds the whole sequence (0 = unbounded); on timeout
+the worker escalates to a hard stop. In-flight SF100-class tasks can run
+for minutes — size the bound (and the pod's grace period) accordingly.
+
+Probes on the metrics port (`--metrics-addr`, default `:9100`):
+`GET /healthz` (liveness), `GET /readyz` (readiness; 503 once draining).
+
+```yaml
+# Pod spec sketch
+terminationGracePeriodSeconds: 900   # >= --drain-timeout + margin
+containers:
+- name: wadjet-worker
+  args: ["serve", "--mode=worker", "--drain-timeout=10m", ...]
+  livenessProbe:  { httpGet: { path: /healthz, port: 9100 } }
+  readinessProbe: { httpGet: { path: /readyz,  port: 9100 } }
+```
+
+### 1.8 Edge federation
 
 Edge clusters connect to central via NATS leaf nodes:
 `--leaf-remote=nats://central:7422` (repeatable), `--cluster-id=<name>`,
 mTLS via `--nats-tls-cert/-key/-ca`. See `distributed.md`.
 
-### 1.8 Benchmarks
+### 1.9 Benchmarks
 
 Use `deploy/benchmark/` (OpenTofu + `run-benchmark.sh`); see its
 README. Local gate first: `cmd/tpch-harness --mode=local` (~11s)

--- a/internal/worker/heap_profiler.go
+++ b/internal/worker/heap_profiler.go
@@ -64,9 +64,9 @@ func (w *Worker) startHeapPressureProfiler(ctx context.Context) {
 		w.logger.Warn("heap pressure profiler: mkdir failed", "dir", dir, "err", err)
 		return
 	}
-	w.wg.Add(1)
+	w.bgWG.Add(1)
 	go func() {
-		defer w.wg.Done()
+		defer w.bgWG.Done()
 		var lastWrite time.Time
 		ticker := time.NewTicker(heapPressureProfilePoll)
 		defer ticker.Stop()
@@ -220,9 +220,9 @@ func (w *Worker) startLongTaskWatcher(ctx context.Context, task distributed.Task
 		}
 	}
 
-	w.wg.Add(1)
+	w.bgWG.Add(1)
 	go func() {
-		defer w.wg.Done()
+		defer w.bgWG.Done()
 		select {
 		case <-ctx.Done():
 			return

--- a/internal/worker/upload_manager.go
+++ b/internal/worker/upload_manager.go
@@ -126,6 +126,40 @@ func (m *uploadManager) CancelQuery(root string) {
 	}
 }
 
+// Flush waits for every pending background upload to complete (land in the
+// object store or exhaust its retries) WITHOUT cancelling — the graceful
+// counterpart of Drain, used by Worker.Drain so that consumers of this
+// worker's stage outputs keep their durable S3 fallback after the
+// peer-exchange server goes away. Callers must ensure no new StartTask
+// calls can arrive (Worker.Drain runs it after the task WaitGroup drains),
+// so a single snapshot of the query states covers everything. Returns
+// ctx.Err() if the context expires first; the caller then falls back to
+// Drain (cancel).
+func (m *uploadManager) Flush(ctx context.Context) error {
+	if m == nil {
+		return nil
+	}
+	m.mu.Lock()
+	states := make([]*queryUploadState, 0, len(m.queries))
+	for _, qs := range m.queries {
+		states = append(states, qs)
+	}
+	m.mu.Unlock()
+	for _, qs := range states {
+		done := make(chan struct{})
+		go func(q *queryUploadState) {
+			q.inflight.Wait()
+			close(done)
+		}(qs)
+		select {
+		case <-done:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
 // Drain cancels everything (worker shutdown).
 func (m *uploadManager) Drain() {
 	if m == nil {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -47,6 +47,11 @@ type Config struct {
 	MemoryBudget     int64  // per-task memory budget in bytes (0 = unlimited, no spill); used as legacy fallback when SharedPoolBudget is unset
 	SharedPoolBudget int64  // worker-wide memory pool in bytes (0 = derived as MemoryBudget*MaxConcurrent). All concurrent tasks Reserve against this pool; spill triggers fire on cumulative worker pressure.
 	SpillDir         string // directory for spill files (default: os temp dir)
+	// DrainTimeout bounds Drain(): how long to wait for in-flight tasks and
+	// then pending stage-output uploads before escalating to a hard stop.
+	// 0 = unbounded (the platform's kill timeout — e.g. the Kubernetes
+	// termination grace period — is the backstop).
+	DrainTimeout     time.Duration
 	ResultStoreBytes int64  // in-memory result store capacity (0 = disabled, results go to S3)
 
 	// Reservoirs is the Phase-3 system-reservoir registry. When non-nil, the
@@ -144,8 +149,16 @@ type Worker struct {
 	logger    *slog.Logger
 	metrics   *metrics.Metrics
 
-	cancel    context.CancelFunc
+	cancel context.CancelFunc
+	// wg tracks the TASK side of the lifecycle: intake loops (which exit on
+	// drain) and per-task goroutines. bgWG tracks background services
+	// (heartbeat, stats, heap profiler) that exit only on context cancel.
+	// The split is what makes Drain possible: wait for wg (tasks finish)
+	// while bgWG keeps heartbeating Draining=true, THEN cancel and wait for
+	// bgWG. With a single group, Drain's pre-cancel Wait deadlocked on the
+	// heartbeat loop.
 	wg        sync.WaitGroup
+	bgWG      sync.WaitGroup
 	drainCh   chan struct{} // closed when drain is requested
 	drainOnce sync.Once
 
@@ -432,7 +445,7 @@ func (w *Worker) Start(ctx context.Context) error {
 	drainSubject := fmt.Sprintf("wadjet.worker.%s.drain", w.config.WorkerID)
 	w.nc.Subscribe(drainSubject, func(msg *nats.Msg) {
 		w.logger.Info("received drain request via NATS")
-		w.drainOnce.Do(func() { close(w.drainCh) })
+		w.BeginDrain()
 		if msg.Reply != "" {
 			msg.Respond([]byte("ok"))
 		}
@@ -456,10 +469,13 @@ func (w *Worker) Start(ctx context.Context) error {
 	// Start task pull loop
 	sem := make(chan struct{}, w.config.MaxConcurrent)
 
-	// Start heartbeat (needs sem to report active task count)
-	w.wg.Add(1)
+	// Start heartbeat (needs sem to report active task count). Background
+	// group: must keep running through a drain so the coordinator sees
+	// Draining=true (dispatch exclusion) instead of heartbeat silence
+	// (reap + re-dispatch of work this worker is still finishing).
+	w.bgWG.Add(1)
 	go func() {
-		defer w.wg.Done()
+		defer w.bgWG.Done()
 		w.heartbeatLoop(ctx, sem)
 	}()
 
@@ -541,6 +557,12 @@ func (w *Worker) dispatchLoop(ctx context.Context, in <-chan dataplane.TaskDispa
 	for {
 		select {
 		case <-ctx.Done():
+			return
+		case <-w.drainCh:
+			// Without this case an IDLE worker never exits the loop on
+			// drain — it sits blocked on `in` and Drain's task-group Wait
+			// hangs (caught by the SIGTERM e2e, 2026-07-04). A task already
+			// popped from `in` still runs to completion below.
 			return
 		case td := <-in:
 			if w.Draining() {
@@ -643,19 +665,82 @@ func (w *Worker) waitForPoolHeadroom(ctx context.Context, estBytes int64) {
 	}
 }
 
-// Drain puts the worker into drain mode: it stops pulling new tasks and waits
-// for all in-flight tasks to complete, then cancels the context so heartbeat
-// and other background loops exit. Use this for zero-downtime rolling updates.
-func (w *Worker) Drain() {
+// BeginDrain marks the worker as draining without blocking: intake loops
+// stop pulling new tasks and the next heartbeat advertises Draining=true so
+// the coordinator excludes this worker from dispatch. Idempotent. The full
+// shutdown sequence is Drain(); process owners typically select on
+// DrainRequested() and call Drain when it fires.
+func (w *Worker) BeginDrain() {
 	w.drainOnce.Do(func() {
 		w.logger.Info("worker entering drain mode", "worker_id", w.config.WorkerID)
 		close(w.drainCh)
 	})
-	// Wait for in-flight tasks to finish, then stop.
-	w.wg.Wait()
+}
+
+// DrainRequested returns a channel that is closed once drain has been
+// requested from ANY source: BeginDrain, the NATS drain subject (the
+// coordinator sends it on reap), or the /drain admin endpoint.
+func (w *Worker) DrainRequested() <-chan struct{} { return w.drainCh }
+
+// Drain performs a graceful shutdown: stop pulling new tasks, let in-flight
+// tasks run to completion, flush pending stage-output uploads to the object
+// store (so consumers of this worker's outputs keep their durable fallback
+// once the peer-exchange server goes away), then stop background services.
+// Use this for zero-downtime rolling updates and Kubernetes pod termination
+// (SIGTERM). Config.DrainTimeout bounds the whole sequence; on timeout the
+// remaining work is aborted exactly like Stop.
+func (w *Worker) Drain() {
+	w.BeginDrain()
+
+	var deadline <-chan time.Time
+	var deadlineAt time.Time
+	if w.config.DrainTimeout > 0 {
+		deadlineAt = time.Now().Add(w.config.DrainTimeout)
+		t := time.NewTimer(w.config.DrainTimeout)
+		defer t.Stop()
+		deadline = t.C
+	}
+
+	// Phase 1: in-flight tasks. The intake loops exit on the drain flag;
+	// heartbeats (bgWG) keep publishing Draining=true throughout.
+	tasksDone := make(chan struct{})
+	go func() { w.wg.Wait(); close(tasksDone) }()
+	select {
+	case <-tasksDone:
+	case <-deadline:
+		w.logger.Warn("drain timeout waiting for in-flight tasks; escalating to hard stop",
+			"worker_id", w.config.WorkerID, "timeout", w.config.DrainTimeout)
+		w.Stop()
+		return
+	}
+
+	// Phase 2: flush pending async stage-output uploads. Tasks are done, so
+	// no new uploads can start; a single pass suffices. Peer fetches are
+	// still served during the flush.
+	flushCtx := context.Background()
+	if !deadlineAt.IsZero() {
+		var cancel context.CancelFunc
+		flushCtx, cancel = context.WithDeadline(flushCtx, deadlineAt)
+		defer cancel()
+	}
+	if err := w.executor.uploads.Flush(flushCtx); err != nil {
+		w.logger.Warn("drain timeout flushing stage-output uploads; remaining uploads cancelled",
+			"worker_id", w.config.WorkerID, "error", err)
+	}
+
+	// Phase 3: tear down. Consumers mid-fetch fall through to the (now
+	// flushed) S3 copies.
+	if w.peerServer != nil {
+		w.peerServer.Stop()
+	}
+	if w.peerClient != nil {
+		w.peerClient.Close()
+	}
+	w.executor.uploads.Drain()
 	if w.cancel != nil {
 		w.cancel()
 	}
+	w.bgWG.Wait()
 	w.logger.Info("worker drained and stopped", "worker_id", w.config.WorkerID)
 }
 
@@ -676,6 +761,7 @@ func (w *Worker) Stop() {
 		w.cancel()
 	}
 	w.wg.Wait()
+	w.bgWG.Wait()
 
 	if w.peerServer != nil {
 		w.peerServer.Stop()
@@ -828,9 +914,15 @@ func (w *Worker) taskLoop(ctx context.Context, consumer jetstream.Consumer, sem 
 		}
 	fetch:
 		if available == 0 {
-			// All slots occupied — wait for one to free up
+			// All slots occupied — wait for one to free up. The drain case
+			// matters twice over: without it a saturated worker blocks here
+			// through the whole drain, and when a slot finally freed it
+			// would pull one MORE task past the Draining check at the loop
+			// top (intake leak during drain).
 			select {
 			case <-ctx.Done():
+				return
+			case <-w.drainCh:
 				return
 			case sem <- struct{}{}:
 				available = 1
@@ -1421,9 +1513,9 @@ func computeStatsGauges(heapInuse, rss, driftBytes int64) (driftMB int64, driftP
 
 func (w *Worker) heartbeatLoop(ctx context.Context, sem chan struct{}) {
 	cache := &statsCache{}
-	w.wg.Add(1)
+	w.bgWG.Add(1)
 	go func() {
-		defer w.wg.Done()
+		defer w.bgWG.Done()
 		w.statsRefreshLoop(ctx, cache)
 	}()
 

--- a/internal/worker/worker_drain_test.go
+++ b/internal/worker/worker_drain_test.go
@@ -1,0 +1,194 @@
+package worker
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+)
+
+// TestUploadManagerFlush_WaitsForPendingUploads: Flush must block until
+// pending background uploads land (the graceful-drain durability handoff:
+// once the worker exits, consumers of its stage outputs have only the S3
+// copy). Contrast with Drain, which cancels.
+func TestUploadManagerFlush_WaitsForPendingUploads(t *testing.T) {
+	gate := &gatedStore{MemStore: objstore.NewMemStore(), gate: make(chan struct{})}
+	if err := gate.MakeBucket(context.Background(), "b"); err != nil {
+		t.Fatal(err)
+	}
+	m := newUploadManager(gate, nil, slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+	src := writeTempFile(t, []byte("stage output bytes"))
+	m.StartTask("root-q", "task-1", "w-1", []uploadJob{{bucket: "b", key: "queries/root-q/out.wshf", srcPath: src}})
+
+	flushed := make(chan error, 1)
+	go func() { flushed <- m.Flush(context.Background()) }()
+
+	select {
+	case err := <-flushed:
+		t.Fatalf("Flush returned (%v) while the upload was still gated", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(gate.gate)
+	select {
+	case err := <-flushed:
+		if err != nil {
+			t.Fatalf("Flush: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Flush did not return after the upload completed")
+	}
+	if _, _, err := gate.Get(context.Background(), "b", "queries/root-q/out.wshf"); err != nil {
+		t.Fatalf("uploaded object missing after Flush: %v", err)
+	}
+}
+
+// TestUploadManagerFlush_Timeout: an expired context aborts the wait with
+// ctx.Err() so Drain can escalate to the cancel path.
+func TestUploadManagerFlush_Timeout(t *testing.T) {
+	gate := &gatedStore{MemStore: objstore.NewMemStore(), gate: make(chan struct{})} // never opens
+	if err := gate.MakeBucket(context.Background(), "b"); err != nil {
+		t.Fatal(err)
+	}
+	m := newUploadManager(gate, nil, slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	src := writeTempFile(t, []byte("x"))
+	m.StartTask("root-q", "task-1", "w-1", []uploadJob{{bucket: "b", key: "k", srcPath: src}})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	if err := m.Flush(ctx); err != context.DeadlineExceeded {
+		t.Fatalf("Flush = %v, want DeadlineExceeded", err)
+	}
+	m.Drain() // release the stuck job so the test goroutine can exit
+}
+
+func TestUploadManagerFlush_NilAndEmpty(t *testing.T) {
+	var m *uploadManager
+	if err := m.Flush(context.Background()); err != nil {
+		t.Fatalf("nil Flush: %v", err)
+	}
+	m2 := newUploadManager(objstore.NewMemStore(), nil, nil)
+	if err := m2.Flush(context.Background()); err != nil {
+		t.Fatalf("empty Flush: %v", err)
+	}
+}
+
+// TestWorkerDrain_CompletesWithBackgroundLoops is the regression test for
+// the drain deadlock: heartbeat-style background goroutines exit only on
+// context cancel, and the old single-WaitGroup Drain waited for them BEFORE
+// cancelling — so Drain never returned. With the wg/bgWG split, Drain must
+// (1) wait for in-flight task goroutines, (2) flush uploads, (3) cancel and
+// join the background group.
+func TestWorkerDrain_CompletesWithBackgroundLoops(t *testing.T) {
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(context.Background(), "b"); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	w := &Worker{
+		config:   Config{WorkerID: "drain-test"},
+		logger:   slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn})),
+		drainCh:  make(chan struct{}),
+		cancel:   cancel,
+		executor: NewExecutor(store, NewLRUCache(1024), nil),
+	}
+
+	// Background loop: exits only on ctx cancel (the heartbeat shape).
+	bgExited := atomic.Bool{}
+	w.bgWG.Add(1)
+	go func() {
+		defer w.bgWG.Done()
+		<-ctx.Done()
+		bgExited.Store(true)
+	}()
+
+	// In-flight task: finishes on its own shortly after drain begins, and
+	// must NOT be aborted by drain (ctx must still be alive when it ends).
+	taskSawCancel := atomic.Bool{}
+	w.wg.Add(1)
+	go func() {
+		defer w.wg.Done()
+		select {
+		case <-ctx.Done():
+			taskSawCancel.Store(true)
+		case <-time.After(150 * time.Millisecond):
+		}
+	}()
+
+	done := make(chan struct{})
+	go func() { w.Drain(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Drain did not complete (background-loop deadlock)")
+	}
+	if taskSawCancel.Load() {
+		t.Fatal("in-flight task was cancelled during drain; drain must let tasks finish")
+	}
+	if !bgExited.Load() {
+		t.Fatal("background loop still running after Drain returned")
+	}
+	if !w.Draining() {
+		t.Fatal("Draining() must report true after Drain")
+	}
+}
+
+// TestWorkerDrain_TimeoutEscalatesToStop: with DrainTimeout set and a task
+// that never finishes, Drain must give up and hard-stop (cancel) instead of
+// hanging past the platform's kill window.
+func TestWorkerDrain_TimeoutEscalatesToStop(t *testing.T) {
+	store := objstore.NewMemStore()
+	ctx, cancel := context.WithCancel(context.Background())
+	w := &Worker{
+		config:   Config{WorkerID: "drain-timeout-test", DrainTimeout: 200 * time.Millisecond},
+		logger:   slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn})),
+		drainCh:  make(chan struct{}),
+		cancel:   cancel,
+		executor: NewExecutor(store, NewLRUCache(1024), nil),
+	}
+	// Wedged task: only exits when ctx is cancelled (i.e. by the escalation).
+	w.wg.Add(1)
+	go func() {
+		defer w.wg.Done()
+		<-ctx.Done()
+	}()
+
+	done := make(chan struct{})
+	go func() { w.Drain(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Drain did not escalate on timeout")
+	}
+}
+
+// TestWorkerBeginDrain_Idempotent: BeginDrain from multiple sources (signal,
+// NATS drain subject, /drain endpoint) must not panic on double-close and
+// must trip DrainRequested exactly once.
+func TestWorkerBeginDrain_Idempotent(t *testing.T) {
+	w := &Worker{
+		config:  Config{WorkerID: "idem"},
+		logger:  slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn})),
+		drainCh: make(chan struct{}),
+	}
+	select {
+	case <-w.DrainRequested():
+		t.Fatal("DrainRequested fired before BeginDrain")
+	default:
+	}
+	w.BeginDrain()
+	w.BeginDrain()
+	select {
+	case <-w.DrainRequested():
+	default:
+		t.Fatal("DrainRequested not fired after BeginDrain")
+	}
+	if !w.Draining() {
+		t.Fatal("Draining() false after BeginDrain")
+	}
+}


### PR DESCRIPTION
Workers now shut down gracefully on the signal Kubernetes actually sends.

## What was there / what was broken

The drain machinery was ~70% built (drain flag, `Draining` heartbeat bit, coordinator dispatch exclusion, NATS drain subject) but had four gaps, including a deadlock that meant the existing SIGQUIT drain path could never have completed:

1. **Drain deadlocked**: the heartbeat/stats/profiler goroutines shared the WaitGroup that `Drain()` waited on *before* the context cancel those loops need to exit. Fixed with a task-WG / background-WG split — heartbeats now keep advertising `Draining=true` through the whole drain (dispatch exclusion instead of reap).
2. **Idle/saturated intake never stopped**: `dispatchLoop` blocked on the dispatch channel with no drain case (caught live by the SIGTERM e2e — an idle worker hung in drain forever); `taskLoop`'s slot-wait had the same gap *plus* an intake leak (it would pull one more task after a slot freed mid-drain). Both selects gained drain cases.
3. **No upload flush**: `uploadManager` could only *cancel* pending async stage-output uploads. New `Flush(ctx)` waits for them to land, so consumers of a departed worker's outputs keep their durable S3 fallback. Runs after the task group drains (single snapshot suffices); timeout escalates to the cancel path.
4. **K8s mismatch**: SIGTERM did a hard stop. New contract (worker mode): **SIGTERM/SIGQUIT → drain**, SIGINT → hard stop; `runWorker` detaches from the serve `NotifyContext` so SIGTERM can't race into the hard-cancel path and abort in-flight tasks mid-drain. `--drain-timeout` (default 0 = unbounded; pod grace period is the backstop) bounds tasks+flush and escalates to `Stop` on expiry.

Also new on the metrics port: `GET /healthz`, `GET /readyz` (503 once draining), `POST /drain` (202; same path as SIGTERM). The NATS drain subject and `/drain` now terminate the process via `DrainRequested` instead of only stopping intake.

## Verification

- Live e2e on a coordinator+worker pair: SIGTERM and `POST /drain` both produce `worker entering drain mode` → `worker drained and stopped` → clean process exit; `/readyz` flips to 503 during drain.
- Unit: Flush wait/timeout semantics, drain-with-background-loops deadlock regression, in-flight tasks not cancelled during drain, timeout escalation, `BeginDrain` idempotence.
- Gates: worker `-race` suite, internal suite, SF0.01 22/22, harness local PASS.
- Runbook §1.7 documents the contract with a pod-spec sketch (includes the runbook base from #182; merging either first is fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)