### PR TITLE
perf: standalone cold-S3 read path — 21m40s → 7m29s SF10 suite (+ Q21 crash fix)

### DIFF
--- a/benchmarks/tpch/q21_reverse_bloom_test.go
+++ b/benchmarks/tpch/q21_reverse_bloom_test.go
@@ -1,0 +1,37 @@
+package tpch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/planner/physical"
+)
+
+// TestQ21ReverseBloomSemiAnti reproduces the 2026-07-05 SF10 standalone
+// Q21 crash at SF0.01 by forcing the reverse-bloom path for semi/anti
+// joins (in production it fires when the build-side estimate exceeds
+// 10M rows — SF10 lineitem is 60M, so every cold-S3 SF10 standalone run
+// panicked in HashJoin.PruneBuildColumns with a nil build batch, killing
+// the suite after Q20).
+//
+// Q21 stacks an EXISTS (semi) and NOT EXISTS (anti) join on lineitem,
+// both with join filters (l_suppkey <>), so SemiAntiKeyOnly is false and
+// the reverse-bloom build goroutine runs FixKeyAssignment +
+// PruneBuildColumns after Build.
+func TestQ21ReverseBloomSemiAnti(t *testing.T) {
+	oldSemi := physical.ReverseBloomThreshold
+	physical.ReverseBloomThreshold = 1
+	defer func() { physical.ReverseBloomThreshold = oldSemi }()
+
+	db := setupTPCH(t, SF001)
+	ctx := context.Background()
+
+	q := TPCHQueries[21]
+	result, err := db.Query(ctx, q.SQL)
+	if err != nil {
+		t.Fatalf("Q21 failed: %v", err)
+	}
+	if want := expectedRowsSF001[21]; len(result.Rows) != want {
+		t.Errorf("Q21 rows = %d, want %d", len(result.Rows), want)
+	}
+}

