### PR TITLE
fix(auth): gate alert DDL on admin; run scheduled alerts under creator identity

### DIFF
--- a/internal/alerts/scheduler.go
+++ b/internal/alerts/scheduler.go
@@ -13,12 +13,21 @@ import (
 // doesn't know about WebhookSink/TableSink concretely and tests can stub.
 type SinkFactory func(m catalog.AlertMeta) []AlertSink
 
+// EvalContextFunc decorates the per-evaluation context for an alert before its
+// query runs. Injected so the scheduler stays decoupled from the auth package:
+// the owner (coordinator / embedded DB) supplies a func that stamps the alert
+// creator's identity onto the context (definer's rights), so the scheduled
+// query enforces the creator's ABAC row/column policies instead of running
+// unfiltered. A nil func (or a nil return) leaves the context unchanged.
+type EvalContextFunc func(ctx context.Context, m catalog.AlertMeta) context.Context
+
 // Scheduler runs alerts on their configured cadence. It owns one goroutine
 // that ticks and dispatches per-alert evaluations as short-lived goroutines.
 type Scheduler struct {
 	cat          *catalog.Catalog
 	exec         SQLExecutor
 	sinks        SinkFactory
+	evalCtxFunc  EvalContextFunc
 	tickInterval time.Duration
 	logger       *slog.Logger
 
@@ -29,12 +38,15 @@ type Scheduler struct {
 	wg sync.WaitGroup
 }
 
-// NewScheduler constructs a scheduler with a default 1s tick cadence.
-func NewScheduler(cat *catalog.Catalog, exec SQLExecutor, sinks SinkFactory) *Scheduler {
+// NewScheduler constructs a scheduler with a default 1s tick cadence. evalCtx
+// may be nil (no per-alert context decoration); production callers pass a func
+// that stamps the alert creator's identity for definer's-rights enforcement.
+func NewScheduler(cat *catalog.Catalog, exec SQLExecutor, sinks SinkFactory, evalCtx EvalContextFunc) *Scheduler {
 	return &Scheduler{
 		cat:          cat,
 		exec:         exec,
 		sinks:        sinks,
+		evalCtxFunc:  evalCtx,
 		tickInterval: 1 * time.Second,
 		inflight:     make(map[string]bool),
 		logger:       slog.Default(),
@@ -117,6 +129,17 @@ func (s *Scheduler) evaluate(ctx context.Context, a catalog.AlertMeta, now time.
 	}
 	evalCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
+
+	// Stamp the creator's identity (definer's rights) so the alert query
+	// enforces that identity's ABAC policies. A nil decorator leaves the
+	// context untouched (auth disabled / embedded). When auth is enabled the
+	// decorator fails an unattributed (legacy) alert closed — see
+	// alertEvalDecorator.
+	if s.evalCtxFunc != nil {
+		if decorated := s.evalCtxFunc(evalCtx, a); decorated != nil {
+			evalCtx = decorated
+		}
+	}
 
 	start := time.Now()
 	rows, schema, total, truncated, err := s.exec.Query(evalCtx, a.QueryText, MaxRowsPerFire)

--- a/internal/alerts/scheduler_test.go
+++ b/internal/alerts/scheduler_test.go
@@ -62,7 +62,7 @@ func TestSchedulerFiresDueAlert(t *testing.T) {
 	})
 	s := NewScheduler(cat, ex, SinkFactory(func(m catalog.AlertMeta) []AlertSink {
 		return []AlertSink{sink}
-	}))
+	}), nil)
 	s.tickInterval = 10 * time.Millisecond
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
@@ -79,7 +79,7 @@ func TestSchedulerSkipsDisabled(t *testing.T) {
 		Name: "a1", QueryText: "SELECT 1", IntervalSeconds: 1, Enabled: false,
 	})
 	_ = ex
-	s := NewScheduler(cat, ex, SinkFactory(func(catalog.AlertMeta) []AlertSink { return []AlertSink{sink} }))
+	s := NewScheduler(cat, ex, SinkFactory(func(catalog.AlertMeta) []AlertSink { return []AlertSink{sink} }), nil)
 	s.tickInterval = 10 * time.Millisecond
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -117,7 +117,7 @@ func TestSchedulerSkipsConcurrent(t *testing.T) {
 	defer close(release)
 	ex := &blockingExec{release: release, rows: []map[string]any{{"n": 1}}, total: 1}
 
-	s := NewScheduler(cat, ex, SinkFactory(func(catalog.AlertMeta) []AlertSink { return []AlertSink{sink} }))
+	s := NewScheduler(cat, ex, SinkFactory(func(catalog.AlertMeta) []AlertSink { return []AlertSink{sink} }), nil)
 	s.tickInterval = 10 * time.Millisecond
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
@@ -150,7 +150,7 @@ func TestSchedulerNoFireOnZeroRows(t *testing.T) {
 		Name: "a1", QueryText: "SELECT 1", IntervalSeconds: 1, Enabled: true,
 	})
 	emptyExec := &stubExec{rows: nil, total: 0}
