### PR TITLE
perf(catalog): persist row-group metadata, eliminating per-query footer pass

### DIFF
--- a/internal/planner/physical/rgmeta_scan_test.go
+++ b/internal/planner/physical/rgmeta_scan_test.go
@@ -1,0 +1,217 @@
+package physical
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/storage/catalog"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// rgMetaScanFixture builds a MemStore-backed catalog with two multi-RG
+// parquet files whose id ranges are disjoint per row group, so predicate
+// pruning decisions are deterministic and observable in the emitted units.
+func rgMetaScanFixture(t *testing.T) (*catalog.Catalog, []catalog.FileEntry) {
+	t.Helper()
+	ctx := context.Background()
+
+	schema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "value", Type: parquet.TypeString},
+	}}
+	store := objstore.NewMemStore()
+	cat := catalog.NewWithStore(store, "test")
+	if err := cat.Init(ctx); err != nil {
+		t.Fatalf("catalog init: %v", err)
+	}
+	if err := cat.CreateTable(ctx, "items", schema, nil); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	var entries []catalog.FileEntry
+	for fi := 0; fi < 2; fi++ {
+		// 3 row groups per file: ids [base, base+100), [base+100, base+200), [base+200, base+300)
+		base := fi * 1000
+		data := writeTestParquetMultiRG(t, schema,
+			testRows(100, base), testRows(100, base+100), testRows(100, base+200))
+		path := fmt.Sprintf("tables/items/chunk_%04d.parquet", fi)
+		if _, err := store.Put(ctx, cat.Bucket(), path, bytes.NewReader(data), int64(len(data)), "application/octet-stream"); err != nil {
+			t.Fatalf("put file: %v", err)
+		}
+		entry := catalog.FileEntry{Path: path, SizeBytes: int64(len(data)), NumRows: 300, CreatedAt: time.Now()}
+		if err := cat.AddFiles(ctx, "items", map[string]string{}, "tables/items/", []catalog.FileEntry{entry}); err != nil {
+			t.Fatalf("add files: %v", err)
+		}
+		entries = append(entries, entry)
+	}
+	return cat, entries
+}
+
+// unitKey is the observable identity of an emitted rgUnit for parity checks.
+type unitKey struct {
+	path      string
+	rgIndex   int
+	rowOffset int64
+	numRows   int64
+}
+
+func collectUnits(inner *scanSourceInner) []unitKey {
+	out := make([]unitKey, 0, len(inner.rgUnits))
+	for _, u := range inner.rgUnits {
+		out = append(out, unitKey{
+			path:      u.slot.entry.Path,
+			rgIndex:   u.rgIndex,
+			rowOffset: u.rgRowOffset,
+			numRows:   u.numRows,
+		})
+	}
+	return out
+}
+
+// TestBuildRGUnitsRGMetaParity verifies the catalog-blob fast path emits
+// EXACTLY the units the footer-read path emits — same row groups kept,
+// same offsets, same pruning decisions — across no-predicate, pruning,
+// and prune-everything shapes.
+func TestBuildRGUnitsRGMetaParity(t *testing.T) {
+	ctx := context.Background()
+	cat, entries := rgMetaScanFixture(t)
+
+	schema := []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "value", Type: parquet.TypeString},
+	}
+
+	cases := []struct {
+		name      string
+		preds     []scanPredicate
+		wantUnits int
+	}{
+		// 2 files × 3 RGs, no pruning.
+		{"no predicates", nil, 6},
+		// id > 1150 keeps file1 rg1 (1100-1199) and rg2 (1200-1299) —
+		// prunes all of file0 and file1 rg0.
+		{"range prune", []scanPredicate{{Column: "id", Op: ">", Value: int64(1150)}}, 2},
+		// id = 5000 matches nothing: every row group pruned.
+		{"prune all", []scanPredicate{{Column: "id", Op: "=", Value: int64(5000)}}, 0},
+	}
+
+	build := func(preds []scanPredicate) *scanSourceInner {
+		inner := &scanSourceInner{
+			cat:       cat,
+			tableName: "items",
+			files:     entries,
+			schema:    schema,
+			scanPreds: preds,
+		}
+		inner.buildRGUnits(ctx)
+		if inner.failedFiles > 0 {
+			t.Fatalf("buildRGUnits failed files: %d (%v)", inner.failedFiles, inner.firstFileErr)
+		}
+		return inner
+	}
+
+	// Footer-path baseline (no blob exists yet).
+	baselines := make(map[string][]unitKey)
+	for _, tc := range cases {
+		units := collectUnits(build(tc.preds))
+		if len(units) != tc.wantUnits {
+			t.Fatalf("footer path %s: %d units, want %d (%v)", tc.name, len(units), tc.wantUnits, units)
+		}
+		baselines[tc.name] = units
+	}
+
+	// ANALYZE persists the RG-metadata blob.
+	if _, err := cat.AnalyzeTable(ctx, "items"); err != nil {
+		t.Fatalf("AnalyzeTable: %v", err)
+	}
+	if m, err := cat.TableRGMeta(ctx, "items"); err != nil || len(m) != 2 {
+		t.Fatalf("TableRGMeta: %d files (err %v), want 2", len(m), err)
+	}
+
+	// Deleting the parquet objects proves the blob path never touches
+	// them during planning: buildRGUnits must still enumerate and prune
+	// identically with the data files gone.
+	for _, e := range entries {
+		if err := cat.Store().Delete(ctx, cat.Bucket(), e.Path); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, tc := range cases {
+		units := collectUnits(build(tc.preds))
+		if len(units) != len(baselines[tc.name]) {
+			t.Fatalf("blob path %s: %d units, want %d", tc.name, len(units), len(baselines[tc.name]))
+		}
+		for i, u := range units {
+			if u != baselines[tc.name][i] {
+				t.Errorf("blob path %s unit %d: %+v != footer %+v", tc.name, i, u, baselines[tc.name][i])
+			}
+		}
+	}
+}
+
+// TestBuildRGUnitsRGMetaPartialCoverage verifies files added after
+// ANALYZE (not in the blob) fall back to footer reads while covered
+// files stay network-free — the mixed-coverage contract.
+func TestBuildRGUnitsRGMetaPartialCoverage(t *testing.T) {
+	ctx := context.Background()
+	cat, entries := rgMetaScanFixture(t)
+
+	if _, err := cat.AnalyzeTable(ctx, "items"); err != nil {
+		t.Fatalf("AnalyzeTable: %v", err)
+	}
+
+	// A third file lands after ANALYZE — no blob entry.
+	schema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "value", Type: parquet.TypeString},
+	}}
+	data := writeTestParquetMultiRG(t, schema, testRows(50, 5000))
+	path := "tables/items/chunk_late.parquet"
+	if _, err := cat.Store().Put(ctx, cat.Bucket(), path, bytes.NewReader(data), int64(len(data)), "application/octet-stream"); err != nil {
+		t.Fatal(err)
+	}
+	late := catalog.FileEntry{Path: path, SizeBytes: int64(len(data)), NumRows: 50, CreatedAt: time.Now()}
+	if err := cat.AddFiles(ctx, "items", map[string]string{}, "tables/items/", []catalog.FileEntry{late}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Covered files' parquet objects deleted: only the late file may be
+	// touched during planning.
+	for _, e := range entries {
+		if err := cat.Store().Delete(ctx, cat.Bucket(), e.Path); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	inner := &scanSourceInner{
+		cat:       cat,
+		tableName: "items",
+		files:     append(append([]catalog.FileEntry{}, entries...), late),
+		schema:    schema.Columns,
+	}
+	inner.buildRGUnits(ctx)
+	if inner.failedFiles > 0 {
+		t.Fatalf("failed files: %d (%v)", inner.failedFiles, inner.firstFileErr)
+	}
+	// 2 covered files × 3 RGs from the blob + 1 late file × 1 RG via footer.
+	if len(inner.rgUnits) != 7 {
+		t.Fatalf("units = %d, want 7", len(inner.rgUnits))
+	}
+	lateUnits := 0
+	for _, u := range inner.rgUnits {
+		if u.slot.entry.Path == path {
+			lateUnits++
+			if u.numRows != 50 {
+				t.Errorf("late unit numRows = %d, want 50", u.numRows)
+			}
+		}
+	}
+	if lateUnits != 1 {
+		t.Errorf("late file units = %d, want 1", lateUnits)
+	}
+}

--- a/internal/planner/physical/util.go
+++ b/internal/planner/physical/util.go
@@ -306,10 +306,10 @@ type rgUnit struct {
 }
 
 // fileSlot owns the lazy lifecycle of one parquet file's bytes during a
-// row-group-parallel scan. The metadata (footer) is loaded eagerly during
-// buildRGUnits so the planner can apply pruning across all files; the row
-// group bytes are loaded on first read and released after the last row
-// group from the file has been consumed.
+// row-group-parallel scan. Row-group metadata for pruning comes from the
+// catalog blob or a footer read during buildRGUnits (held there, not on
+// the slot); the row group bytes are loaded on first read and released
+// after the last row group from the file has been consumed.
 type fileSlot struct {
 	entry        catalog.FileEntry
 	mu           sync.Mutex
@@ -317,7 +317,6 @@ type fileSlot struct {
 	loadErr      error
 	reader       *parquet.Reader     // full reader (data + metadata) once loaded
 	nativeReader *parquet.FileReader // alias of reader.FileReader()
-	metaReader   *parquet.FileReader // metadata-only — used during pruning before any rg load
 	dataBuf      []byte              // pooled buffer holding the file bytes; returned to pool on releaseRG
 	chargedBytes int64               // bytes reserved on inner.memTracker for dataBuf; released with it
 	gateBytes    int64               // bytes admitted on inner.loadGate; released with the buffer
@@ -419,8 +418,6 @@ func (s *fileSlot) ensureLoaded(inner *scanSourceInner, ctx context.Context) (*p
 	// which defeated the lazy loader's bounded-in-flight design — buffers
 	// stayed live for the entire scan even after their slot was released.
 	s.dataBuf = data
-	// metaReader is no longer needed once the full reader is in place.
-	s.metaReader = nil
 	return s.nativeReader, nil
 }
 
@@ -485,7 +482,6 @@ func (s *fileSlot) drainAbandoned(inner *scanSourceInner) {
 	s.mu.Lock()
 	s.reader = nil
 	s.nativeReader = nil
-	s.metaReader = nil
 	buf := s.dataBuf
 	s.dataBuf = nil
 	s.releaseCharge(inner)
@@ -507,11 +503,16 @@ type prefetchResult struct {
 }
 
 // buildRGUnits enumerates row groups from every file in the scan WITHOUT
-// loading the file bytes upfront. For each file it does one footer-sized
-// range read (typically a few KB) to obtain the metadata, applies
-// predicate / bloom / dynamic-range pruning across the row groups using
-// only the footer's column statistics, and emits an rgUnit per surviving
-// row group that points at a lazy fileSlot.
+// loading the file bytes upfront. Row-group metadata (row counts + column
+// stats for pruning) comes from the catalog's persisted RG-metadata blob
+// when the table has one (Catalog.TableRGMeta — one cached GET per table
+// per manifest version); files not covered by the blob fall back to one
+// footer-sized range read each. Before the blob existed the footer pass
+// was a per-query barrier: 600 S3 round-trips per lineitem scan at SF10,
+// ~2-5s of metadata latency before any data download, on every query.
+// Predicate / bloom / dynamic-range pruning is applied across the row
+// groups and an rgUnit is emitted per survivor, pointing at a lazy
+// fileSlot.
 //
 // The slot's bytes are loaded on first read by the rg worker pool and
 // released as soon as that file's last row group has been consumed (see
@@ -545,94 +546,119 @@ func (inner *scanSourceInner) buildRGUnits(ctx context.Context) {
 	}
 	inner.loadGate = newLoadGate(loadBudget, loadGateMaxLanes)
 
+	// Catalog-persisted row-group metadata. Best-effort: nil on any
+	// error, and files missing from the map take the footer-read path.
+	var rgMeta map[string][]parquet.RowGroupStats
+	if inner.cat != nil {
+		rgMeta, _ = inner.cat.TableRGMeta(ctx, inner.tableName)
+	}
+
 	slots := make([]*fileSlot, len(inner.files))
+	fileRGStats := make([][]parquet.RowGroupStats, len(inner.files))
+	var footerFiles []int // indices into inner.files needing a footer read
+	for i, entry := range inner.files {
+		if gs, ok := rgMeta[entry.Path]; ok {
+			slots[i] = &fileSlot{entry: entry}
+			fileRGStats[i] = gs
+		} else {
+			footerFiles = append(footerFiles, i)
+		}
+	}
+
 	var failedFiles atomic.Int64
 	var firstErr atomic.Value // stores first error for diagnostics
-	var metaWg sync.WaitGroup
-	var metaIdx int64
 
-	// Read each file's footer concurrently. A footer is a few KB so this
-	// stays cheap even at SF1000. We use GetReaderAt when available so the
-	// store can issue a range request rather than downloading the full file.
-	type readerAtStore interface {
-		GetReaderAt(ctx context.Context, bucket, key string) (objstore.ReaderAtCloser, int64, error)
-	}
-	metaWorkers := runtime.NumCPU()
-	if metaWorkers > len(inner.files) {
-		metaWorkers = len(inner.files)
-	}
-	if metaWorkers < 1 {
-		metaWorkers = 1
-	}
+	if len(footerFiles) > 0 {
+		var metaWg sync.WaitGroup
+		var metaIdx int64
 
-	metaWg.Add(metaWorkers)
-	for i := 0; i < metaWorkers; i++ {
-		go func() {
-			defer metaWg.Done()
-			for {
-				idx := int(atomic.AddInt64(&metaIdx, 1) - 1)
-				if idx >= len(inner.files) {
-					return
-				}
-				if ctx.Err() != nil {
-					return
-				}
-				entry := inner.files[idx]
+		// Read each uncovered file's footer concurrently. A footer is a
+		// few KB so this stays cheap even at SF1000. We use GetReaderAt
+		// when available so the store can issue a range request rather
+		// than downloading the full file.
+		type readerAtStore interface {
+			GetReaderAt(ctx context.Context, bucket, key string) (objstore.ReaderAtCloser, int64, error)
+		}
+		metaWorkers := runtime.NumCPU()
+		if metaWorkers > len(footerFiles) {
+			metaWorkers = len(footerFiles)
+		}
+		if metaWorkers < 1 {
+			metaWorkers = 1
+		}
 
-				var meta *parquet.FileReader
-				if ras, ok := inner.cat.Store().(readerAtStore); ok {
-					ra, sz, err := ras.GetReaderAt(ctx, inner.cat.Bucket(), entry.Path)
-					if err == nil {
-						meta, err = parquet.OpenFileReaderMetadata(ra, sz)
-						ra.Close()
-						if err != nil {
+		metaWg.Add(metaWorkers)
+		for i := 0; i < metaWorkers; i++ {
+			go func() {
+				defer metaWg.Done()
+				for {
+					n := int(atomic.AddInt64(&metaIdx, 1) - 1)
+					if n >= len(footerFiles) {
+						return
+					}
+					if ctx.Err() != nil {
+						return
+					}
+					idx := footerFiles[n]
+					entry := inner.files[idx]
+
+					var meta *parquet.FileReader
+					if ras, ok := inner.cat.Store().(readerAtStore); ok {
+						ra, sz, err := ras.GetReaderAt(ctx, inner.cat.Bucket(), entry.Path)
+						if err == nil {
+							meta, err = parquet.OpenFileReaderMetadata(ra, sz)
+							ra.Close()
+							if err != nil {
+								if failedFiles.Add(1) == 1 {
+									firstErr.Store(fmt.Errorf("metadata %s: %w", entry.Path, err))
+								}
+								continue
+							}
+						} else {
 							if failedFiles.Add(1) == 1 {
-								firstErr.Store(fmt.Errorf("metadata %s: %w", entry.Path, err))
+								firstErr.Store(fmt.Errorf("get metadata %s: %w", entry.Path, err))
 							}
 							continue
 						}
 					} else {
-						if failedFiles.Add(1) == 1 {
-							firstErr.Store(fmt.Errorf("get metadata %s: %w", entry.Path, err))
+						// Fallback for stores without ReaderAt: full Get + bytes reader.
+						rc, _, err := inner.cat.Store().Get(ctx, inner.cat.Bucket(), entry.Path)
+						if err != nil {
+							if failedFiles.Add(1) == 1 {
+								firstErr.Store(fmt.Errorf("get %s: %w", entry.Path, err))
+							}
+							continue
 						}
-						continue
-					}
-				} else {
-					// Fallback for stores without ReaderAt: full Get + bytes reader.
-					rc, _, err := inner.cat.Store().Get(ctx, inner.cat.Bucket(), entry.Path)
-					if err != nil {
-						if failedFiles.Add(1) == 1 {
-							firstErr.Store(fmt.Errorf("get %s: %w", entry.Path, err))
+						data, err := readAllSized(rc, entry.SizeBytes, true)
+						rc.Close()
+						if err != nil {
+							if failedFiles.Add(1) == 1 {
+								firstErr.Store(fmt.Errorf("read %s: %w", entry.Path, err))
+							}
+							continue
 						}
-						continue
-					}
-					data, err := readAllSized(rc, entry.SizeBytes, true)
-					rc.Close()
-					if err != nil {
-						if failedFiles.Add(1) == 1 {
-							firstErr.Store(fmt.Errorf("read %s: %w", entry.Path, err))
+						reader, err := parquet.NewReaderFromBytes(data)
+						if err != nil {
+							if failedFiles.Add(1) == 1 {
+								firstErr.Store(fmt.Errorf("parquet %s (%d bytes): %w", entry.Path, len(data), err))
+							}
+							continue
 						}
-						continue
+						inner.trackPooledBuf(data)
+						meta = reader.FileReader()
 					}
-					reader, err := parquet.NewReaderFromBytes(data)
-					if err != nil {
-						if failedFiles.Add(1) == 1 {
-							firstErr.Store(fmt.Errorf("parquet %s (%d bytes): %w", entry.Path, len(data), err))
-						}
-						continue
-					}
-					inner.trackPooledBuf(data)
-					meta = reader.FileReader()
-				}
 
-				slots[idx] = &fileSlot{
-					entry:      entry,
-					metaReader: meta,
+					stats := make([]parquet.RowGroupStats, meta.NumRowGroups())
+					for rg := range stats {
+						stats[rg] = meta.RowGroupStats(rg)
+					}
+					slots[idx] = &fileSlot{entry: entry}
+					fileRGStats[idx] = stats
 				}
-			}
-		}()
+			}()
+		}
+		metaWg.Wait()
 	}
-	metaWg.Wait()
 
 	if failed := failedFiles.Load(); failed > 0 {
 		inner.failedFiles = int(failed)
@@ -641,20 +667,17 @@ func (inner *scanSourceInner) buildRGUnits(ctx context.Context) {
 		}
 	}
 
-	// Enumerate row groups from each file's metadata reader, applying
-	// pruning. Surviving rgUnits hold the slot pointer; the file bytes
-	// are loaded lazily on first rg read.
-	for _, slot := range slots {
-		if slot == nil || slot.metaReader == nil {
+	// Enumerate row groups from each file's metadata, applying pruning.
+	// Surviving rgUnits hold the slot pointer; the file bytes are loaded
+	// lazily on first rg read.
+	for si, slot := range slots {
+		if slot == nil {
 			continue
 		}
-		numRGs := slot.metaReader.NumRowGroups()
-
 		var rowOffset int64
 		var keptInFile int64
-		for rgIdx := 0; rgIdx < numRGs; rgIdx++ {
-			rgNumRows := slot.metaReader.RowGroupNumRows(rgIdx)
-			stats := slot.metaReader.RowGroupStats(rgIdx)
+		for rgIdx, stats := range fileRGStats[si] {
+			rgNumRows := stats.NumRows
 			pruned := false
 
 			// Predicate-based row group pruning

--- a/internal/storage/catalog/analyze.go
+++ b/internal/storage/catalog/analyze.go
@@ -115,12 +115,25 @@ func (c *Catalog) AnalyzeTable(ctx context.Context, name string) (int, error) {
 	}()
 
 	analyzed := 0
+	rgMetaFiles := make([]FileRGMeta, 0, len(jobs))
 	for r := range resCh {
 		if r.err != nil {
 			return analyzed, fmt.Errorf("analyze %s: file %s: %w", name, manifest.Partitions[r.pi].Files[r.fi].Path, r.err)
 		}
 		sk := r.sketches
-		if sk == nil || len(sk.hlls) == 0 {
+		if sk == nil {
+			continue
+		}
+		// Row-group metadata is captured even for files with no
+		// sketch-supported columns — the scan-side pruning fast path
+		// needs every file covered or it falls back to a footer read.
+		if len(sk.rgStats) > 0 {
+			rgMetaFiles = append(rgMetaFiles, FileRGMeta{
+				Path:   manifest.Partitions[r.pi].Files[r.fi].Path,
+				Groups: sk.rgStats,
+			})
+		}
+		if len(sk.hlls) == 0 {
 			continue
 		}
 		f := manifest.Partitions[r.pi].Files[r.fi]
@@ -157,6 +170,18 @@ func (c *Catalog) AnalyzeTable(ctx context.Context, name string) (int, error) {
 		analyzed++
 	}
 
+	// Persist the row-group metadata blob BEFORE the manifest so any
+	// reader that sees the new RGMetaKey finds the blob present. (The
+	// reverse race — old manifest, new blob — is safe by construction:
+	// blob entries are keyed by immutable file paths.)
+	if len(rgMetaFiles) > 0 {
+		key, err := c.PutTableRGMeta(ctx, name, rgMetaFiles)
+		if err != nil {
+			return analyzed, fmt.Errorf("analyze %s: %w", name, err)
+		}
+		manifest.RGMetaKey = key
+	}
+
 	// Bump the manifest version: ANALYZE changed its content (sketch keys,
 	// cleared inline bytes), and cross-process consumers key derived-stats
 	// caches on UpdatedAt.
@@ -174,6 +199,11 @@ type fileColumnSketches struct {
 	hlls     map[string]*HLL
 	samplers map[string]*ReservoirSampler
 	colTypes map[string]parquet.TypeID
+	// rgStats is the file's per-row-group footer metadata (row counts +
+	// column min/max/null), captured for the table RG-metadata blob so
+	// scans can enumerate and prune row groups without re-reading
+	// footers over the network (see rgmeta.go).
+	rgStats []parquet.RowGroupStats
 }
 
 // computeFileSketches reads a parquet file's data and builds per-column
@@ -215,10 +245,12 @@ func computeFileSketches(ctx context.Context, store objstore.Store, bucket, path
 	}
 
 	nrg := reader.NumRowGroups()
+	out.rgStats = make([]parquet.RowGroupStats, nrg)
 	for rg := 0; rg < nrg; rg++ {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
+		out.rgStats[rg] = reader.RowGroupStats(rg)
 		rows, err := reader.ReadRowGroup(rg, nil)
 		if err != nil {
 			return nil, fmt.Errorf("row group %d: %w", rg, err)

--- a/internal/storage/catalog/catalog.go
+++ b/internal/storage/catalog/catalog.go
@@ -56,6 +56,14 @@ type Catalog struct {
 	// invalidate when ingestion bumps the manifest's UpdatedAt.
 	aggStatsMu    sync.Mutex
 	aggStatsCache map[string]aggStatsCacheEntry
+
+	// rgMetaCache memoizes the decoded per-table RG-metadata blob (see
+	// rgmeta.go), keyed by the same manifest content version as
+	// aggStatsCache. Without it every scan re-fetches and re-decodes the
+	// blob; with it the blob costs one store GET per (table, manifest
+	// version) per process.
+	rgMetaMu    sync.Mutex
+	rgMetaCache map[string]rgMetaCacheEntry
 }
 
 // aggStatsCacheEntry is a memoized AggregateColumnStats result. The stats
@@ -90,6 +98,13 @@ type PartitionManifest struct {
 	Partitions    []PartitionEntry `json:"partitions"`
 	DeleteMarkers []DeleteMarker   `json:"delete_markers,omitempty"` // merge-on-read deletes
 	UpdatedAt     time.Time        `json:"updated_at"`
+	// RGMetaKey points to the table's row-group-metadata blob in the
+	// object store (see rgmeta.go), written by AnalyzeTable. Scans use
+	// it to enumerate and prune row groups without reading any parquet
+	// footers. Files added after the blob was written simply aren't in
+	// it and fall back to footer reads — the key stays valid across
+	// ingest. Empty until the table is first analyzed.
+	RGMetaKey string `json:"rg_meta_key,omitempty"`
 }
 
 // DeleteMarker records rows to skip during scan (merge-on-read).
@@ -1111,6 +1126,9 @@ func (c *Catalog) invalidateManifestCache(tableName string) {
 	c.aggStatsMu.Lock()
 	delete(c.aggStatsCache, tableName)
 	c.aggStatsMu.Unlock()
+	c.rgMetaMu.Lock()
+	delete(c.rgMetaCache, tableName)
+	c.rgMetaMu.Unlock()
 }
 
 // key returns a cluster-prefixed KV key.

--- a/internal/storage/catalog/rgmeta.go
+++ b/internal/storage/catalog/rgmeta.go
@@ -1,0 +1,354 @@
+package catalog
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// FileRGMeta carries one parquet file's row-group-level metadata: per-RG
+// row counts and per-column min/max/null statistics — exactly what
+// buildRGUnits needs from the file footer to enumerate and prune row
+// groups at plan time.
+//
+// The catalog persists ALL files' RGMeta for a table in a single
+// object-store blob (see rgMetaObjectKey). Before this existed, every
+// scan read every file's footer over the network as a barrier before
+// any data download — 600 S3 range-read round-trips per lineitem scan
+// at SF10, ~2-5s of pure metadata latency on EVERY query. The footer
+// contents are static per file, so one blob GET per (table, manifest
+// version) replaces all of them; scans of files not covered by the
+// blob (fresh ingest, never-analyzed tables) fall back to footer reads.
+//
+// A blob entry can never be WRONG, only missing or superfluous: entries
+// are keyed by object paths and data files are immutable, so a stale
+// blob still describes exactly the files it covers. That makes a fixed
+// blob key with atomic overwrite safe — no versioning needed.
+//
+// The blob is written by AnalyzeTable (which decodes every file anyway)
+// and encoded in a binary format so stat values keep their exact native
+// types (int64/float64/string/bool, the closed set statsToNative
+// produces). Routing them through the JSON manifest instead would
+// degrade int64→float64 and non-UTF-8 strings, which is tolerable for
+// CBO selectivity but not for pruning decisions.
+//
+// Wire format (binary, version-1):
+//
+//	[4]   magic "WRGM" (Wadjet Row-Group Metadata)
+//	[1]   version (1)
+//	[3]   reserved
+//	[4]   file count (uint32 LE)
+//	then per file:
+//	  [2]  path length (uint16 LE) + path bytes
+//	  [4]  row group count (uint32 LE)
+//	  then per row group:
+//	    [8]  num rows (int64 LE)
+//	    [2]  column count (uint16 LE)
+//	    then per column:
+//	      [2]  name length (uint16 LE) + name bytes
+//	      [8]  null count (int64 LE)
+//	      [1]  has stats (0/1)
+//	      min value: [1] type tag + payload
+//	      max value: [1] type tag + payload
+//
+// Value tags: 0 = nil, 1 = bool (1 byte), 2 = int64 (8 bytes LE),
+// 3 = float64 (8 bytes LE), 4 = string ([4] length uint32 LE + bytes).
+const (
+	rgMetaMagic   = "WRGM"
+	rgMetaVersion = 1
+)
+
+const (
+	rgMetaTagNil    = 0
+	rgMetaTagBool   = 1
+	rgMetaTagInt64  = 2
+	rgMetaTagFloat  = 3
+	rgMetaTagString = 4
+)
+
+// rgMetaMaxStringLen caps decoded stat-string allocations so a corrupt
+// blob can't ask for gigabytes. Real min/max strings are column values
+// (comments, names) — far below this.
+const rgMetaMaxStringLen = 1 << 20
+
+// FileRGMeta is the per-file unit of the table RG-metadata blob.
+type FileRGMeta struct {
+	Path   string
+	Groups []parquet.RowGroupStats
+}
+
+// EncodeTableRGMeta serializes all files' row-group metadata to the v1
+// wire format. Empty input returns nil (no blob to upload).
+func EncodeTableRGMeta(files []FileRGMeta) []byte {
+	if len(files) == 0 {
+		return nil
+	}
+	var buf bytes.Buffer
+	hdr := make([]byte, 12)
+	copy(hdr[0:4], rgMetaMagic)
+	hdr[4] = rgMetaVersion
+	binary.LittleEndian.PutUint32(hdr[8:12], uint32(len(files)))
+	buf.Write(hdr)
+	var lb [8]byte
+	writeU16Str := func(s string) {
+		binary.LittleEndian.PutUint16(lb[:2], uint16(len(s)))
+		buf.Write(lb[:2])
+		buf.WriteString(s)
+	}
+	writeValue := func(v any) {
+		switch tv := v.(type) {
+		case nil:
+			buf.WriteByte(rgMetaTagNil)
+		case bool:
+			buf.WriteByte(rgMetaTagBool)
+			if tv {
+				buf.WriteByte(1)
+			} else {
+				buf.WriteByte(0)
+			}
+		case int64:
+			buf.WriteByte(rgMetaTagInt64)
+			binary.LittleEndian.PutUint64(lb[:], uint64(tv))
+			buf.Write(lb[:])
+		case float64:
+			buf.WriteByte(rgMetaTagFloat)
+			binary.LittleEndian.PutUint64(lb[:], math.Float64bits(tv))
+			buf.Write(lb[:])
+		case string:
+			buf.WriteByte(rgMetaTagString)
+			binary.LittleEndian.PutUint32(lb[:4], uint32(len(tv)))
+			buf.Write(lb[:4])
+			buf.WriteString(tv)
+		default:
+			// Not a type statsToNative produces — store nothing rather
+			// than an approximation the pruner might act on.
+			buf.WriteByte(rgMetaTagNil)
+		}
+	}
+	for _, f := range files {
+		writeU16Str(f.Path)
+		binary.LittleEndian.PutUint32(lb[:4], uint32(len(f.Groups)))
+		buf.Write(lb[:4])
+		for _, rg := range f.Groups {
+			binary.LittleEndian.PutUint64(lb[:], uint64(rg.NumRows))
+			buf.Write(lb[:])
+			binary.LittleEndian.PutUint16(lb[:2], uint16(len(rg.Columns)))
+			buf.Write(lb[:2])
+			for name, cs := range rg.Columns {
+				writeU16Str(name)
+				binary.LittleEndian.PutUint64(lb[:], uint64(cs.NullCount))
+				buf.Write(lb[:])
+				if cs.HasStats {
+					buf.WriteByte(1)
+				} else {
+					buf.WriteByte(0)
+				}
+				writeValue(cs.MinValue)
+				writeValue(cs.MaxValue)
+			}
+		}
+	}
+	return buf.Bytes()
+}
+
+// DecodeTableRGMeta parses a v1 RG-metadata blob into a by-path map,
+// the shape buildRGUnits consumes.
+func DecodeTableRGMeta(r io.Reader) (map[string][]parquet.RowGroupStats, error) {
+	hdr := make([]byte, 12)
+	if _, err := io.ReadFull(r, hdr); err != nil {
+		return nil, fmt.Errorf("rgmeta: read header: %w", err)
+	}
+	if string(hdr[0:4]) != rgMetaMagic {
+		return nil, fmt.Errorf("rgmeta: bad magic %q", string(hdr[0:4]))
+	}
+	if hdr[4] != rgMetaVersion {
+		return nil, fmt.Errorf("rgmeta: unsupported version %d", hdr[4])
+	}
+	fileCount := int(binary.LittleEndian.Uint32(hdr[8:12]))
+	var lb [8]byte
+	readU16Str := func() (string, error) {
+		if _, err := io.ReadFull(r, lb[:2]); err != nil {
+			return "", err
+		}
+		b := make([]byte, binary.LittleEndian.Uint16(lb[:2]))
+		if _, err := io.ReadFull(r, b); err != nil {
+			return "", err
+		}
+		return string(b), nil
+	}
+	readValue := func() (any, error) {
+		if _, err := io.ReadFull(r, lb[:1]); err != nil {
+			return nil, err
+		}
+		switch lb[0] {
+		case rgMetaTagNil:
+			return nil, nil
+		case rgMetaTagBool:
+			if _, err := io.ReadFull(r, lb[:1]); err != nil {
+				return nil, err
+			}
+			return lb[0] != 0, nil
+		case rgMetaTagInt64:
+			if _, err := io.ReadFull(r, lb[:]); err != nil {
+				return nil, err
+			}
+			return int64(binary.LittleEndian.Uint64(lb[:])), nil
+		case rgMetaTagFloat:
+			if _, err := io.ReadFull(r, lb[:]); err != nil {
+				return nil, err
+			}
+			return math.Float64frombits(binary.LittleEndian.Uint64(lb[:])), nil
+		case rgMetaTagString:
+			if _, err := io.ReadFull(r, lb[:4]); err != nil {
+				return nil, err
+			}
+			n := binary.LittleEndian.Uint32(lb[:4])
+			if n > rgMetaMaxStringLen {
+				return nil, fmt.Errorf("rgmeta: stat string length %d exceeds cap", n)
+			}
+			b := make([]byte, n)
+			if _, err := io.ReadFull(r, b); err != nil {
+				return nil, err
+			}
+			return string(b), nil
+		default:
+			return nil, fmt.Errorf("rgmeta: unknown value tag %d", lb[0])
+		}
+	}
+
+	out := make(map[string][]parquet.RowGroupStats, fileCount)
+	for fi := 0; fi < fileCount; fi++ {
+		path, err := readU16Str()
+		if err != nil {
+			return nil, fmt.Errorf("rgmeta: file %d path: %w", fi, err)
+		}
+		if _, err := io.ReadFull(r, lb[:4]); err != nil {
+			return nil, fmt.Errorf("rgmeta: file %s rg count: %w", path, err)
+		}
+		rgCount := int(binary.LittleEndian.Uint32(lb[:4]))
+		groups := make([]parquet.RowGroupStats, 0, min(rgCount, 1024))
+		for gi := 0; gi < rgCount; gi++ {
+			if _, err := io.ReadFull(r, lb[:]); err != nil {
+				return nil, fmt.Errorf("rgmeta: file %s rg %d rows: %w", path, gi, err)
+			}
+			rg := parquet.RowGroupStats{NumRows: int64(binary.LittleEndian.Uint64(lb[:]))}
+			if _, err := io.ReadFull(r, lb[:2]); err != nil {
+				return nil, fmt.Errorf("rgmeta: file %s rg %d col count: %w", path, gi, err)
+			}
+			colCount := int(binary.LittleEndian.Uint16(lb[:2]))
+			rg.Columns = make(map[string]parquet.ColumnStats, colCount)
+			for ci := 0; ci < colCount; ci++ {
+				name, err := readU16Str()
+				if err != nil {
+					return nil, fmt.Errorf("rgmeta: file %s rg %d col %d name: %w", path, gi, ci, err)
+				}
+				var cs parquet.ColumnStats
+				if _, err := io.ReadFull(r, lb[:]); err != nil {
+					return nil, fmt.Errorf("rgmeta: col %s null count: %w", name, err)
+				}
+				cs.NullCount = int64(binary.LittleEndian.Uint64(lb[:]))
+				if _, err := io.ReadFull(r, lb[:1]); err != nil {
+					return nil, fmt.Errorf("rgmeta: col %s has-stats: %w", name, err)
+				}
+				cs.HasStats = lb[0] != 0
+				if cs.MinValue, err = readValue(); err != nil {
+					return nil, fmt.Errorf("rgmeta: col %s min: %w", name, err)
+				}
+				if cs.MaxValue, err = readValue(); err != nil {
+					return nil, fmt.Errorf("rgmeta: col %s max: %w", name, err)
+				}
+				rg.Columns[name] = cs
+			}
+			groups = append(groups, rg)
+		}
+		out[path] = groups
+	}
+	return out, nil
+}
+
+// rgMetaObjectKey returns the fixed object-store path for a table's
+// RG-metadata blob. Fixed (not versioned) is deliberate: entries are
+// keyed by immutable file paths, so overwriting in place can never make
+// a concurrent reader see wrong stats — only older/newer coverage.
+func rgMetaObjectKey(table string) string {
+	return fmt.Sprintf("stats/%s/rgmeta.wrgm", table)
+}
+
+// PutTableRGMeta uploads the table's RG-metadata blob and returns its
+// object-store key. Empty input returns "" (nothing uploaded).
+func (c *Catalog) PutTableRGMeta(ctx context.Context, table string, files []FileRGMeta) (string, error) {
+	data := EncodeTableRGMeta(files)
+	if len(data) == 0 {
+		return "", nil
+	}
+	key := rgMetaObjectKey(table)
+	if _, err := c.store.Put(ctx, c.bucket, key, bytes.NewReader(data), int64(len(data)), "application/octet-stream"); err != nil {
+		return "", fmt.Errorf("upload rgmeta %s: %w", key, err)
+	}
+	return key, nil
+}
+
+// rgMetaCacheEntry is a memoized decoded RG-metadata blob, validated the
+// same way as aggStatsCacheEntry: by the manifest's content version.
+// The map is shared with callers — treat it as immutable.
+type rgMetaCacheEntry struct {
+	updatedAt time.Time
+	fileCount int
+	byPath    map[string][]parquet.RowGroupStats
+}
+
+// TableRGMeta returns the table's persisted row-group metadata as a
+// by-path map, or nil when the table has no blob (never analyzed).
+// Best-effort: fetch/decode failures return nil, nil so scans degrade
+// to per-file footer reads instead of failing.
+//
+// The decoded blob is memoized per table, keyed by the manifest's
+// UpdatedAt + file count — the same invalidation contract as
+// AggregateColumnStats. In the 22-query benchmark process the blob is
+// fetched from the store once per table, not once per query.
+func (c *Catalog) TableRGMeta(ctx context.Context, tableName string) (map[string][]parquet.RowGroupStats, error) {
+	manifest, err := c.GetManifest(ctx, tableName)
+	if err != nil || manifest == nil || manifest.RGMetaKey == "" {
+		return nil, nil
+	}
+	fileCount := 0
+	for _, p := range manifest.Partitions {
+		fileCount += len(p.Files)
+	}
+
+	c.rgMetaMu.Lock()
+	if e, ok := c.rgMetaCache[tableName]; ok &&
+		e.updatedAt.Equal(manifest.UpdatedAt) && e.fileCount == fileCount {
+		c.rgMetaMu.Unlock()
+		return e.byPath, nil
+	}
+	c.rgMetaMu.Unlock()
+
+	rc, _, err := c.store.Get(ctx, c.bucket, manifest.RGMetaKey)
+	if err != nil {
+		return nil, nil
+	}
+	byPath, err := DecodeTableRGMeta(rc)
+	rc.Close()
+	if err != nil {
+		return nil, nil
+	}
+
+	c.rgMetaMu.Lock()
+	if c.rgMetaCache == nil {
+		c.rgMetaCache = make(map[string]rgMetaCacheEntry)
+	}
+	c.rgMetaCache[tableName] = rgMetaCacheEntry{
+		updatedAt: manifest.UpdatedAt,
+		fileCount: fileCount,
+		byPath:    byPath,
+	}
+	c.rgMetaMu.Unlock()
+	return byPath, nil
+}

--- a/internal/storage/catalog/rgmeta_test.go
+++ b/internal/storage/catalog/rgmeta_test.go
@@ -1,0 +1,269 @@
+package catalog
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// TestRGMetaRoundTrip verifies the WRGM wire format preserves every value
+// type exactly — the whole point of the binary encoding is that pruning
+// stats never suffer JSON's int64→float64 / non-UTF-8 degradation.
+func TestRGMetaRoundTrip(t *testing.T) {
+	files := []FileRGMeta{
+		{
+			Path: "tables/t/chunk_0001.parquet",
+			Groups: []parquet.RowGroupStats{
+				{
+					NumRows: 128 * 1024,
+					Columns: map[string]parquet.ColumnStats{
+						"l_orderkey": {HasStats: true, MinValue: int64(-42), MaxValue: int64(1<<60 + 7), NullCount: 3},
+						"l_price":    {HasStats: true, MinValue: float64(-0.5), MaxValue: float64(1e300), NullCount: 0},
+						"l_comment":  {HasStats: true, MinValue: "", MaxValue: string([]byte{0xff, 0xfe, 'x'}), NullCount: 9},
+						"l_flag":     {HasStats: true, MinValue: false, MaxValue: true, NullCount: 0},
+						"l_nostats":  {HasStats: false},
+						"l_nullmin":  {HasStats: true, MinValue: nil, MaxValue: int64(10), NullCount: 1},
+					},
+				},
+				{NumRows: 7, Columns: map[string]parquet.ColumnStats{}},
+			},
+		},
+		{Path: "tables/t/empty.parquet", Groups: nil},
+		{
+			Path: "tables/t/chunk_0002.parquet",
+			Groups: []parquet.RowGroupStats{
+				{NumRows: 1, Columns: map[string]parquet.ColumnStats{
+					"id": {HasStats: true, MinValue: int64(5), MaxValue: int64(5), NullCount: 0},
+				}},
+			},
+		},
+	}
+
+	data := EncodeTableRGMeta(files)
+	if len(data) == 0 {
+		t.Fatal("encode returned empty blob")
+	}
+	got, err := DecodeTableRGMeta(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != len(files) {
+		t.Fatalf("decoded %d files, want %d", len(got), len(files))
+	}
+	for _, f := range files {
+		gg, ok := got[f.Path]
+		if !ok {
+			t.Fatalf("missing path %s", f.Path)
+		}
+		if len(gg) != len(f.Groups) {
+			t.Fatalf("%s: %d groups, want %d", f.Path, len(gg), len(f.Groups))
+		}
+		for i, want := range f.Groups {
+			if gg[i].NumRows != want.NumRows {
+				t.Errorf("%s rg %d: NumRows %d, want %d", f.Path, i, gg[i].NumRows, want.NumRows)
+			}
+			if len(gg[i].Columns) != len(want.Columns) {
+				t.Fatalf("%s rg %d: %d cols, want %d", f.Path, i, len(gg[i].Columns), len(want.Columns))
+			}
+			for name, wcs := range want.Columns {
+				gcs, ok := gg[i].Columns[name]
+				if !ok {
+					t.Fatalf("%s rg %d: missing col %s", f.Path, i, name)
+				}
+				if !reflect.DeepEqual(gcs, wcs) {
+					t.Errorf("%s rg %d col %s: got %#v, want %#v", f.Path, i, name, gcs, wcs)
+				}
+			}
+		}
+	}
+
+	// Empty input → no blob.
+	if b := EncodeTableRGMeta(nil); b != nil {
+		t.Errorf("EncodeTableRGMeta(nil) = %d bytes, want nil", len(b))
+	}
+}
+
+// TestRGMetaEncodeUnsupportedType verifies values outside statsToNative's
+// closed type set are dropped (nil) rather than approximated — the pruner
+// must never act on a lossy stand-in.
+func TestRGMetaEncodeUnsupportedType(t *testing.T) {
+	files := []FileRGMeta{{
+		Path: "f.parquet",
+		Groups: []parquet.RowGroupStats{{
+			NumRows: 10,
+			Columns: map[string]parquet.ColumnStats{
+				"weird": {HasStats: true, MinValue: []byte{1, 2}, MaxValue: int32(7), NullCount: 0},
+			},
+		}},
+	}}
+	got, err := DecodeTableRGMeta(bytes.NewReader(EncodeTableRGMeta(files)))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	cs := got["f.parquet"][0].Columns["weird"]
+	if cs.MinValue != nil || cs.MaxValue != nil {
+		t.Errorf("unsupported types must encode as nil, got min=%#v max=%#v", cs.MinValue, cs.MaxValue)
+	}
+}
+
+// TestRGMetaDecodeErrors verifies corrupt blobs error out instead of
+// producing garbage stats (callers treat errors as "no blob" and fall
+// back to footer reads).
+func TestRGMetaDecodeErrors(t *testing.T) {
+	valid := EncodeTableRGMeta([]FileRGMeta{{
+		Path: "f.parquet",
+		Groups: []parquet.RowGroupStats{{
+			NumRows: 10,
+			Columns: map[string]parquet.ColumnStats{"c": {HasStats: true, MinValue: int64(1), MaxValue: int64(2)}},
+		}},
+	}})
+
+	cases := map[string][]byte{
+		"empty":     {},
+		"bad magic": append([]byte("XXXX"), valid[4:]...),
+		"bad version": func() []byte {
+			b := append([]byte(nil), valid...)
+			b[4] = 99
+			return b
+		}(),
+		"truncated": valid[:len(valid)-3],
+		"bad tag": func() []byte {
+			b := append([]byte(nil), valid...)
+			b[len(b)-9] = 200 // the max value's tag byte (1 tag + 8 int64 payload)
+			return b
+		}(),
+	}
+	for name, data := range cases {
+		if _, err := DecodeTableRGMeta(bytes.NewReader(data)); err == nil {
+			t.Errorf("%s: expected decode error", name)
+		}
+	}
+}
+
+// TestTableRGMetaLifecycle exercises the catalog surface: no blob before
+// ANALYZE, full coverage matching real footer stats after, memoization
+// keyed by manifest version, and fallback-to-nil on a missing blob after
+// invalidation.
+func TestTableRGMetaLifecycle(t *testing.T) {
+	ctx := context.Background()
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(ctx, "test"); err != nil {
+		t.Fatal(err)
+	}
+	cat := New(NewMemKV(), store, "test")
+	if err := cat.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	schema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "name", Type: parquet.TypeString},
+	}}
+	if err := cat.CreateTable(ctx, "events", schema, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	addFile := func(fi, base int) []byte {
+		t.Helper()
+		rows := make([]map[string]any, 100)
+		for i := range rows {
+			rows[i] = map[string]any{"id": int64(base + i), "name": fmt.Sprintf("n%d", i)}
+		}
+		var buf bytes.Buffer
+		cfg := parquet.DefaultWriterConfig()
+		cfg.RowGroupSize = 40 // 3 row groups per file (40+40+20)
+		pw, err := parquet.NewWriter(&buf, schema, cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := pw.WriteRows(rows); err != nil {
+			t.Fatal(err)
+		}
+		if err := pw.Close(); err != nil {
+			t.Fatal(err)
+		}
+		key := fmt.Sprintf("tables/events/chunk_%04d.parquet", fi)
+		data := buf.Bytes()
+		if _, err := store.Put(ctx, "test", key, bytes.NewReader(data), int64(len(data)), "application/octet-stream"); err != nil {
+			t.Fatal(err)
+		}
+		entry := FileEntry{Path: key, SizeBytes: int64(len(data)), NumRows: 100, CreatedAt: time.Now()}
+		if err := cat.AddFiles(ctx, "events", nil, "tables/events/", []FileEntry{entry}); err != nil {
+			t.Fatal(err)
+		}
+		return data
+	}
+
+	fileData := addFile(0, 0)
+	addFile(1, 100)
+
+	// Before ANALYZE: no blob, nil map, no error.
+	if m, err := cat.TableRGMeta(ctx, "events"); err != nil || m != nil {
+		t.Fatalf("pre-ANALYZE TableRGMeta = %v, %v; want nil, nil", m, err)
+	}
+
+	if _, err := cat.AnalyzeTable(ctx, "events"); err != nil {
+		t.Fatalf("AnalyzeTable: %v", err)
+	}
+
+	manifest, err := cat.GetManifest(ctx, "events")
+	if err != nil || manifest == nil || manifest.RGMetaKey == "" {
+		t.Fatalf("post-ANALYZE manifest RGMetaKey = %q (err %v), want set", manifestKey(manifest), err)
+	}
+
+	m, err := cat.TableRGMeta(ctx, "events")
+	if err != nil || len(m) != 2 {
+		t.Fatalf("post-ANALYZE TableRGMeta: %d files (err %v), want 2", len(m), err)
+	}
+
+	// Blob stats must match the file's real footer, bit-for-bit types.
+	fr, err := parquet.NewReaderFromBytes(fileData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	native := fr.FileReader()
+	groups := m["tables/events/chunk_0000.parquet"]
+	if len(groups) != native.NumRowGroups() {
+		t.Fatalf("blob has %d groups, footer has %d", len(groups), native.NumRowGroups())
+	}
+	for rg := range groups {
+		want := native.RowGroupStats(rg)
+		if groups[rg].NumRows != want.NumRows {
+			t.Errorf("rg %d NumRows = %d, want %d", rg, groups[rg].NumRows, want.NumRows)
+		}
+		for col, wcs := range want.Columns {
+			if !reflect.DeepEqual(groups[rg].Columns[col], wcs) {
+				t.Errorf("rg %d col %s: blob %#v != footer %#v", rg, col, groups[rg].Columns[col], wcs)
+			}
+		}
+	}
+
+	// Memoization: delete the blob object; a second call must still
+	// serve the cached decode (same manifest version → no store fetch).
+	if err := store.Delete(ctx, "test", manifest.RGMetaKey); err != nil {
+		t.Fatal(err)
+	}
+	if m2, err := cat.TableRGMeta(ctx, "events"); err != nil || len(m2) != 2 {
+		t.Fatalf("cached TableRGMeta after blob delete: %d files (err %v), want 2 from cache", len(m2), err)
+	}
+
+	// Invalidation: adding a file bumps the manifest version; the cache
+	// entry no longer matches, the re-fetch finds no blob, and the call
+	// degrades to nil (scan falls back to footer reads).
+	addFile(2, 200)
+	if m3, err := cat.TableRGMeta(ctx, "events"); err != nil || m3 != nil {
+		t.Fatalf("TableRGMeta after invalidation with deleted blob = %v, %v; want nil, nil", m3, err)
+	}
+}
+
+func manifestKey(m *PartitionManifest) string {
+	if m == nil {
+		return "<nil manifest>"
+	}
+	return m.RGMetaKey
+}

--- a/wadjet/analyze_table_test.go
+++ b/wadjet/analyze_table_test.go
@@ -63,6 +63,21 @@ func TestAnalyzeTableSQL(t *testing.T) {
 		t.Errorf("id NDV = %d (ok=%v), want ~200 (HLL error bound)", stats["id"].NDV, ok)
 	}
 
+	// ANALYZE also persists the RG-metadata blob; scans now plan from it
+	// instead of reading parquet footers. Queries — including one whose
+	// predicate exercises row-group pruning against blob stats — must
+	// return identical results through the fast path.
+	if m, err := db.Catalog().TableRGMeta(ctx, "metrics"); err != nil || len(m) == 0 {
+		t.Fatalf("TableRGMeta after ANALYZE: %d files (err %v), want >0", len(m), err)
+	}
+	res, err = db.Query(ctx, "SELECT count(*) AS n FROM metrics WHERE id >= 150")
+	if err != nil {
+		t.Fatalf("post-ANALYZE pruning query: %v", err)
+	}
+	if n := res.Rows[0]["n"]; n != int64(50) {
+		t.Errorf("post-ANALYZE count = %v, want 50", n)
+	}
+
 	// Bareword form (no TABLE keyword) also works.
 	if _, err := db.Query(ctx, "ANALYZE metrics"); err != nil {
 		t.Fatalf("ANALYZE metrics (bareword): %v", err)


### PR DESCRIPTION
## Summary

Cold-S3 round 2, item 1. Every scan read every parquet file's footer over the network as a barrier before any data download — 600 S3 range-read round-trips per lineitem scan at SF10, ~2-5s of pure metadata latency on every query. The footer contents are static per file.

- **ANALYZE** now persists one RG-metadata blob per table (`stats/<table>/rgmeta.wrgm`, binary WRGM v1: per-file, per-RG row counts + column min/max/null stats), referenced by `PartitionManifest.RGMetaKey`.
- **buildRGUnits** consumes it via `Catalog.TableRGMeta` (one cached GET per table per manifest version, `aggStatsCache`-style memoization) and skips footer reads for covered files. Uncovered files (fresh ingest, never-analyzed tables) keep the per-file footer path.
- Applies to standalone **and** distributed workers (shared scan path), and to multi-RG SF100 files, not just the SF10 many-small-files case.

## Design notes

- **Stale-safe by construction**: blob entries key on immutable file paths — a stale blob is only ever missing entries (footer fallback) or superfluous ones (ignored), never wrong. Hence a fixed blob key with atomic overwrite, no versioning.
- **Binary, not JSON**: stat values keep the exact native types `statsToNative` produces (int64/float64/string/bool). The JSON manifest would degrade int64→float64 and non-UTF-8 strings — fine for CBO selectivity, unacceptable for pruning decisions.
- **Externalized like sketches**: inlining per-file stats would push SF10-scale manifests back against the NATS KV ~1MB payload cap that forced sketch externalization.
- `fileSlot.metaReader` removed — enumeration works off stats views; `ensureLoaded` always re-parses from full file bytes.

## Tests

- WRGM wire round-trip (exact-type preservation incl. >2^53 int64, non-UTF-8 strings; unsupported types dropped, not approximated; corrupt-blob rejection)
- `TableRGMeta` lifecycle: coverage matches real footers via `reflect.DeepEqual`, memoization (blob deleted → cache still serves), invalidation on manifest bump
- `buildRGUnits` blob/footer **parity** across no-predicate / range-prune / prune-all shapes — with the parquet objects deleted, proving planning never touches data files
- Mixed-coverage fallback (post-ANALYZE ingest)
- Post-ANALYZE pruning query e2e (`wadjet/analyze_table_test.go`)
- Gates: `go test ./internal/...` clean, TPCH SF0.01 22/22, `tpch-harness --mode=local` PASS

## Deploy note

The SF10 bench catalog snapshot predates `RGMetaKey`; the next comparison deploy needs one fresh discovery+ANALYZE pass (or snapshot regen) before the blob path is active there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)