### PR TITLE
fix(exec): guard FixKeyAssignment rebuild against evicted build partitions

### DIFF
--- a/internal/engine/exec/join.go
+++ b/internal/engine/exec/join.go
@@ -1622,6 +1622,28 @@ func (h *HashJoin) FixKeyAssignment() {
 
 	// Rebuild hash index if keys were swapped
 	if needsRebuild {
+		// A build that EVICTED partitions cannot rebuild from buildBatches:
+		// eviction nils their entries (dereferencing them here is the same
+		// crash class as PruneBuildColumns, the SF10 standalone Q21 SIGSEGV
+		// of 2026-07-05) and the evicted rows aren't in memory at all, so a
+		// rebuild would silently drop them from the index. The key SWAP
+		// above stands — probe-side resolution needs the corrected names —
+		// and the arrival-time index stays authoritative: buildPartitioned
+		// resolved buildKeyIdx through columnIndexFallback, which maps the
+		// misassigned name to the same physical build column (had it
+		// resolved to nothing, the build itself would have failed).
+		// NOTE: the guard keys on nil'd entries, not on spillState —
+		// buildPartitioned creates spillState for every spill-eligible
+		// build, and a partitioned build with nothing evicted has complete
+		// buildBatches and still relies on this rebuild (Q02's scalar-
+		// subquery join at SF0.01 breaks if it's skipped).
+		if h.spillState != nil {
+			for _, b := range h.buildBatches {
+				if b == nil {
+					return
+				}
+			}
+		}
 		// Re-resolve build key indices after swap
 		if len(h.buildBatches) > 0 {
 			b := h.buildBatches[0]

--- a/internal/engine/exec/join_fixkey_spill_test.go
+++ b/internal/engine/exec/join_fixkey_spill_test.go
@@ -1,0 +1,94 @@
+package exec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/memory"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// TestFixKeyAssignment_PartitionedBuildSafe: FixKeyAssignment's rebuild
+// path must not touch buildBatches after a partition-on-arrival build —
+// evicted partitions nil their entries (join_partition_arrival.go), the
+// same hazard PruneBuildColumns hit on SF10 standalone Q21. The trigger
+// needs BOTH a spilled build and a misassigned key pair: the SQL put the
+// build column on the left of "=", so RightKeys carries a probe-qualified
+// name that only resolves in the build schema via columnIndexFallback.
+// Pre-guard, the swap set needsRebuild and the rebuild walked the nil'd
+// entries. The guard keeps the swap (probe resolution needs the corrected
+// names) and skips the rebuild — the arrival-time index is already keyed
+// on the correct physical column, so it must survive untouched.
+func TestFixKeyAssignment_PartitionedBuildSafe(t *testing.T) {
+	rightSchema := []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "val", Type: parquet.TypeString},
+	}
+	const buildN = 10000
+	rightRows := make([]map[string]any, buildN)
+	for i := range rightRows {
+		rightRows[i] = map[string]any{
+			"id":  int64(i),
+			"val": "build-row-padding-for-size",
+		}
+	}
+
+	tmpDir := t.TempDir()
+	// Budget tight enough that partitions must evict during build —
+	// eviction is what nils buildBatches entries (matches
+	// TestPruneBuildColumns_PartitionedBuildSafe's working point).
+	tracker := memory.NewTracker("test", 400_000)
+	sm, err := memory.NewSpillManager(tmpDir, tracker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sm.Cleanup()
+
+	// Misassigned pair: "id" (build column) landed in LeftKeys, and
+	// RightKeys got the probe-qualified "src.id" — which
+	// columnIndexFallback resolves to the build's "id" at arrival time,
+	// so the build succeeds and indexes the correct column. Semi join
+	// with a join filter keeps SemiAntiKeyOnly false, so batches are
+	// stored and the build dispatches to buildPartitioned.
+	hj := NewHashJoin(SemiJoin, []string{"id"}, []string{"src.id"})
+	hj.Spill = sm
+	hj.MemTracker = tracker
+
+	if err := hj.Build(context.Background(), NewSliceSource(rightSchema, rightRows)); err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	if hj.spillState == nil {
+		t.Fatal("test setup: build did not take the partition-on-arrival path")
+	}
+	nilEntries := 0
+	for _, b := range hj.buildBatches {
+		if b == nil {
+			nilEntries++
+		}
+	}
+	if nilEntries == 0 {
+		t.Fatal("test setup: no partition was evicted — budget too generous to exercise the crash")
+	}
+	rowsBefore := hj.buildRows
+	keyIdxBefore := append([]int(nil), hj.buildKeyIdx...)
+
+	// The planner's post-build hook. Pre-guard this swapped the keys,
+	// set needsRebuild, and dereferenced the nil'd entries.
+	hj.FixKeyAssignment()
+
+	// The swap itself must stand — probe-side resolution depends on it.
+	if hj.LeftKeys[0] != "src.id" || hj.RightKeys[0] != "id" {
+		t.Fatalf("keys not swapped: left=%v right=%v", hj.LeftKeys, hj.RightKeys)
+	}
+	// The partitioned index must be untouched: same rows, same build key
+	// column — a rebuild from the nil-holed buildBatches would have
+	// dropped every evicted partition's rows even if it didn't crash.
+	if hj.buildRows != rowsBefore {
+		t.Fatalf("buildRows changed %d → %d; partitioned index was rebuilt", rowsBefore, hj.buildRows)
+	}
+	for i, idx := range hj.buildKeyIdx {
+		if idx != keyIdxBefore[i] {
+			t.Fatalf("buildKeyIdx[%d] changed %d → %d", i, keyIdxBefore[i], idx)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Cold-S3 round 2, item 3. `FixKeyAssignment`'s `needsRebuild` path walks `buildBatches` exactly like `PruneBuildColumns` did before its guard (the SF10 standalone Q21 SIGSEGV class): partition-on-arrival builds nil their entries on eviction, so the rebuild crashes on a nil dereference — and even without the crash it would rebuild the index from in-memory batches only, silently dropping every evicted partition's rows. Dormant: needs a misassigned key pair (build column left of `=`) coinciding with a build that evicted.

## Key subtlety

The guard keys on **nil'd entries, not on `spillState`**: `buildPartitioned` creates `spillState` for every spill-eligible build, and a partitioned build with nothing evicted has complete `buildBatches` and still needs the rebuild — a first-cut `spillState != nil` guard broke Q02's scalar-subquery join at SF0.01 (caught by the TPCH gate during development). When the rebuild is skipped, the key swap still stands (probe-side resolution needs the corrected names) and the arrival-time index — built through `columnIndexFallback`, which resolves the misassigned name to the same physical column — remains authoritative.

## Tests

- `TestFixKeyAssignment_PartitionedBuildSafe` mirrors `join_prune_spill_test.go`: semi join, misassigned qualified key (`src.id`), budget forcing eviction. Verified to crash (nil deref) with the guard disabled and pass with it; asserts the swap survives and `buildRows`/`buildKeyIdx` are untouched.
- Gates: `go test ./internal/engine/exec/`, TPCH SF0.01 22/22, `tpch-harness --mode=local` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)