-	s := NewScheduler(cat, emptyExec, SinkFactory(func(catalog.AlertMeta) []AlertSink { return []AlertSink{sink} }))
+	s := NewScheduler(cat, emptyExec, SinkFactory(func(catalog.AlertMeta) []AlertSink { return []AlertSink{sink} }), nil)
 	s.tickInterval = 10 * time.Millisecond
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -158,5 +158,58 @@ func TestSchedulerNoFireOnZeroRows(t *testing.T) {
 	s.Wait()
 	if atomic.LoadInt32(&sink.calls) != 0 {
 		t.Errorf("want no fire on zero rows, got %d calls", sink.calls)
+	}
+}
+
+// ctxCapturingExec records the context its Query received so tests can assert
+// the scheduler applied the EvalContextFunc decorator before executing.
+type ctxCapturingExec struct {
+	mu     sync.Mutex
+	gotCtx context.Context
+	fired  int32
+}
+
+func (*ctxCapturingExec) Execute(context.Context, string) error { return nil }
+func (e *ctxCapturingExec) Query(ctx context.Context, _ string, _ int) ([]map[string]any, []ColumnMeta, int64, bool, error) {
+	e.mu.Lock()
+	e.gotCtx = ctx
+	e.mu.Unlock()
+	atomic.AddInt32(&e.fired, 1)
+	return []map[string]any{{"n": int64(1)}}, []ColumnMeta{{Name: "n"}}, 1, false, nil
+}
+
+type evalCtxKey struct{}
+
+// TestSchedulerAppliesEvalDecorator proves the injected EvalContextFunc runs
+// and its returned context is the one handed to exec.Query — the plumbing that
+// carries the alert creator's identity into query execution. Without the
+// decorator wiring in evaluate(), the executor would see the bare tick context.
+func TestSchedulerAppliesEvalDecorator(t *testing.T) {
+	cat, _, sink := newSchedulerTest(t)
+	_ = cat.CreateAlert(context.Background(), catalog.AlertMeta{
+		Name: "a1", QueryText: "SELECT 1", IntervalSeconds: 1, Enabled: true,
+	})
+	exec := &ctxCapturingExec{}
+	decorator := EvalContextFunc(func(ctx context.Context, m catalog.AlertMeta) context.Context {
+		return context.WithValue(ctx, evalCtxKey{}, m.Name)
+	})
+	s := NewScheduler(cat, exec, SinkFactory(func(catalog.AlertMeta) []AlertSink { return []AlertSink{sink} }), decorator)
+	s.tickInterval = 10 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	s.Start(ctx)
+	s.Wait()
+
+	if atomic.LoadInt32(&exec.fired) == 0 {
+		t.Fatal("alert never fired")
+	}
+	exec.mu.Lock()
+	got := exec.gotCtx
+	exec.mu.Unlock()
+	if got == nil {
+		t.Fatal("executor received no context")
+	}
+	if v, _ := got.Value(evalCtxKey{}).(string); v != "a1" {
+		t.Fatalf("decorator context did not reach exec.Query: got value %q, want %q", v, "a1")
 	}
 }

