### PR TITLE
perf(exec): filtered semi/anti key+filter-column builds; fix(planner): JoinFilter survival through decorrelation

### DIFF
--- a/internal/engine/exec/join.go
+++ b/internal/engine/exec/join.go
@@ -98,6 +98,25 @@ type HashJoin struct {
 	// for large build sides (e.g., 6M-row lineitem scan for EXISTS subqueries).
 	SemiAntiKeyOnly bool
 
+	// BuildStoreCols, when non-empty, narrows every stored build batch to the
+	// named columns (join keys + SemiAntiFilter-referenced columns) at arrival
+	// time. Filtered semi/anti joins never emit build rows, but the probe must
+	// evaluate SemiAntiFilter against the filter's build-side columns — storing
+	// only keys + those columns keeps partitioned builds, their per-partition
+	// accumulators, and their spill files narrow from the first batch. The
+	// post-build PruneBuildColumns cannot achieve this: it skips partition-on-
+	// arrival builds entirely (evicted entries are nil'd and spilled files
+	// carry the storage schema), which is every spill-eligible build. Names
+	// are resolved once against the first arrival batch; if any name fails to
+	// resolve, projection is disabled and full batches are stored.
+	BuildStoreCols []string
+
+	// buildStore* hold the once-resolved projection state for BuildStoreCols.
+	buildStoreChecked  bool
+	buildStoreDisabled bool
+	buildStoreIdx      []int
+	buildStoreSchema   []parquet.Column
+
 	// BuildRowHint is an optional hint for the expected number of build-side rows.
 	// When set, the arena and hash table are pre-allocated to avoid repeated growth.
 	BuildRowHint int64
@@ -731,6 +750,8 @@ func (h *HashJoin) Build(ctx context.Context, source Source) error {
 		}
 
 		h.mu.Lock()
+		arrival := b
+		b = h.projectForStore(b)
 		if h.buildSchema == nil {
 			h.buildSchema = b.Schema
 			// Pre-resolve build key column indices. Use fallback to handle
@@ -863,7 +884,10 @@ func (h *HashJoin) Build(ctx context.Context, source Source) error {
 		// Skip Compact() — iterate through Sel (if any) directly.
 		// Avoids copying entire batch just to remove selection vector gaps.
 		// Arena refs store original row indices, which are valid for direct access.
-		b.Detach() // prevent pooled batches from being recycled — build stores references
+		// Detach the ARRIVAL batch: b may be a projectForStore view sharing its
+		// vectors, and a pooled arrival recycled under the view would corrupt
+		// the stored build data. When projection is off, arrival == b.
+		arrival.Detach() // prevent pooled batches from being recycled — build stores references
 		batchIdx := int32(len(h.buildBatches))
 		h.buildBatches = append(h.buildBatches, b)
 
@@ -1480,6 +1504,47 @@ func bloomHashBytes(key []byte) uint64 {
 		h *= 16777619
 	}
 	return h ^ (h >> 32)
+}
+
+// projectForStore narrows an arrival build batch to BuildStoreCols before it
+// is stored, partitioned, or spilled. The returned batch is a view sharing
+// b's vectors (Sel and Len preserved), so buildRef row indices stay valid;
+// callers that retain the view must Detach the original arrival batch (a
+// pooled original could otherwise be recycled under the view). Resolution
+// happens once, against the first batch, via the same columnIndexFallback
+// the key index uses; an unresolvable name disables projection so behavior
+// degrades to full-width storage. Caller must hold h.mu.
+func (h *HashJoin) projectForStore(b *batch.RecordBatch) *batch.RecordBatch {
+	if len(h.BuildStoreCols) == 0 || h.buildStoreDisabled {
+		return b
+	}
+	if !h.buildStoreChecked {
+		h.buildStoreChecked = true
+		keep := make(map[int]bool, len(h.BuildStoreCols))
+		for _, name := range h.BuildStoreCols {
+			idx := columnIndexFallback(b, name)
+			if idx < 0 {
+				h.buildStoreDisabled = true
+				return b
+			}
+			keep[idx] = true
+		}
+		if len(keep) == len(b.Columns) {
+			h.buildStoreDisabled = true // nothing to drop
+			return b
+		}
+		for i := range b.Schema {
+			if keep[i] {
+				h.buildStoreIdx = append(h.buildStoreIdx, i)
+				h.buildStoreSchema = append(h.buildStoreSchema, b.Schema[i])
+			}
+		}
+	}
+	cols := make([]*batch.Vector, len(h.buildStoreIdx))
+	for j, i := range h.buildStoreIdx {
+		cols[j] = b.Columns[i]
+	}
+	return &batch.RecordBatch{Columns: cols, Schema: h.buildStoreSchema, Len: b.Len, Sel: b.Sel}
 }
 
 // PruneBuildColumns removes non-essential columns from the build-side batches.

--- a/internal/engine/exec/join_partition_arrival.go
+++ b/internal/engine/exec/join_partition_arrival.go
@@ -70,6 +70,14 @@ func (h *HashJoin) buildPartitioned(ctx context.Context, source Source) error {
 
 		h.mu.Lock()
 
+		// Narrow filtered semi/anti builds to keys + filter columns before any
+		// storage decision: the partition scatter, per-partition accumulators,
+		// spill files, and the tracker Reserve below all see only the retained
+		// columns. The view shares the arrival batch's vectors; every path
+		// below copies rows out (appendRows / compactBatchForRows), so the
+		// arrival batch is never retained and needs no Detach here.
+		b = h.projectForStore(b)
+
 		if h.buildSchema == nil {
 			h.buildSchema = b.Schema
 			h.buildKeyIdx = make([]int, len(h.RightKeys))

--- a/internal/engine/exec/join_store_projection_test.go
+++ b/internal/engine/exec/join_store_projection_test.go
@@ -1,0 +1,231 @@
+package exec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/engine/memory"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// storeProjBuildSchema is the wide build schema for the projection tests:
+// only id (join key) and threshold (filter column) are needed at probe time;
+// pad1/pad2 exist to be dropped by BuildStoreCols.
+var storeProjBuildSchema = []parquet.Column{
+	{Name: "id", Type: parquet.TypeInt64},
+	{Name: "pad1", Type: parquet.TypeString},
+	{Name: "threshold", Type: parquet.TypeFloat64},
+	{Name: "pad2", Type: parquet.TypeString},
+}
+
+func storeProjBuildRows(n int) []map[string]any {
+	rows := make([]map[string]any, n)
+	for i := range rows {
+		rows[i] = map[string]any{
+			"id":        int64(i),
+			"pad1":      "wide-column-that-projection-should-drop-aaaaaaaa",
+			"threshold": float64(i % 100),
+			"pad2":      "wide-column-that-projection-should-drop-bbbbbbbb",
+		}
+	}
+	return rows
+}
+
+var storeProjProbeSchema = []parquet.Column{
+	{Name: "id", Type: parquet.TypeInt64},
+	{Name: "val", Type: parquet.TypeFloat64},
+}
+
+func storeProjProbeRows(n int) []map[string]any {
+	rows := make([]map[string]any, n)
+	for i := range rows {
+		rows[i] = map[string]any{"id": int64(i), "val": 50.0}
+	}
+	return rows
+}
+
+// storeProjFilter mirrors physical.BuildSemiAntiFilter's contract: columns
+// are resolved by NAME against whatever storage the build retained — this is
+// what makes name-preserving projection transparent to the probe.
+func storeProjFilter(probe *batch.RecordBatch, probeRow int, build *batch.RecordBatch, buildRow int) bool {
+	pi := probe.ColumnIndex("val")
+	bi := build.ColumnIndex("threshold")
+	if pi < 0 || bi < 0 {
+		return false
+	}
+	return probe.Columns[pi].Float64Data[probeRow] > build.Columns[bi].Float64Data[buildRow]
+}
+
+// runStoreProjProbe probes hj with probeN rows and returns the emitted ids.
+func runStoreProjProbe(t *testing.T, hj *HashJoin, probeN int) map[int64]bool {
+	t.Helper()
+	probe := hj.Probe()
+	sink := &CollectSink{}
+	pipe := &Pipeline{
+		Source: NewSliceSource(storeProjProbeSchema, storeProjProbeRows(probeN)),
+		Ops:    []UnaryOperator{probe},
+		Sink:   sink,
+	}
+	if err := pipe.Run(context.Background()); err != nil {
+		t.Fatalf("probe pipeline: %v", err)
+	}
+	ids := make(map[int64]bool, len(sink.Rows))
+	for _, row := range sink.Rows {
+		id, ok := row["id"].(int64)
+		if !ok {
+			t.Fatalf("expected int64 id, got %T", row["id"])
+		}
+		if ids[id] {
+			t.Fatalf("duplicate id %d in semi/anti output", id)
+		}
+		ids[id] = true
+	}
+	return ids
+}
+
+// TestBuildStoreCols_FilteredSemiPartitionedSpill: the arrival-time
+// projection must keep a partition-on-arrival build narrow (keys + filter
+// columns only) through eviction, spill files, and the spilled-partition
+// probe replay — while producing exactly the rows an unprojected filtered
+// semi join produces. This is the production Q21 shape: semi join with a
+// JoinFilter, build too large for the budget.
+func TestBuildStoreCols_FilteredSemiPartitionedSpill(t *testing.T) {
+	const buildN, probeN = 10000, 1000
+
+	tmpDir := t.TempDir()
+	tracker := memory.NewTracker("test", 400_000)
+	sm, err := memory.NewSpillManager(tmpDir, tracker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sm.Cleanup()
+
+	hj := NewHashJoin(SemiJoin, []string{"id"}, []string{"id"})
+	hj.Spill = sm
+	hj.MemTracker = tracker
+	hj.SemiAntiFilter = storeProjFilter
+	hj.BuildStoreCols = []string{"id", "threshold"}
+
+	if err := hj.Build(context.Background(), NewSliceSource(storeProjBuildSchema, storeProjBuildRows(buildN))); err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	if hj.spillState == nil {
+		t.Fatal("test setup: build did not take the partition-on-arrival path")
+	}
+	if len(hj.spillState.spilledParts) == 0 {
+		t.Fatal("test setup: no partition spilled — budget too generous to exercise the spilled replay")
+	}
+	if got, want := len(hj.buildSchema), 2; got != want {
+		t.Fatalf("buildSchema has %d columns, want %d (projection did not narrow the stored build)", got, want)
+	}
+
+	// Probe row i (val=50.0) matches iff build threshold (id%100) < 50.
+	ids := runStoreProjProbe(t, hj, probeN)
+	if len(ids) != probeN/2 {
+		t.Fatalf("semi join emitted %d rows, want %d", len(ids), probeN/2)
+	}
+	for id := range ids {
+		if id%100 >= 50 {
+			t.Fatalf("semi join emitted id %d whose filter (threshold=%d < 50) is false", id, id%100)
+		}
+	}
+}
+
+// TestBuildStoreCols_FilteredAntiPartitionedSpill: the anti variant of the
+// spill test — unmatched-or-filter-false probe rows must be emitted, and the
+// spilled-partition replay must evaluate the filter against the narrow
+// spilled build data (which is why the join keys ride along in
+// BuildStoreCols: the replay re-indexes spilled batches by key).
+func TestBuildStoreCols_FilteredAntiPartitionedSpill(t *testing.T) {
+	const buildN, probeN = 10000, 1000
+
+	tmpDir := t.TempDir()
+	tracker := memory.NewTracker("test", 400_000)
+	sm, err := memory.NewSpillManager(tmpDir, tracker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sm.Cleanup()
+
+	hj := NewHashJoin(AntiJoin, []string{"id"}, []string{"id"})
+	hj.Spill = sm
+	hj.MemTracker = tracker
+	hj.SemiAntiFilter = storeProjFilter
+	hj.BuildStoreCols = []string{"id", "threshold"}
+
+	if err := hj.Build(context.Background(), NewSliceSource(storeProjBuildSchema, storeProjBuildRows(buildN))); err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	if hj.spillState == nil || len(hj.spillState.spilledParts) == 0 {
+		t.Fatal("test setup: build did not spill")
+	}
+	if got, want := len(hj.buildSchema), 2; got != want {
+		t.Fatalf("buildSchema has %d columns, want %d", got, want)
+	}
+
+	ids := runStoreProjProbe(t, hj, probeN)
+	if len(ids) != probeN/2 {
+		t.Fatalf("anti join emitted %d rows, want %d", len(ids), probeN/2)
+	}
+	for id := range ids {
+		if id%100 < 50 {
+			t.Fatalf("anti join emitted id %d whose filter (threshold=%d < 50) is true — should have been suppressed", id, id%100)
+		}
+	}
+}
+
+// TestBuildStoreCols_FlatPathNarrowsStorage: the no-spill flat build path
+// (embedded queries, tests) stores projectForStore views over the arrival
+// batches; results and storage width must match the partitioned path.
+func TestBuildStoreCols_FlatPathNarrowsStorage(t *testing.T) {
+	const buildN, probeN = 5000, 1000
+
+	hj := NewHashJoin(SemiJoin, []string{"id"}, []string{"id"})
+	hj.SemiAntiFilter = storeProjFilter
+	hj.BuildStoreCols = []string{"id", "threshold"}
+
+	if err := hj.Build(context.Background(), NewSliceSource(storeProjBuildSchema, storeProjBuildRows(buildN))); err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	if hj.spillState != nil {
+		t.Fatal("test setup: expected the flat (no-spill) build path")
+	}
+	if got, want := len(hj.buildSchema), 2; got != want {
+		t.Fatalf("buildSchema has %d columns, want %d", got, want)
+	}
+	for i, bb := range hj.buildBatches {
+		if bb != nil && len(bb.Columns) != 2 {
+			t.Fatalf("buildBatches[%d] has %d columns, want 2", i, len(bb.Columns))
+		}
+	}
+
+	ids := runStoreProjProbe(t, hj, probeN)
+	if len(ids) != probeN/2 {
+		t.Fatalf("semi join emitted %d rows, want %d", len(ids), probeN/2)
+	}
+}
+
+// TestBuildStoreCols_UnresolvableNameDisablesProjection: a store column that
+// doesn't resolve against the first arrival batch must disable projection
+// entirely (full-width storage, pre-projection behavior) rather than break
+// the build or the filter.
+func TestBuildStoreCols_UnresolvableNameDisablesProjection(t *testing.T) {
+	const buildN, probeN = 5000, 1000
+
+	hj := NewHashJoin(SemiJoin, []string{"id"}, []string{"id"})
+	hj.SemiAntiFilter = storeProjFilter
+	hj.BuildStoreCols = []string{"id", "no_such_column"}
+
+	if err := hj.Build(context.Background(), NewSliceSource(storeProjBuildSchema, storeProjBuildRows(buildN))); err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	if got, want := len(hj.buildSchema), len(storeProjBuildSchema); got != want {
+		t.Fatalf("buildSchema has %d columns, want full width %d (projection should be disabled)", got, want)
+	}
+
+	ids := runStoreProjProbe(t, hj, probeN)
+	if len(ids) != probeN/2 {
+		t.Fatalf("semi join emitted %d rows, want %d", len(ids), probeN/2)
+	}
+}

--- a/internal/planner/logical/filtered_exists_dedup_test.go
+++ b/internal/planner/logical/filtered_exists_dedup_test.go
@@ -1,0 +1,102 @@
+package logical
+
+import (
+	"testing"
+
+	plansql "github.com/citc-tech/wadjet/internal/planner/sql"
+)
+
+// findFirstNode returns the first node (pre-order) matching pred.
+func findFirstNode(n *Node, pred func(*Node) bool) *Node {
+	if n == nil {
+		return nil
+	}
+	if pred(n) {
+		return n
+	}
+	for _, c := range n.Children {
+		if found := findFirstNode(c, pred); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// TestFilteredExistsDecorrelation_FlipsOpAndSkipsDedup covers two logical-
+// layer bugs on decorrelated EXISTS with a non-equality correlated condition
+// (fixed 2026-07-06):
+//
+//  1. extractCorrelatedCols normalizes the condition to probe-left form; when
+//     the OUTER column was written on the right ("o_totalprice > c_acctbal"),
+//     the operator must flip ("c_acctbal < o_totalprice") or the comparison
+//     inverts.
+//  2. dedupSemiAntiBuildSide must skip filtered semi/anti joins — its
+//     Project(keys)→Distinct wrapper drops the filter's build-side column
+//     (o_totalprice), making the probe-time filter reject every row.
+func TestFilteredExistsDecorrelation_FlipsOpAndSkipsDedup(t *testing.T) {
+	q := `SELECT c_name FROM customer
+		WHERE EXISTS (
+			SELECT 1 FROM orders
+			WHERE o_custkey = c_custkey AND o_totalprice > c_acctbal)`
+
+	parsed, err := plansql.Parse(q)
+	if err != nil {
+		t.Fatal("Parse error:", err)
+	}
+	info, err := plansql.ExtractSelect(parsed)
+	if err != nil {
+		t.Fatal("Extract error:", err)
+	}
+	plan, err := BuildFromSelect(info)
+	if err != nil {
+		t.Fatal("Build error:", err)
+	}
+	annotateScanColumnsForTest(plan)
+	optimized := Optimize(plan, annotateScanColumnsForTest)
+
+	semi := findFirstNode(optimized, func(n *Node) bool {
+		return n.Type == NodeJoin && n.JoinType == "semi"
+	})
+	if semi == nil {
+		t.Fatal("no semi join found — EXISTS decorrelation did not fire")
+	}
+	if semi.JoinFilter != "c_acctbal < o_totalprice" {
+		t.Fatalf("JoinFilter = %q, want %q (probe-left with flipped operator)",
+			semi.JoinFilter, "c_acctbal < o_totalprice")
+	}
+	// The dedup wrapper is Distinct at insertion and may be rewritten to a
+	// GroupBy aggregate by rewriteDistinctAsGroupBy — reject both.
+	if dist := findFirstNode(semi.Children[1], func(n *Node) bool {
+		return n.Type == NodeDistinct || n.Type == NodeAggregate
+	}); dist != nil {
+		t.Fatal("filtered semi join's build side was wrapped in a key-only dedup — it drops the JoinFilter's build column")
+	}
+	// The unfiltered shape must still dedup (the guard is filter-scoped).
+	q2 := `SELECT c_name FROM customer
+		WHERE EXISTS (SELECT 1 FROM orders WHERE o_custkey = c_custkey)`
+	parsed2, err := plansql.Parse(q2)
+	if err != nil {
+		t.Fatal("Parse error:", err)
+	}
+	info2, err := plansql.ExtractSelect(parsed2)
+	if err != nil {
+		t.Fatal("Extract error:", err)
+	}
+	plan2, err := BuildFromSelect(info2)
+	if err != nil {
+		t.Fatal("Build error:", err)
+	}
+	annotateScanColumnsForTest(plan2)
+	optimized2 := Optimize(plan2, annotateScanColumnsForTest)
+	semi2 := findFirstNode(optimized2, func(n *Node) bool {
+		return n.Type == NodeJoin && n.JoinType == "semi"
+	})
+	if semi2 == nil {
+		t.Fatal("no semi join found for unfiltered EXISTS")
+	}
+	if dist := findFirstNode(semi2.Children[1], func(n *Node) bool {
+		return n.Type == NodeDistinct || n.Type == NodeAggregate
+	}); dist == nil {
+		t.Fatal("unfiltered semi join build side lost its key dedup — the JoinFilter guard is over-broad")
+	}
+}

--- a/internal/planner/logical/optimizer.go
+++ b/internal/planner/logical/optimizer.go
@@ -2127,7 +2127,17 @@ func tryDecorrelateExists(exists *plansql.ExistsNode, outerTables map[string]boo
 			if cmp.Op == "=" {
 				eqKeys = append(eqKeys, outerCol+" = "+innerCol)
 			} else {
-				filterConds = append(filterConds, outerCol+" "+cmp.Op+" "+innerCol)
+				// JoinFilter convention is "probe(outer) OP build(inner)".
+				// extractCorrelatedCols returns (outer, inner) regardless of
+				// which side of the comparison each was written on, so when
+				// the OUTER column was on the RIGHT (e.g. "i.date > o.date"),
+				// the operator must flip ("o.date < i.date") to preserve the
+				// comparison's meaning.
+				op := cmp.Op
+				if _, leftIsOuter := getColRefInfo(cmp.Left, outerTables, innerTables, outerColMap); !leftIsOuter {
+					op = flipCmpOp(op)
+				}
+				filterConds = append(filterConds, outerCol+" "+op+" "+innerCol)
 			}
 		} else if hasInner {
 			innerFilterNodes = append(innerFilterNodes, node)
@@ -2328,6 +2338,23 @@ func nodeTableRefs(node plansql.Node, outerTables, innerTables map[string]bool, 
 // extractCorrelatedCols extracts the outer and inner column names from a
 // comparison expression between outer and inner tables.
 // Returns the unqualified column names (outer, inner) and ok=true if extraction succeeded.
+// flipCmpOp mirrors a comparison operator for operand-order reversal:
+// a OP b ⇔ b flip(OP) a. Equality and inequality are symmetric.
+func flipCmpOp(op string) string {
+	switch op {
+	case ">":
+		return "<"
+	case "<":
+		return ">"
+	case ">=":
+		return "<="
+	case "<=":
+		return ">="
+	default: // =, !=, <> are symmetric
+		return op
+	}
+}
+
 func extractCorrelatedCols(cmp *plansql.CmpExpr, outerTables, innerTables map[string]bool, outerColMap map[string]string) (outerCol, innerCol string, ok bool) {
 	leftCol, leftIsOuter := getColRefInfo(cmp.Left, outerTables, innerTables, outerColMap)
 	rightCol, rightIsOuter := getColRefInfo(cmp.Right, outerTables, innerTables, outerColMap)

--- a/internal/planner/logical/semi_anti_dedup.go
+++ b/internal/planner/logical/semi_anti_dedup.go
@@ -39,6 +39,16 @@ func dedupSemiAntiBuildSide(n *Node) *Node {
 	default:
 		return n
 	}
+	// A filtered semi/anti join (non-equality correlated condition from
+	// decorrelated EXISTS) evaluates JoinFilter against build-side columns
+	// at probe time. Project(keys)→Distinct would drop those columns (the
+	// filter then resolves to nothing and rejects every row) and dedup on
+	// keys alone discards the duplicate rows the filter must see. Skip;
+	// the exec layer narrows filtered builds to keys + filter columns via
+	// HashJoin.BuildStoreCols instead.
+	if n.JoinFilter != "" {
+		return n
+	}
 	if len(n.Children) < 2 {
 		return n
 	}

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -3898,7 +3898,11 @@ func (p *Planner) buildJoin(ctx context.Context, node *logical.Node) (exec.Sourc
 	// 16GB lineitem hash table to 1.7GB orders hash table per worker.
 	rightEst := findScanRowEstimate(node.Children[1])
 	leftEst := findScanRowEstimate(node.Children[0])
-	if (joinType == exec.SemiJoin || joinType == exec.AntiJoin) &&
+	// A filtered semi/anti join must NOT swap: the RightSemi/RightAnti probe
+	// (markMatchedBuildEntries) marks every key-chain entry matched and never
+	// evaluates SemiAntiFilter, so the non-equality condition would silently
+	// vanish from the query — wrong results, not a performance trade.
+	if (joinType == exec.SemiJoin || joinType == exec.AntiJoin) && node.JoinFilter == "" &&
 		rightEst > 0 && leftEst > 0 && rightEst > 3*leftEst {
 		// Swap: build the small outer table, probe with the large inner table
 		if joinType == exec.SemiJoin {
@@ -3926,16 +3930,30 @@ func (p *Planner) buildJoin(ctx context.Context, node *logical.Node) (exec.Sourc
 		hj.SemiAntiKeyOnly = true
 	}
 
+	// Filtered semi/anti builds must store rows for probe-time SemiAntiFilter
+	// evaluation, but only the join keys + filter-referenced columns — narrow
+	// the stored batches at arrival (see HashJoin.BuildStoreCols; the post-
+	// build PruneBuildColumns below is a no-op for partition-on-arrival
+	// builds, i.e. for every spill-eligible build).
+	if (joinType == exec.SemiJoin || joinType == exec.AntiJoin) && node.JoinFilter != "" {
+		hj.BuildStoreCols = SemiAntiBuildStoreCols(hj.RightKeys, node.JoinFilter)
+	}
+
 	// Pass build-side row estimate to pre-allocate arena and hash table.
 	est := findScanRowEstimate(node.Children[1])
 	if est > 0 {
 		hj.BuildRowHint = est
 	}
 
-	// Determine if build should be deferred: large semi/anti key-only builds
-	// overlap with the early probe pipeline for better I/O utilization.
+	// Determine if build should be deferred: large semi/anti builds overlap
+	// with the early probe pipeline for better I/O utilization. Applies to
+	// key-only builds and to filtered builds (whose arrival-time projection
+	// keeps the deferred build's storage narrow); the deferred path's post-
+	// build FixKeyAssignment is safe for partitioned builds via the nil'd-
+	// entry guard, and PruneBuildColumns self-skips them.
 	const deferBuildThreshold int64 = 1_000_000
-	deferBuild := est > deferBuildThreshold && hj.SemiAntiKeyOnly
+	deferBuild := est > deferBuildThreshold &&
+		(hj.SemiAntiKeyOnly || len(hj.BuildStoreCols) > 0)
 
 	// Reverse bloom: for very large builds (>10M rows), run the probe side
 	// first, build a bloom from its join key values, then filter the build
@@ -7373,6 +7391,35 @@ func cleanExpr(s string) string {
 		return parts[1]
 	}
 	return s
+}
+
+// SemiAntiBuildStoreCols returns the build-side columns a filtered semi/anti
+// join must retain in stored build batches: the join keys (required to
+// re-index spilled partitions and to survive FixKeyAssignment's rebuild)
+// plus the JoinFilter's build-side columns. Returns nil when the filter is
+// empty — unfiltered semi/anti builds are key-only and store nothing. Shared
+// by the single-process planner and the worker fragment executor so both
+// paths narrow their builds identically.
+func SemiAntiBuildStoreCols(rightKeys []string, joinFilter string) []string {
+	if joinFilter == "" {
+		return nil
+	}
+	filterCols := extractFilterBuildColumns(joinFilter)
+	cols := make([]string, 0, len(rightKeys)+len(filterCols))
+	seen := make(map[string]bool, len(rightKeys)+len(filterCols))
+	for _, c := range rightKeys {
+		if !seen[c] {
+			seen[c] = true
+			cols = append(cols, c)
+		}
+	}
+	for _, c := range filterCols {
+		if !seen[c] {
+			seen[c] = true
+			cols = append(cols, c)
+		}
+	}
+	return cols
 }
 
 // extractFilterBuildColumns extracts the build-side column names from a

--- a/internal/planner/physical/semi_anti_store_cols_test.go
+++ b/internal/planner/physical/semi_anti_store_cols_test.go
@@ -1,0 +1,68 @@
+package physical
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestSemiAntiBuildStoreCols(t *testing.T) {
+	tests := []struct {
+		name      string
+		rightKeys []string
+		filter    string
+		want      []string // nil = expect nil; keys prefix is order-stable, filter cols sorted for comparison
+	}{
+		{
+			name:      "empty filter is key-only, stores nothing",
+			rightKeys: []string{"l_orderkey"},
+			filter:    "",
+			want:      nil,
+		},
+		{
+			name:      "q21 shape: key plus one filter column",
+			rightKeys: []string{"l_orderkey"},
+			filter:    "l_suppkey <> l_suppkey",
+			want:      []string{"l_orderkey", "l_suppkey"},
+		},
+		{
+			name:      "filter column equal to the key dedups",
+			rightKeys: []string{"id"},
+			filter:    "id != id",
+			want:      []string{"id"},
+		},
+		{
+			name:      "multi-condition filter",
+			rightKeys: []string{"k"},
+			filter:    "a > a AND b <= b",
+			want:      []string{"k", "a", "b"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SemiAntiBuildStoreCols(tt.rightKeys, tt.filter)
+			if tt.want == nil {
+				if got != nil {
+					t.Fatalf("got %v, want nil", got)
+				}
+				return
+			}
+			// Keys come first in input order; filter columns (map-ordered)
+			// follow — compare the tail as a set.
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			nk := len(tt.rightKeys)
+			if tt.want[0] == tt.rightKeys[0] && !reflect.DeepEqual(got[:min(nk, len(got))], tt.rightKeys[:min(nk, len(got))]) {
+				// only check key prefix when keys survive dedup as a prefix
+				t.Fatalf("key prefix of %v != %v", got, tt.rightKeys)
+			}
+			gs, ws := append([]string{}, got...), append([]string{}, tt.want...)
+			sort.Strings(gs)
+			sort.Strings(ws)
+			if !reflect.DeepEqual(gs, ws) {
+				t.Fatalf("got %v, want (as set) %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/worker/executor_fragment.go
+++ b/internal/worker/executor_fragment.go
@@ -1624,6 +1624,12 @@ func (e *Executor) buildFragmentJoinProbe(ctx context.Context, task distributed.
 		hj.SemiAntiKeyOnly = spec.SemiAntiKeyOnly
 		if spec.JoinFilter != "" {
 			hj.SemiAntiFilter = physical.BuildSemiAntiFilter(spec.JoinFilter)
+			// Filtered semi/anti builds store only keys + filter columns —
+			// the worker has no post-build prune at all, so without this a
+			// broadcast lineitem build retains every scanned column.
+			if hj.JoinType == exec.SemiJoin || hj.JoinType == exec.AntiJoin {
+				hj.BuildStoreCols = physical.SemiAntiBuildStoreCols(spec.RightKeys, spec.JoinFilter)
+			}
 		}
 		if e.sharedSpill != nil {
 			// Wiring a Spill manager + tracker makes Build partition on arrival

--- a/wadjet/filtered_exists_swap_test.go
+++ b/wadjet/filtered_exists_swap_test.go
@@ -1,0 +1,104 @@
+package wadjet
+
+import (
+	"context"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/storage/ingest"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// TestFilteredExistsLargeInnerKeepsFilter: a decorrelated EXISTS with a
+// non-equality correlated condition becomes a semi join with a JoinFilter.
+// This shape stacked THREE independent wrong-results bugs (all fixed
+// 2026-07-06), each with a distinct failure signature on this data:
+//
+//   - count 0: dedupSemiAntiBuildSide wrapped the filtered build side in
+//     Project(keys)→Distinct, dropping the filter's build column — the
+//     probe-time SemiAntiFilter resolved nothing and rejected every row.
+//   - count 19: extractCorrelatedCols normalized "i.i_date > o.o_date" to
+//     probe-left form without flipping the operator ("o_date > i_date").
+//   - count 20: with the inner table >3x the outer, the physical planner
+//     swapped to RightSemiJoin, whose probe (markMatchedBuildEntries) marks
+//     every key match and never evaluates SemiAntiFilter — the condition
+//     silently vanished.
+//
+// Data: 20 orders (o_id=i, o_date=i), 100 items (5 per order, i_date in
+// 0..4). EXISTS(i_date > o_date) holds only for orders with o_date < 4 →
+// 4 rows; NOT EXISTS → 16.
+func TestFilteredExistsLargeInnerKeepsFilter(t *testing.T) {
+	ctx := context.Background()
+	db, err := Open(ctx, Config{Store: objstore.NewMemStore(), Bucket: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ordersSchema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "o_id", Type: parquet.TypeInt64},
+		{Name: "o_date", Type: parquet.TypeInt64},
+	}}
+	if err := db.CreateTable(ctx, "orders", ordersSchema, nil); err != nil {
+		t.Fatal(err)
+	}
+	orderRows := make([]map[string]any, 20)
+	for i := range orderRows {
+		orderRows[i] = map[string]any{"o_id": int64(i), "o_date": int64(i)}
+	}
+	ing := db.NewIngester("orders", ordersSchema, nil, ingest.Config{MaxBufferRows: 10000})
+	if err := ing.Ingest(ctx, orderRows); err != nil {
+		t.Fatal(err)
+	}
+	if err := ing.FlushAll(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	itemsSchema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "i_oid", Type: parquet.TypeInt64},
+		{Name: "i_date", Type: parquet.TypeInt64},
+	}}
+	if err := db.CreateTable(ctx, "items", itemsSchema, nil); err != nil {
+		t.Fatal(err)
+	}
+	itemRows := make([]map[string]any, 100)
+	for k := range itemRows {
+		itemRows[k] = map[string]any{"i_oid": int64(k % 20), "i_date": int64(k / 20)}
+	}
+	ing = db.NewIngester("items", itemsSchema, nil, ingest.Config{MaxBufferRows: 10000})
+	if err := ing.Ingest(ctx, itemRows); err != nil {
+		t.Fatal(err)
+	}
+	if err := ing.FlushAll(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := db.Query(ctx, `SELECT COUNT(*) AS n FROM orders o
+		WHERE EXISTS (SELECT 1 FROM items i WHERE i.i_oid = o.o_id AND i.i_date > o.o_date)`)
+	if err != nil {
+		t.Fatalf("filtered EXISTS query: %v", err)
+	}
+	if n := res.Rows[0]["n"]; n != int64(4) {
+		t.Fatalf("filtered EXISTS count = %v, want 4 (0 = dedup dropped the filter column; 19 = operator not flipped; 20 = swap dropped the JoinFilter)", n)
+	}
+
+	// NOT EXISTS over the same shape — the anti-join complement must also
+	// keep the filter through the swap decision.
+	res, err = db.Query(ctx, `SELECT COUNT(*) AS n FROM orders o
+		WHERE NOT EXISTS (SELECT 1 FROM items i WHERE i.i_oid = o.o_id AND i.i_date > o.o_date)`)
+	if err != nil {
+		t.Fatalf("filtered NOT EXISTS query: %v", err)
+	}
+	if n := res.Rows[0]["n"]; n != int64(16) {
+		t.Fatalf("filtered NOT EXISTS count = %v, want 16 (20 = dedup dropped the filter column; 1 = operator not flipped; 0 = swap dropped the JoinFilter)", n)
+	}
+
+	// Outer-column-on-the-left spelling — the no-flip path — must agree.
+	res, err = db.Query(ctx, `SELECT COUNT(*) AS n FROM orders o
+		WHERE EXISTS (SELECT 1 FROM items i WHERE i.i_oid = o.o_id AND o.o_date < i.i_date)`)
+	if err != nil {
+		t.Fatalf("filtered EXISTS (outer-left) query: %v", err)
+	}
+	if n := res.Rows[0]["n"]; n != int64(4) {
+		t.Fatalf("filtered EXISTS (outer-left) count = %v, want 4", n)
+	}
+}


### PR DESCRIPTION
## Summary

Lever 1 from the Q21/join-heavy ranking (approved 2026-07-06): filtered semi/anti joins now store only the join keys + JoinFilter-referenced build columns, from the first arrival batch. Grounding for it also surfaced **three stacked wrong-results bugs** in the decorrelated-filtered-EXISTS class, fixed here first.

### Commit 1 — fix(planner): keep JoinFilter alive through decorrelated filtered EXISTS

One query shape, three independent silent-wrong-results bugs (regression test distinguishes all three by count):

1. **`dedupSemiAntiBuildSide`** wrapped filtered build sides in `Project(keys)→Distinct`, dropping the filter's build column — SemiAntiFilter resolved nothing and rejected every row (EXISTS returned 0).
2. **`extractCorrelatedCols`** normalized `inner OP outer` to probe-left form without flipping the operator — inverted comparisons.
3. **Build/probe swap** to RightSemi/RightAnti wasn't gated on JoinFilter — `markMatchedBuildEntries` never evaluates SemiAntiFilter, so the condition vanished.

TPC-H Q21 dodges all three by accident (self-join name ambiguity, outer-left spelling, large probe side), which is why the suite never caught them.

### Commit 2 — perf(exec): arrival-time build-column projection

`PruneBuildColumns` is a no-op for partition-on-arrival builds (every spill-eligible build), and the worker path never pruned — so filtered semi/anti builds retained every scanned column for the query's life. SF10 Q21 = two ~60M-row lineitem builds at full width; that footprint is what drives eviction + grace churn.

- New `HashJoin.BuildStoreCols`: planner/worker provide keys + filter columns (`SemiAntiBuildStoreCols`); `projectForStore` narrows every arrival batch before partitioning/accumulation/spill/tracker accounting. Spilled-partition replay re-indexes by the retained keys. Unresolvable names degrade to full-width storage.
- **deferBuild unlocked** for filtered semi/anti (was key-only): storage is now narrow; FixKeyAssignment covered by the PR #188 guard.

### Gates

- Unit suites (`./internal/...`, `./wadjet`) green; new coverage: partitioned+spill semi and anti with projection, flat path, fallback, planner helper, logical dedup/flip, end-to-end EXISTS integration
- TPC-H SF0.01: 22/22
- tpch-harness `--mode=local`: PASS (25 queries, 2 workers)
- SF1 same-window: 63.6s vs main 64.2s, 22/22 — parity as expected; the target is build-side memory at SF10+

🤖 Generated with [Claude Code](https://claude.com/claude-code)