### PR TITLE
fix(auth): enforce ABAC on MCP queries; remove unauthenticated HTTP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,10 +219,23 @@ wadjet serve --mode=worker         # Stateless task executor, scale horizontally
 
 Wadjet includes a native [Model Context Protocol](https://modelcontextprotocol.io/) server, enabling AI agents to discover tables, inspect schemas, and execute SQL queries.
 
+The MCP server communicates over **stdio only** — there is no network listener.
+
 ```bash
-# Start MCP server on stdio (for Claude Desktop, Claude Code, Cursor)
-wadjet mcp --endpoint localhost:9000
+# Local/dev: unauthenticated, direct-to-store (no ABAC enforced)
+wadjet mcp
+
+# Secured: enforce row/column ABAC under an authenticated identity
+wadjet mcp --config /etc/wadjet/config.yaml --api-key "$WADJET_MCP_API_KEY"
 ```
+
+**Security:** when `--config` supplies an auth block, MCP enforces the same
+ABAC row filters, column masks, and table-access rules as the pgwire and gRPC
+paths, under the identity resolved from `--api-key` (or `WADJET_MCP_API_KEY`).
+If auth is configured but no valid credential is supplied, the server refuses
+to start (fail closed). Without a config, MCP runs unauthenticated against a
+direct-to-store DB — appropriate only where the operator already holds the
+store credentials.
 
 Configure in Claude Desktop (`claude_desktop_config.json`):
 
@@ -231,7 +244,7 @@ Configure in Claude Desktop (`claude_desktop_config.json`):
   "mcpServers": {
     "wadjet": {
       "command": "wadjet",
-      "args": ["mcp", "--endpoint", "localhost:9000"]
+      "args": ["mcp", "--config", "/etc/wadjet/config.yaml", "--api-key", "..."]
     }
   }
 }

--- a/cmd/wadjet/main.go
+++ b/cmd/wadjet/main.go
@@ -1749,6 +1749,27 @@ func buildPolicyConfigs(cfgs []config.AuthPolicy) []auth.PolicyConfig {
 	return policyCfgs
 }
 