--- a/internal/auth/require.go
+++ b/internal/auth/require.go
@@ -1,0 +1,103 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+)
+
+// RequirePermission enforces that the caller in ctx holds perm, but only when
+// the provider is present and auth is enabled. It is the gate for privileged
+// DDL (e.g. CREATE/DROP/ALTER ALERT) that has no per-row ABAC surface of its
+// own. Fail-closed contract: with auth enabled, a missing identity or an
+// identity lacking perm is rejected; with auth absent/disabled it returns nil
+// (dev/embedded, nothing to enforce).
+func RequirePermission(provider *Provider, ctx context.Context, perm string) error {
+	if provider == nil || !provider.Enabled() {
+		return nil
+	}
+	id := IdentityFromContext(ctx)
+	if id == nil {
+		return fmt.Errorf("%w: authentication required for this operation", ErrUnauthorized)
+	}
+	if authz := provider.Authorizer(); authz != nil && authz.HasPermission(id, perm) {
+		return nil
+	}
+	return fmt.Errorf("%w: %q permission required (identity %q, role %q)",
+		ErrUnauthorized, perm, id.Name, id.Role)
+}
+
+// IdentitySnapshot is the persistable subset of an Identity sufficient to
+// re-establish its ABAC subject later (see Identity.ToSubject, which keys on
+// role/name/method plus attributes). It is stored with definer's-rights
+// resources — an alert runs under its creator's identity on every scheduled
+// tick, so the creator's role and attributes must survive in the catalog.
+// Tables/Perms are intentionally omitted: they gate RBAC operations (table
+// access, DDL) that the scheduled-query path does not perform — that path
+// applies only ABAC plan enforcement, which reads role/attributes.
+type IdentitySnapshot struct {
+	Name       string            `json:"name,omitempty"`
+	Role       string            `json:"role,omitempty"`
+	Method     string            `json:"method,omitempty"`
+	Attributes map[string]string `json:"attributes,omitempty"`
+}
+
+// SnapshotIdentity captures the identity in ctx as an IdentitySnapshot. The
+// zero snapshot (all fields empty) means no identity was present — callers
+// persisting it record "no definer", which the scheduler treats fail-closed.
+func SnapshotIdentity(ctx context.Context) IdentitySnapshot {
+	id := IdentityFromContext(ctx)
+	if id == nil {
+		return IdentitySnapshot{}
+	}
+	var attrs map[string]string
+	if len(id.Attributes) > 0 {
+		attrs = make(map[string]string, len(id.Attributes))
+		for k, v := range id.Attributes {
+			if s, ok := v.(string); ok {
+				attrs[k] = s
+			} else {
+				attrs[k] = fmt.Sprintf("%v", v)
+			}
+		}
+	}
+	return IdentitySnapshot{Name: id.Name, Role: id.Role, Method: id.Method, Attributes: attrs}
+}
+
+// Empty reports whether the snapshot carries no usable identity — either no
+// definer was recorded (pre-definer-rights alert) or it was created with no
+// authenticated identity. Enforcement treats an empty snapshot fail-closed.
+func (s IdentitySnapshot) Empty() bool {
+	return s.Name == "" && s.Role == "" && s.Method == "" && len(s.Attributes) == 0
+}
+
+// StampDefiner stamps snap's identity onto ctx for definer's-rights execution
+// (e.g. a scheduled alert query running as its creator) and reports whether
+// the definer is attributed — i.e. whether a real identity was recorded.
+//
+//   - provider nil / auth disabled: ctx is returned unchanged with true —
+//     there is no policy to enforce (dev/embedded).
+//   - auth enabled: snap.ToIdentity() is ALWAYS stamped, even for an empty
+//     (legacy) snapshot. This is deliberate: EnforcePlanPolicies fail-OPENS on
+//     a nil identity, so stamping a non-nil role-less identity instead routes
+//     an unattributed alert into ABAC default-deny (fail closed) rather than
+//     unfiltered execution. attributed is false in that case so the caller can
+//     warn that the alert needs recreating under an identity.
+func StampDefiner(ctx context.Context, provider *Provider, snap IdentitySnapshot) (context.Context, bool) {
+	if provider == nil || !provider.Enabled() {
+		return ctx, true
+	}
+	return ContextWithIdentity(ctx, snap.ToIdentity()), !snap.Empty()
+}
+
+// ToIdentity reconstructs an *Identity for context stamping. Attributes are
+// widened back to the Attributes (map[string]any) shape ToSubject expects.
+func (s IdentitySnapshot) ToIdentity() *Identity {
+	var attrs Attributes
+	if len(s.Attributes) > 0 {
+		attrs = make(Attributes, len(s.Attributes))
+		for k, v := range s.Attributes {
+			attrs[k] = v
+		}
+	}
+	return &Identity{Name: s.Name, Role: s.Role, Method: s.Method, Attributes: attrs}
+}

