### PR TITLE
fix(planner): scan cache — per-consumer projection, Sel preservation, tracked pin

### DIFF
--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/citc-tech/wadjet/internal/config"
 	"github.com/citc-tech/wadjet/internal/engine/batch"
@@ -451,12 +452,34 @@ type cteMaterialized struct {
 // times within a single query (e.g., decorrelated subqueries). The first scan
 // populates the cache, and subsequent scans replay from it. Thread-safe for
 // concurrent builds: subsequent scans block on ready until the first completes.
+//
+// The cache holds the UNION of all consumers' columns (unionCols) so one
+// scan serves everyone; each consumer projects back down to its own
+// columns in catalogScanSource.Next. Without the projection, every
+// consumer — including hash-join BUILD sides, which store their input
+// batches — carried the widest consumer's columns: Q21's two 60M-row
+// lineitem semi/anti builds each stored l1's 4-column set instead of
+// the 2 columns they need, and partition-on-arrival evictions spilled
+// the dead columns to disk (the SF10 cold-S3 Q21 churn, 2026-07-06).
+//
+// The cache's heap pin is reserved on the query's memory tracker as it
+// grows (ReserveOrForce — asks operators to spill, never fails) and
+// released by Planner.releaseScanCache. Untracked, the pin was a
+// multi-GB accounting hole that made every spill decision downstream
+// operate on a fictional budget.
 type scanCached struct {
 	mu      sync.Mutex
 	batches []*batch.RecordBatch
 	schema  []parquet.Column
 	done    bool          // true when the first scan is complete
 	ready   chan struct{} // closed when first scan completes; nil until first scan claims the cache
+	// unionCols is the union of every consumer's RequiredColumns, in
+	// first-seen order. nil = full schema (some consumer needs all).
+	unionCols []string
+	// tracker/trackedBytes: the cache's reservation on the query memory
+	// tracker. Written under mu; released by Planner.releaseScanCache.
+	tracker      *memory.Tracker
+	trackedBytes int64
 }
 
 // NewPlanner creates a new physical planner.
@@ -906,6 +929,26 @@ func (p *Planner) materializeCTEColumnar(ctx context.Context, sql string) (*exec
 		schema = p.inferCTESchema(sql, nil)
 	}
 	return coll, schema, nil
+}
+
+// releaseScanCache drops every duplicate-scan cache entry and returns
+// its memory-tracker reservation. Idempotent; wired into
+// PhysicalPlan.Cleanup, Plan's error paths, and Plan's per-query reset.
+// On the shared (worker-injected) tracker path a missed release would
+// be a permanent phantom reservation, so every Plan exit must pass
+// through here.
+func (p *Planner) releaseScanCache() {
+	for _, c := range p.scanCache {
+		c.mu.Lock()
+		if c.tracker != nil && c.trackedBytes > 0 {
+			c.tracker.Release(c.trackedBytes)
+		}
+		c.tracker = nil
+		c.trackedBytes = 0
+		c.batches = nil
+		c.mu.Unlock()
+	}
+	p.scanCache = nil
 }
 
 // releaseCTECache frees every columnar CTE collector (tracker charge +