+// buildProviderFromConfig constructs an auth.Provider from a loaded config,
+// mirroring the coordinator/standalone wiring but WITHOUT the hot-reload
+// watcher (callers that need a one-shot provider, e.g. the mcp command). Auth
+// disabled in config yields an enabled==false provider, which enforcement
+// treats as a no-op. logger may be nil.
+func buildProviderFromConfig(cfg *config.Config, logger *slog.Logger) *auth.Provider {
+	authn, authz := buildAuth(cfg.Auth)
+	var policies *auth.PolicySet
+	if len(cfg.Auth.Policies) > 0 {
+		policies = buildPolicies(cfg.Auth.Policies)
+	}
+	provider := auth.NewProvider(authn, authz, policies, logger)
+	if len(cfg.Auth.ABACPolicies) > 0 {
+		abac := buildABACPolicies(cfg.Auth.ABACPolicies)
+		provider.UpdateFromConfig(buildAuthConfig(cfg.Auth), buildPolicyConfigs(cfg.Auth.Policies), abac...)
+	} else if len(cfg.Auth.Roles) > 0 {
+		provider.UpdateFromConfig(buildAuthConfig(cfg.Auth), buildPolicyConfigs(cfg.Auth.Policies))
+	}
+	return provider
+}
+
 func buildAuth(cfg config.Auth) (*auth.Authenticator, *auth.Authorizer) {
 	authCfg := auth.Config{
 		Enabled: cfg.Enabled,
@@ -2029,13 +2050,48 @@ func applyNATSTLS(cfg *distributed.NATSConfig, logger *slog.Logger) {
 	}
 }
 
+// resolveMCPAuth decides the MCP session identity and enforces fail-closed
+// behavior. When the provider is nil or auth is not enabled, it returns
+// (nil, nil) — the caller runs unauthenticated (dev/embedded, no policy to
+// enforce). When auth IS enabled, a valid credential is mandatory: an empty
+// or unauthenticated token is a hard error, never a silent unauthenticated
+// session. This is the guard that prevents MCP from bypassing ABAC.
+func resolveMCPAuth(provider *auth.Provider, token string) (*auth.Identity, error) {
+	if provider == nil || !provider.Enabled() {
+		return nil, nil
+	}
+	if token == "" {
+		return nil, fmt.Errorf("auth is enabled but no MCP credential provided: " +
+			"pass --api-key or set WADJET_MCP_API_KEY (refusing to serve unauthenticated)")
+	}
+	id, err := provider.Authenticator().AuthenticateToken(token)
+	if err != nil {
+		return nil, fmt.Errorf("authenticating MCP credential: %w (refusing to serve)", err)
+	}
+	return id, nil
+}
+
 func mcpCmd() *cobra.Command {
-	return &cobra.Command{
+	var mcpAPIKey string
+	cmd := &cobra.Command{
 		Use:   "mcp",
 		Short: "Start MCP (Model Context Protocol) server on stdio for AI agent integration",
 		Long: `Start a Model Context Protocol server that communicates over stdin/stdout.
 This allows AI agents (Claude Desktop, Claude Code, Cursor, etc.) to discover
 tables, inspect schemas, and execute SQL queries against Wadjet.
+
+Transport is stdio only — there is deliberately no network listener.
+
+Security: pass --config with an auth block to enforce ABAC (row filters,
+column masks, table access) on MCP queries. When auth is configured you must
+also supply a credential via --api-key (or the WADJET_MCP_API_KEY env var);
+the resolved identity governs every query for the session. If auth is
+configured but no valid credential is supplied, the server refuses to start
+(fail closed) rather than serving unfiltered data.
+
+Without --config (or with auth disabled), MCP runs unauthenticated against a
+direct-to-store DB — appropriate only for local/dev use, where the operator
+already holds the store credentials.
 
 Configure in Claude Desktop's claude_desktop_config.json:
 
@@ -2043,7 +2099,7 @@ Configure in Claude Desktop's claude_desktop_config.json:
     "mcpServers": {
       "wadjet": {
         "command": "wadjet",
-        "args": ["mcp", "--endpoint", "localhost:9000"]
+        "args": ["mcp", "--config", "/etc/wadjet/config.yaml", "--api-key", "..."]
       }
     }
   }`,
@@ -2053,24 +2109,56 @@ Configure in Claude Desktop's claude_desktop_config.json:
 
 			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
+			// Resolve the auth provider and the operator's identity BEFORE
+			// opening the DB, so a misconfigured secure deployment fails closed
+			// without ever exposing a query surface.
+			var provider *auth.Provider
+			var identity *auth.Identity
+			if configFile != "" {
+				cfg, loadErr := config.Load(configFile)
+				if loadErr != nil {
+					return fmt.Errorf("loading config %q: %w", configFile, loadErr)
+				}
+				provider = buildProviderFromConfig(cfg, logger)
+			}
+
+			token := mcpAPIKey
+			if token == "" {
+				token = os.Getenv("WADJET_MCP_API_KEY")
+			}
+			identity, err := resolveMCPAuth(provider, token)
+			if err != nil {
+				return err
+			}
+			if identity != nil {
+				logger.Info("MCP auth enabled", "identity", identity.Name, "role", identity.Role, "method", identity.Method)
+			} else {
+				logger.Warn("MCP server running WITHOUT authentication — ABAC row/column security is not enforced; " +
+					"use --config with an auth block for secured deployments")
+			}
+
 			store, err := newStore()
 			if err != nil {
 				return fmt.Errorf("initializing storage: %w", err)
 			}
 
 			db, err := wadjet.Open(ctx, wadjet.Config{
-				Store:  store,
-				Bucket: bucket,
-				Logger: logger,
+				Store:        store,
+				Bucket:       bucket,
+				Logger:       logger,
+				AuthProvider: provider,
 			})
 			if err != nil {
 				return fmt.Errorf("opening database: %w", err)
 			}
 
-			srv := mcp.NewServer(db, logger)
+			srv := mcp.NewServerWithIdentity(db, logger, identity)
 			return srv.ServeStdio(ctx, os.Stdin, os.Stdout)
 		},
 	}
+	cmd.Flags().StringVar(&mcpAPIKey, "api-key", "",
+		"API key/bearer token establishing the MCP session identity (or set WADJET_MCP_API_KEY). Required when auth is configured.")
+	return cmd
 }
 
 // parseS3URL splits "s3://bucket/path/..." into (bucket, path).

--- a/cmd/wadjet/mcp_auth_test.go
+++ b/cmd/wadjet/mcp_auth_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/auth"
+)
+
+// TestResolveMCPAuth is the fail-closed guard for the MCP entrypoint: when an
+// auth provider is configured, an MCP session must present a valid credential
+// or the server refuses to start. This is the fix for MCP bypassing ABAC —
+// before it, MCP opened an unauthenticated DB regardless of config.
+func TestResolveMCPAuth(t *testing.T) {
+	// A provider with an API key configured → Enabled() true.
+	authn, authz := auth.New(auth.Config{
+		Enabled: true,
+		APIKeys: []auth.APIKeyDef{{Key: "good-key", Name: "analyst", Role: "analyst"}},
+		Roles:   []auth.RoleConfig{{Name: "analyst", Tables: []string{"*"}, Allow: []string{"read"}}},
+	})
+	secured := auth.NewProvider(authn, authz, nil, nil)
+	if !secured.Enabled() {
+		t.Fatal("test setup: provider with an API key should report Enabled()")
+	}
+
+	// A provider with no credential mechanism → Enabled() false.
+	openAuthn, openAuthz := auth.New(auth.Config{Enabled: false})
+	openProvider := auth.NewProvider(openAuthn, openAuthz, nil, nil)
+	if openProvider.Enabled() {
+		t.Fatal("test setup: provider with no mechanism should report !Enabled()")
+	}
+
+	t.Run("secured_missing_token_fails_closed", func(t *testing.T) {
+		id, err := resolveMCPAuth(secured, "")
+		if err == nil {
+			t.Fatal("expected error when auth enabled and no token supplied")
+		}
+		if id != nil {
+			t.Fatalf("expected nil identity on failure, got %v", id)
+		}
+	})
+
+	t.Run("secured_bad_token_fails_closed", func(t *testing.T) {
+		id, err := resolveMCPAuth(secured, "wrong-key")
+		if err == nil {
+			t.Fatal("expected error for an invalid credential")
+		}
+		if id != nil {
+			t.Fatalf("expected nil identity on failure, got %v", id)
+		}
+	})
+
+	t.Run("secured_good_token_yields_identity", func(t *testing.T) {
+		id, err := resolveMCPAuth(secured, "good-key")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if id == nil || id.Role != "analyst" {
+			t.Fatalf("expected analyst identity, got %v", id)
+		}
+	})
+
+	t.Run("no_provider_runs_unauthenticated", func(t *testing.T) {
+		id, err := resolveMCPAuth(nil, "")
+		if err != nil || id != nil {
+			t.Fatalf("nil provider should yield (nil, nil), got (%v, %v)", id, err)
+		}
+	})
+
+	t.Run("auth_disabled_runs_unauthenticated", func(t *testing.T) {
+		// No mechanism configured: nothing to enforce, no token required.
+		id, err := resolveMCPAuth(openProvider, "")
+		if err != nil || id != nil {
+			t.Fatalf("disabled-auth provider should yield (nil, nil), got (%v, %v)", id, err)
+		}
+	})
+}