--- a/internal/auth/require_test.go
+++ b/internal/auth/require_test.go
@@ -1,0 +1,145 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func newTestProvider(t *testing.T, enabled bool) *Provider {
+	t.Helper()
+	cfg := Config{Enabled: enabled}
+	if enabled {
+		cfg.APIKeys = []APIKeyDef{{Key: "k", Name: "svc", Role: "admin"}}
+		cfg.Roles = []RoleConfig{
+			{Name: "admin", Tables: []string{"*"}, Allow: []string{"admin"}},
+			{Name: "reader", Tables: []string{"*"}, Allow: []string{"read"}},
+		}
+	}
+	authn, authz := New(cfg)
+	return NewProvider(authn, authz, nil, nil)
+}
+
+func TestRequirePermission(t *testing.T) {
+	secured := newTestProvider(t, true)
+	if !secured.Enabled() {
+		t.Fatal("provider with an API key should be Enabled()")
+	}
+
+	adminID := &Identity{Name: "svc", Role: "admin", Perms: []string{"admin"}}
+	readerID := &Identity{Name: "bob", Role: "reader", Perms: []string{"read"}}
+
+	t.Run("nil provider is a no-op", func(t *testing.T) {
+		if err := RequirePermission(nil, context.Background(), "admin"); err != nil {
+			t.Fatalf("nil provider should permit, got %v", err)
+		}
+	})
+
+	t.Run("disabled provider is a no-op", func(t *testing.T) {
+		if err := RequirePermission(newTestProvider(t, false), context.Background(), "admin"); err != nil {
+			t.Fatalf("disabled provider should permit, got %v", err)
+		}
+	})
+
+	t.Run("enabled + no identity is rejected", func(t *testing.T) {
+		err := RequirePermission(secured, context.Background(), "admin")
+		if err == nil {
+			t.Fatal("expected rejection with no identity")
+		}
+		if !errors.Is(err, ErrUnauthorized) {
+			t.Fatalf("expected ErrUnauthorized, got %v", err)
+		}
+	})
+
+	t.Run("enabled + wrong permission is rejected", func(t *testing.T) {
+		ctx := ContextWithIdentity(context.Background(), readerID)
+		if err := RequirePermission(secured, ctx, "admin"); err == nil {
+			t.Fatal("reader should not hold admin")
+		}
+	})
+
+	t.Run("enabled + correct permission passes", func(t *testing.T) {
+		ctx := ContextWithIdentity(context.Background(), adminID)
+		if err := RequirePermission(secured, ctx, "admin"); err != nil {
+			t.Fatalf("admin should pass, got %v", err)
+		}
+	})
+}
+
+func TestIdentitySnapshotRoundTrip(t *testing.T) {
+	id := &Identity{
+		Name:       "alice",
+		Role:       "analyst",
+		Method:     "apikey",
+		Attributes: Attributes{"clearance": "secret", "team": "blue"},
+	}
+	ctx := ContextWithIdentity(context.Background(), id)
+
+	snap := SnapshotIdentity(ctx)
+	if snap.Empty() {
+		t.Fatal("snapshot of a real identity should not be Empty()")
+	}
+	if snap.Name != "alice" || snap.Role != "analyst" || snap.Method != "apikey" {
+		t.Fatalf("snapshot lost core fields: %+v", snap)
+	}
+	if snap.Attributes["clearance"] != "secret" || snap.Attributes["team"] != "blue" {
+		t.Fatalf("snapshot lost attributes: %+v", snap.Attributes)
+	}
+
+	// Round-trip through ToIdentity → ToSubject must carry role + attributes,
+	// which is what the ABAC evaluator keys on.
+	sub := snap.ToIdentity().ToSubject()
+	if sub.Attributes["role"] != "analyst" || sub.Attributes["clearance"] != "secret" {
+		t.Fatalf("reconstructed subject lost attributes: %+v", sub.Attributes)
+	}
+}
+
+func TestSnapshotIdentityNoIdentity(t *testing.T) {
+	if snap := SnapshotIdentity(context.Background()); !snap.Empty() {
+		t.Fatalf("snapshot with no identity should be Empty(), got %+v", snap)
+	}
+}
+
+func TestStampDefiner(t *testing.T) {
+	secured := newTestProvider(t, true)
+
+	t.Run("disabled provider leaves context unchanged", func(t *testing.T) {
+		snap := IdentitySnapshot{Name: "alice", Role: "analyst"}
+		ctx, attributed := StampDefiner(context.Background(), nil, snap)
+		if !attributed {
+			t.Fatal("nil provider should report attributed=true (nothing to enforce)")
+		}
+		if IdentityFromContext(ctx) != nil {
+			t.Fatal("nil provider should not stamp an identity")
+		}
+	})
+
+	t.Run("enabled + attributed stamps the reconstructed identity", func(t *testing.T) {
+		snap := IdentitySnapshot{Name: "alice", Role: "analyst", Method: "apikey"}
+		ctx, attributed := StampDefiner(context.Background(), secured, snap)
+		if !attributed {
+			t.Fatal("a non-empty snapshot should be attributed")
+		}
+		got := IdentityFromContext(ctx)
+		if got == nil || got.Role != "analyst" {
+			t.Fatalf("expected analyst identity stamped, got %+v", got)
+		}
+	})
+
+	t.Run("enabled + empty snapshot fails closed with a non-nil identity", func(t *testing.T) {
+		// The critical invariant: a legacy alert (empty snapshot) must stamp a
+		// NON-NIL identity so EnforcePlanPolicies does not fail-open on a nil
+		// identity — a role-less identity routes into ABAC default-deny.
+		ctx, attributed := StampDefiner(context.Background(), secured, IdentitySnapshot{})
+		if attributed {
+			t.Fatal("empty snapshot must report attributed=false")
+		}
+		got := IdentityFromContext(ctx)
+		if got == nil {
+			t.Fatal("empty snapshot under enabled auth must still stamp a non-nil identity (else ABAC fail-opens)")
+		}
+		if got.Role != "" {
+			t.Fatalf("expected a role-less identity, got role %q", got.Role)
+		}
+	})
+}

--- a/internal/coordinator/alerts.go
+++ b/internal/coordinator/alerts.go
@@ -3,6 +3,7 @@ package coordinator
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/citc-tech/wadjet/internal/alerts"
@@ -15,6 +16,11 @@ import (
 func (c *Coordinator) handleCreateAlertSQL(ctx context.Context, sqlText string) error {
 	if !c.alertsEnabled {
 		return fmt.Errorf("alerts are disabled on this cluster; set --enable-alerts or WADJET_ENABLE_ALERTS=1")
+	}
+	// An alert is a persistent server-side job that runs arbitrary SQL on a
+	// cadence under its creator's identity — a privileged management action.
+	if err := auth.RequirePermission(c.authProvider, ctx, "admin"); err != nil {
+		return err
 	}
 	pq, err := sql.Parse(sqlText)
 	if err != nil {
@@ -39,6 +45,9 @@ func (c *Coordinator) handleCreateAlertSQL(ctx context.Context, sqlText string) 
 		}
 	}
 
+	// Snapshot the creator's identity so the scheduler can run this alert
+	// under it (definer's rights) on every tick — see alertEvalDecorator.
+	snap := auth.SnapshotIdentity(ctx)
 	m := catalog.AlertMeta{
 		Name:            info.Name,
 		QueryText:       info.QueryText,
@@ -48,7 +57,10 @@ func (c *Coordinator) handleCreateAlertSQL(ctx context.Context, sqlText string) 
 		InsertIntoTable: info.InsertInto,
 		Enabled:         true,
 		CreatedAt:       time.Now().UTC(),
-		CreatedBy:       identityFromCtx(ctx),
+		CreatedBy:       snap.Name,
+		CreatedByRole:   snap.Role,
+		CreatedByMethod: snap.Method,
+		CreatedByAttrs:  snap.Attributes,
 	}
 	return c.catalog.CreateAlert(ctx, m)
 }
