### PR TITLE
fix(planner): drop scan-cache tracker reservation — shared-vector double charge

### DIFF
--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/citc-tech/wadjet/internal/config"
 	"github.com/citc-tech/wadjet/internal/engine/batch"
@@ -462,11 +461,11 @@ type cteMaterialized struct {
 // the 2 columns they need, and partition-on-arrival evictions spilled
 // the dead columns to disk (the SF10 cold-S3 Q21 churn, 2026-07-06).
 //
-// The cache's heap pin is reserved on the query's memory tracker as it
-// grows (ReserveOrForce — asks operators to spill, never fails) and
-// released by Planner.releaseScanCache. Untracked, the pin was a
-// multi-GB accounting hole that made every spill decision downstream
-// operate on a fictional budget.
+// The cache's vectors are shared with its consumers and are therefore
+// NOT charged to the memory tracker here — see the comment at the
+// append site in catalogScanSource.Next for the 2026-07-06 stall
+// incident that rule prevents. Batches are dropped by
+// Planner.releaseScanCache on every Plan exit path.
 type scanCached struct {
 	mu      sync.Mutex
 	batches []*batch.RecordBatch
@@ -476,10 +475,6 @@ type scanCached struct {
 	// unionCols is the union of every consumer's RequiredColumns, in
 	// first-seen order. nil = full schema (some consumer needs all).
 	unionCols []string
-	// tracker/trackedBytes: the cache's reservation on the query memory
-	// tracker. Written under mu; released by Planner.releaseScanCache.
-	tracker      *memory.Tracker
-	trackedBytes int64
 }
 
 // NewPlanner creates a new physical planner.
@@ -931,20 +926,12 @@ func (p *Planner) materializeCTEColumnar(ctx context.Context, sql string) (*exec
 	return coll, schema, nil
 }
 
-// releaseScanCache drops every duplicate-scan cache entry and returns
-// its memory-tracker reservation. Idempotent; wired into
+// releaseScanCache drops every duplicate-scan cache entry so cached
+// batches don't outlive their query. Idempotent; wired into
 // PhysicalPlan.Cleanup, Plan's error paths, and Plan's per-query reset.
-// On the shared (worker-injected) tracker path a missed release would
-// be a permanent phantom reservation, so every Plan exit must pass
-// through here.
 func (p *Planner) releaseScanCache() {
 	for _, c := range p.scanCache {
 		c.mu.Lock()
-		if c.tracker != nil && c.trackedBytes > 0 {
-			c.tracker.Release(c.trackedBytes)
-		}
-		c.tracker = nil
-		c.trackedBytes = 0
 		c.batches = nil
 		c.mu.Unlock()
 	}
@@ -6313,30 +6300,25 @@ func (s *catalogScanSource) Next(ctx context.Context) (*batch.RecordBatch, error
 			Sel:     b.Sel,
 		}
 		copy(cached.Columns, b.Columns)
+		// NOT charged to the memory tracker, deliberately. The cache's
+		// vectors are SHARED with its consumers — hash-join builds
+		// Reserve hashBuildBytes for these same vectors, and the scan
+		// source charges them transiently in flight. Reserving them
+		// again here (tried 2026-07-06) triple-counted the same physical
+		// memory: the ledger hit the budget while RSS was fine, every
+		// append stalled in ReserveOrForce's relief wait, and the forced
+		// build spills turned SF10 Q21 from 1m28s into 8m35s on EC2
+		// (CPU profile: 4.76% utilization — pure stall). Honest cache
+		// accounting needs the cache to OWN spillable bytes
+		// (SpillableBatchCollector, like the CTE cache) — not a second
+		// charge for memory the ledger already sees.
 		s.cache.batches = append(s.cache.batches, cached)
-		// Reserve the pinned bytes on the query tracker so downstream
-		// spill decisions see the cache instead of discovering it as RSS
-		// drift. ReserveOrForce asks operators for relief and never
-		// fails; released by Planner.releaseScanCache.
-		if s.memTracker != nil {
-			n := cached.MemBytes()
-			if n > 0 {
-				memory.ReserveOrForce(ctx, s.memTracker, s.spillMgr, n, scanCacheReserveWait, "scan cache")
-				s.cache.tracker = s.memTracker
-				s.cache.trackedBytes += n
-			}
-		}
 		return s.projectForConsumer(b), nil
 	}
 
 	// No cache: inner.Next() is thread-safe for channel-based scan sources.
 	return s.inner.Next(ctx)
 }
-
-// scanCacheReserveWait bounds how long a cache append waits for a clean
-// reservation after asking operators for relief. Past it the reservation
-// is forced — population never fails or deadlocks on the budget.
-const scanCacheReserveWait = 2 * time.Second
 
 // projectForConsumer narrows a union-column cache batch down to this
 // consumer's RequiredColumns. Shallow: shares vectors, no copies. The

--- a/internal/planner/physical/scan_cache_test.go
+++ b/internal/planner/physical/scan_cache_test.go
@@ -76,8 +76,10 @@ func drainSource(t *testing.T, src *catalogScanSource) []*batch.RecordBatch {
 // consumers' columns, but each consumer must receive only its OWN
 // columns — a hash-join build side stores its input batches verbatim,
 // so leaking the union into consumers multiplies build memory and spill
-// bytes (the Q21 semi/anti churn). Also verifies the cache pin is
-// reserved on the memory tracker and released by releaseScanCache.
+// bytes (the Q21 semi/anti churn). Also verifies the cache does NOT
+// reserve its (consumer-shared) vectors on the memory tracker — the
+// 2026-07-06 double-charge stalled SF10 Q21 6× — and that
+// releaseScanCache drops the batches.
 func TestScanCachePerConsumerProjection(t *testing.T) {
 	cat := scanCacheFixture(t, 100)
 	tracker := memory.NewTracker("scan-cache-test", 1<<30)
@@ -106,7 +108,10 @@ func TestScanCachePerConsumerProjection(t *testing.T) {
 		t.Fatalf("consumer A rows = %d, want 100", rowsA)
 	}
 
-	// The cache itself holds the union and is charged to the tracker.
+	// The cache itself holds the union. Its vectors are shared with
+	// consumers (builds charge them via hashBuildBytes), so the cache
+	// must NOT add a second charge — the ledger would exceed RSS and
+	// stall every append in relief waits.
 	if len(cache.batches) == 0 {
 		t.Fatal("cache not populated")
 	}
@@ -115,8 +120,8 @@ func TestScanCachePerConsumerProjection(t *testing.T) {
 			t.Fatalf("cache schema = %v, want union [id id2]", cb.Schema)
 		}
 	}
-	if tracker.Used() <= 0 {
-		t.Fatal("cache pin not reserved on the memory tracker")
+	if used := tracker.Used(); used != 0 {
+		t.Fatalf("cache double-charged %d bytes to the tracker; shared vectors must not be re-reserved", used)
 	}
 
 	// Consumer B replays: receives only "id2", values intact.
@@ -144,11 +149,11 @@ func TestScanCachePerConsumerProjection(t *testing.T) {
 		t.Fatalf("consumer B rows = %d, want 100", rowsB)
 	}
 
-	// releaseScanCache returns the reservation in full.
+	// releaseScanCache drops the cached batches and the map.
 	p := &Planner{scanCache: map[string]*scanCached{"items": cache}}
 	p.releaseScanCache()
-	if used := tracker.Used(); used != 0 {
-		t.Fatalf("tracker used = %d after releaseScanCache, want 0", used)
+	if cache.batches != nil {
+		t.Fatal("cached batches not dropped by releaseScanCache")
 	}
 	if p.scanCache != nil {
 		t.Fatal("scanCache not cleared")


### PR DESCRIPTION
## Summary

The EC2 comparison run convicted the tracker reservation added in #189: **SF10 Q21 went 1m28s → 8m35s**, with the per-query CPU profile showing 4.76% utilization over 516s — pure stall, not compute or I/O saturation.

Root cause: the scan cache's vectors are **shared** with its consumers. Hash-join builds `Reserve(hashBuildBytes)` for those same vectors, and the scan source charges them transiently in flight — so the cache's `ReserveOrForce` was a second (sometimes third) ledger charge for the same physical memory. The ledger exhausted the 24GB budget while RSS was fine; every cache append (~29k for SF10 lineitem) could stall up to 2s in the relief wait, and the forced build spills landed on EBS gp3.

This drops only the reservation. The **per-consumer projection** and **Sel-preservation correctness fix** from #189 stay (validated by their regression tests, which are updated here to assert the cache does NOT double-charge). Honest cache accounting returns as a follow-on where the cache owns spillable bytes (`SpillableBatchCollector`, the CTE-cache pattern) instead of re-charging memory the ledger already sees.

## Evidence

- This run: Q21 8m35.5s, 100 rows (correct); every other query improved (footer-pass elimination): suite-minus-Q21 saved ~55s vs the 2026-07-05 baseline.
- Q21 profile: Duration 516s, samples 24.5s (4.76%) — stall-dominated.
- Local NVMe run of the same code showed no regression (2m23s) — the EBS spill target amplified the forced evictions.

## Gates

`go test ./internal/... ./wadjet/`, TPCH SF0.01 22/22, `tpch-harness --mode=local` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)