--- a/internal/server/mcp/server.go
+++ b/internal/server/mcp/server.go
@@ -2,9 +2,21 @@
 // This allows AI agents (Claude, Cursor, etc.) to discover tables, inspect schemas,
 // and execute SQL queries against a Wadjet instance.
 //
-// Supports two transports:
-//   - stdio: JSON-RPC over stdin/stdout (for CLI integration with Claude Desktop/Code)
-//   - HTTP+SSE: Server-Sent Events for server-to-client, HTTP POST for client-to-server
+// Transport: JSON-RPC 2.0 over stdio (stdin/stdout), for CLI integration with
+// Claude Desktop/Code. There is deliberately no network transport — an
+// HTTP+SSE server was removed because it accepted SQL with no authentication
+// and no ABAC identity, which bypassed row/column security. If a network MCP
+// endpoint is ever reintroduced it must authenticate every request and stamp
+// an identity onto the context (see identity handling below) before reaching
+// db.Query.
+//
+// Security model: when the backing DB is opened with an AuthProvider, the MCP
+// server is constructed with the identity that authenticated the operator
+// launching it (see NewServerWithIdentity). That identity is stamped onto
+// every request context so db.Query → EnforcePlanPolicies applies table/row/
+// column policies. Without a provider (dev/embedded, no policy to enforce)
+// the server runs unauthenticated over a direct-to-store DB — the same access
+// the operator already holds via the store credentials.
 package mcp
 
 import (
@@ -14,12 +26,11 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"net"
-	"net/http"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/citc-tech/wadjet/internal/auth"
 	"github.com/citc-tech/wadjet/wadjet"
 )
 