@@ -57,6 +69,9 @@ func (c *Coordinator) handleCreateAlertSQL(ctx context.Context, sqlText string) 
 func (c *Coordinator) handleDropAlertSQL(ctx context.Context, sqlText string) error {
 	if !c.alertsEnabled {
 		return fmt.Errorf("alerts are disabled on this cluster; set --enable-alerts or WADJET_ENABLE_ALERTS=1")
+	}
+	if err := auth.RequirePermission(c.authProvider, ctx, "admin"); err != nil {
+		return err
 	}
 	pq, err := sql.Parse(sqlText)
 	if err != nil {
@@ -79,6 +94,9 @@ func (c *Coordinator) handleAlterAlertSQL(ctx context.Context, sqlText string) e
 	if !c.alertsEnabled {
 		return fmt.Errorf("alerts are disabled on this cluster; set --enable-alerts or WADJET_ENABLE_ALERTS=1")
 	}
+	if err := auth.RequirePermission(c.authProvider, ctx, "admin"); err != nil {
+		return err
+	}
 	pq, err := sql.Parse(sqlText)
 	if err != nil {
 		return err
@@ -87,14 +105,6 @@ func (c *Coordinator) handleAlterAlertSQL(ctx context.Context, sqlText string) e
 		return fmt.Errorf("not an ALTER ALERT statement")
 	}
 	return c.catalog.SetAlertEnabled(ctx, pq.AlterAlert.Name, pq.AlterAlert.Enable)
-}
-
-// identityFromCtx returns a string identity from ctx using the auth package.
-func identityFromCtx(ctx context.Context) string {
-	if id := auth.IdentityFromContext(ctx); id != nil {
-		return id.Name
-	}
-	return ""
 }
 
 // SetAlertsEnabled toggles the feature flag. When false, StartAlertScheduler
@@ -116,7 +126,7 @@ func (c *Coordinator) StartAlertScheduler(parent context.Context) {
 	c.StopAlertScheduler()
 	ctx, cancel := context.WithCancel(parent)
 	c.alertSchedulerCancel = cancel
-	c.alertScheduler = alerts.NewScheduler(c.catalog, c.asSQLExecutor(), c.alertSinkFactory)
+	c.alertScheduler = alerts.NewScheduler(c.catalog, c.asSQLExecutor(), c.alertSinkFactory, c.alertEvalDecorator())
 	c.alertScheduler.Start(ctx)
 }
 
@@ -130,6 +140,31 @@ func (c *Coordinator) StopAlertScheduler() {
 	if c.alertScheduler != nil {
 		c.alertScheduler.Wait()
 		c.alertScheduler = nil
+	}
+}
+
+// alertEvalDecorator returns the scheduler's per-alert context decorator that
+// runs each alert query under its creator's identity (definer's rights). When
+// auth is disabled the context is untouched. Legacy alerts with no stored
+// identity run fail-closed under ABAC (auth.StampDefiner) and are warned about
+// once per process so operators know to recreate them.
+func (c *Coordinator) alertEvalDecorator() alerts.EvalContextFunc {
+	var warned sync.Map
+	return func(ctx context.Context, m catalog.AlertMeta) context.Context {
+		snap := auth.IdentitySnapshot{
+			Name:       m.CreatedBy,
+			Role:       m.CreatedByRole,
+			Method:     m.CreatedByMethod,
+			Attributes: m.CreatedByAttrs,
+		}
+		newCtx, attributed := auth.StampDefiner(ctx, c.authProvider, snap)
+		if !attributed {
+			if _, seen := warned.LoadOrStore(m.Name, true); !seen {
+				c.logger.Warn("alert has no stored creator identity; running fail-closed under ABAC — recreate it to attribute a definer",
+					"alert", m.Name)
+			}
+		}
+		return newCtx
 	}
 }
 

--- a/internal/storage/catalog/alerts.go
+++ b/internal/storage/catalog/alerts.go
@@ -21,6 +21,13 @@ type AlertMeta struct {
 	Enabled         bool              `json:"enabled"`
 	CreatedAt       time.Time         `json:"created_at"`
 	CreatedBy       string            `json:"created_by,omitempty"`
+	// Creator identity snapshot for definer's-rights scheduled execution: the
+	// alert query runs under this identity's ABAC subject on every tick (see
+	// auth.IdentitySnapshot). Empty on alerts created before this existed —
+	// the scheduler treats those fail-closed under enabled auth.
+	CreatedByRole   string            `json:"created_by_role,omitempty"`
+	CreatedByMethod string            `json:"created_by_method,omitempty"`
+	CreatedByAttrs  map[string]string `json:"created_by_attrs,omitempty"`
 	LastEvaluatedAt time.Time         `json:"last_evaluated_at,omitempty"`
 	Version         int64             `json:"version"`
 }

--- a/wadjet/alert_auth_test.go
+++ b/wadjet/alert_auth_test.go
@@ -1,0 +1,204 @@
+package wadjet
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/auth"
+	"github.com/citc-tech/wadjet/internal/storage/catalog"
+	"github.com/citc-tech/wadjet/internal/storage/ingest"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// alertAuthFixture opens an alerts-enabled DB whose ABAC policy applies a
+// row filter (severity='high') and denies secret_col for role "analyst".
+// The analyst role also holds "admin" so it can create alerts. Returns the DB
+// and the analyst identity.
+func alertAuthFixture(t *testing.T) (*DB, *auth.Identity) {
+	t.Helper()
+	ctx := context.Background()
+	store := objstore.NewMemStore()
+	db, err := Open(ctx, Config{Store: store, Bucket: "test", EnableAlerts: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(db.Close)
+
+	schema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "severity", Type: parquet.TypeString},
+		{Name: "secret_col", Type: parquet.TypeString},
+	}}
+	if err := db.CreateTable(ctx, "findings", schema, nil); err != nil {
+		t.Fatal(err)
+	}
+	ing := db.NewIngester("findings", schema, nil, ingest.Config{MaxBufferRows: 100, RowGroupSize: 100})
+	if err := ing.Ingest(ctx, []map[string]any{
+		{"id": int64(1), "severity": "high", "secret_col": "a"},
+		{"id": int64(2), "severity": "low", "secret_col": "b"},
+		{"id": int64(3), "severity": "high", "secret_col": "c"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ing.FlushAll(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	evaluator := auth.NewPolicyEvaluator([]auth.AccessControlPolicy{{
+		Name: "p", Version: 1, Enabled: true,
+		Rules: []auth.PolicyRule{{
+			ID: "restrict-findings", EffectStr: "allow", Priority: 10,
+			Subjects:  []auth.Condition{{Attribute: "subject.role", Op: "eq", Value: "analyst"}},
+			Resources: []auth.Condition{{Attribute: "resource.name", Op: "eq", Value: "findings"}},
+			Actions:   []auth.Action{auth.ActionRead},
+			Obligations: []auth.Obligation{
+				{Type: "deny_column", Target: "secret_col"},
+				{Type: "row_filter", Value: "severity = 'high'"},
+			},
+		}},
+	}})
+	// A rule allowing alert_history reads so the alert's INSERT-less query and
+	// history table checks aren't blocked for the analyst (not exercised here,
+	// but keeps the fixture realistic).
+	authn, authz := auth.New(auth.Config{
+		Enabled: true,
+		APIKeys: []auth.APIKeyDef{{Key: "analyst-key", Name: "analyst", Role: "analyst"}},
+		Roles:   []auth.RoleConfig{{Name: "analyst", Tables: []string{"*"}, Allow: []string{"admin", "read"}}},
+	})
+	provider := auth.NewProvider(authn, authz, nil, nil)
+	provider.UpdateWithEvaluator(authn, authz, nil, evaluator)
+	db.SetAuthProvider(provider)
+
+	return db, &auth.Identity{Name: "analyst", Role: "analyst", Method: "apikey", Perms: []string{"admin", "read"}}
+}
+
+// TestAlertDDLRequiresAdmin: CREATE/DROP/ALTER ALERT must be rejected without
+// admin, accepted with it. Before the gate, any caller (or an unauthenticated
+// MCP session) could persist a server-side job.
+func TestAlertDDLRequiresAdmin(t *testing.T) {
+	db, admin := alertAuthFixture(t)
+	ctx := context.Background()
+	const create = `CREATE ALERT a1 AS SELECT id FROM findings EVERY 24 HOURS WEBHOOK 'https://x'`
+
+	t.Run("no identity rejected", func(t *testing.T) {
+		if _, err := db.Query(ctx, create); err == nil {
+			t.Fatal("expected rejection with no identity")
+		}
+	})
+
+	t.Run("reader rejected", func(t *testing.T) {
+		readerCtx := auth.ContextWithIdentity(ctx, &auth.Identity{Name: "bob", Role: "reader", Perms: []string{"read"}})
+		if _, err := db.Query(readerCtx, create); err == nil {
+			t.Fatal("expected rejection for a non-admin identity")
+		}
+	})
+
+	t.Run("admin accepted", func(t *testing.T) {
+		adminCtx := auth.ContextWithIdentity(ctx, admin)
+		if _, err := db.Query(adminCtx, create); err != nil {
+			t.Fatalf("admin CREATE ALERT should succeed, got %v", err)
+		}
+		// DROP also requires admin: reader rejected, admin ok.
+		readerCtx := auth.ContextWithIdentity(ctx, &auth.Identity{Name: "bob", Role: "reader", Perms: []string{"read"}})
+		if _, err := db.Query(readerCtx, `DROP ALERT a1`); err == nil {
+			t.Fatal("expected DROP ALERT rejection for non-admin")
+		}
+		if _, err := db.Query(adminCtx, `DROP ALERT a1`); err != nil {
+			t.Fatalf("admin DROP ALERT should succeed, got %v", err)
+		}
+	})
+}
+
+// rowCount runs the alert executor path (what the scheduler uses) and returns
+// the visible row count and whether a column was present in the result schema.
+func alertQuery(t *testing.T, db *DB, ctx context.Context, sql string) (int, map[string]bool, error) {
+	t.Helper()
+	ex := &dbExecutor{db: db}
+	rows, schema, _, _, err := ex.Query(ctx, sql, 100)
+	cols := make(map[string]bool, len(schema))
+	for _, c := range schema {
+		cols[c.Name] = true
+	}
+	return len(rows), cols, err
+}
+
+// TestAlertRunsUnderCreatorIdentity: the scheduler's eval decorator makes an
+// alert query enforce its creator's ABAC (row filter + column deny). A bare
+// context (no decorator) runs unfiltered — the exact pre-fix behavior — so the
+// contrast proves the decorator is what carries the security.
+func TestAlertRunsUnderCreatorIdentity(t *testing.T) {
+	db, admin := alertAuthFixture(t)
+	ctx := context.Background()
+	adminCtx := auth.ContextWithIdentity(ctx, admin)
+
+	const create = `CREATE ALERT a1 AS SELECT * FROM findings EVERY 24 HOURS WEBHOOK 'https://x'`
+	if _, err := db.Query(adminCtx, create); err != nil {
+		t.Fatalf("CREATE ALERT: %v", err)
+	}
+	m, err := db.catalog.GetAlert(ctx, "a1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.CreatedByRole != "analyst" {
+		t.Fatalf("alert did not persist creator role: %+v", m)
+	}
+
+	decorate := db.alertEvalDecorator()
+
+	// Definer's-rights: decorated context enforces the analyst policy.
+	n, cols, err := alertQuery(t, db, decorate(ctx, *m), m.QueryText)
+	if err != nil {
+		t.Fatalf("decorated alert query failed: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("row filter severity='high' not applied under creator identity: got %d rows, want 2", n)
+	}
+	if cols["secret_col"] {
+		t.Errorf("denied column secret_col leaked under creator identity")
+	}
+
+	// Contrast: without the decorator (bare context, no identity) ABAC
+	// fail-opens — this is exactly the pre-fix unfiltered behavior.
+	nBare, colsBare, err := alertQuery(t, db, ctx, m.QueryText)
+	if err != nil {
+		t.Fatalf("bare alert query failed: %v", err)
+	}
+	if nBare != 3 || !colsBare["secret_col"] {
+		t.Fatalf("expected unfiltered result on a bare context (3 rows, secret_col present); got %d rows, cols=%v", nBare, colsBare)
+	}
+}
+
+// TestLegacyAlertFailsClosed: an alert persisted before creator identity was
+// captured (no CreatedByRole) must NOT run unfiltered under enabled auth. The
+// decorator stamps a role-less identity → ABAC default-deny → the query is
+// rejected rather than returning unfiltered rows.
+func TestLegacyAlertFailsClosed(t *testing.T) {
+	db, _ := alertAuthFixture(t)
+	ctx := context.Background()
+
+	legacy := catalog.AlertMeta{
+		Name:            "legacy",
+		QueryText:       "SELECT * FROM findings",
+		IntervalSeconds: 86400,
+		Enabled:         true,
+		// No CreatedBy* identity fields — pre-definer-rights alert.
+	}
+	if err := db.catalog.CreateAlert(ctx, legacy); err != nil {
+		t.Fatal(err)
+	}
+	m, err := db.catalog.GetAlert(ctx, "legacy")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	decorate := db.alertEvalDecorator()
+	n, _, err := alertQuery(t, db, decorate(ctx, *m), m.QueryText)
+	if err == nil {
+		t.Fatalf("legacy alert ran unfiltered (got %d rows) — must fail closed under enabled auth", n)
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "denied") {
+		t.Fatalf("expected an access-denied error for a legacy alert, got %v", err)
+	}
+}

--- a/wadjet/wadjet.go
+++ b/wadjet/wadjet.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/citc-tech/wadjet/internal/alerts"
@@ -89,7 +90,7 @@ func Open(ctx context.Context, cfg Config) (*DB, error) {
 			}
 			return sinks
 		})
-		sched := alerts.NewScheduler(cat, ex, sinkFactory)
+		sched := alerts.NewScheduler(cat, ex, sinkFactory, db.alertEvalDecorator())
 		schedCtx, cancel := context.WithCancel(context.Background())
 		db.alertScheduler = sched
 		db.alertSchedulerStop = cancel
@@ -733,14 +734,43 @@ func (db *DB) showTables(ctx context.Context) (*QueryResult, error) {
 	}, nil
 }
 
+// alertEvalDecorator returns the scheduler's per-alert context decorator that
+// runs each alert query under its creator's identity (definer's rights). Auth
+// disabled → context untouched; legacy alerts with no stored identity run
+// fail-closed under ABAC and are warned about once per process.
+func (db *DB) alertEvalDecorator() alerts.EvalContextFunc {
+	var warned sync.Map
+	return func(ctx context.Context, m catalog.AlertMeta) context.Context {
+		snap := auth.IdentitySnapshot{
+			Name:       m.CreatedBy,
+			Role:       m.CreatedByRole,
+			Method:     m.CreatedByMethod,
+			Attributes: m.CreatedByAttrs,
+		}
+		newCtx, attributed := auth.StampDefiner(ctx, db.authProvider, snap)
+		if !attributed {
+			if _, seen := warned.LoadOrStore(m.Name, true); !seen {
+				db.logger.Warn("alert has no stored creator identity; running fail-closed under ABAC — recreate it to attribute a definer",
+					"alert", m.Name)
+			}
+		}
+		return newCtx
+	}
+}
+
 // createAlertSQL handles CREATE ALERT DDL in embedded mode.
 func (db *DB) createAlertSQL(ctx context.Context, info *plansql.CreateAlertInfo, _ string) (*QueryResult, error) {
 	if db.alertScheduler == nil {
 		return nil, fmt.Errorf("alerts are disabled; set Config.EnableAlerts=true")
 	}
+	if err := auth.RequirePermission(db.authProvider, ctx, "admin"); err != nil {
+		return nil, err
+	}
 	if err := alerts.EnsureHistoryTable(ctx, db.catalog); err != nil {
 		return nil, fmt.Errorf("ensuring alert_history: %w", err)
 	}
+	// Snapshot the creator's identity for definer's-rights scheduled runs.
+	snap := auth.SnapshotIdentity(ctx)
 	m := catalog.AlertMeta{
 		Name:            info.Name,
 		QueryText:       info.QueryText,
@@ -750,6 +780,10 @@ func (db *DB) createAlertSQL(ctx context.Context, info *plansql.CreateAlertInfo,
 		InsertIntoTable: info.InsertInto,
 		Enabled:         true,
 		CreatedAt:       time.Now().UTC(),
+		CreatedBy:       snap.Name,
+		CreatedByRole:   snap.Role,
+		CreatedByMethod: snap.Method,
+		CreatedByAttrs:  snap.Attributes,
 	}
 	if err := db.catalog.CreateAlert(ctx, m); err != nil {
 		return nil, err
@@ -764,6 +798,9 @@ func (db *DB) createAlertSQL(ctx context.Context, info *plansql.CreateAlertInfo,
 func (db *DB) dropAlertSQL(ctx context.Context, info *plansql.DropAlertInfo) (*QueryResult, error) {
 	if db.alertScheduler == nil {
 		return nil, fmt.Errorf("alerts are disabled; set Config.EnableAlerts=true")
+	}
+	if err := auth.RequirePermission(db.authProvider, ctx, "admin"); err != nil {
+		return nil, err
 	}
 	if _, err := db.catalog.GetAlert(ctx, info.Name); err != nil {
 		if info.IfExists {
@@ -787,6 +824,9 @@ func (db *DB) dropAlertSQL(ctx context.Context, info *plansql.DropAlertInfo) (*Q
 func (db *DB) alterAlertSQL(ctx context.Context, info *plansql.AlterAlertInfo) (*QueryResult, error) {
 	if db.alertScheduler == nil {
 		return nil, fmt.Errorf("alerts are disabled; set Config.EnableAlerts=true")
+	}
+	if err := auth.RequirePermission(db.authProvider, ctx, "admin"); err != nil {
+		return nil, err
 	}
 	if err := db.catalog.SetAlertEnabled(ctx, info.Name, info.Enable); err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Closes the two residual fail-open gaps in the **alerts** subsystem flagged during the MCP ABAC review (#193). Both are pre-existing and independent of MCP, and both are fixed on both entrances — the coordinator (`ExecuteSQL`) and the embedded `wadjet.DB`.

### The gaps

1. **No authorization on alert DDL.** `CREATE/DROP/ALTER ALERT` ran with zero permission check. Any caller — including an unauthenticated MCP session — could persist a server-side job that runs arbitrary SQL on a cadence and can `INSERT INTO` tables.
2. **Scheduler ran alerts unfiltered.** The scheduler re-executed stored alert SQL on a bare background context with no identity, so `EnforcePlanPolicies` fail-opened — every alert query bypassed the row/column ABAC its creator was subject to, on every tick.

### Fixes

- **Admin gate** (`auth.RequirePermission`): alert DDL now requires the `admin` permission when auth is enabled (fail-closed: missing identity or insufficient permission → rejected). No-op when auth is absent/disabled.
- **Definer's rights**: the creator's identity snapshot (role + method + attributes) is persisted in `AlertMeta` at creation and re-stamped onto the eval context every tick, so the scheduled query enforces the **creator's** ABAC policies — the standard `SECURITY DEFINER` / authorized-view model.

### Design notes

- `auth.StampDefiner` always stamps a **non-nil** identity under enabled auth. That's the fail-closed lever: `EnforcePlanPolicies` fail-opens only on a *nil* identity, so a legacy alert (no stored creator) gets a role-less identity that routes into ABAC **default-deny** instead of unfiltered execution.
- The scheduler stays decoupled from `auth` via an injected `EvalContextFunc` (compiler-enforced 4th `NewScheduler` arg); the coordinator and embedded DB each supply a decorator bound to their provider.
- **Legacy alerts** (created before this change, per your decision): fail closed under enabled auth + a one-time warning naming each so operators know to recreate them. Unchanged under disabled auth. `AlertMeta`'s new fields are `omitempty`, so old persisted records deserialize cleanly.

### Tests (each verified to fail before the fix)

- **auth:** `RequirePermission` matrix; snapshot round-trip; `StampDefiner` including the non-nil-identity fail-closed invariant.
- **alerts:** the injected decorator's context actually reaches `exec.Query`.
- **wadjet e2e:** DDL rejected without admin / accepted with it (both CREATE and DROP); a created alert's query enforces the creator's row filter + column deny (vs unfiltered on a bare context); a legacy alert fails closed with access-denied.

Separate from #193 (MCP) — no overlapping files; branched off main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)