--- a/cmd/s3probe/main.go
+++ b/cmd/s3probe/main.go
@@ -1,0 +1,153 @@
+// s3probe measures raw objstore.MinIOStore GET throughput against a bucket
+// prefix at several concurrency levels. Diagnostic tool for the standalone
+// cold-S3 scan investigation (2026-07-05): decomposes scan-path wall time
+// into store-layer throughput vs scan-machinery overhead.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+)
+
+func main() {
+	var (
+		endpoint = flag.String("endpoint", "s3.us-east-2.amazonaws.com", "S3 endpoint")
+		bucket   = flag.String("bucket", "wadjet-bench-sf10-use2", "bucket")
+		region   = flag.String("region", "us-east-2", "region")
+		prefix   = flag.String("prefix", "tables/lineitem/", "key prefix")
+		maxFiles = flag.Int("max-files", 300, "max objects per pass")
+		levels   = flag.String("levels", "1,4,8,16,32", "comma-separated concurrency levels")
+	)
+	flag.Parse()
+
+	ctx := context.Background()
+	store, err := objstore.NewMinIOStore(objstore.MinIOConfig{
+		Endpoint: *endpoint,
+		UseSSL:   true,
+		Region:   *region,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	keys, err := listKeys(ctx, store, *bucket, *prefix, *maxFiles)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if len(keys) == 0 {
+		log.Fatalf("no objects under %s/%s", *bucket, *prefix)
+	}
+	fmt.Printf("objects: %d under %s\n", len(keys), *prefix)
+
+	var lvls []int
+	for _, part := range splitInts(*levels) {
+		lvls = append(lvls, part)
+	}
+
+	// Per-object latency at c=1 over a small sample first.
+	sample := keys
+	if len(sample) > 24 {
+		sample = keys[:24]
+	}
+	var lats []time.Duration
+	var sampleBytes int64
+	for _, k := range sample {
+		t0 := time.Now()
+		n, err := getAll(ctx, store, *bucket, k)
+		if err != nil {
+			log.Fatalf("get %s: %v", k, err)
+		}
+		lats = append(lats, time.Since(t0))
+		sampleBytes += n
+	}
+	sort.Slice(lats, func(i, j int) bool { return lats[i] < lats[j] })
+	fmt.Printf("c=1 per-object: p50=%v p90=%v max=%v avg_size=%.1fMB\n",
+		lats[len(lats)/2], lats[len(lats)*9/10], lats[len(lats)-1],
+		float64(sampleBytes)/float64(len(sample))/1e6)
+
+	for _, c := range lvls {
+		wall, bytes := pass(ctx, store, *bucket, keys, c)
+		mbs := float64(bytes) / 1e6 / wall.Seconds()
+		fmt.Printf("c=%-3d wall=%-10v bytes=%.1fGB agg=%.1f MB/s per-lane=%.1f MB/s\n",
+			c, wall.Round(time.Millisecond), float64(bytes)/1e9, mbs, mbs/float64(c))
+	}
+}
+
+func pass(ctx context.Context, store objstore.Store, bucket string, keys []string, conc int) (time.Duration, int64) {
+	var idx, total int64
+	var wg sync.WaitGroup
+	t0 := time.Now()
+	wg.Add(conc)
+	for w := 0; w < conc; w++ {
+		go func() {
+			defer wg.Done()
+			for {
+				i := int(atomic.AddInt64(&idx, 1) - 1)
+				if i >= len(keys) {
+					return
+				}
+				n, err := getAll(ctx, store, bucket, keys[i])
+				if err != nil {
+					log.Printf("get %s: %v", keys[i], err)
+					continue
+				}
+				atomic.AddInt64(&total, n)
+			}
+		}()
+	}
+	wg.Wait()
+	return time.Since(t0), total
+}
+
+func getAll(ctx context.Context, store objstore.Store, bucket, key string) (int64, error) {
+	rc, _, err := store.Get(ctx, bucket, key)
+	if err != nil {
+		return 0, err
+	}
+	defer rc.Close()
+	return io.Copy(io.Discard, rc)
+}
+
+func listKeys(ctx context.Context, store objstore.Store, bucket, prefix string, max int) ([]string, error) {
+	infos, err := store.List(ctx, bucket, objstore.ListOptions{Prefix: prefix, MaxKeys: max})
+	if err != nil {
+		return nil, err
+	}
+	var keys []string
+	for _, o := range infos {
+		keys = append(keys, o.Key)
+		if len(keys) >= max {
+			break
+		}
+	}
+	return keys, nil
+}
+
+func splitInts(s string) []int {
+	var out []int
+	cur := 0
+	has := false
+	for i := 0; i <= len(s); i++ {
+		if i == len(s) || s[i] == ',' {
+			if has {
+				out = append(out, cur)
+			}
+			cur, has = 0, false
+			continue
+		}
+		if s[i] >= '0' && s[i] <= '9' {
+			cur = cur*10 + int(s[i]-'0')
+			has = true
+		}
+	}
+	return out
+}

--- a/internal/engine/exec/join.go
+++ b/internal/engine/exec/join.go
@@ -1487,6 +1487,16 @@ func bloomHashBytes(key []byte) uint64 {
 // the hash index is built we only need columns referenced by SemiAntiFilter.
 // If keepCols is empty and no SemiAntiFilter is set, buildBatches are cleared.
 func (h *HashJoin) PruneBuildColumns(keepCols []string) {
+	// Partition-on-arrival builds are incompatible with pruning: evicted
+	// partitions nil their buildBatches entries (dereferencing them here
+	// was the SF10 standalone Q21 SIGSEGV, 2026-07-05), and a partition
+	// restored from disk carries the UNPRUNED schema — pruning
+	// buildSchema would desync it from the spilled data. The prune is
+	// purely a memory optimization and the spill machinery already bounds
+	// build memory, so skip it. Mirrors consolidateBuild's guard.
+	if h.spillState != nil {
+		return
+	}
 	if len(h.buildBatches) == 0 {
 		return
 	}

--- a/internal/engine/exec/join_prune_spill_test.go
+++ b/internal/engine/exec/join_prune_spill_test.go
@@ -1,0 +1,76 @@
+package exec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/memory"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// TestPruneBuildColumns_PartitionedBuildSafe: PruneBuildColumns after a
+// partition-on-arrival build must not touch buildBatches — evicted
+// partitions nil their entries (join_partition_arrival.go), and restored
+// partitions carry the unpruned schema. Before the guard, every SF10+
+// standalone Q21 run (semi/anti join with a join filter, build side large
+// enough to evict) crashed with a nil dereference in PruneBuildColumns
+// called from the planner's post-build hook — the 2026-07-05 finding that
+// killed the cold-S3 suite after Q20.
+func TestPruneBuildColumns_PartitionedBuildSafe(t *testing.T) {
+	rightSchema := []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "val", Type: parquet.TypeString},
+	}
+	const buildN = 10000
+	rightRows := make([]map[string]any, buildN)
+	for i := range rightRows {
+		rightRows[i] = map[string]any{
+			"id":  int64(i),
+			"val": "build-row-padding-for-size",
+		}
+	}
+
+	tmpDir := t.TempDir()
+	// Budget tight enough that partitions must evict during build —
+	// eviction is what nils buildBatches entries (matches
+	// TestPartitionOnArrival_BasicSpill's working point).
+	tracker := memory.NewTracker("test", 400_000)
+	sm, err := memory.NewSpillManager(tmpDir, tracker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sm.Cleanup()
+
+	// Semi join with a join filter keeps SemiAntiKeyOnly false, so the
+	// build stores batches and dispatches to buildPartitioned.
+	hj := NewHashJoin(SemiJoin, []string{"id"}, []string{"id"})
+	hj.Spill = sm
+	hj.MemTracker = tracker
+
+	if err := hj.Build(context.Background(), NewSliceSource(rightSchema, rightRows)); err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	if hj.spillState == nil {
+		t.Fatal("test setup: build did not take the partition-on-arrival path")
+	}
+	nilEntries := 0
+	for _, b := range hj.buildBatches {
+		if b == nil {
+			nilEntries++
+		}
+	}
+	if nilEntries == 0 {
+		t.Fatal("test setup: no partition was evicted — budget too generous to exercise the crash")
+	}
+
+	// The planner's post-build hook for semi/anti joins with a filter.
+	// Pre-guard this dereferenced the nil'd entries and crashed.
+	hj.PruneBuildColumns([]string{"val"})
+
+	// The partitioned representation must be untouched: schema unpruned,
+	// batch slots still consistent with the partition bookkeeping.
+	if len(hj.buildSchema) != len(rightSchema) {
+		t.Fatalf("buildSchema pruned to %d cols on a partitioned build, want untouched %d",
+			len(hj.buildSchema), len(rightSchema))
+	}
+}

--- a/internal/planner/physical/load_gate.go
+++ b/internal/planner/physical/load_gate.go
@@ -1,0 +1,91 @@
+package physical
+
+import (
+	"context"
+	"sync"
+)
+
+// loadGate admits concurrent file loads by BYTES instead of file count.
+//
+// Its predecessor was a 4-slot counting semaphore (loadConcurrency = 4),
+// sized for SF100 lineitem files: "4 × 300 MB = 1.2 GB peak". That bound
+// was really a byte bound expressed in file units, and it collapsed on
+// small-file layouts: SF10 ships 600 × 6.5 MB lineitem files, and 4
+// concurrent GETs left a 16-core box ~98% idle on cold S3 (2026-07-05
+// Q06 profile: 56.6s wall, 7.98s CPU — pure download wait; suite 7×
+// slower than DuckDB httpfs on the same instance). Bounding bytes
+// directly gives small-file scans the lane count they need while holding
+// the same heap ceiling for large files.
+//
+// Semantics match the old semaphore: a slot's bytes are held from load
+// admission until the file's last row group is consumed (releaseRG) or
+// the scan is torn down (drainAbandoned), because the admitted bytes ARE
+// the live heap of the loaded file, not just the download window.
+//
+// Progress guarantee: a load is always admitted when nothing is inflight,
+// so a file larger than the whole budget still loads — alone.
+type loadGate struct {
+	budget   int64 // max inflight bytes (soft: single oversized load admits alone)
+	maxLanes int   // hard cap on concurrent loads (connection sanity)
+
+	mu       sync.Mutex
+	inflight int64
+	lanes    int
+	freeCh   chan struct{} // closed+replaced on every release (broadcast)
+}
+
+// defaultLoadBudgetBytes bounds inflight loaded-file bytes per scan source
+// when no per-query memory budget is configured. 1 GiB ≈ 3 concurrent
+// SF100 lineitem files (the old semaphore's working point) and ~32 lanes
+// of SF10-sized files (capped by loadGateMaxLanes).
+const defaultLoadBudgetBytes = int64(1) << 30
+
+// loadGateMaxLanes caps concurrent loads regardless of file size. 32
+// matches the fan-out S3 handles comfortably at file granularity and
+// keeps worst-case connection counts bounded on many-column scans.
+const loadGateMaxLanes = 32
+
+func newLoadGate(budget int64, maxLanes int) *loadGate {
+	return &loadGate{
+		budget:   budget,
+		maxLanes: maxLanes,
+		freeCh:   make(chan struct{}),
+	}
+}
+
+// acquire blocks until n bytes fit under the budget (and a lane is free),
+// or nothing is inflight, or ctx is cancelled.
+func (g *loadGate) acquire(ctx context.Context, n int64) error {
+	if n < 1 {
+		n = 1
+	}
+	for {
+		g.mu.Lock()
+		if g.lanes == 0 || (g.inflight+n <= g.budget && g.lanes < g.maxLanes) {
+			g.inflight += n
+			g.lanes++
+			g.mu.Unlock()
+			return nil
+		}
+		wait := g.freeCh
+		g.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-wait:
+		}
+	}
+}
+
+// release returns n bytes to the budget and frees a lane.
+func (g *loadGate) release(n int64) {
+	if n < 1 {
+		n = 1
+	}
+	g.mu.Lock()
+	g.inflight -= n
+	g.lanes--
+	close(g.freeCh)
+	g.freeCh = make(chan struct{})
+	g.mu.Unlock()
+}

--- a/internal/planner/physical/load_gate_test.go
+++ b/internal/planner/physical/load_gate_test.go
@@ -1,0 +1,120 @@
+package physical
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestLoadGate_ByteBudget: loads pack under the byte budget, block past it,
+// and unblock on release.
+func TestLoadGate_ByteBudget(t *testing.T) {
+	ctx := context.Background()
+	g := newLoadGate(100, 32)
+
+	if err := g.acquire(ctx, 60); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.acquire(ctx, 40); err != nil {
+		t.Fatal(err)
+	}
+
+	// Third acquire exceeds the budget — must block until a release.
+	blocked := make(chan error, 1)
+	go func() { blocked <- g.acquire(ctx, 10) }()
+	select {
+	case <-blocked:
+		t.Fatal("acquire over budget did not block")
+	case <-time.After(50 * time.Millisecond):
+	}
+	g.release(60)
+	select {
+	case err := <-blocked:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("acquire did not unblock after release")
+	}
+}
+
+// TestLoadGate_OversizedLoadAdmitsAlone: a single load larger than the whole
+// budget is admitted when nothing is inflight — progress guarantee.
+func TestLoadGate_OversizedLoadAdmitsAlone(t *testing.T) {
+	ctx := context.Background()
+	g := newLoadGate(100, 32)
+	if err := g.acquire(ctx, 500); err != nil {
+		t.Fatal(err)
+	}
+	// A second load must wait for the oversized one.
+	ctx2, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+	defer cancel()
+	if err := g.acquire(ctx2, 1); err == nil {
+		t.Fatal("second acquire admitted alongside an over-budget load")
+	}
+	g.release(500)
+	if err := g.acquire(ctx, 1); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestLoadGate_LaneCap: small loads cannot exceed maxLanes even when the
+// byte budget has room.
+func TestLoadGate_LaneCap(t *testing.T) {
+	ctx := context.Background()
+	g := newLoadGate(1<<30, 2)
+	if err := g.acquire(ctx, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.acquire(ctx, 1); err != nil {
+		t.Fatal(err)
+	}
+	ctx2, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+	defer cancel()
+	if err := g.acquire(ctx2, 1); err == nil {
+		t.Fatal("third acquire admitted past the lane cap")
+	}
+}
+
+// TestLoadGate_ConcurrentChurn: hammer the gate from many goroutines and
+// verify inflight bytes never exceed the budget (single-oversized excepted)
+// and everything completes. Run with -race.
+func TestLoadGate_ConcurrentChurn(t *testing.T) {
+	ctx := context.Background()
+	const budget = 1000
+	g := newLoadGate(budget, 8)
+
+	var inflight, peak atomic.Int64
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		n := int64(50 + (i%7)*40) // all under budget individually
+		wg.Add(1)
+		go func(n int64) {
+			defer wg.Done()
+			for k := 0; k < 20; k++ {
+				if err := g.acquire(ctx, n); err != nil {
+					t.Error(err)
+					return
+				}
+				cur := inflight.Add(n)
+				for {
+					p := peak.Load()
+					if cur <= p || peak.CompareAndSwap(p, cur) {
+						break
+					}
+				}
+				inflight.Add(-n)
+				g.release(n)
+			}
+		}(n)
+	}
+	wg.Wait()
+	// Peak can exceed budget by at most one admission's worth (the check
+	// is admit-if-fits, so the last admitted load fits by definition —
+	// peak should never pass budget at all for under-budget loads).
+	if p := peak.Load(); p > budget {
+		t.Fatalf("inflight peak %d exceeded budget %d", p, budget)
+	}
+}

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -7451,10 +7451,10 @@ type scanSourceInner struct {
 	rowLimit       int64                     // >0: lazy file downloading (LIMIT pushdown)
 
 	// row-group-level parallel scan
-	rgUnits   []rgUnit      // flat list of row group work units
-	rgIdx     int64         // atomic index for parallel RG workers
-	useNative bool          // true if native page decoder can be used (no Decimal/Array/Map)
-	loadSem   chan struct{} // bounded semaphore for in-flight file LOADs (data, not metadata)
+	rgUnits   []rgUnit  // flat list of row group work units
+	rgIdx     int64     // atomic index for parallel RG workers
+	useNative bool      // true if native page decoder can be used (no Decimal/Array/Map)
+	loadGate  *loadGate // byte-budgeted admission for in-flight file LOADs (data, not metadata)
 
 	// batch pooling — reuse batch allocations across row groups
 	pool *batch.BatchPool
@@ -7533,7 +7533,7 @@ func (inner *scanSourceInner) releaseScanBatch(b *batch.RecordBatch) {
 }
 
 // drainSlotCharges releases the lazy fileSlot state of every slot whose row
-// groups were not fully consumed — buffers, loadSem slots and shared-tracker
+// groups were not fully consumed — buffers, load-gate bytes and shared-tracker
 // charges abandoned by an early Close (LIMIT, cancel, error). Must run after
 // wg.Wait (no rg worker may still be loading) and BEFORE releasePooledBufs,
 // which nils rgUnits (the only reference to the slots).

--- a/internal/planner/physical/scan_accounting_test.go
+++ b/internal/planner/physical/scan_accounting_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"testing"
+	"time"
 
 	"github.com/citc-tech/wadjet/internal/engine/batch"
 	"github.com/citc-tech/wadjet/internal/engine/memory"
@@ -241,7 +242,9 @@ func TestScanAccounting_DrainSlotChargesOnAbandonedScan(t *testing.T) {
 
 	tracker := memory.NewTracker("scan-test", 1<<30)
 	inner := &scanSourceInner{cat: cat, memTracker: tracker}
-	inner.loadSem = make(chan struct{}, 1)
+	// Budget of one file's bytes with a single lane: the drain must free
+	// the admitted bytes or the follow-up acquire below would block.
+	inner.loadGate = newLoadGate(entry.SizeBytes, 1)
 
 	slot := &fileSlot{entry: entry}
 	slot.rgRemaining.Store(2)
@@ -259,9 +262,11 @@ func TestScanAccounting_DrainSlotChargesOnAbandonedScan(t *testing.T) {
 	if used := tracker.Used(); used != 0 {
 		t.Fatalf("used = %d after drainSlotCharges, want 0 (phantom reservation)", used)
 	}
-	select {
-	case inner.loadSem <- struct{}{}: // sem slot must have been released
-	default:
-		t.Fatal("loadSem slot still held after drain")
+	// The gate bytes must have been released by the drain: an acquire for
+	// the full budget only succeeds if inflight is back to zero.
+	acquireCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := inner.loadGate.acquire(acquireCtx, entry.SizeBytes); err != nil {
+		t.Fatal("load-gate bytes still held after drain")
 	}
 }

--- a/internal/planner/physical/util.go
+++ b/internal/planner/physical/util.go
@@ -296,7 +296,7 @@ func decimalFromBytes(b []byte) batch.Int128 {
 // are loaded LAZILY via slot.ensureLoaded() the first time any row group
 // from that file is read, and released as soon as the slot's last row
 // group has been processed. This caps peak heap usage from the scan source
-// at (loadConcurrency × file_size) instead of (total_files × file_size),
+// at (load-gate budget) instead of (total_files × file_size),
 // which at SF100 is the difference between ~1 GB and ~6 GB per scan.
 type rgUnit struct {
 	slot        *fileSlot
@@ -320,6 +320,7 @@ type fileSlot struct {
 	metaReader   *parquet.FileReader // metadata-only — used during pruning before any rg load
 	dataBuf      []byte              // pooled buffer holding the file bytes; returned to pool on releaseRG
 	chargedBytes int64               // bytes reserved on inner.memTracker for dataBuf; released with it
+	gateBytes    int64               // bytes admitted on inner.loadGate; released with the buffer
 	rgRemaining  atomic.Int64        // refcount of unprocessed row groups; release on 0
 }
 
@@ -346,16 +347,19 @@ func (s *fileSlot) ensureLoaded(inner *scanSourceInner, ctx context.Context) (*p
 	}
 	s.loaded = true
 
-	// Acquire a slot in the bounded loader semaphore so peak heap is
-	// (loadConcurrency × file_size) regardless of how many files are in
-	// the scan. The semaphore is released by releaseLoaded() when the
-	// last rg is consumed.
-	if inner.loadSem != nil {
-		select {
-		case inner.loadSem <- struct{}{}:
-		case <-ctx.Done():
-			s.loadErr = ctx.Err()
+	// Admit this load against the byte-budgeted gate so peak heap from
+	// loaded files is bounded by the gate's budget regardless of how many
+	// files are in the scan. The admitted bytes are released when the
+	// slot's last row group is consumed (releaseRG) or the scan is torn
+	// down (drainAbandoned).
+	if inner.loadGate != nil {
+		if err := inner.loadGate.acquire(ctx, s.entry.SizeBytes); err != nil {
+			s.loadErr = err
 			return nil, s.loadErr
+		}
+		s.gateBytes = s.entry.SizeBytes
+		if s.gateBytes < 1 {
+			s.gateBytes = 1
 		}
 	}
 
@@ -373,9 +377,7 @@ func (s *fileSlot) ensureLoaded(inner *scanSourceInner, ctx context.Context) (*p
 	rc, _, err := inner.cat.Store().Get(ctx, inner.cat.Bucket(), s.entry.Path)
 	if err != nil {
 		s.releaseCharge(inner)
-		if inner.loadSem != nil {
-			<-inner.loadSem
-		}
+		s.releaseGate(inner)
 		s.loadErr = fmt.Errorf("get %s: %w", s.entry.Path, err)
 		return nil, s.loadErr
 	}
@@ -383,9 +385,7 @@ func (s *fileSlot) ensureLoaded(inner *scanSourceInner, ctx context.Context) (*p
 	rc.Close()
 	if err != nil {
 		s.releaseCharge(inner)
-		if inner.loadSem != nil {
-			<-inner.loadSem
-		}
+		s.releaseGate(inner)
 		s.loadErr = fmt.Errorf("read %s: %w", s.entry.Path, err)
 		return nil, s.loadErr
 	}
@@ -404,9 +404,7 @@ func (s *fileSlot) ensureLoaded(inner *scanSourceInner, ctx context.Context) (*p
 	reader, err := parquet.NewReaderFromBytes(data)
 	if err != nil {
 		s.releaseCharge(inner)
-		if inner.loadSem != nil {
-			<-inner.loadSem
-		}
+		s.releaseGate(inner)
 		// Buffer wasn't installed in a slot — return it directly.
 		putReadBuf(data)
 		s.loadErr = fmt.Errorf("parquet %s (%d bytes): %w", s.entry.Path, len(data), err)
@@ -440,6 +438,15 @@ func (s *fileSlot) releaseCharge(inner *scanSourceInner) {
 	s.chargedBytes = 0
 }
 
+// releaseGate returns this slot's admitted bytes to the load gate.
+// Idempotent. Caller must hold s.mu.
+func (s *fileSlot) releaseGate(inner *scanSourceInner) {
+	if s.gateBytes > 0 && inner.loadGate != nil {
+		inner.loadGate.release(s.gateBytes)
+	}
+	s.gateBytes = 0
+}
+
 // releaseRG decrements the row-group refcount and frees the file bytes
 // once the last row group has been processed. Safe to call from any worker.
 func (s *fileSlot) releaseRG(inner *scanSourceInner) {
@@ -447,47 +454,49 @@ func (s *fileSlot) releaseRG(inner *scanSourceInner) {
 		return
 	}
 	s.mu.Lock()
-	wasLoaded := s.loaded && s.loadErr == nil && s.reader != nil
 	s.reader = nil
 	s.nativeReader = nil
 	buf := s.dataBuf
 	s.dataBuf = nil
 	s.releaseCharge(inner)
+	gateN := s.gateBytes
+	s.gateBytes = 0
 	s.mu.Unlock()
 	// Return the file's pooled buffer to the read buf pool so it's
 	// immediately available for the next file the loader brings in. This
-	// is what makes the bounded loader semaphore actually bound peak heap.
+	// is what makes the byte-budgeted load gate actually bound peak heap.
 	if buf != nil {
 		putReadBuf(buf)
 	}
-	if wasLoaded && inner.loadSem != nil {
-		<-inner.loadSem
+	if gateN > 0 && inner.loadGate != nil {
+		inner.loadGate.release(gateN)
 	}
 }
 
 // drainAbandoned releases everything a slot still holds when its scan is
 // torn down before all row groups were consumed (ctx cancel, LIMIT
-// satisfied, downstream error): the pooled buffer, the loadSem slot, and —
+// satisfied, downstream error): the pooled buffer, the load-gate bytes, and —
 // critically — the memTracker charge, which lives on the worker-lifetime
 // SHARED tracker and would otherwise remain a permanent phantom reservation
-// (up to loadConcurrency x file_size per cancelled scan), starving later
+// (up to the load-gate budget per cancelled scan), starving later
 // tasks' admission and forcing chronic over-spilling. Callers must ensure
 // the rg workers have exited (Close does wg.Wait first).
 func (s *fileSlot) drainAbandoned(inner *scanSourceInner) {
 	s.mu.Lock()
-	wasLoaded := s.loaded && s.loadErr == nil && s.reader != nil
 	s.reader = nil
 	s.nativeReader = nil
 	s.metaReader = nil
 	buf := s.dataBuf
 	s.dataBuf = nil
 	s.releaseCharge(inner)
+	gateN := s.gateBytes
+	s.gateBytes = 0
 	s.mu.Unlock()
 	if buf != nil {
 		putReadBuf(buf)
 	}
-	if wasLoaded && inner.loadSem != nil {
-		<-inner.loadSem
+	if gateN > 0 && inner.loadGate != nil {
+		inner.loadGate.release(gateN)
 	}
 }
 
@@ -506,12 +515,11 @@ type prefetchResult struct {
 //
 // The slot's bytes are loaded on first read by the rg worker pool and
 // released as soon as that file's last row group has been consumed (see
-// fileSlot.ensureLoaded / releaseRG). A bounded loadConcurrency cap on
-// inner.loadSem keeps peak heap from the scan source at
-// (loadConcurrency × file_size) regardless of how many files the scan
-// covers — replaces the previous "load all files into heap upfront"
-// behaviour that OOMed SF100 workers when lineitem partitions hit
-// 21 × 283 MB ≈ 6 GB per scan per task.
+// fileSlot.ensureLoaded / releaseRG). The byte-budgeted inner.loadGate
+// keeps peak heap from the scan source at the gate's budget regardless
+// of how many files the scan covers — replaces the previous "load all
+// files into heap upfront" behaviour that OOMed SF100 workers when
+// lineitem partitions hit 21 × 283 MB ≈ 6 GB per scan per task.
 func (inner *scanSourceInner) buildRGUnits(ctx context.Context) {
 	// Check for nested types — fall back to file-level scan
 	pqSchema := parquet.Schema{Columns: inner.schema}
@@ -520,12 +528,22 @@ func (inner *scanSourceInner) buildRGUnits(ctx context.Context) {
 		return
 	}
 
-	// Bound concurrent file LOADs (data bytes, not metadata). 4 concurrent
-	// loads × 300 MB lineitem files = 1.2 GB peak from this scan source —
-	// fits comfortably in any worker, including a 30 GB c7gd at SF100 with
-	// other tasks running. Tunable upward when memory is plentiful.
-	const loadConcurrency = 4
-	inner.loadSem = make(chan struct{}, loadConcurrency)
+	// Bound concurrent file LOADs (data bytes, not metadata) by BYTES.
+	// The old 4-slot semaphore was a byte bound in file units ("4 × 300 MB
+	// = 1.2 GB peak") and collapsed on small-file layouts: 600 × 6.5 MB
+	// SF10 files at 4 lanes left a 16-core box ~98% idle on cold S3. A
+	// byte budget holds the same heap ceiling for SF100-sized files
+	// (~3 lanes at 300 MB) while giving small files real download
+	// parallelism (lane-capped at loadGateMaxLanes). When the query has a
+	// memory budget, the gate takes a quarter of it at most so scans
+	// can't crowd out join/aggregate state.
+	loadBudget := defaultLoadBudgetBytes
+	if inner.memTracker != nil {
+		if b := inner.memTracker.Budget(); b > 0 && b/4 < loadBudget {
+			loadBudget = b / 4
+		}
+	}
+	inner.loadGate = newLoadGate(loadBudget, loadGateMaxLanes)
 
 	slots := make([]*fileSlot, len(inner.files))
 	var failedFiles atomic.Int64
@@ -861,7 +879,7 @@ func (inner *scanSourceInner) rgWorker(ctx context.Context) {
 }
 
 // readRG reads a row group using the native page decoder. Loads the file's
-// bytes lazily on first call (bounded by inner.loadSem) and releases them
+// bytes lazily on first call (bounded by inner.loadGate) and releases them
 // once this slot's last row group has been processed. The decoded batch is
 // charged to the memory tracker until it leaves the scan source.
 func (inner *scanSourceInner) readRG(ctx context.Context, unit rgUnit) *batch.RecordBatch {

--- a/internal/storage/catalog/agg_stats_cache_test.go
+++ b/internal/storage/catalog/agg_stats_cache_test.go
@@ -1,0 +1,132 @@
+package catalog
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// sketchCountingStore wraps a Store and counts Get calls to sketch blobs.
+type sketchCountingStore struct {
+	objstore.Store
+	mu         sync.Mutex
+	sketchGets int
+}
+
+func (s *sketchCountingStore) Get(ctx context.Context, bucket, key string) (io.ReadCloser, objstore.ObjectInfo, error) {
+	if strings.Contains(key, "sketches") {
+		s.mu.Lock()
+		s.sketchGets++
+		s.mu.Unlock()
+	}
+	return s.Store.Get(ctx, bucket, key)
+}
+
+func (s *sketchCountingStore) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sketchGets
+}
+
+// TestAggregateColumnStats_Memoized: computing table stats reads one
+// sketches blob per file — on an object-store-backed catalog that was 600
+// serial S3 GETs of PLANNING on every query at SF10 (2026-07-05: ~40s per
+// query, the dominant cold-S3 standalone cost). The aggregate must be
+// memoized per manifest version: repeat calls fetch nothing, and a
+// manifest update (re-ANALYZE, ingest) invalidates the entry.
+func TestAggregateColumnStats_Memoized(t *testing.T) {
+	ctx := context.Background()
+	mem := objstore.NewMemStore()
+	if err := mem.MakeBucket(ctx, "test"); err != nil {
+		t.Fatal(err)
+	}
+	store := &sketchCountingStore{Store: mem}
+	cat := New(NewMemKV(), store, "test")
+	if err := cat.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	schema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64, Nullable: false},
+	}}
+	if err := cat.CreateTable(ctx, "events", schema, nil); err != nil {
+		t.Fatal(err)
+	}
+	const numFiles = 3
+	const rowsPerFile = 1000
+	for fi := 0; fi < numFiles; fi++ {
+		rows := make([]map[string]any, rowsPerFile)
+		for i := range rows {
+			rows[i] = map[string]any{"id": int64(fi*rowsPerFile + i)}
+		}
+		var buf bytes.Buffer
+		pw, err := parquet.NewWriter(&buf, schema, parquet.DefaultWriterConfig())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := pw.WriteRows(rows); err != nil {
+			t.Fatal(err)
+		}
+		if err := pw.Close(); err != nil {
+			t.Fatal(err)
+		}
+		key := fmt.Sprintf("tables/events/chunk_%04d.parquet", fi)
+		data := buf.Bytes()
+		if _, err := mem.Put(ctx, "test", key, bytes.NewReader(data), int64(len(data)), "application/octet-stream"); err != nil {
+			t.Fatal(err)
+		}
+		entry := FileEntry{Path: key, SizeBytes: int64(len(data)), NumRows: rowsPerFile, CreatedAt: time.Now()}
+		if err := cat.AddFiles(ctx, "events", nil, "tables/events/", []FileEntry{entry}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := cat.AnalyzeTable(ctx, "events"); err != nil {
+		t.Fatalf("AnalyzeTable: %v", err)
+	}
+
+	base := store.count()
+	stats1, err := cat.AggregateColumnStats(ctx, "events")
+	if err != nil {
+		t.Fatalf("AggregateColumnStats #1: %v", err)
+	}
+	if stats1 == nil || stats1["id"].NDV == 0 {
+		t.Fatal("first aggregate returned no NDV — fixture broken")
+	}
+	afterFirst := store.count()
+	if afterFirst == base {
+		t.Fatal("test setup: first aggregate fetched no sketch blobs — externalized path not exercised")
+	}
+
+	// Second call: memoized, zero sketch fetches.
+	stats2, err := cat.AggregateColumnStats(ctx, "events")
+	if err != nil {
+		t.Fatalf("AggregateColumnStats #2: %v", err)
+	}
+	if got := store.count(); got != afterFirst {
+		t.Fatalf("second aggregate fetched %d sketch blobs, want 0 (memoization broken)", got-afterFirst)
+	}
+	if stats2["id"].NDV != stats1["id"].NDV {
+		t.Fatalf("memoized NDV %d != original %d", stats2["id"].NDV, stats1["id"].NDV)
+	}
+
+	// Manifest update (re-ANALYZE rewrites sketch keys and bumps
+	// UpdatedAt) must invalidate the memoized entry.
+	if _, err := cat.AnalyzeTable(ctx, "events"); err != nil {
+		t.Fatalf("re-AnalyzeTable: %v", err)
+	}
+	preThird := store.count()
+	if _, err := cat.AggregateColumnStats(ctx, "events"); err != nil {
+		t.Fatalf("AggregateColumnStats #3: %v", err)
+	}
+	if got := store.count(); got == preThird {
+		t.Fatal("aggregate after manifest update fetched no sketch blobs — stale cache served")
+	}
+}

--- a/internal/storage/catalog/analyze.go
+++ b/internal/storage/catalog/analyze.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"runtime"
 	"sync"
+	"time"
 
 	"github.com/citc-tech/wadjet/internal/storage/objstore"
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
@@ -156,6 +157,10 @@ func (c *Catalog) AnalyzeTable(ctx context.Context, name string) (int, error) {
 		analyzed++
 	}
 
+	// Bump the manifest version: ANALYZE changed its content (sketch keys,
+	// cleared inline bytes), and cross-process consumers key derived-stats
+	// caches on UpdatedAt.
+	manifest.UpdatedAt = time.Now().UTC()
 	c.invalidateManifestCache(name)
 	if err := c.putJSON(c.key("manifest."+name), manifest); err != nil {
 		return analyzed, fmt.Errorf("analyze %s: persist manifest: %w", name, err)

--- a/internal/storage/catalog/catalog.go
+++ b/internal/storage/catalog/catalog.go
@@ -17,6 +17,7 @@ import (
 	"math/rand/v2"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/citc-tech/wadjet/internal/storage/objstore"
@@ -44,6 +45,25 @@ type Catalog struct {
 
 	manifestMu    sync.Mutex
 	manifestCache map[string]manifestCacheEntry
+
+	// aggStatsCache memoizes AggregateColumnStats per table, keyed by the
+	// manifest's content version (UpdatedAt + file count). The aggregate
+	// is a pure function of the manifest, but computing it reads one
+	// sketches blob PER FILE — on an object-store-backed catalog that was
+	// 600 serial S3 GETs (~40s) of PLANNING on every query touching
+	// lineitem at SF10 (2026-07-05 finding: the dominant cost of the
+	// cold-S3 standalone suite, dwarfing the scan itself). Entries
+	// invalidate when ingestion bumps the manifest's UpdatedAt.
+	aggStatsMu    sync.Mutex
+	aggStatsCache map[string]aggStatsCacheEntry
+}
+
+// aggStatsCacheEntry is a memoized AggregateColumnStats result. The stats
+// map is shared with callers — treat it as immutable.
+type aggStatsCacheEntry struct {
+	updatedAt time.Time
+	fileCount int
+	stats     map[string]TableColumnStats
 }
 
 // CatalogMeta is the top-level catalog metadata.
@@ -772,6 +792,27 @@ func (c *Catalog) AggregateColumnStats(_ context.Context, tableName string) (map
 		return nil, err
 	}
 
+	fileCount := 0
+	for _, part := range manifest.Partitions {
+		fileCount += len(part.Files)
+	}
+
+	// Memoized result for this manifest version? The stats map is shared —
+	// callers must not mutate it (both planner call sites only read).
+	c.aggStatsMu.Lock()
+	if e, ok := c.aggStatsCache[tableName]; ok &&
+		e.updatedAt.Equal(manifest.UpdatedAt) && e.fileCount == fileCount {
+		c.aggStatsMu.Unlock()
+		return e.stats, nil
+	}
+	c.aggStatsMu.Unlock()
+
+	// Prefetch all externalized sketch blobs concurrently. Loads are
+	// best-effort (a failed blob degrades that file to inline/heuristic
+	// stats, matching loadFileSketches' contract) and merged strictly in
+	// file order below so results stay deterministic.
+	prefetched := c.prefetchFileSketches(manifest)
+
 	agg := make(map[string]TableColumnStats)
 	// HLL sketches are merged outside the TableColumnStats struct because
 	// merging is incremental (byte-wise max) and the merged sketch can be
@@ -783,12 +824,12 @@ func (c *Catalog) AggregateColumnStats(_ context.Context, tableName string) (map
 	for _, part := range manifest.Partitions {
 		for _, f := range part.Files {
 			totalRows += f.NumRows
-			// Externalized sketches: fetch the per-file bundle once,
+			// Externalized sketches: use the prefetched per-file bundle,
 			// merge each column's HLL + collect each column's sample
 			// bytes. SF100 catalogs use this path (manifests too big to
 			// hold sketches inline).
 			if f.SketchesKey != "" {
-				if entries, _ := c.loadFileSketches(context.Background(), f.SketchesKey); entries != nil {
+				if entries := prefetched[f.SketchesKey]; entries != nil {
 					for _, e := range entries {
 						if len(e.HLL) > 0 {
 							if h := HLLFromBytes(e.HLL); h != nil {
@@ -858,9 +899,70 @@ func (c *Catalog) AggregateColumnStats(_ context.Context, tableName string) (map
 	}
 
 	if len(agg) == 0 {
-		return nil, nil
+		agg = nil
 	}
+	c.aggStatsMu.Lock()
+	if c.aggStatsCache == nil {
+		c.aggStatsCache = make(map[string]aggStatsCacheEntry)
+	}
+	c.aggStatsCache[tableName] = aggStatsCacheEntry{
+		updatedAt: manifest.UpdatedAt,
+		fileCount: fileCount,
+		stats:     agg,
+	}
+	c.aggStatsMu.Unlock()
 	return agg, nil
+}
+
+// sketchPrefetchConcurrency bounds concurrent sketch-blob fetches during
+// AggregateColumnStats. Blobs are small (tens to hundreds of KB), so this
+// is a round-trip bound, not a bandwidth one.
+const sketchPrefetchConcurrency = 16
+
+// prefetchFileSketches loads every externalized sketches blob referenced
+// by the manifest concurrently and returns them keyed by SketchesKey.
+// Failed loads are simply absent (best-effort, matching loadFileSketches).
+func (c *Catalog) prefetchFileSketches(manifest *PartitionManifest) map[string][]FileSketchesEntry {
+	var keys []string
+	for _, part := range manifest.Partitions {
+		for _, f := range part.Files {
+			if f.SketchesKey != "" {
+				keys = append(keys, f.SketchesKey)
+			}
+		}
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	results := make([][]FileSketchesEntry, len(keys))
+	var idx int64
+	var wg sync.WaitGroup
+	workers := sketchPrefetchConcurrency
+	if workers > len(keys) {
+		workers = len(keys)
+	}
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func() {
+			defer wg.Done()
+			for {
+				i := int(atomic.AddInt64(&idx, 1) - 1)
+				if i >= len(keys) {
+					return
+				}
+				entries, _ := c.loadFileSketches(context.Background(), keys[i])
+				results[i] = entries
+			}
+		}()
+	}
+	wg.Wait()
+	out := make(map[string][]FileSketchesEntry, len(keys))
+	for i, k := range keys {
+		if results[i] != nil {
+			out[k] = results[i]
+		}
+	}
+	return out
 }
 
 // compareStatValues compares two statistic values for ordering.
@@ -1003,6 +1105,12 @@ func (c *Catalog) invalidateManifestCache(tableName string) {
 	c.manifestMu.Lock()
 	delete(c.manifestCache, tableName)
 	c.manifestMu.Unlock()
+	// The aggregated column stats are derived from the manifest — every
+	// manifest invalidation must drop them too, so a writer that forgets
+	// to bump UpdatedAt still can't serve stale stats from this process.
+	c.aggStatsMu.Lock()
+	delete(c.aggStatsCache, tableName)
+	c.aggStatsMu.Unlock()
 }
 
 // key returns a cluster-prefixed KV key.

--- a/internal/worker/scan_prefetch.go
+++ b/internal/worker/scan_prefetch.go
@@ -1,0 +1,294 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/citc-tech/wadjet/internal/engine/diskio"
+	"github.com/citc-tech/wadjet/internal/engine/exec"
+)
+
+// Prefetch tuning. Vars (not consts) so tests can shrink them to exercise
+// the window/ordering machinery with small files.
+var (
+	// scanPrefetchConcurrency bounds concurrent S3 GETs per source. Each
+	// worker task can hold one source per input alias, and the worker runs
+	// up to MaxConcurrent tasks, so total GET fan-out on one box is roughly
+	// MaxConcurrent × this. 4 matches the shape of the existing 8-way
+	// download pools (readParquetFilesConcurrentBatches) halved to leave
+	// headroom for the async-upload pool sharing the NIC.
+	scanPrefetchConcurrency = 4
+
+	// scanPrefetchWindowBytes bounds bytes downloaded-but-not-yet-consumed
+	// on the spill volume per source. Disk-backed, so this is a disk/page-
+	// cache bound, not heap — SF10 files (~6.5 MB) never hit it; SF100
+	// lineitem files (~200 MB) get ~1 file of read-ahead plus the file
+	// currently decoding.
+	scanPrefetchWindowBytes = int64(256 << 20)
+)
+
+// prefetchResult is the outcome of one prefetch job. Exactly one of the
+// three states holds: a usable localPath, skipped (file not eligible —
+// the consumer must run the normal tiered open path), or err (download
+// attempted and failed — the consumer falls back to the normal path,
+// which re-resolves through every tier and produces the authoritative
+// error if the object is truly gone).
+type prefetchResult struct {
+	localPath   string
+	windowBytes int64 // amount acquired from the byte window; released on take
+	skipped     bool
+	err         error
+}
+
+// filePrefetcher downloads a source's upcoming S3 parquet files to the
+// spill dir while the current file decodes. Before it existed, the scan
+// path was strictly serial per task: one full-object GET blocked in
+// io.Copy until the entire file landed on NVMe, then decode ran with the
+// connection idle — on a standalone box that capped effective S3 read
+// parallelism at MaxConcurrent streams and produced the 2026-07-05 SF10
+// cold-S3 finding (suite 20m15s vs DuckDB httpfs 2m51s, same instance).
+//
+// Design constraints:
+//   - Strictly best-effort: any failure (miss, transient error, open
+//     failure on the temp) makes the consumer fall through to the
+//     untouched tiered open path in openNextFile. Prefetch can therefore
+//     never change results, only overlap I/O with decode.
+//   - Parquet keys only. Shuffle inputs (.wshf / partition=) resolve via
+//     the LocalStageCache / NATS-KV / peer tiers, which are either local
+//     or explicitly preferred over the durable S3 copy; blind-GETting
+//     them here would race the producer's async upload for no benefit.
+//   - Delivery is by file index and the consumer takes indices in order.
+//     The byte window admits the lowest not-yet-taken index regardless of
+//     occupancy: workers can finish downloads out of order, so without
+//     the bypass the window could fill with later files while the one the
+//     consumer is blocked on cannot start — a deadlock, not just a stall.
+//   - Whole-object GETs, no ranged reads: per-column ranged reads were
+//     tried 2026-03-20 and reverted the same day for S3 throttling
+//     (fe52a79); file-granularity requests at this fan-out are the shape
+//     S3 likes.
+type filePrefetcher struct {
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+	results []chan *prefetchResult
+
+	mu         sync.Mutex
+	window     int64         // bytes admitted, not yet released by take/fetch-error
+	nextNeeded int           // lowest index take() has not been called for
+	windowFree chan struct{} // closed+replaced whenever window/nextNeeded changes
+}
+
+// hasPrefetchableFiles reports whether any key in the list is a parquet
+// object the prefetcher would act on.
+func hasPrefetchableFiles(files []string) bool {
+	for _, f := range files {
+		if strings.HasSuffix(f, ".parquet") {
+			return true
+		}
+	}
+	return false
+}
+
+// startFilePrefetcher spawns the download workers for s.files. ctx should
+// be the task context (from the first Next call); cancellation stops all
+// workers. The caller must Close() the returned prefetcher.
+func startFilePrefetcher(ctx context.Context, s *cachedFileStreamSource) *filePrefetcher {
+	pctx, cancel := context.WithCancel(ctx)
+	p := &filePrefetcher{
+		cancel:     cancel,
+		results:    make([]chan *prefetchResult, len(s.files)),
+		windowFree: make(chan struct{}),
+	}
+	jobs := make(chan int, len(s.files))
+	for i := range p.results {
+		p.results[i] = make(chan *prefetchResult, 1)
+		jobs <- i
+	}
+	close(jobs)
+	workers := scanPrefetchConcurrency
+	if workers > len(s.files) {
+		workers = len(s.files)
+	}
+	p.wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go p.run(pctx, s, jobs)
+	}
+	return p
+}
+
+func (p *filePrefetcher) run(ctx context.Context, s *cachedFileStreamSource, jobs <-chan int) {
+	defer p.wg.Done()
+	for idx := range jobs {
+		if ctx.Err() != nil {
+			return
+		}
+		// results[idx] is buffered (cap 1) and each index is fetched by
+		// exactly one worker, so the send never blocks.
+		p.results[idx] <- p.fetch(ctx, s, idx)
+	}
+}
+
+// fetch resolves one file index. It re-checks the cheap tiers (local
+// stage cache, peer hint) so it only spends a GET on files that would
+// have reached the S3 tier anyway.
+func (p *filePrefetcher) fetch(ctx context.Context, s *cachedFileStreamSource, idx int) *prefetchResult {
+	filePath := s.files[idx]
+	if !strings.HasSuffix(filePath, ".parquet") {
+		return &prefetchResult{skipped: true}
+	}
+	if s.queryID != "" && s.executor.localCache != nil &&
+		s.executor.localCache.Get(s.queryID, filePath) != "" {
+		return &prefetchResult{skipped: true}
+	}
+	if peers := s.executor.peers; peers != nil && peers.client != nil {
+		if addr, _ := peers.hintFor(filePath); addr != "" {
+			return &prefetchResult{skipped: true}
+		}
+	}
+
+	rc, info, err := s.executor.store.Get(ctx, s.bucket, filePath)
+	if err != nil {
+		return &prefetchResult{err: err}
+	}
+	defer rc.Close()
+
+	// Admit against the byte window using the object's advertised size.
+	// A size the store didn't report (0) gets a nominal charge so an
+	// endless run of unknown-size objects can't bypass the bound.
+	winBytes := info.Size
+	if winBytes <= 0 {
+		winBytes = 8 << 20
+	}
+	if err := p.acquireWindow(ctx, idx, winBytes); err != nil {
+		return &prefetchResult{err: err}
+	}
+
+	localPath, err := p.streamToSpill(ctx, s, filePath, rc)
+	if err != nil {
+		p.releaseWindow(winBytes)
+		return &prefetchResult{err: err}
+	}
+	return &prefetchResult{localPath: localPath, windowBytes: winBytes}
+}
+
+// streamToSpill copies the object body to a temp file in the spill dir,
+// reporting bytes to the per-task ProgressReporter so the coordinator's
+// stale-worker reap sees I/O progress during long download windows (same
+// rationale as streamParquetToLocalMmap).
+func (p *filePrefetcher) streamToSpill(ctx context.Context, s *cachedFileStreamSource, srcPath string, rc io.Reader) (string, error) {
+	spillDir := s.executor.spillDir
+	if err := os.MkdirAll(spillDir, 0o755); err != nil {
+		return "", fmt.Errorf("creating spill dir: %w", err)
+	}
+	tmp, err := os.CreateTemp(spillDir, "scan-prefetch-*.parquet")
+	if err != nil {
+		return "", fmt.Errorf("creating prefetch file: %w", err)
+	}
+	localPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			tmp.Close()
+			_ = os.Remove(localPath)
+		}
+	}()
+
+	rep := exec.ProgressReporterFromContext(ctx)
+	// KeepResident: the file is mmap'd and decoded shortly after landing —
+	// bound dirty pages during the write, keep them resident for the read.
+	wf, _ := diskio.NewWriter(tmp, diskio.KeepResident)
+	dst := io.Writer(wf)
+	if rep != nil {
+		dst = &progressWriter{w: wf, rep: rep}
+	}
+	if _, err := io.Copy(dst, rc); err != nil {
+		return "", fmt.Errorf("prefetching %s: %w", srcPath, err)
+	}
+	if err := tmp.Sync(); err != nil {
+		return "", fmt.Errorf("syncing prefetch file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return "", fmt.Errorf("closing prefetch file: %w", err)
+	}
+	cleanup = false
+	return localPath, nil
+}
+
+// acquireWindow blocks until winBytes fits in the byte window OR idx is
+// the lowest index the consumer has not yet taken. The bypass is what
+// makes the window deadlock-free: the consumer takes indices strictly in
+// order, so the file it is (or will next be) blocked on must always be
+// admitted even when later, out-of-order completions filled the window.
+func (p *filePrefetcher) acquireWindow(ctx context.Context, idx int, winBytes int64) error {
+	for {
+		p.mu.Lock()
+		if idx <= p.nextNeeded || p.window+winBytes <= scanPrefetchWindowBytes {
+			p.window += winBytes
+			p.mu.Unlock()
+			return nil
+		}
+		wait := p.windowFree
+		p.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-wait:
+		}
+	}
+}
+
+func (p *filePrefetcher) releaseWindow(winBytes int64) {
+	p.mu.Lock()
+	p.window -= winBytes
+	close(p.windowFree)
+	p.windowFree = make(chan struct{})
+	p.mu.Unlock()
+}
+
+// take returns the prefetch outcome for idx, blocking until the download
+// resolves or ctx is cancelled. On a successful result the caller owns
+// localPath (must remove it when done). Must be called for indices in
+// strictly increasing order — the window's deadlock-freedom depends on it.
+func (p *filePrefetcher) take(ctx context.Context, idx int) *prefetchResult {
+	p.mu.Lock()
+	if idx+1 > p.nextNeeded {
+		p.nextNeeded = idx + 1
+	}
+	// Wake any worker parked in acquireWindow: the bypass condition just
+	// changed even though window occupancy didn't.
+	close(p.windowFree)
+	p.windowFree = make(chan struct{})
+	p.mu.Unlock()
+
+	select {
+	case res := <-p.results[idx]:
+		if res.windowBytes > 0 {
+			p.releaseWindow(res.windowBytes)
+		}
+		return res
+	case <-ctx.Done():
+		return &prefetchResult{err: ctx.Err()}
+	}
+}
+
+// Close cancels outstanding downloads, waits for workers to exit, and
+// removes any downloaded-but-never-taken temp files. Idempotent.
+func (p *filePrefetcher) Close() {
+	if p == nil {
+		return
+	}
+	p.cancel()
+	p.wg.Wait()
+	for _, ch := range p.results {
+		select {
+		case res := <-ch:
+			if res != nil && res.localPath != "" {
+				_ = os.Remove(res.localPath)
+			}
+		default:
+		}
+	}
+}

--- a/internal/worker/scan_prefetch_test.go
+++ b/internal/worker/scan_prefetch_test.go
@@ -1,0 +1,287 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+)
+
+// writePrefetchFixture writes n small parquet files ("id" int64, "val"
+// int64) to store and returns the keys plus the expected sum of "val"
+// across all files.
+func writePrefetchFixture(t *testing.T, store *objstore.MemStore, bucket string, n, rowsPerFile int) ([]string, int64) {
+	t.Helper()
+	if err := store.MakeBucket(context.Background(), bucket); err != nil {
+		t.Fatal(err)
+	}
+	keys := make([]string, 0, n)
+	var wantSum int64
+	rowID := 0
+	for f := 0; f < n; f++ {
+		rows := make([]map[string]any, 0, rowsPerFile)
+		for r := 0; r < rowsPerFile; r++ {
+			v := int64(rowID * 3)
+			rows = append(rows, map[string]any{"id": int64(rowID), "val": v})
+			wantSum += v
+			rowID++
+		}
+		key := fmt.Sprintf("tables/t/part-%04d.parquet", f)
+		writeParquetFile(t, store, bucket, key, rows)
+		keys = append(keys, key)
+	}
+	return keys, wantSum
+}
+
+// drainValSum reads the source to exhaustion and sums the "val" column.
+func drainValSum(t *testing.T, ctx context.Context, src *cachedFileStreamSource) (sum int64, rows int) {
+	t.Helper()
+	valIdx := -1
+	for {
+		b, err := src.Next(ctx)
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+		if b == nil {
+			return sum, rows
+		}
+		if valIdx < 0 {
+			for i, c := range b.Schema {
+				if c.Name == "val" {
+					valIdx = i
+					break
+				}
+			}
+			if valIdx < 0 {
+				t.Fatalf("val column not in schema %v", b.Schema)
+			}
+		}
+		for i := 0; i < b.Len; i++ {
+			sum += b.Columns[valIdx].Int64Data[i]
+			rows++
+		}
+	}
+}
+
+// assertNoPrefetchTemps fails if any scan-prefetch temp files remain in dir.
+func assertNoPrefetchTemps(t *testing.T, dir string) {
+	t.Helper()
+	leftover, err := filepath.Glob(filepath.Join(dir, "scan-prefetch-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leftover) > 0 {
+		t.Fatalf("leaked prefetch temp files: %v", leftover)
+	}
+}
+
+// TestScanPrefetchEndToEnd verifies the prefetched path yields identical
+// data to the serial path over a multi-file parquet input.
+func TestScanPrefetchEndToEnd(t *testing.T) {
+	ctx := context.Background()
+	store := objstore.NewMemStore()
+	const bucket = "test"
+	keys, wantSum := writePrefetchFixture(t, store, bucket, 9, 40)
+
+	spill := t.TempDir()
+	e := &Executor{store: store, spillDir: spill}
+	src := newCachedFileStreamSource(e, "", bucket, keys)
+	if err := src.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	sum, rows := drainValSum(t, ctx, src)
+	if src.prefetch == nil {
+		t.Fatal("prefetcher did not engage on a multi-file parquet input")
+	}
+	if err := src.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if sum != wantSum || rows != 9*40 {
+		t.Fatalf("prefetched read: sum=%d rows=%d, want sum=%d rows=%d", sum, rows, wantSum, 9*40)
+	}
+	assertNoPrefetchTemps(t, spill)
+
+	// Serial control: same input with prefetch disabled.
+	e2 := &Executor{store: store, spillDir: t.TempDir()}
+	src2 := newCachedFileStreamSource(e2, "", bucket, keys)
+	src2.prefetchDisabled = true
+	if err := src2.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer src2.Close()
+	sum2, rows2 := drainValSum(t, ctx, src2)
+	if src2.prefetch != nil {
+		t.Fatal("prefetcher engaged despite prefetchDisabled")
+	}
+	if sum2 != sum || rows2 != rows {
+		t.Fatalf("serial control disagrees: sum=%d rows=%d vs prefetched sum=%d rows=%d", sum2, rows2, sum, rows)
+	}
+}
+
+// TestScanPrefetchMissingObjectFallsThrough verifies that a prefetch miss
+// falls back to the tiered path, whose error (naming the file) is
+// authoritative.
+func TestScanPrefetchMissingObjectFallsThrough(t *testing.T) {
+	ctx := context.Background()
+	store := objstore.NewMemStore()
+	const bucket = "test"
+	keys, _ := writePrefetchFixture(t, store, bucket, 3, 10)
+	keys = append(keys, "tables/t/part-9999.parquet") // never written
+
+	e := &Executor{store: store, spillDir: t.TempDir()}
+	src := newCachedFileStreamSource(e, "", bucket, keys)
+	if err := src.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer src.Close()
+	for {
+		b, err := src.Next(ctx)
+		if err != nil {
+			if !strings.Contains(err.Error(), "part-9999.parquet") {
+				t.Fatalf("error does not name the missing file: %v", err)
+			}
+			return
+		}
+		if b == nil {
+			t.Fatal("source exhausted without surfacing the missing-object error")
+		}
+	}
+}
+
+// TestScanPrefetchCloseReapsTemps verifies that closing a source
+// mid-stream cancels the download workers and removes every temp file
+// they produced.
+func TestScanPrefetchCloseReapsTemps(t *testing.T) {
+	ctx := context.Background()
+	store := objstore.NewMemStore()
+	const bucket = "test"
+	keys, _ := writePrefetchFixture(t, store, bucket, 8, 50)
+
+	spill := t.TempDir()
+	e := &Executor{store: store, spillDir: spill}
+	src := newCachedFileStreamSource(e, "", bucket, keys)
+	if err := src.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	// Read a single batch so the prefetcher is running with most files
+	// still ahead, then abandon the source.
+	if b, err := src.Next(ctx); err != nil || b == nil {
+		t.Fatalf("first Next: b=%v err=%v", b, err)
+	}
+	if src.prefetch == nil {
+		t.Fatal("prefetcher did not engage")
+	}
+	if err := src.Close(); err != nil {
+		t.Fatal(err)
+	}
+	assertNoPrefetchTemps(t, spill)
+}
+
+// gateCountingStore wraps a Store and tracks the maximum number of
+// concurrent Get calls.
+type gateCountingStore struct {
+	objstore.Store
+	mu      sync.Mutex
+	current int
+	max     int
+}
+
+func (g *gateCountingStore) Get(ctx context.Context, bucket, key string) (io.ReadCloser, objstore.ObjectInfo, error) {
+	g.mu.Lock()
+	g.current++
+	if g.current > g.max {
+		g.max = g.current
+	}
+	g.mu.Unlock()
+	rc, info, err := g.Store.Get(ctx, bucket, key)
+	if err != nil {
+		g.mu.Lock()
+		g.current--
+		g.mu.Unlock()
+		return nil, info, err
+	}
+	return &gateClosingReader{ReadCloser: rc, g: g}, info, nil
+}
+
+type gateClosingReader struct {
+	io.ReadCloser
+	g    *gateCountingStore
+	once sync.Once
+}
+
+func (r *gateClosingReader) Close() error {
+	r.once.Do(func() {
+		r.g.mu.Lock()
+		r.g.current--
+		r.g.mu.Unlock()
+	})
+	return r.ReadCloser.Close()
+}
+
+// TestScanPrefetchConcurrencyBound verifies concurrent GETs never exceed
+// scanPrefetchConcurrency (plus the tiered path's own synchronous Get,
+// which cannot overlap itself).
+func TestScanPrefetchConcurrencyBound(t *testing.T) {
+	ctx := context.Background()
+	mem := objstore.NewMemStore()
+	const bucket = "test"
+	keys, wantSum := writePrefetchFixture(t, mem, bucket, 16, 30)
+	store := &gateCountingStore{Store: mem}
+
+	e := &Executor{store: store, spillDir: t.TempDir()}
+	src := newCachedFileStreamSource(e, "", bucket, keys)
+	if err := src.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer src.Close()
+	sum, _ := drainValSum(t, ctx, src)
+	if sum != wantSum {
+		t.Fatalf("sum=%d want %d", sum, wantSum)
+	}
+	// +1: openNextFile's own fallback Get could in principle overlap the
+	// workers, though with all prefetches succeeding it shouldn't fire.
+	if store.max > scanPrefetchConcurrency+1 {
+		t.Fatalf("max concurrent Gets = %d, want <= %d", store.max, scanPrefetchConcurrency+1)
+	}
+	if store.max < 2 {
+		t.Fatalf("max concurrent Gets = %d — prefetch never overlapped downloads", store.max)
+	}
+}
+
+// TestScanPrefetchTinyWindowNoDeadlock forces every admission through the
+// lowest-unconsumed-index bypass (window smaller than any file) and
+// verifies the pipeline still completes. Guards the out-of-order
+// window-fill deadlock the bypass exists for.
+func TestScanPrefetchTinyWindowNoDeadlock(t *testing.T) {
+	oldWin := scanPrefetchWindowBytes
+	scanPrefetchWindowBytes = 1
+	defer func() { scanPrefetchWindowBytes = oldWin }()
+
+	// A deadline on the drain context turns a deadlock into a test
+	// failure instead of a suite hang: take()/acquireWindow both abort
+	// on ctx cancellation. (Draining on a goroutine isn't an option —
+	// drainValSum uses t.Fatalf, which must run on the test goroutine.)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	store := objstore.NewMemStore()
+	const bucket = "test"
+	keys, wantSum := writePrefetchFixture(t, store, bucket, 12, 25)
+
+	e := &Executor{store: store, spillDir: t.TempDir()}
+	src := newCachedFileStreamSource(e, "", bucket, keys)
+	if err := src.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer src.Close()
+
+	sum, _ := drainValSum(t, ctx, src)
+	if sum != wantSum {
+		t.Fatalf("sum=%d want %d", sum, wantSum)
+	}
+}

--- a/internal/worker/stream_source.go
+++ b/internal/worker/stream_source.go
@@ -111,6 +111,14 @@ type cachedFileStreamSource struct {
 	// whose stats don't intersect the build-side bloom or range.
 	dynamicRanges []exec.DynamicRange
 	bloomFilters  []*exec.BloomScanFilter
+
+	// Download-ahead for S3 parquet inputs (see filePrefetcher). Started
+	// lazily on the first openNextFile so it inherits the task context;
+	// nil when the input has no parquet files, there's no spill dir, or
+	// prefetchDisabled is set (tests exercising the serial path).
+	prefetch         *filePrefetcher
+	prefetchStarted  bool
+	prefetchDisabled bool
 }
 
 // SetDynamicFilters attaches dynamic-filter pushdowns to this source.
@@ -235,6 +243,12 @@ func (s *cachedFileStreamSource) Next(ctx context.Context) (*batch.RecordBatch, 
 }
 
 func (s *cachedFileStreamSource) Close() error {
+	// Stop the download-ahead workers first and reap any temp files they
+	// downloaded that were never consumed.
+	if s.prefetch != nil {
+		s.prefetch.Close()
+		s.prefetch = nil
+	}
 	// Parquet refs must be cleared BEFORE munmap: parquet.NewReaderFromBytes
 	// keeps the input slice live inside FileReader.data, and the streaming
 	// parquet-mmap path (added 2026-05-22) hands the mmap'd region in as
@@ -289,7 +303,33 @@ func (s *cachedFileStreamSource) releaseCurrentFile() {
 // (for WSHF) or batches (for Parquet). Advances fileIdx.
 func (s *cachedFileStreamSource) openNextFile(ctx context.Context) error {
 	filePath := s.files[s.fileIdx]
+	idx := s.fileIdx
 	s.fileIdx++
+
+	// Start the download-ahead pipeline on first open. Before this
+	// existed, a scan task's files were downloaded strictly one at a time
+	// with decode idle during each download — on a standalone box that
+	// capped effective S3 read parallelism at MaxConcurrent streams
+	// (2026-07-05 SF10 cold-S3: suite 20m15s vs DuckDB 2m51s, same box).
+	if !s.prefetchStarted {
+		s.prefetchStarted = true
+		if !s.prefetchDisabled && s.executor.spillDir != "" &&
+			len(s.files) > 1 && hasPrefetchableFiles(s.files) {
+			s.prefetch = startFilePrefetcher(ctx, s)
+		}
+	}
+	if s.prefetch != nil {
+		if res := s.prefetch.take(ctx, idx); !res.skipped && res.err == nil {
+			if err := s.openPrefetchedParquet(res.localPath, filePath); err == nil {
+				return nil
+			}
+			// Open failed (truncated download, unexpected payload) — the
+			// temp was removed; fall through to the tiered path below,
+			// which re-resolves from the durable copy.
+		}
+		// skipped or err: strictly best-effort — the tiered path below is
+		// authoritative for both resolution and error reporting.
+	}
 
 	// Tier-0 same-worker fast path: if a producer task on this worker
 	// already wrote this stage output to local disk and registered it in
@@ -435,6 +475,41 @@ func (s *cachedFileStreamSource) openNextFile(ctx context.Context) error {
 		}
 		data = append(magic[:], rest...)
 	}
+	return s.finishOpenParquet(filePath, data, mmapData, localPath)
+}
+
+// openPrefetchedParquet opens a parquet file the prefetcher already
+// downloaded to localPath: mmap it and hand the region to the shared
+// open tail. On any failure the temp file is removed and the caller
+// falls back to the normal tiered path.
+func (s *cachedFileStreamSource) openPrefetchedParquet(localPath, filePath string) error {
+	f, err := os.Open(localPath)
+	if err != nil {
+		_ = os.Remove(localPath)
+		return fmt.Errorf("opening prefetched file %s: %w", localPath, err)
+	}
+	defer f.Close()
+	fi, err := f.Stat()
+	if err != nil || fi.Size() == 0 {
+		_ = os.Remove(localPath)
+		return fmt.Errorf("prefetched file %s unusable (err=%v)", localPath, err)
+	}
+	mmapData, err := syscall.Mmap(int(f.Fd()), 0, int(fi.Size()), syscall.PROT_READ, syscall.MAP_SHARED)
+	if err != nil {
+		_ = os.Remove(localPath)
+		return fmt.Errorf("mmap prefetched file %s: %w", localPath, err)
+	}
+	// finishOpenParquet unwinds mmap+file itself if the payload isn't
+	// valid parquet (e.g. a legacy shuffle object under a .parquet key).
+	return s.finishOpenParquet(filePath, mmapData, mmapData, localPath)
+}
+
+// finishOpenParquet is the shared tail of the parquet open path: build the
+// reader over data, transfer mmap/file ownership to the source, apply the
+// column projection guard, and set up the row-group iterator (or the
+// eager fallback for Array/Map schemas). mmapData/localPath may be
+// nil/empty for the in-memory path.
+func (s *cachedFileStreamSource) finishOpenParquet(filePath string, data, mmapData []byte, localPath string) error {
 	reader, err := parquet.NewReaderFromBytes(data)
 	if err != nil {
 		if mmapData != nil {
@@ -445,7 +520,7 @@ func (s *cachedFileStreamSource) openNextFile(ctx context.Context) error {
 	}
 	// Transfer mmap/file ownership to the source so Next()/Close()
 	// release them when the iterator exhausts. nil/empty are fine for
-	// the in-memory fallback above.
+	// the in-memory fallback.
 	s.mmapData = mmapData
 	s.mmapRegion = registerMmap(mmapData) // nil when relief disabled
 	s.localPath = localPath

--- a/internal/worker/stream_source_fallback_release_test.go
+++ b/internal/worker/stream_source_fallback_release_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/citc-tech/wadjet/internal/storage/objstore"
@@ -70,8 +71,11 @@ func TestFallbackPath_ReleasesMmapAndTempPerFile(t *testing.T) {
 		}
 		rows += b.Len
 		// The fallback path must never hold more than ONE file's temp at a
-		// time — the leak left every prior file's temp behind.
-		if n := countFiles(t, spillDir); n > 1 {
+		// time — the leak left every prior file's temp behind. Download-ahead
+		// temps (scan-prefetch-*) are excluded: the prefetcher holds a
+		// bounded set by design, and the after-Close check below still
+		// requires ALL of them gone.
+		if n := countFilesExcluding(t, spillDir, "scan-prefetch-"); n > 1 {
 			t.Fatalf("%d temp files held mid-stream, want <=1 (per-file release missing)", n)
 		}
 	}
@@ -91,12 +95,22 @@ func TestFallbackPath_ReleasesMmapAndTempPerFile(t *testing.T) {
 
 func countFiles(t *testing.T, dir string) int {
 	t.Helper()
+	return countFilesExcluding(t, dir, "")
+}
+
+// countFilesExcluding counts regular files under dir, skipping names with
+// the given prefix ("" excludes nothing).
+func countFilesExcluding(t *testing.T, dir, excludePrefix string) int {
+	t.Helper()
 	n := 0
 	if err := filepath.Walk(dir, func(_ string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 		if !info.IsDir() {
+			if excludePrefix != "" && strings.HasPrefix(info.Name(), excludePrefix) {
+				return nil
+			}
 			n++
 		}
 		return nil


### PR DESCRIPTION
## Problem

SF10 cold-S3 comparison (2026-07-05, c7g.4xlarge, same box, same data): wadjet standalone ~20m for Q01-Q20 vs DuckDB 1.5 httpfs **2m50s** for all 22 — and every run **crashed on Q21** (nil deref in `HashJoin.PruneBuildColumns`), so no run had ever completed the full suite. The April README table (unpublished in #184) measured warm page cache, not the read path.

## Root causes found (in order of discovery)

1. **Worker scan path had zero download-ahead** — `cachedFileStreamSource` blocked in `io.Copy` for each full-object GET, connection idle during decode. (Affects distributed + `wadjet serve` standalone; the benchmark's embedded path has its own scan source.)
2. **Embedded scan loads were gated by a hardcoded `loadConcurrency = 4`** — a byte bound expressed in file units, sized for SF100's 300MB files; at SF10 (600 × 6.5MB) it left a 16-core box ~98% idle (Q06: 56.6s wall, 7.98s CPU).
3. **The dominant cost was plan-time, not scan-time**: `AnnotateScanColumns → catalog.AggregateColumnStats` read one externalized sketches blob **per file, serially, on every query** — 600 S3 round-trips ≈ 40s of planning per lineitem query, re-paid every query. Live sampling showed each query spending ~40s at 2 connections / 9MB/s before a 400-680MB/s data burst; a goroutine dump pinned the main goroutine in `DecodeFileSketches`. (Distributed catalogs use NATS KV, so only the embedded object-store catalog paid this.)
4. **Q21 crash (pre-existing)**: partition-on-arrival builds nil their evicted `buildBatches` entries; the planner's post-build `PruneBuildColumns` hook assumed the flat representation. Deterministic whenever a filtered semi/anti build was big enough to evict.

## Fixes (one commit each)

- `perf(worker)`: `filePrefetcher` — bounded download-ahead for S3 parquet scan inputs (4 GETs/source, 256MiB byte window, deadlock-free lowest-unconsumed-index bypass, strictly best-effort fallback).
- `perf(planner)`: `loadGate` — byte-budgeted load admission (1GiB default, budget/4 with a tracker, 32-lane cap, oversized-load progress guarantee). SF100 file sizes still yield ~3 lanes — the old working point — by construction.
- `perf(catalog)`: memoize `AggregateColumnStats` per manifest version (UpdatedAt + file count), 16-way sketch prefetch on miss, `invalidateManifestCache` drops the derived cache, `AnalyzeTable` now bumps `UpdatedAt`.
- `fix(exec)`: guard `PruneBuildColumns` on `spillState` (mirrors `consolidateBuild`) — pruning a partitioned build is wrong even without the crash (restored partitions carry the unpruned schema).
- `chore(bench)`: `cmd/s3probe` diagnostic tool.

## Acceptance (EC2, same-window, same box, cold S3, SF10)

| | Before | After | DuckDB v1.5.4 (same window) |
|---|---|---|---|
| Suite | ~20m for Q01-Q20, **Q21 crash** | **7m29s, 22/22** | 2m52s |
| Q06 (pure scan) | 56.5s | **9.0s** | 10.2s |
| Q03/Q05/Q07/Q08 | 67-73s | 20-24s | 7-10s |
| Q21 | crash | 1m28s | ~30s |

Runs: results/20260705-175642 (control @ f945e64, first-ever 22/22: 21m40s), results/20260705-181650 (acceptance @ 56e0529: 7m29s). Remaining gap (~2.6×) is footer-metadata round-trips per query, per-query full re-downloads (DuckDB pays the same), and join-heavy compute — tracked as follow-on work.

## Gates

- New unit/regression tests for all four fixes (`-race`): prefetcher (incl. 1-byte-window deadlock guard), load gate (churn/peak/oversized), catalog memoization (sketch-GET counting, invalidation), partitioned-prune (panicked pre-fix)
- `go test ./internal/...`, TPC-H SF0.01 correctness, `tpch-harness --mode=local` 25/25 PASS (after every commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)