@@ -33,14 +44,28 @@ const (
 type Server struct {
 	db     *wadjet.DB
 	logger *slog.Logger
+	// identity, when non-nil, is stamped onto every request context so
+	// db.Query enforces ABAC row/column policies for this caller. Nil means
+	// the DB has no AuthProvider (nothing to enforce) — see package docs.
+	identity *auth.Identity
 }
 
-// NewServer creates a new MCP server backed by a Wadjet DB.
+// NewServer creates a new MCP server backed by a Wadjet DB with no ABAC
+// identity. Use this only for DBs opened WITHOUT an AuthProvider (dev/embedded)
+// — there is no security policy to enforce. For a DB with an AuthProvider, use
+// NewServerWithIdentity so queries run under an authenticated identity.
 func NewServer(db *wadjet.DB, logger *slog.Logger) *Server {
+	return NewServerWithIdentity(db, logger, nil)
+}
+
+// NewServerWithIdentity creates an MCP server that runs every query under the
+// given identity. When identity is non-nil, its ABAC subject is applied to all
+// tool queries; when nil, the server behaves like NewServer.
+func NewServerWithIdentity(db *wadjet.DB, logger *slog.Logger, identity *auth.Identity) *Server {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Server{db: db, logger: logger}
+	return &Server{db: db, logger: logger, identity: identity}
 }
 
 // ServeStdio runs the MCP server over stdin/stdout using JSON-RPC 2.0.
@@ -55,56 +80,6 @@ func (s *Server) ServeStdio(ctx context.Context, in io.Reader, out io.Writer) er
 	}
 	t.scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
 	return s.serve(ctx, t)
-}
-
-// ServeHTTP starts an HTTP+SSE MCP server on the given address.
-// Returns after the listener is established. Call Shutdown to stop.
-func ServeHTTP(s *Server, addr string) (*HTTPServer, error) {
-	hs := &HTTPServer{
-		mcp:    s,
-		done:   make(chan struct{}),
-		logger: s.logger,
-	}
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("/sse", hs.handleSSE)
-	mux.HandleFunc("/message", hs.handleMessage)
-
-	ln, err := net.Listen("tcp", addr)
-	if err != nil {
-		return nil, fmt.Errorf("mcp http listen: %w", err)
-	}
-	hs.listener = ln
-	hs.httpServer = &http.Server{Handler: mux}
-
-	s.logger.Info("MCP HTTP+SSE server listening", "addr", ln.Addr().String())
-	go hs.httpServer.Serve(ln)
-	return hs, nil
-}
-
-// HTTPServer wraps the HTTP+SSE transport lifecycle.
-type HTTPServer struct {
-	mcp        *Server
-	httpServer *http.Server
-	listener   net.Listener
-	done       chan struct{}
-	logger     *slog.Logger
-}
-
-// Addr returns the listener address.
-func (h *HTTPServer) Addr() string {
-	if h.listener == nil {
-		return ""
-	}
-	return h.listener.Addr().String()
-}
-
-// Shutdown stops the HTTP server gracefully.
-func (h *HTTPServer) Shutdown() {
-	close(h.done)
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	h.httpServer.Shutdown(ctx)
 }
 
 // JSON-RPC 2.0 types