@@ -1510,33 +1553,45 @@ func (p *Planner) mergeDuplicateScans(node *logical.Node) {
 		if incompatible {
 			continue
 		}
-		// Compute the union of required columns.
+		// Compute the union of required columns in first-seen order. The
+		// union lives on the CACHE entry only — each scan node keeps its
+		// own RequiredColumns and catalogScanSource projects the cached
+		// (union-wide) batches back down per consumer. Rewriting the scan
+		// nodes to the union, as this used to do, silently widened every
+		// consumer: hash-join build sides stored the union's columns and
+		// spilled them on eviction (Q21's semi/anti lineitem builds).
+		// A scan with no RequiredColumns needs every column: the union
+		// degrades to nil (full schema).
+		var merged []string
 		colSet := map[string]bool{}
+		needAll := false
 		for _, s := range scans {
+			if len(s.RequiredColumns) == 0 {
+				needAll = true
+				break
+			}
 			for _, col := range s.RequiredColumns {
-				colSet[col] = true
+				if !colSet[col] {
+					colSet[col] = true
+					merged = append(merged, col)
+				}
 			}
 		}
-		merged := make([]string, 0, len(colSet))
-		for col := range colSet {
-			merged = append(merged, col)
-		}
-		// Update all scan nodes to use the merged column set.
-		for _, s := range scans {
-			s.RequiredColumns = merged
+		if needAll {
+			merged = nil
 		}
 		// Initialize the scan cache entry.
 		if p.scanCache == nil {
 			p.scanCache = make(map[string]*scanCached)
 		}
-		p.scanCache[table] = &scanCached{}
+		p.scanCache[table] = &scanCached{unionCols: merged}
 	}
 }
 
 // Plan converts a logical plan to a physical plan for local execution.
 func (p *Planner) Plan(ctx context.Context, node *logical.Node) (*PhysicalPlan, error) {
-	p.planCtx = ctx   // store for subquery runner context propagation
-	p.scanCache = nil // reset per-query scan cache
+	p.planCtx = ctx       // store for subquery runner context propagation
+	p.releaseScanCache() // reset per-query scan cache (drops tracker reservation)
 	p.spillMgr = nil  // reset per-query spill manager
 	p.memTracker = nil
 	p.releaseCTECache() // reset per-query CTE cache (frees stale spill scratch)
@@ -1558,7 +1613,8 @@ func (p *Planner) Plan(ctx context.Context, node *logical.Node) (*PhysicalPlan, 
 
 	source, ops, sink, err := p.buildPipeline(ctx, node)
 	if err != nil {
-		p.releaseCTECache() // free CTE spill scratch on the no-Cleanup path
+		p.releaseCTECache()  // free CTE spill scratch on the no-Cleanup path
+		p.releaseScanCache() // drop the scan cache's tracker reservation
 		return nil, err
 	}
 
@@ -1585,18 +1641,25 @@ func (p *Planner) Plan(ctx context.Context, node *logical.Node) (*PhysicalPlan, 
 		},
 	}
 
-	// Attach spill file cleanup. CTE collectors release first (tracker
-	// charge + their scratch files) so the SpillManager sweep that follows
-	// never races their removal.
+	// Attach spill file cleanup. CTE collectors and the scan cache
+	// release first (tracker charge + their scratch files) so the
+	// SpillManager sweep that follows never races their removal. The
+	// scan cache release matters most on the shared-tracker path: its
+	// reservation would otherwise outlive the query as a permanent
+	// phantom on the worker-lifetime tracker.
 	if sm := p.spillMgr; sm != nil {
 		plan.Cleanup = func() {
 			p.releaseCTECache()
+			p.releaseScanCache()
 			sm.Cleanup()
 		}
-	} else if p.cteCacheHasCollectors() {
+	} else if p.cteCacheHasCollectors() || p.scanCache != nil {
 		// Shared (worker-injected) spill manager: its dir outlives this
 		// query, so the collectors' scratch must be released explicitly.
-		plan.Cleanup = func() { p.releaseCTECache() }
+		plan.Cleanup = func() {
+			p.releaseCTECache()
+			p.releaseScanCache()
+		}
 	}
 
 	// Generate distributed stages for coordinator dispatch
@@ -1604,6 +1667,7 @@ func (p *Planner) Plan(ctx context.Context, node *logical.Node) (*PhysicalPlan, 
 
 	if err := p.enforceQueryLimits(plan.Stages, node); err != nil {
 		p.releaseCTECache()
+		p.releaseScanCache()
 		return nil, err
 	}
 
@@ -6104,6 +6168,9 @@ type catalogScanSource struct {
 	inner           exec.Source
 	cache           *scanCached           // non-nil when this table is scanned multiple times
 	replayIdx       atomic.Int64          // position in cache replay (atomic for parallel pipeline)
+	projOnce        sync.Once             // guards projIdx/projSchema init (replay Next is concurrent)
+	projIdx         []int                 // cache-batch column indices for this consumer; nil = no projection
+	projSchema      []parquet.Column      // this consumer's projected schema
 	isReplay        bool                  // true when reading from cache instead of scanning; written once in Init before runParallel starts, so no synchronization needed
 	bloomFilter     *exec.BloomScanFilter // bloom filter pushdown from hash join build side
 	dynamicFilter   []exec.DynamicRange   // dynamic min/max range filter from hash join build side
@@ -6148,8 +6215,15 @@ func (s *catalogScanSource) Init(ctx context.Context) error {
 		s.cache.ready = make(chan struct{})
 		s.cache.mu.Unlock()
 	}
-	// First scan (or no cache) — scan from storage.
-	sc := newScannerSource(s.catalog, s.tableName, s.partitionFilter, s.requiredCols, s.scanPreds)
+	// First scan (or no cache) — scan from storage. A cache-populating
+	// scan reads the UNION of all consumers' columns so the cache can
+	// serve every consumer; each consumer (this one included) projects
+	// back down to its own columns in Next.
+	scanCols := s.requiredCols
+	if s.cache != nil {
+		scanCols = s.cache.unionCols
+	}
+	sc := newScannerSource(s.catalog, s.tableName, s.partitionFilter, scanCols, s.scanPreds)
 	if ses, ok := sc.(*scannerExecSource); ok {
 		if s.bloomFilter != nil {
 			ses.bloomFilter = s.bloomFilter
@@ -6184,14 +6258,18 @@ func (s *catalogScanSource) Next(ctx context.Context) (*batch.RecordBatch, error
 		cached := s.cache.batches[idx]
 		// Return a shallow copy: shared column vectors (read-only), independent Sel.
 		// This prevents downstream operators from corrupting cached data via in-place
-		// Sel mutation.
+		// Sel mutation. Sel itself is carried over (slice header copy —
+		// downstream filters replace Sel rather than mutating in place):
+		// dropping it, as this used to, resurrected delete-marker-filtered
+		// rows on replay.
 		clone := &batch.RecordBatch{
 			Schema:  cached.Schema,
 			Columns: make([]*batch.Vector, len(cached.Columns)),
 			Len:     cached.Len,
+			Sel:     cached.Sel,
 		}
 		copy(clone.Columns, cached.Columns)
-		return clone, nil
+		return s.projectForConsumer(clone), nil
 	}
 
 	// When this scan is populating a shared cache, the entire pull-and-cache
@@ -6225,19 +6303,91 @@ func (s *catalogScanSource) Next(ctx context.Context) (*batch.RecordBatch, error
 		// overwrites the Vectors that the cache references.
 		b.Detach()
 		// Cache a shallow copy so the first consumer's operators don't
-		// corrupt cached data by setting Sel in-place.
+		// corrupt cached data by setting Sel in-place. Sel is preserved
+		// (delete markers arrive from the scan as Sel) — see the replay
+		// branch.
 		cached := &batch.RecordBatch{
 			Schema:  b.Schema,
 			Columns: make([]*batch.Vector, len(b.Columns)),
 			Len:     b.Len,
+			Sel:     b.Sel,
 		}
 		copy(cached.Columns, b.Columns)
 		s.cache.batches = append(s.cache.batches, cached)
-		return b, nil
+		// Reserve the pinned bytes on the query tracker so downstream
+		// spill decisions see the cache instead of discovering it as RSS
+		// drift. ReserveOrForce asks operators for relief and never
+		// fails; released by Planner.releaseScanCache.
+		if s.memTracker != nil {
+			n := cached.MemBytes()
+			if n > 0 {
+				memory.ReserveOrForce(ctx, s.memTracker, s.spillMgr, n, scanCacheReserveWait, "scan cache")
+				s.cache.tracker = s.memTracker
+				s.cache.trackedBytes += n
+			}
+		}
+		return s.projectForConsumer(b), nil
 	}
 
 	// No cache: inner.Next() is thread-safe for channel-based scan sources.
 	return s.inner.Next(ctx)
+}
+
+// scanCacheReserveWait bounds how long a cache append waits for a clean
+// reservation after asking operators for relief. Past it the reservation
+// is forced — population never fails or deadlocks on the budget.
+const scanCacheReserveWait = 2 * time.Second
+
+// projectForConsumer narrows a union-column cache batch down to this
+// consumer's RequiredColumns. Shallow: shares vectors, no copies. The
+// no-cache path, SELECT-* consumers (empty requiredCols), and batches
+// already matching the consumer's set pass through untouched. Also
+// defensive: any required column missing from the batch schema (e.g.,
+// synthetic columns) disables projection rather than dropping data.
+func (s *catalogScanSource) projectForConsumer(b *batch.RecordBatch) *batch.RecordBatch {
+	if s.cache == nil || len(s.requiredCols) == 0 || b == nil {
+		return b
+	}
+	s.projOnce.Do(func() {
+		if len(s.requiredCols) >= len(b.Schema) {
+			return
+		}
+		want := make(map[string]bool, len(s.requiredCols))
+		for _, name := range s.requiredCols {
+			want[name] = true
+		}
+		// Keep BATCH-SCHEMA (table) order, matching what a standalone
+		// scan of this node would emit via buildReadSchema — downstream
+		// operators may have bound positions against that shape.
+		idx := make([]int, 0, len(s.requiredCols))
+		schema := make([]parquet.Column, 0, len(s.requiredCols))
+		found := 0
+		for i, col := range b.Schema {
+			if want[col.Name] {
+				idx = append(idx, i)
+				schema = append(schema, col)
+				found++
+			}
+		}
+		if found < len(want) {
+			return // some required column missing — pass through unprojected
+		}
+		s.projIdx = idx
+		s.projSchema = schema
+	})
+	if s.projIdx == nil {
+		return b
+	}
+	nb := &batch.RecordBatch{
+		Schema:  s.projSchema,
+		Columns: make([]*batch.Vector, len(s.projIdx)),
+		Len:     b.Len,
+		Sel:     b.Sel,
+	}
+	for i, ci := range s.projIdx {
+		nb.Columns[i] = b.Columns[ci]
+	}
+	return nb
 }
 
 func (s *catalogScanSource) Close() error {

--- a/internal/planner/physical/scan_cache_test.go
+++ b/internal/planner/physical/scan_cache_test.go
@@ -1,0 +1,199 @@
+package physical
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/engine/memory"
+	"github.com/citc-tech/wadjet/internal/planner/logical"
+	"github.com/citc-tech/wadjet/internal/storage/catalog"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// scanCacheFixture builds a MemStore catalog with one 3-column file so
+// two consumers with different RequiredColumns can share a cache.
+func scanCacheFixture(t *testing.T, rows int) *catalog.Catalog {
+	t.Helper()
+	ctx := context.Background()
+	schema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "id2", Type: parquet.TypeInt64},
+		{Name: "val", Type: parquet.TypeString},
+	}}
+	rowMaps := make([]map[string]any, rows)
+	for i := range rowMaps {
+		rowMaps[i] = map[string]any{"id": int64(i), "id2": int64(i + 10), "val": "v"}
+	}
+	data := writeTestParquetMultiRG(t, schema, rowMaps)
+
+	store := objstore.NewMemStore()
+	cat := catalog.NewWithStore(store, "test")
+	if err := cat.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := cat.CreateTable(ctx, "items", schema, nil); err != nil {
+		t.Fatal(err)
+	}
+	path := "tables/items/chunk_001.parquet"
+	if _, err := store.Put(ctx, cat.Bucket(), path, bytes.NewReader(data), int64(len(data)), "application/octet-stream"); err != nil {
+		t.Fatal(err)
+	}
+	entry := catalog.FileEntry{Path: path, SizeBytes: int64(len(data)), NumRows: int64(rows), CreatedAt: time.Now()}
+	if err := cat.AddFiles(ctx, "items", map[string]string{}, "tables/items/", []catalog.FileEntry{entry}); err != nil {
+		t.Fatal(err)
+	}
+	return cat
+}
+
+func drainSource(t *testing.T, src *catalogScanSource) []*batch.RecordBatch {
+	t.Helper()
+	ctx := context.Background()
+	if err := src.Init(ctx); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	var out []*batch.RecordBatch
+	for {
+		b, err := src.Next(ctx)
+		if err != nil {
+			t.Fatalf("next: %v", err)
+		}
+		if b == nil {
+			break
+		}
+		out = append(out, b)
+	}
+	if err := src.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	return out
+}
+
+// TestScanCachePerConsumerProjection: the cache stores the UNION of all
+// consumers' columns, but each consumer must receive only its OWN
+// columns — a hash-join build side stores its input batches verbatim,
+// so leaking the union into consumers multiplies build memory and spill
+// bytes (the Q21 semi/anti churn). Also verifies the cache pin is
+// reserved on the memory tracker and released by releaseScanCache.
+func TestScanCachePerConsumerProjection(t *testing.T) {
+	cat := scanCacheFixture(t, 100)
+	tracker := memory.NewTracker("scan-cache-test", 1<<30)
+	cache := &scanCached{unionCols: []string{"id", "id2"}}
+
+	// Consumer A populates: scans the union, receives only "id".
+	a := &catalogScanSource{
+		catalog:      cat,
+		tableName:    "items",
+		requiredCols: []string{"id"},
+		cache:        cache,
+		memTracker:   tracker,
+	}
+	batchesA := drainSource(t, a)
+	if len(batchesA) == 0 {
+		t.Fatal("consumer A got no batches")
+	}
+	var rowsA int
+	for _, b := range batchesA {
+		if len(b.Schema) != 1 || b.Schema[0].Name != "id" {
+			t.Fatalf("consumer A schema = %v, want [id]", b.Schema)
+		}
+		rowsA += b.Len
+	}
+	if rowsA != 100 {
+		t.Fatalf("consumer A rows = %d, want 100", rowsA)
+	}
+
+	// The cache itself holds the union and is charged to the tracker.
+	if len(cache.batches) == 0 {
+		t.Fatal("cache not populated")
+	}
+	for _, cb := range cache.batches {
+		if len(cb.Schema) != 2 {
+			t.Fatalf("cache schema = %v, want union [id id2]", cb.Schema)
+		}
+	}
+	if tracker.Used() <= 0 {
+		t.Fatal("cache pin not reserved on the memory tracker")
+	}
+
+	// Consumer B replays: receives only "id2", values intact.
+	b := &catalogScanSource{
+		catalog:      cat,
+		tableName:    "items",
+		requiredCols: []string{"id2"},
+		cache:        cache,
+		memTracker:   tracker,
+	}
+	batchesB := drainSource(t, b)
+	var rowsB int
+	for _, rb := range batchesB {
+		if len(rb.Schema) != 1 || rb.Schema[0].Name != "id2" {
+			t.Fatalf("consumer B schema = %v, want [id2]", rb.Schema)
+		}
+		for i := 0; i < rb.Len; i++ {
+			if got := rb.Columns[0].Int64Data[i]; got < 10 {
+				t.Fatalf("consumer B saw id2=%d < 10 — wrong column data", got)
+			}
+		}
+		rowsB += rb.Len
+	}
+	if rowsB != 100 {
+		t.Fatalf("consumer B rows = %d, want 100", rowsB)
+	}
+
+	// releaseScanCache returns the reservation in full.
+	p := &Planner{scanCache: map[string]*scanCached{"items": cache}}
+	p.releaseScanCache()
+	if used := tracker.Used(); used != 0 {
+		t.Fatalf("tracker used = %d after releaseScanCache, want 0", used)
+	}
+	if p.scanCache != nil {
+		t.Fatal("scanCache not cleared")
+	}
+}
+
+// TestMergeDuplicateScansKeepsConsumerColumns: the union goes on the
+// cache entry; the scan NODES keep their own RequiredColumns (the old
+// behavior rewrote every node to the union).
+func TestMergeDuplicateScansKeepsConsumerColumns(t *testing.T) {
+	newTestScanNode := func(table string, cols []string) *logical.Node {
+		return &logical.Node{Type: logical.NodeScan, TableName: table, RequiredColumns: cols}
+	}
+	newTestJoinNode := func(l, r *logical.Node) *logical.Node {
+		return &logical.Node{Type: logical.NodeJoin, Children: []*logical.Node{l, r}}
+	}
+
+	p := &Planner{}
+	nodeA := newTestScanNode("items", []string{"id"})
+	nodeB := newTestScanNode("items", []string{"id2"})
+	root := newTestJoinNode(nodeA, nodeB)
+
+	p.mergeDuplicateScans(root)
+
+	if got := nodeA.RequiredColumns; len(got) != 1 || got[0] != "id" {
+		t.Fatalf("nodeA columns rewritten to %v, want [id]", got)
+	}
+	if got := nodeB.RequiredColumns; len(got) != 1 || got[0] != "id2" {
+		t.Fatalf("nodeB columns rewritten to %v, want [id2]", got)
+	}
+	entry := p.scanCache["items"]
+	if entry == nil {
+		t.Fatal("no cache entry created")
+	}
+	if len(entry.unionCols) != 2 {
+		t.Fatalf("unionCols = %v, want [id id2]", entry.unionCols)
+	}
+
+	// A SELECT-* consumer degrades the union to full schema (nil).
+	p2 := &Planner{}
+	root2 := newTestJoinNode(
+		newTestScanNode("items", []string{"id"}),
+		newTestScanNode("items", nil))
+	p2.mergeDuplicateScans(root2)
+	if entry := p2.scanCache["items"]; entry == nil || entry.unionCols != nil {
+		t.Fatalf("unionCols = %v with a SELECT-* consumer, want nil (full schema)", entry.unionCols)
+	}
+}

--- a/wadjet/scan_cache_delete_test.go
+++ b/wadjet/scan_cache_delete_test.go
@@ -1,0 +1,72 @@
+package wadjet
+
+import (
+	"context"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/storage/ingest"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// TestScanCacheReplayHonorsDeleteMarkers: a table scanned twice in one
+// query goes through the duplicate-scan cache (mergeDuplicateScans).
+// Delete markers reach the scan as batch selection vectors — and the
+// cache's replay path used to drop Sel from its shallow clones,
+// resurrecting deleted rows for whichever consumer replayed. The
+// self-join is built so a resurrected row on EITHER side changes the
+// count (which side populates vs replays is a race), making the
+// assertion deterministic.
+//
+// Rows: id 0..99, id2 = id+10. Join a.id = b.id2 pairs a(k+10) with
+// b(k) for k = 0..89. DELETE 40 <= id < 60 kills a-side ids [40,60)
+// (k in [30,50)) and b-side ids [40,60) (k in [40,60)) — correct count
+// is 90 - |[30,60)| = 60. Resurrecting either side adds its 10
+// non-overlapping k values back (a-side: [30,40); b-side: [50,60)),
+// so the buggy result is 70 regardless of which side replayed.
+func TestScanCacheReplayHonorsDeleteMarkers(t *testing.T) {
+	ctx := context.Background()
+	db, err := Open(ctx, Config{Store: objstore.NewMemStore(), Bucket: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "id2", Type: parquet.TypeInt64},
+	}}
+	if err := db.CreateTable(ctx, "pairs", schema, nil); err != nil {
+		t.Fatal(err)
+	}
+	rows := make([]map[string]any, 100)
+	for i := range rows {
+		rows[i] = map[string]any{"id": int64(i), "id2": int64(i + 10)}
+	}
+	ing := db.NewIngester("pairs", schema, nil, ingest.Config{MaxBufferRows: 10000})
+	if err := ing.Ingest(ctx, rows); err != nil {
+		t.Fatal(err)
+	}
+	if err := ing.FlushAll(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sanity pre-delete: 90 pairs.
+	res, err := db.Query(ctx, "SELECT COUNT(*) AS n FROM pairs a JOIN pairs b ON a.id = b.id2")
+	if err != nil {
+		t.Fatalf("pre-delete join: %v", err)
+	}
+	if n := res.Rows[0]["n"]; n != int64(90) {
+		t.Fatalf("pre-delete count = %v, want 90", n)
+	}
+
+	if _, err := db.Query(ctx, "DELETE FROM pairs WHERE id >= 40 AND id < 60"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	res, err = db.Query(ctx, "SELECT COUNT(*) AS n FROM pairs a JOIN pairs b ON a.id = b.id2")
+	if err != nil {
+		t.Fatalf("post-delete join: %v", err)
+	}
+	if n := res.Rows[0]["n"]; n != int64(60) {
+		t.Fatalf("post-delete count = %v, want 60 (70 = a deleted-row side was resurrected from the scan cache)", n)
+	}
+}


### PR DESCRIPTION
## Summary

Cold-S3 round 2, item 2 (Q21 spill-churn diagnosis → fix). Profiling Q21 against the SF10 bucket exposed three defects in the duplicate-scan cache (`mergeDuplicateScans` / `catalogScanSource`):

1. **Correctness (user-visible)**: the cache's shallow batch copies dropped `Sel` on both populate and replay paths. Delete markers reach the scan as selection vectors — so **any `DELETE` followed by a query that scans that table twice resurrected the deleted rows** for whichever consumer replayed from cache. New e2e regression (`wadjet/scan_cache_delete_test.go`) returns 70 instead of 60 pre-fix, built so a resurrection on *either* side of the self-join changes the count (populate-vs-replay is a race).

2. **Column-union leak**: `mergeDuplicateScans` rewrote every scan node's `RequiredColumns` to the union across consumers. Hash-join build sides store input batches verbatim, so Q21's two 60M-row lineitem semi/anti builds carried l1's 4-column set instead of the 2 they need — inflating build memory, partition evictions, and grace-join respill bytes. The union now lives on the cache entry only; each consumer's batches are projected back down (shallow, batch-schema order — exactly what a standalone scan of that node would emit).

3. **Untracked heap pin**: the cache (the entire decoded table, held to query end) was invisible to the memory ledger — the "Q21 evicts despite 24GB" mystery. Appends now `ReserveOrForce` on the query tracker, released deterministically via `releaseScanCache` on every `Plan` exit path (on the shared worker-injected tracker a missed release would be a permanent phantom).

## Measurements (local SF10 cold-S3 repro)

`buildPartitioned` CPU 9.74s → 7.94s (−18%); l2's build halves its stored columns, l3's is unchanged (its filter sits between scan and build — post-filter column pruning is the late-materialization roadmap item, not this PR). Local wall flat (network-dominated, high variance); the EC2 same-window comparison comes with the round-2 deploy.

## Tests

- Per-consumer projection parity + tracker reserve/release lifecycle (`scan_cache_test.go`)
- Planner keeps consumer columns, union on cache entry, SELECT-* degrades union to full schema
- Delete-marker replay regression — verified fail-before (70) / pass-after (60)
- Gates: `go test ./internal/...` + `./wadjet/` clean, TPCH SF0.01 22/22, `tpch-harness --mode=local` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)