@@ -189,6 +164,14 @@ type transport interface {
 
 // serve is the main dispatch loop.
 func (s *Server) serve(ctx context.Context, t transport) error {
+	// Stamp the operator's identity onto the base context so every query
+	// enforces ABAC. When identity is nil the context is unchanged (no policy
+	// to enforce). This is the single place identity enters query execution —
+	// there is no per-request credential over stdio (one local session, one
+	// operator), so the process-lifetime identity is authoritative.
+	if s.identity != nil {
+		ctx = auth.ContextWithIdentity(ctx, s.identity)
+	}
 	for {
 		if ctx.Err() != nil {
 			return ctx.Err()
@@ -702,96 +685,3 @@ func (t *stdioTransport) Send(resp jsonRPCResponse) error {
 	_, err = fmt.Fprintf(t.out, "%s\n", data)
 	return err
 }
-
-// HTTP+SSE transport
-
-func (h *HTTPServer) handleSSE(w http.ResponseWriter, r *http.Request) {
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		http.Error(w, "streaming not supported", http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-
-	// Generate a session ID and create a message channel
-	sessionID := fmt.Sprintf("session-%d", time.Now().UnixNano())
-	msgCh := make(chan jsonRPCResponse, 64)
-
-	sseSessionsMu.Lock()
-	sseSessions[sessionID] = msgCh
-	sseSessionsMu.Unlock()
-
-	defer func() {
-		sseSessionsMu.Lock()
-		delete(sseSessions, sessionID)
-		sseSessionsMu.Unlock()
-	}()
-
-	// Send the endpoint event so the client knows where to POST
-	fmt.Fprintf(w, "event: endpoint\ndata: /message?sessionId=%s\n\n", sessionID)
-	flusher.Flush()
-
-	// Stream responses
-	ctx := r.Context()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-h.done:
-			return
-		case resp := <-msgCh:
-			data, err := json.Marshal(resp)
-			if err != nil {
-				continue
-			}
-			fmt.Fprintf(w, "event: message\ndata: %s\n\n", data)
-			flusher.Flush()
-		}
-	}
-}
-
-func (h *HTTPServer) handleMessage(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-
-	sessionID := r.URL.Query().Get("sessionId")
-	if sessionID == "" {
-		http.Error(w, "missing sessionId", http.StatusBadRequest)
-		return
-	}
-
-	sseSessionsMu.RLock()
-	ch, ok := sseSessions[sessionID]
-	sseSessionsMu.RUnlock()
-	if !ok {
-		http.Error(w, "unknown session", http.StatusNotFound)
-		return
-	}
-
-	var req jsonRPCRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid JSON-RPC: "+err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	resp := h.mcp.handleRequest(r.Context(), &req)
-	if resp != nil {
-		select {
-		case ch <- *resp:
-		default:
-			h.logger.Warn("MCP SSE channel full, dropping response")
-		}
-	}
-
-	w.WriteHeader(http.StatusAccepted)
-}
-
-var (
-	sseSessions   = make(map[string]chan jsonRPCResponse)
-	sseSessionsMu sync.RWMutex
-)

--- a/internal/server/mcp/server_test.go
+++ b/internal/server/mcp/server_test.go
@@ -7,14 +7,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/citc-tech/wadjet/wadjet"
+	"github.com/citc-tech/wadjet/internal/auth"
+	"github.com/citc-tech/wadjet/internal/storage/ingest"
 	"github.com/citc-tech/wadjet/internal/storage/objstore"
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
+	"github.com/citc-tech/wadjet/wadjet"
 )
 
 func setupTestDB(t *testing.T) *wadjet.DB {
@@ -383,90 +384,126 @@ func TestUnknownMethod(t *testing.T) {
 	}
 }
 
-func TestHTTPSSE(t *testing.T) {
-	db := setupTestDB(t)
-	srv := NewServer(db, nil)
-
-	hs, err := ServeHTTP(srv, ":0")
+// TestMCPQueryEnforcesABAC proves the MCP query tool applies row/column
+// security when the server is constructed with an identity against an
+// AuthProvider-backed DB. Without identity stamping in serve(), the denied
+// column would appear and the row filter would not apply — the exact bypass
+// this change closes. A companion NewServer (no identity) run confirms the
+// enforcement is driven by the stamped identity, not by the DB alone.
+func TestMCPQueryEnforcesABAC(t *testing.T) {
+	ctx := context.Background()
+	store := objstore.NewMemStore()
+	store.MakeBucket(ctx, "test")
+	db, err := wadjet.Open(ctx, wadjet.Config{Store: store, Bucket: "test"})
 	if err != nil {
-		t.Fatalf("starting HTTP server: %v", err)
-	}
-	defer hs.Shutdown()
-
-	addr := hs.Addr()
-
-	// Connect to SSE endpoint
-	resp, err := http.Get(fmt.Sprintf("http://%s/sse", addr))
-	if err != nil {
-		t.Fatalf("connecting to SSE: %v", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.Header.Get("Content-Type") != "text/event-stream" {
-		t.Errorf("expected text/event-stream, got %s", resp.Header.Get("Content-Type"))
+		t.Fatalf("opening DB: %v", err)
 	}
 
-	// Read the endpoint event
-	scanner := strings.NewReader("")
-	_ = scanner
-	buf := make([]byte, 4096)
-	n, err := resp.Body.Read(buf)
-	if err != nil {
-		t.Fatalf("reading SSE: %v", err)
+	schema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "severity", Type: parquet.TypeString},
+		{Name: "secret_col", Type: parquet.TypeString},
+	}}
+	if err := db.CreateTable(ctx, "findings", schema, nil); err != nil {
+		t.Fatal(err)
 	}
-	sseData := string(buf[:n])
-
-	if !strings.Contains(sseData, "event: endpoint") {
-		t.Fatalf("expected endpoint event, got: %s", sseData)
+	ing := db.NewIngester("findings", schema, nil, ingest.Config{MaxBufferRows: 100, RowGroupSize: 100})
+	if err := ing.Ingest(ctx, []map[string]any{
+		{"id": int64(1), "severity": "high", "secret_col": "classified-a"},
+		{"id": int64(2), "severity": "low", "secret_col": "classified-b"},
+		{"id": int64(3), "severity": "high", "secret_col": "classified-c"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ing.FlushAll(ctx); err != nil {
+		t.Fatal(err)
 	}
 
-	// Extract session ID from the data line
-	var sessionID string
-	for _, line := range strings.Split(sseData, "\n") {
-		if strings.HasPrefix(line, "data: ") {
-			endpoint := strings.TrimPrefix(line, "data: ")
-			parts := strings.Split(endpoint, "sessionId=")
-			if len(parts) == 2 {
-				sessionID = parts[1]
+	evaluator := auth.NewPolicyEvaluator([]auth.AccessControlPolicy{{
+		Name: "test-policy", Version: 1, Enabled: true,
+		Rules: []auth.PolicyRule{{
+			ID: "restrict-findings", EffectStr: "allow", Priority: 10,
+			Subjects:  []auth.Condition{{Attribute: "subject.role", Op: "eq", Value: "analyst"}},
+			Resources: []auth.Condition{{Attribute: "resource.name", Op: "eq", Value: "findings"}},
+			Actions:   []auth.Action{auth.ActionRead},
+			Obligations: []auth.Obligation{
+				{Type: "deny_column", Target: "secret_col"},
+				{Type: "row_filter", Value: "severity = 'high'"},
+			},
+		}},
+	}})
+	authn, authz := auth.New(auth.Config{
+		Enabled: true,
+		APIKeys: []auth.APIKeyDef{{Key: "test-key", Name: "analyst", Role: "analyst"}},
+		Roles:   []auth.RoleConfig{{Name: "analyst", Tables: []string{"*"}, Allow: []string{"read"}}},
+	})
+	provider := auth.NewProvider(authn, authz, nil, nil)
+	provider.UpdateWithEvaluator(authn, authz, nil, evaluator)
+	db.SetAuthProvider(provider)
+
+	identity := &auth.Identity{Name: "analyst", Role: "analyst", Method: "apikey"}
+
+	queryRows := func(t *testing.T, srv *Server) (cols []any, rowCount int) {
+		t.Helper()
+		in := &bytes.Buffer{}
+		sendRPC(t, in, "tools/call", callToolParams{
+			Name:      "query",
+			Arguments: map[string]any{"sql": "SELECT * FROM findings"},
+		}, 1)
+		out := runStdio(t, srv, in)
+		resp := readResponse(t, out)
+		if resp.Error != nil {
+			t.Fatalf("query error: %v", resp.Error.Message)
+		}
+		data, _ := json.Marshal(resp.Result)
+		var result callToolResult
+		json.Unmarshal(data, &result)
+		if len(result.Content) == 0 {
+			t.Fatal("empty tool result")
+		}
+		var payload struct {
+			Columns  []any `json:"columns"`
+			RowCount int   `json:"row_count"`
+		}
+		if err := json.Unmarshal([]byte(result.Content[0].Text), &payload); err != nil {
+			t.Fatalf("unmarshaling query payload %q: %v", result.Content[0].Text, err)
+		}
+		return payload.Columns, payload.RowCount
+	}
+
+	t.Run("with_identity_enforces_row_and_column_policy", func(t *testing.T) {
+		srv := NewServerWithIdentity(db, nil, identity)
+		cols, rowCount := queryRows(t, srv)
+		for _, c := range cols {
+			if c == "secret_col" {
+				t.Errorf("denied column 'secret_col' leaked through MCP query: cols=%v", cols)
 			}
 		}
-	}
-	if sessionID == "" {
-		t.Fatalf("could not extract session ID from: %s", sseData)
-	}
-
-	// POST a tools/list request
-	reqBody, _ := json.Marshal(map[string]any{
-		"jsonrpc": "2.0",
-		"id":      1,
-		"method":  "tools/list",
+		if rowCount != 2 {
+			t.Errorf("row filter severity='high' not applied: got %d rows, want 2", rowCount)
+		}
 	})
-	postResp, err := http.Post(
-		fmt.Sprintf("http://%s/message?sessionId=%s", addr, sessionID),
-		"application/json",
-		bytes.NewReader(reqBody),
-	)
-	if err != nil {
-		t.Fatalf("posting message: %v", err)
-	}
-	postResp.Body.Close()
 
-	if postResp.StatusCode != http.StatusAccepted {
-		t.Errorf("expected 202 Accepted, got %d", postResp.StatusCode)
-	}
-
-	// Read the SSE response
-	n, err = resp.Body.Read(buf)
-	if err != nil {
-		t.Fatalf("reading SSE response: %v", err)
-	}
-	sseResp := string(buf[:n])
-	if !strings.Contains(sseResp, "event: message") {
-		t.Errorf("expected message event, got: %s", sseResp)
-	}
-	if !strings.Contains(sseResp, "list_tables") {
-		t.Errorf("expected tool list in response, got: %s", sseResp)
-	}
+	t.Run("without_identity_no_enforcement_context", func(t *testing.T) {
+		// Sanity anchor: enforcement is identity-driven. A server with no
+		// stamped identity (which mcpCmd only permits when no AuthProvider is
+		// configured) does not gain policy from the DB alone — proving the
+		// stamp in serve() is what carries security, so an unauthenticated
+		// network path could never inherit it by accident.
+		srv := NewServer(db, nil)
+		cols, rowCount := queryRows(t, srv)
+		leaked := false
+		for _, c := range cols {
+			if c == "secret_col" {
+				leaked = true
+			}
+		}
+		if !leaked || rowCount != 3 {
+			t.Fatalf("expected unenforced result (secret_col present, 3 rows); got cols=%v rows=%d — "+
+				"if this now enforces, the identity-driven invariant changed and mcpCmd's fail-closed guard must be re-audited",
+				cols, rowCount)
+		}
+	})
 }
 
 func TestToolUnknown(t *testing.T) {


### PR DESCRIPTION
## Summary

MCP-received queries bypassed row/column (cell-level) security entirely. This closes it and removes a latent unauthenticated network SQL surface.

### The gaps

1. **No enforcement on the MCP query path.** `wadjet mcp` opened its embedded DB with **no AuthProvider** and never stamped an identity onto the query context. `auth.EnforcePlanPolicies` fail-opens when either the provider or the identity is nil, so every MCP query ran with zero row filters, column masks, or table-access checks — fully unfiltered reads.

2. **Unauthenticated HTTP+SSE transport.** `ServeHTTP`/`handleSSE`/`handleMessage` accepted JSON-RPC SQL over the network with no auth and no identity. It was wired into no command (the shipped binary is stdio-only), but it was a latent unauthenticated network SQL surface. **Removed entirely.**

### Fixes

- **`mcp.NewServerWithIdentity`** stamps the operator's identity onto every request context in `serve()`, so `db.Query → EnforcePlanPolicies` applies ABAC. `NewServer` (no identity) is retained only for AuthProvider-less dev/embedded DBs where there's no policy to enforce.
- **`wadjet mcp`** builds an AuthProvider from `--config` and resolves the session identity from `--api-key` / `WADJET_MCP_API_KEY`. **`resolveMCPAuth` fails closed**: auth enabled + missing/invalid credential → refuse to start. No auth configured → unauthenticated with a prominent warning (the direct-to-store embedded model — the operator already holds store creds).
- Removed the HTTP+SSE transport; the package doc now records that any future network transport must authenticate every request and stamp an identity before reaching `db.Query`.
- README MCP section updated (stdio-only, secured vs dev invocations, fail-closed note).

### Tests

- **mcp:** `TestMCPQueryEnforcesABAC` drives the `query` tool over stdio and asserts a denied column is stripped and a row filter applies under an identity; a no-identity control proves enforcement is identity-driven. Verified the test **fails without** the `serve()` stamp (secret_col leaks, 3 rows instead of 2).
- **cmd:** `TestResolveMCPAuth` covers the fail-closed matrix (missing / bad / good token, nil / disabled provider).
- Manually drove all five CLI paths: fail-closed on missing and bad token, serve-under-identity via flag and via env var, unauthenticated warning without config.

Full `./internal/... ./cmd/... ./wadjet/...` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)