### PR TITLE
feat: sort-merge join for big-vs-big shuffled joins (dormant, flag-gated)

### DIFF
--- a/benchmarks/tpch/sort_merge_join_test.go
+++ b/benchmarks/tpch/sort_merge_join_test.go
@@ -1,0 +1,147 @@
+package tpch
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/planner/physical"
+	"github.com/citc-tech/wadjet/internal/storage/ingest"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/wadjet"
+)
+
+// TestTPCHQueriesSortMergeJoinForced is the phase-2 gate from
+// docs/design/sort-merge-join.md §4: with --sort-merge-join-bytes forced to 1,
+// every gate-eligible inner equi-join in the suite routes through
+// SortMergeJoin, and all 22 queries must return the same rows as the default
+// (hash join) configuration over identical data.
+//
+// Q02/Q22 compare row counts with the same tolerance as TestTPCHQueries:
+// their float-threshold predicates admit borderline rows that legitimately
+// shift with accumulation order, which differs between join algorithms.
+func TestTPCHQueriesSortMergeJoinForced(t *testing.T) {
+	ctx := context.Background()
+
+	// Two independent DBs, each loaded from the deterministic generator: a
+	// DB's catalog metadata is in-memory per instance, so sharing one store
+	// between two Opens leaves the second catalog empty.
+	openAndLoad := func(smjBytes int64) *wadjet.DB {
+		db, err := wadjet.Open(ctx, wadjet.Config{
+			Store:              objstore.NewMemStore(),
+			Bucket:             "tpch",
+			SortMergeJoinBytes: smjBytes,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		data := Generate(SF001)
+		for tableName, schema := range AllTables {
+			if err := db.CreateTable(ctx, tableName, schema, nil); err != nil {
+				t.Fatalf("creating table %s: %v", tableName, err)
+			}
+			rows := data[tableName]
+			if len(rows) == 0 {
+				continue
+			}
+			ing := db.NewIngester(tableName, schema, nil, ingest.Config{
+				MaxBufferRows: len(rows) + 1,
+				RowGroupSize:  max(100, len(rows)/4),
+			})
+			if err := ing.Ingest(ctx, rows); err != nil {
+				t.Fatalf("ingesting %s: %v", tableName, err)
+			}
+			if err := ing.FlushAll(ctx); err != nil {
+				t.Fatalf("flushing %s: %v", tableName, err)
+			}
+		}
+		return db
+	}
+
+	baseline := openAndLoad(0)
+	defer baseline.Close()
+	forced := openAndLoad(1)
+	defer forced.Close()
+
+	queryNums := make([]int, 0, len(TPCHQueries))
+	for n := range TPCHQueries {
+		queryNums = append(queryNums, n)
+	}
+	sort.Ints(queryNums)
+
+	plannedBefore := physical.SortMergeJoinsPlanned.Load()
+	for _, qNum := range queryNums {
+		q := TPCHQueries[qNum]
+		t.Run(fmt.Sprintf("Q%02d_%s", qNum, q.Name), func(t *testing.T) {
+			baseCount := physical.SortMergeJoinsPlanned.Load()
+			want, err := baseline.Query(ctx, q.SQL)
+			if err != nil {
+				t.Fatalf("baseline Q%d failed: %v", qNum, err)
+			}
+			if got := physical.SortMergeJoinsPlanned.Load(); got != baseCount {
+				t.Fatalf("dormancy broken: default config planned %d sort-merge joins", got-baseCount)
+			}
+
+			got, err := forced.Query(ctx, q.SQL)
+			if err != nil {
+				t.Fatalf("forced-SMJ Q%d failed: %v", qNum, err)
+			}
+
+			// Q02/Q22: float-threshold borderline rows shift with
+			// accumulation order — count tolerance, matching TestTPCHQueries.
+			if qNum == 2 || qNum == 22 {
+				diff := len(got.Rows) - len(want.Rows)
+				if diff < -4 || diff > 4 {
+					t.Fatalf("Q%d row count: forced %d vs baseline %d (tolerance 4)", qNum, len(got.Rows), len(want.Rows))
+				}
+				return
+			}
+
+			w, g := canonicalRows(want.Rows), canonicalRows(got.Rows)
+			if len(w) != len(g) {
+				t.Fatalf("Q%d row count: forced %d vs baseline %d", qNum, len(g), len(w))
+			}
+			for i := range w {
+				if w[i] != g[i] {
+					t.Fatalf("Q%d row %d differs:\n  baseline %s\n  forced   %s", qNum, i, w[i], g[i])
+				}
+			}
+		})
+	}
+	if planned := physical.SortMergeJoinsPlanned.Load() - plannedBefore; planned == 0 {
+		t.Fatal("forced threshold planned zero sort-merge joins — the gate never fired and this test proved nothing")
+	} else {
+		t.Logf("sort-merge joins planned across the suite: %d", planned)
+	}
+}
+
+// canonicalRows renders rows order-independently with floats at 6 significant
+// digits, absorbing accumulation-order noise between join algorithms.
+func canonicalRows(rows []map[string]any) []string {
+	out := make([]string, 0, len(rows))
+	var sb strings.Builder
+	for _, r := range rows {
+		keys := make([]string, 0, len(r))
+		for k := range r {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		sb.Reset()
+		for _, k := range keys {
+			switch v := r[k].(type) {
+			case float64:
+				sb.WriteString(k + "=" + strconv.FormatFloat(v, 'g', 6, 64) + "|")
+			case float32:
+				sb.WriteString(k + "=" + strconv.FormatFloat(float64(v), 'g', 6, 32) + "|")
+			default:
+				fmt.Fprintf(&sb, "%s=%v|", k, v)
+			}
+		}
+		out = append(out, sb.String())
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cmd/tpch-bench/main.go
+++ b/cmd/tpch-bench/main.go
@@ -23,6 +23,7 @@ import (
 	"runtime/debug"
 	"runtime/pprof"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -42,25 +43,25 @@ import (
 
 func main() {
 	var (
-		configPath    = flag.String("config", "", "Path to benchmark profile YAML (values override defaults; CLI flags override profile)")
-		scale         = flag.Int("scale", 1, "TPC-H scale factor (1, 10, 100)")
-		s3Endpoint    = flag.String("endpoint", "", "S3 endpoint (empty = in-memory standalone)")
-		s3Bucket      = flag.String("bucket", "wadjet-bench-sf1", "S3 bucket name")
-		s3Region      = flag.String("region", "", "S3 region")
-		ssl           = flag.Bool("ssl", false, "Use TLS for S3")
-		workers       = flag.Int("workers", 0, "Expected external workers (0 = standalone in-memory)")
-		natsPort      = flag.Int("nats-port", 4222, "NATS listen port (distributed mode)")
-		dataPlane     = flag.String("data-plane", "", "Worker↔coord data-plane transport: empty/nats (default) or grpc (Phases C+D+E)")
-		dataPlaneAddr = flag.String("data-plane-addr", ":9091", "gRPC data-plane listen address (distributed + --data-plane=grpc)")
-		runs        = flag.Int("runs", 1, "Number of benchmark runs")
-		dataOnly    = flag.Bool("data-only", false, "Generate and upload data only, skip benchmark queries")
-		skipLoad    = flag.Bool("skip-load", false, "Skip data generation; discover existing parquet files from S3")
-		skipQueries = flag.String("skip-queries", "", "Comma-separated query numbers to skip (e.g. 2,17)")
-		queryTimeout = flag.Duration("query-timeout", 10*time.Minute, "Per-query timeout (0 = no timeout)")
-		cpuProf     = flag.String("cpuprofile", "", "Write CPU profile to file")
-		memProf     = flag.String("memprofile", "", "Write memory profile to file")
-		profDir     = flag.String("profdir", "", "Directory for per-query profiles")
-		dataPrefix  = flag.String("data-prefix", "tables/", "S3 prefix for table data (e.g. 'tables/' or '' for root)")
+		configPath            = flag.String("config", "", "Path to benchmark profile YAML (values override defaults; CLI flags override profile)")
+		scale                 = flag.Int("scale", 1, "TPC-H scale factor (1, 10, 100)")
+		s3Endpoint            = flag.String("endpoint", "", "S3 endpoint (empty = in-memory standalone)")
+		s3Bucket              = flag.String("bucket", "wadjet-bench-sf1", "S3 bucket name")
+		s3Region              = flag.String("region", "", "S3 region")
+		ssl                   = flag.Bool("ssl", false, "Use TLS for S3")
+		workers               = flag.Int("workers", 0, "Expected external workers (0 = standalone in-memory)")
+		natsPort              = flag.Int("nats-port", 4222, "NATS listen port (distributed mode)")
+		dataPlane             = flag.String("data-plane", "", "Worker↔coord data-plane transport: empty/nats (default) or grpc (Phases C+D+E)")
+		dataPlaneAddr         = flag.String("data-plane-addr", ":9091", "gRPC data-plane listen address (distributed + --data-plane=grpc)")
+		runs                  = flag.Int("runs", 1, "Number of benchmark runs")
+		dataOnly              = flag.Bool("data-only", false, "Generate and upload data only, skip benchmark queries")
+		skipLoad              = flag.Bool("skip-load", false, "Skip data generation; discover existing parquet files from S3")
+		skipQueries           = flag.String("skip-queries", "", "Comma-separated query numbers to skip (e.g. 2,17)")
+		queryTimeout          = flag.Duration("query-timeout", 10*time.Minute, "Per-query timeout (0 = no timeout)")
+		cpuProf               = flag.String("cpuprofile", "", "Write CPU profile to file")
+		memProf               = flag.String("memprofile", "", "Write memory profile to file")
+		profDir               = flag.String("profdir", "", "Directory for per-query profiles")
+		dataPrefix            = flag.String("data-prefix", "tables/", "S3 prefix for table data (e.g. 'tables/' or '' for root)")
 		catalogSnapshotPrefix = flag.String("catalog-snapshot-prefix", "", "S3 prefix for catalog snapshots (e.g. 'catalog/'). With --skip-load: restore the latest snapshot instead of running discovery+ANALYZE; after a fresh discovery, write one. Empty = disabled.")
 	)
 	flag.Parse()
@@ -338,6 +339,13 @@ func setupDistributed(ctx context.Context, logger *slog.Logger, endpoint, region
 		NATSUrl:        embeddedNATS.ClientURL(),
 		ResultBucket:   bucket,
 		DynamicFilters: os.Getenv("WADJET_DYNAMIC_FILTERS") == "1" || strings.EqualFold(os.Getenv("WADJET_DYNAMIC_FILTERS"), "true"),
+		// Sort-merge join gate (docs/design/sort-merge-join.md): inner
+		// equi-joins whose sides BOTH exceed this many estimated bytes run
+		// as sort-merge joins. 0/unset = disabled (hash/broadcast as before).
+		SortMergeJoinBytes: envInt64("WADJET_SORT_MERGE_JOIN_BYTES"),
+		// Broadcast threshold override: <0 = never broadcast. 0/unset =
+		// cluster-derived default.
+		BroadcastBytesOverride: envInt64("WADJET_BROADCAST_BYTES"),
 		// Streaming exchange (docs/design/streaming-exchange.md): annotate
 		// tasks with peer-location hints + fetch tokens and run stage
 		// uploads async. Workers must run with --streaming-exchange too
@@ -695,14 +703,14 @@ func runBenchmark(ctx context.Context, qf queryFn, sf tpch.ScaleFactor, runs int
 	}
 
 	type result struct {
-		Query    int
-		Name     string
-		Elapsed  time.Duration
-		Rows     int
-		HeapMB   int64
-		DeltaMB  int64
+		Query     int
+		Name      string
+		Elapsed   time.Duration
+		Rows      int
+		HeapMB    int64
+		DeltaMB   int64
 		GCPauseNs uint64
-		Err      error
+		Err       error
 	}
 
 	for run := 1; run <= runs; run++ {
@@ -867,4 +875,19 @@ func collectWorkerProfiles(nc *nats.Conn, workerCount int, profDir string) {
 		collected++
 	}
 	log.Printf("Collected profiles from %d/%d workers", collected, workerCount)
+}
+
+// envInt64 parses an int64 env var; empty or malformed values return 0 so an
+// unset knob keeps the default-off behavior.
+func envInt64(key string) int64 {
+	v := os.Getenv(key)
+	if v == "" {
+		return 0
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		log.Printf("WARN: ignoring %s=%q: %v", key, v, err)
+		return 0
+	}
+	return n
 }

--- a/cmd/wadjet/main.go
+++ b/cmd/wadjet/main.go
@@ -97,6 +97,7 @@ var (
 	coordDataPlane        string
 	localFastPathBytes    int64
 	sortMergeJoinBytes    int64
+	broadcastBytes        int64
 	streamingExchange     bool
 	peerExchangeAddr      string
 	peerExchangeAdvertise string
@@ -153,7 +154,8 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&dataPlane, "data-plane", "nats", "Worker↔coord data-plane transport: nats (default) or grpc. See project_split_plane_design_2026-05-20.")
 	rootCmd.PersistentFlags().StringVar(&dataPlaneAddr, "data-plane-addr", ":9091", "Data-plane gRPC listen address (coord/standalone)")
 	rootCmd.PersistentFlags().StringVar(&coordDataPlane, "coord-data-plane", "", "Coord's data-plane host:port (worker only; defaults to coord-host + 9091)")
-	rootCmd.PersistentFlags().Int64Var(&sortMergeJoinBytes, "sort-merge-join-bytes", 0, "Inner equi-joins whose sides BOTH exceed this estimated size run as sort-merge joins (both sides sort to spill-friendly runs and stream a merge) instead of hash joins, bounding join memory at merge-cursor state instead of a resident build table. Local single-process paths only for now; the distributed stage DAG keeps hash/broadcast joins. 0 = disabled (default). See docs/design/sort-merge-join.md.")
+	rootCmd.PersistentFlags().Int64Var(&broadcastBytes, "broadcast-bytes", 0, "Override the broadcast-join threshold: joins whose estimated build side is under this many bytes replicate the build to every worker. 0 = derive from worker pool budget (default), <0 = never broadcast (every join takes the hash-shuffle/sort-merge path; benchmarking/debugging surface).")
+	rootCmd.PersistentFlags().Int64Var(&sortMergeJoinBytes, "sort-merge-join-bytes", 0, "Inner equi-joins whose sides BOTH exceed this estimated size run as sort-merge joins (both sides sort to spill-friendly runs and stream a merge) instead of hash joins, bounding join memory at merge-cursor state instead of a resident build table. Applies to both the local single-process paths and the distributed stage DAG (the join stage swaps operator; its exchange children are identical). 0 = disabled (default). See docs/design/sort-merge-join.md.")
 	rootCmd.PersistentFlags().Int64Var(&localFastPathBytes, "local-fastpath-bytes", coordinator.DefaultLocalFastPathBytes, "Queries whose post-pruning catalog scan bytes stay under this threshold execute in-process on the coordinator (skipping the distributed stage DAG and its per-stage object-store round trips). 0 = disabled.")
 	rootCmd.PersistentFlags().BoolVar(&streamingExchange, "streaming-exchange", true, "Streaming exchange: consumers fetch stage outputs from the producing workers' local disk over gRPC with async S3 upload; every failure falls through to the durable S3 path. Default true (validated 2026-07-02: SF10 −10%, SF100 −23% suite wall, row-identical, zero fault-tolerance events); --streaming-exchange=false restores synchronous S3-only shuffle. See docs/design/streaming-exchange.md.")
 	rootCmd.PersistentFlags().StringVar(&peerExchangeAddr, "peer-exchange-addr", ":0", "Peer-exchange (FetchShuffle) listen address. Default :0 picks a free port (the address reaches peers via heartbeats, and a fixed default would collide when multiple workers share a host); pin it when firewalls need a known port.")
@@ -875,12 +877,13 @@ func runStandalone(ctx context.Context, store objstore.Store, logger *slog.Logge
 
 	// Start coordinator
 	coord := coordinator.New(coordinator.Config{
-		NATSUrl:            embeddedNATS.ClientURL(),
-		ResultBucket:       bucket,
-		DynamicFilters:     dynamicFiltersFromEnv(),
-		LocalFastPathBytes: localFastPathBytes,
-		SortMergeJoinBytes: sortMergeJoinBytes,
-		StreamingExchange:  streamingExchange,
+		NATSUrl:                embeddedNATS.ClientURL(),
+		ResultBucket:           bucket,
+		DynamicFilters:         dynamicFiltersFromEnv(),
+		LocalFastPathBytes:     localFastPathBytes,
+		BroadcastBytesOverride: broadcastBytes,
+		SortMergeJoinBytes:     sortMergeJoinBytes,
+		StreamingExchange:      streamingExchange,
 	}, cat, nc, js, logger)
 
 	// Phase A: same-process data-plane server + client when enabled.
@@ -1172,12 +1175,13 @@ func runCoordinator(ctx context.Context, store objstore.Store, logger *slog.Logg
 	wireUDFPersistence(cat, logger)
 
 	coord := coordinator.New(coordinator.Config{
-		NATSUrl:            embeddedNATS.ClientURL(),
-		ResultBucket:       bucket,
-		DynamicFilters:     dynamicFiltersFromEnv(),
-		LocalFastPathBytes: localFastPathBytes,
-		SortMergeJoinBytes: sortMergeJoinBytes,
-		StreamingExchange:  streamingExchange,
+		NATSUrl:                embeddedNATS.ClientURL(),
+		ResultBucket:           bucket,
+		DynamicFilters:         dynamicFiltersFromEnv(),
+		LocalFastPathBytes:     localFastPathBytes,
+		BroadcastBytesOverride: broadcastBytes,
+		SortMergeJoinBytes:     sortMergeJoinBytes,
+		StreamingExchange:      streamingExchange,
 	}, cat, nc, js, logger)
 
 	// Phase A: start data-plane gRPC server alongside coord when enabled.

--- a/cmd/wadjet/main.go
+++ b/cmd/wadjet/main.go
@@ -96,6 +96,7 @@ var (
 	dataPlaneAddr         string
 	coordDataPlane        string
 	localFastPathBytes    int64
+	sortMergeJoinBytes    int64
 	streamingExchange     bool
 	peerExchangeAddr      string
 	peerExchangeAdvertise string
@@ -152,6 +153,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&dataPlane, "data-plane", "nats", "Worker↔coord data-plane transport: nats (default) or grpc. See project_split_plane_design_2026-05-20.")
 	rootCmd.PersistentFlags().StringVar(&dataPlaneAddr, "data-plane-addr", ":9091", "Data-plane gRPC listen address (coord/standalone)")
 	rootCmd.PersistentFlags().StringVar(&coordDataPlane, "coord-data-plane", "", "Coord's data-plane host:port (worker only; defaults to coord-host + 9091)")
+	rootCmd.PersistentFlags().Int64Var(&sortMergeJoinBytes, "sort-merge-join-bytes", 0, "Inner equi-joins whose sides BOTH exceed this estimated size run as sort-merge joins (both sides sort to spill-friendly runs and stream a merge) instead of hash joins, bounding join memory at merge-cursor state instead of a resident build table. Local single-process paths only for now; the distributed stage DAG keeps hash/broadcast joins. 0 = disabled (default). See docs/design/sort-merge-join.md.")
 	rootCmd.PersistentFlags().Int64Var(&localFastPathBytes, "local-fastpath-bytes", coordinator.DefaultLocalFastPathBytes, "Queries whose post-pruning catalog scan bytes stay under this threshold execute in-process on the coordinator (skipping the distributed stage DAG and its per-stage object-store round trips). 0 = disabled.")
 	rootCmd.PersistentFlags().BoolVar(&streamingExchange, "streaming-exchange", true, "Streaming exchange: consumers fetch stage outputs from the producing workers' local disk over gRPC with async S3 upload; every failure falls through to the durable S3 path. Default true (validated 2026-07-02: SF10 −10%, SF100 −23% suite wall, row-identical, zero fault-tolerance events); --streaming-exchange=false restores synchronous S3-only shuffle. See docs/design/streaming-exchange.md.")
 	rootCmd.PersistentFlags().StringVar(&peerExchangeAddr, "peer-exchange-addr", ":0", "Peer-exchange (FetchShuffle) listen address. Default :0 picks a free port (the address reaches peers via heartbeats, and a fixed default would collide when multiple workers share a host); pin it when firewalls need a known port.")
@@ -877,6 +879,7 @@ func runStandalone(ctx context.Context, store objstore.Store, logger *slog.Logge
 		ResultBucket:       bucket,
 		DynamicFilters:     dynamicFiltersFromEnv(),
 		LocalFastPathBytes: localFastPathBytes,
+		SortMergeJoinBytes: sortMergeJoinBytes,
 		StreamingExchange:  streamingExchange,
 	}, cat, nc, js, logger)
 
@@ -953,10 +956,11 @@ func runStandalone(ctx context.Context, store objstore.Store, logger *slog.Logge
 
 	// Build config manager and auth provider for hot-reload
 	srvCfg := server.Config{
-		Addr:        httpAddr,
-		Catalog:     cat,
-		Coordinator: coord,
-		Metrics:     m,
+		Addr:               httpAddr,
+		Catalog:            cat,
+		Coordinator:        coord,
+		Metrics:            m,
+		SortMergeJoinBytes: sortMergeJoinBytes,
 	}
 
 	var cfgMgr *config.Manager
@@ -1172,6 +1176,7 @@ func runCoordinator(ctx context.Context, store objstore.Store, logger *slog.Logg
 		ResultBucket:       bucket,
 		DynamicFilters:     dynamicFiltersFromEnv(),
 		LocalFastPathBytes: localFastPathBytes,
+		SortMergeJoinBytes: sortMergeJoinBytes,
 		StreamingExchange:  streamingExchange,
 	}, cat, nc, js, logger)
 
@@ -1237,11 +1242,12 @@ func runCoordinator(ctx context.Context, store objstore.Store, logger *slog.Logg
 	dlq := coordinator.NewDLQ(js)
 
 	srvCfg := server.Config{
-		Addr:        httpAddr,
-		Catalog:     cat,
-		Coordinator: coord,
-		DLQ:         dlq,
-		Metrics:     m,
+		Addr:               httpAddr,
+		Catalog:            cat,
+		Coordinator:        coord,
+		DLQ:                dlq,
+		Metrics:            m,
+		SortMergeJoinBytes: sortMergeJoinBytes,
 	}
 
 	var cfgMgr *config.Manager

--- a/deploy/benchmark/terraform/main.tf
+++ b/deploy/benchmark/terraform/main.tf
@@ -272,6 +272,7 @@ locals {
     echo "WADJET_REVERSE_BLOOM_INNER_THRESHOLD=${var.reverse_bloom_inner_threshold}" >> /etc/environment
     echo "WADJET_JOIN_DEBUG=${var.join_debug}" >> /etc/environment
     echo "WADJET_DYNAMIC_FILTERS=${var.dynamic_filters}" >> /etc/environment
+    echo "WADJET_SORT_MERGE_JOIN_BYTES=${var.sort_merge_join_bytes}" >> /etc/environment
     echo "BUILD_COMPLETE=1" >> /etc/environment
   SCRIPT
 
@@ -305,6 +306,7 @@ locals {
     echo "WADJET_REVERSE_BLOOM_INNER_THRESHOLD=${var.reverse_bloom_inner_threshold}" >> /etc/environment
     echo "WADJET_JOIN_DEBUG=${var.join_debug}" >> /etc/environment
     echo "WADJET_DYNAMIC_FILTERS=${var.dynamic_filters}" >> /etc/environment
+    echo "WADJET_SORT_MERGE_JOIN_BYTES=${var.sort_merge_join_bytes}" >> /etc/environment
     echo "BUILD_COMPLETE=1" >> /etc/environment
   SCRIPT
 
@@ -372,6 +374,7 @@ locals {
     export WADJET_REVERSE_BLOOM_INNER_THRESHOLD="${var.reverse_bloom_inner_threshold}"
     export WADJET_JOIN_DEBUG="${var.join_debug}"
     export WADJET_DYNAMIC_FILTERS="${var.dynamic_filters}"
+    export WADJET_SORT_MERGE_JOIN_BYTES="${var.sort_merge_join_bytes}"
     export USE_NATIVE_DAG="${var.use_native_dag ? "1" : "0"}"
     # Phase C/D/E data-plane selection. Empty/"nats" = legacy NATS reply
     # subjects; "grpc" routes task dispatch + results + gather +
@@ -518,6 +521,7 @@ resource "aws_instance" "worker" {
     export WADJET_REVERSE_BLOOM_INNER_THRESHOLD="${var.reverse_bloom_inner_threshold}"
     export WADJET_JOIN_DEBUG="${var.join_debug}"
     export WADJET_DYNAMIC_FILTERS="${var.dynamic_filters}"
+    export WADJET_SORT_MERGE_JOIN_BYTES="${var.sort_merge_join_bytes}"
 
     # Verify binary was downloaded successfully
     if [ ! -x /usr/local/bin/wadjet ]; then

--- a/deploy/benchmark/terraform/variables.tf
+++ b/deploy/benchmark/terraform/variables.tf
@@ -204,6 +204,12 @@ variable "join_debug" {
   default     = ""
 }
 
+variable "sort_merge_join_bytes" {
+  description = "Sort-merge join gate (docs/design/sort-merge-join.md): inner equi-joins whose sides BOTH exceed this many estimated bytes run as sort-merge joins instead of hash joins. 0 = disabled (default, dormant)."
+  type        = number
+  default     = 0
+}
+
 variable "dynamic_filters" {
   description = "Set to 1 to enable Trino-style semi-join dynamic-filter pushdown on the coordinator. Off by default for v1 rollout."
   type        = string

--- a/docs/design/sort-merge-join.md
+++ b/docs/design/sort-merge-join.md
@@ -1,0 +1,226 @@
+# Sort-merge join for big-vs-big shuffled joins
+
+Status: DESIGN — grounded against main @ `9dbf16e` (2026-07-07), awaiting review.
+Scope: new `exec.SortMergeJoin` operator + planner/coordinator/worker wiring,
+flag-gated and dormant by default (the memory-accounting-overhaul rollout
+pattern: land dark, activate deploy-gated).
+
+## 1. Motivation
+
+The join-task memory model is what pins worker concurrency. A shuffled hash
+join materializes one side's partition as a hash table (grace partition-on-
+arrival, `join_partition_arrival.go:48`), reserving against the shared pool
+(`worker.go:214-219`, budget = MemoryBudget × MaxConcurrent). Resident builds
+are what historically forced `max_concurrent` down to 3 and what the Q17/Q18
+"mc=4 failure mode" (`join.go:711`) was about; today's cooperative-spill
+machinery makes it *safe*, but a big build still consumes pool budget that
+would otherwise admit more tasks (`waitForPoolHeadroom`, `worker.go:594,642`),
+and under pressure the grace path burns re-spill churn (evict → probe-side
+disk routing → per-partition reload/rebuild).
+
+A sort-merge join streams both sides in join-key order: resident memory is
+O(sort-run buffer + one batch per merge cursor), independent of either side's
+size. That converts the worst joins from "resident-build vs pool budget"
+into "sequential disk bandwidth", which is the memory-constrained-scaling
+shape this project prioritizes. It also mechanically removes grace-probe
+respill (each side is written once as sorted runs and read once).
+
+The honest trade: hash join streams its probe side with ZERO materialization.
+SMJ materializes BOTH sides into sorted runs when they don't fit. So SMJ is
+not a general hash-join replacement — it wins precisely when the build side
+is large enough that grace eviction/respill and pool starvation dominate,
+i.e. the both-sides-large class (SF100 lineitem⋈orders, Q18; the forced-
+shuffle join family in `distributed_tpch_test.go:1417-1596`).
+
+## 2. Grounded facts the design stands on (verified 2026-07-07)
+
+- **Co-partitioning is already guaranteed.** Both sides of a shuffled join
+  hash-partition with the identical inlined FNV-1a over the same key columns
+  and the same `numParts` (`partitioned_shuffle_sink.go:698-843`), and one
+  join task receives partition *p* of BOTH sides
+  (`orchestrate_repartition.go:365-400`, `stage_output.go:90-128`). SMJ
+  needs no new exchange machinery.
+- **Partition files are unsorted and readers are order-agnostic.** `.wshf`
+  chunks carry no ordering and may interleave across concurrent consumers
+  (`shuffle_format.go:112-128`, `partitioned_shuffle_sink.go:74-78`); the
+  streaming-exchange fetch path never inspects order
+  (`stream_source.go:168-194`, `peer_exchange.go:145-225`).
+- **The sorted-run facility is shared and SF100-validated.** Sort's external
+  path produces sorted columnar runs (`sortBatchesToRun`,
+  `sort_external.go:184-213`) over the shared spill codec
+  (`spillBatchWriter/Reader`, `join_spill.go:242-432`, nested types
+  included), merges them streaming with bounded fan-in
+  (`runMerger`/`runCursor`/`preMergeRuns`, `sort_external.go:220-427`,
+  `maxMergeFanIn=64`), and Window already consumes the same machinery
+  (`window_external.go:348`), including a re-sort-by-new-keys precedent
+  (`resortRunsByKeys`, `window_external.go:280`).
+- **Typed comparators are standalone.** `kernel.SortCompareKernel`
+  (`kernel/types.go:167`) compares a row of one vector against a row of
+  another and is resolved per type; `mergeHeap.Less`
+  (`sort_external.go:311-326`) shows the multi-key composition pattern. A
+  two-stream join comparison is the same composition over two cursors.
+- **No interesting-order machinery exists.** Nothing tracks sortedness
+  between stages (`Distribution{Kind,Keys,Count}` has no order field;
+  `Stage.SortKeys` only gates serial execution). Order is operator-internal
+  today.
+- **The seams are single points.** Local: `buildJoin`
+  (`plan.go:3857`, the one place `exec.NewHashJoin` is constructed) serves
+  embedded, local fast path, and standalone alike. Distributed: walkStages'
+  join case (`plan.go:3306`) already branches broadcast vs hash_join; op
+  types live in `messages.go:254-283`; the worker maps op→operator in
+  `buildFragmentUnary` (`executor_fragment.go:1556`).
+- **Memory contract template = Sort.** Lazy `RegisterAccounted` on first
+  consume, `TrackBatch`/`PublishOwned` on buffering, self-spill at
+  `ShouldSpillFor(SpillCheap)` past `minSortRunBytes`, `EstimateRelief`/
+  `SpillSome` for cooperative relief, `OpClosed` + unregister at finalize
+  (`sort.go:81-141,381-427`).
+
+## 3. Design
+
+### 3.1 Where the sort happens: at the join, not at shuffle-write (v1)
+
+The sort is operator-internal to the join task. Each side's partition input
+streams into a run-generation phase (Sort's machinery verbatim: buffer under
+tracker, self-spill sorted runs, in-memory remainder as the last cursor),
+then a two-cursor merge joins the two sorted streams.
+
+Rejected for v1 — sorting at shuffle-write:
+
+- Sorting each producer's whole per-partition contribution before writing
+  breaks the shuffle sink's memory bound (64 KB/partition accumulators,
+  `flushPartitionBytes`) — it would buffer entire partition contributions.
+- Sorting individual 64 KB chunks keeps the bound but yields thousands of
+  micro-runs per partition (1 GB partition ⇒ ~16k runs vs `maxMergeFanIn`
+  64), forcing multi-level pre-merge at the join task anyway — the read-side
+  work survives, the format acquires order semantics, and the interleaving-
+  tolerant sink + fetch paths (§2) would all need re-auditing.
+- There is no order-property plumbing to let the planner *know* an exchange
+  output is sorted (§2). Building that is real work with one consumer.
+
+Sort-at-write over sorted exchange becomes attractive only with order
+properties in the distribution system; that is explicitly future work.
+
+### 3.2 The operator: `exec.SortMergeJoin`
+
+A pipeline breaker on BOTH sides (inherent to sort-based joins over unsorted
+input; hash join breaks on one). Shape:
+
+- **Inputs.** Build-side `Source` (as HashJoin.Build takes today) plus the
+  probe side arriving via `Consume` — both funnel into per-side
+  `smjSideState`, each of which is Sort's buffering/spill core parameterized
+  by the side's join-key sort keys (ascending, nulls last).
+- **Sortedness.** Keys sort ascending; rows with a NULL in any join key are
+  excluded from the merge at run-generation time (SQL equi-join semantics:
+  NULL matches nothing; this also mirrors the hash paths where null keys
+  produce no index entry). For LEFT variants (post-v1) null-key probe rows
+  bypass the merge straight to the unmatched output.
+- **Merge.** Two cursors (`runMerger` per side — the existing N-way merger
+  already collapses each side's runs into one sorted stream; SMJ composes
+  two of them). Advance-lesser-side loop using one resolved
+  `SortCompareKernel` per key. On key equality, the classic duplicate-group
+  algorithm: materialize the RIGHT side's current key group into a small
+  buffer, emit the cross product against each LEFT row of the same key,
+  advance. The group buffer is tracker-Reserved; group size is bounded by
+  per-key duplication (TPC-H: ≤7 lineitems per orderkey), and a
+  pathologically hot key fails loudly via Reserve rather than OOMing —
+  documented bound, spillable group buffering is future work if real data
+  demands it.
+- **Output.** Same gather/output-column semantics as HashJoinProbe
+  (OutputColumns filter honored); emits `DefaultBatchSize` batches.
+- **Join types v1: Inner only.** The big-vs-big class is inner joins. LEFT/
+  SEMI/ANTI are mechanical extensions of the merge loop (emit-unmatched /
+  emit-on-first-match / emit-on-no-match) staged after v1 correctness soaks.
+  No JoinFilter in v1 (falls back to hash join).
+
+### 3.3 Memory contract (never-OOM)
+
+One `AccountedOperator` registration owning both side states, mirroring
+Sort's checklist exactly (§2 last bullet): buffered batches
+`TrackBatch`+`PublishOwned`; self-spill a side's buffer to a sorted run at
+`SpillCheap` past the run floor; `SpillSome` sheds the larger buffered side
+first (both sides are spillable pre-merge — strictly better than HashJoin,
+whose arena/index can never shed). Merge phase holds one batch per live
+cursor per side (fan-in ≤ 64/side via `preMergeRuns`) plus the duplicate
+group buffer. Morsel interaction: SMJ is not `Cloneable` in v1 → the
+breaker path runs it k=1 automatically; no new parallel-consume surface.
+
+### 3.4 Planner gate
+
+A join takes SMJ only when ALL hold (else the existing hash paths, entirely
+unchanged):
+
+- equi-join, `JoinType == Inner`, no `JoinFilter`;
+- not a broadcast candidate (`isBroadcastCandidate` false — small builds
+  keep the strictly-better broadcast/hash path);
+- BOTH sides' estimated bytes exceed `SortMergeJoinThreshold`. The build
+  side estimate exists today (`isBroadcastCandidate`'s selectivity-scaled
+  walk, `plan.go:3689-3725`); v1 mirrors that walk on `node.Children[0]`
+  for the probe side (CBO `RelStatsOf` scaling included). Threshold default
+  proposed: the worker pool budget signal the coordinator already computes
+  for broadcast (`broadcastThresholdFromCluster`, `workers.go:334`) scaled
+  up — concretely `4×` the per-worker memory budget, i.e. "this build
+  cannot sit resident without dominating the pool". Single knob
+  (`--sort-merge-join-bytes`), `0 = disabled` = the shipped default.
+
+Decision sites: local `buildJoin` (`plan.go:3857`) grows an SMJ branch
+before `NewHashJoin`; distributed walkStages' join case (`plan.go:3306`)
+emits `StageSortMergeJoin` instead of `StageHashJoin` — the exchange-
+repartition children are IDENTICAL (co-partitioning already suffices), so
+the shuffle plumbing, streaming exchange, and task retry story carry over
+untouched.
+
+### 3.5 Distributed wiring
+
+- `messages.go`: `OpSortMergeJoin` op type; OpSpec reuses the join fields
+  (LeftKeys/RightKeys/BuildAlias/BuildFiles/OutputColumns) — no new fields
+  expected in v1.
+- Coordinator: `buildSortMergeJoinFragment` alongside `buildJoinFragment`
+  (`execute_stage_dag.go:2284`); dispatch gate alongside the join branches
+  (`:2014,:2205`). Task `EstimatedBytes` for admission should reflect SMJ's
+  smaller resident footprint — v1 keeps the existing estimate (conservative:
+  over-admission is the risk to avoid; relaxing admission is the PAYOFF
+  step and comes only after SF100 soak).
+- Worker: `buildFragmentUnary` maps the op type; classified as a breaker
+  (`isFragmentBreakerOp`, `executor_fragment.go:1503-1511`) so it runs on
+  the validated breaker path.
+
+### 3.6 What this explicitly does not do (v1)
+
+- No order-property/interesting-order plumbing (future: sorted exchange,
+  sort elimination when upstream ORDER BY exists).
+- No LEFT/RIGHT/FULL/SEMI/ANTI, no JoinFilter (hash paths remain).
+- No admission-estimate relaxation, no `max_concurrent` change — those are
+  the *reward* once SF100 evidence is in, not part of the operator PR.
+- No morsel-parallel SMJ consume.
+
+## 4. Phases and gates
+
+1. **Operator PR**: `exec.SortMergeJoin` + two-stream merge; unit tests
+   (dup groups both sides incl. cross-batch groups, null keys, empty sides,
+   one-side-empty, forced-spill runs on both sides, nested-type payload
+   columns, -race), micro-bench vs HashJoin build+probe at in-memory and
+   spilled scales. Accounting truth-tests mirroring Sort's.
+2. **Local planner PR**: `buildJoin` gate + flag; TPC-H SF0.01 22/22 with
+   the flag FORCED on (threshold=1) — every inner equi-join in the suite
+   routed through SMJ and row-identical; then flag-off default confirms
+   dormancy (byte-identical plans).
+3. **Distributed PR**: stage/op wiring; `tpch-harness --mode=local` both
+   flag states (forced-on = the correctness gate; the harness's forced-
+   shuffle recipes already exist); -race harness arm.
+4. **Activation evidence** (deploy-gated, user-approved per deploy): SF10
+   same-window A/B flag-on vs off; then SF100 same-window pair watching
+   Q18/Q17/Q05 walls, pool headroom waits, spill volumes, zero reaps.
+   Only after that: the admission/concurrency payoff experiments.
+
+Hard rules carried: architectural fix not benchmark chasing; no per-query
+special cases; harness-local before EC2; every deploy individually
+preflighted; no revert on flat wall if CPU/memory wins are real.
+
+## 5. Open questions for review
+
+1. Threshold shape: fixed bytes knob vs fraction of pool budget (proposal:
+   knob with pool-scaled default, matching the broadcast pattern).
+2. Right-side duplicate-group buffer: accept the loud-Reserve bound for v1
+   (proposed) or require spillable group buffering upfront?
+3. Is Inner-only v1 acceptable given Q18-class is the target (proposed
+   yes)?

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -63,6 +63,13 @@ type Config struct {
 	// unchanged). `wadjet serve` enables it by default via its flag
 	// (DefaultLocalFastPathBytes).
 	LocalFastPathBytes int64
+	// SortMergeJoinBytes routes inner equi-joins whose sides BOTH exceed
+	// this estimated size through the sort-merge join instead of the hash
+	// join (docs/design/sort-merge-join.md). Phase 2 wires the local
+	// single-process paths only (fast path, standalone); the distributed
+	// stage DAG keeps hash/broadcast joins until phase 3. 0 = disabled
+	// (default, dormant).
+	SortMergeJoinBytes int64
 	// StreamingExchange annotates dispatched tasks with peer-location
 	// hints (Task.InputLocations) and per-query fetch tokens so consumers
 	// stream stage outputs from the producing workers' local disk instead

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -63,12 +63,19 @@ type Config struct {
 	// unchanged). `wadjet serve` enables it by default via its flag
 	// (DefaultLocalFastPathBytes).
 	LocalFastPathBytes int64
+	// BroadcastBytesOverride, when non-zero, replaces the cluster-derived
+	// broadcast threshold (broadcastThresholdFromCluster): >0 = fixed byte
+	// threshold, <0 = never broadcast (every join takes the hash-shuffle /
+	// sort-merge path). 0 = derive from worker pool budget (default).
+	// Primarily a benchmarking/debugging surface: forcing the shuffled-join
+	// path at small scale is how the sort-merge join gate gets exercised
+	// before data is big enough to defeat broadcast on its own.
+	BroadcastBytesOverride int64
 	// SortMergeJoinBytes routes inner equi-joins whose sides BOTH exceed
 	// this estimated size through the sort-merge join instead of the hash
-	// join (docs/design/sort-merge-join.md). Phase 2 wires the local
-	// single-process paths only (fast path, standalone); the distributed
-	// stage DAG keeps hash/broadcast joins until phase 3. 0 = disabled
-	// (default, dormant).
+	// join (docs/design/sort-merge-join.md), on the local fast path and in
+	// the distributed stage DAG alike (the join stage swaps operator; its
+	// exchange children are identical). 0 = disabled (default, dormant).
 	SortMergeJoinBytes int64
 	// StreamingExchange annotates dispatched tasks with peer-location
 	// hints (Task.InputLocations) and per-query fetch tokens so consumers
@@ -731,6 +738,10 @@ func (c *Coordinator) ExecuteSQL(ctx context.Context, sql string) (*SQLResult, e
 	planner := physical.NewPlanner(c.catalog)
 	planner.WorkerCount = c.workers.Count()
 	planner.BroadcastBytesThreshold = broadcastThresholdFromCluster(c.workers.MinWorkerPoolBudget())
+	if c.config.BroadcastBytesOverride != 0 {
+		planner.BroadcastBytesThreshold = c.config.BroadcastBytesOverride
+	}
+	planner.SortMergeJoinBytes = c.config.SortMergeJoinBytes
 	planner.DynamicFiltersEnabled = c.config.DynamicFilters
 	physStages, err := planner.PlanDistributed(ctx, logicalPlan)
 	if err != nil {
@@ -2420,6 +2431,10 @@ func (c *Coordinator) SubmitSQL(ctx context.Context, sql string) (queryID string
 	planner := physical.NewPlanner(c.catalog)
 	planner.WorkerCount = c.workers.Count()
 	planner.BroadcastBytesThreshold = broadcastThresholdFromCluster(c.workers.MinWorkerPoolBudget())
+	if c.config.BroadcastBytesOverride != 0 {
+		planner.BroadcastBytesThreshold = c.config.BroadcastBytesOverride
+	}
+	planner.SortMergeJoinBytes = c.config.SortMergeJoinBytes
 	planner.DynamicFiltersEnabled = c.config.DynamicFilters
 	physStages, err := planner.PlanDistributed(ctx, logicalPlan)
 	if err != nil {

--- a/internal/coordinator/distributed_smj_test.go
+++ b/internal/coordinator/distributed_smj_test.go
@@ -1,0 +1,99 @@
+//go:build !race
+
+// Shares setupTPCHDistributed with distributed_tpch_test.go, which is
+// excluded under -race for a known upstream nats-server data race (see that
+// file's header). Distributed -race coverage for the sort-merge join comes
+// from the harness gate run with a race-built wadjet binary.
+package coordinator
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	tpch "github.com/citc-tech/wadjet/benchmarks/tpch"
+	"github.com/citc-tech/wadjet/internal/planner/physical"
+)
+
+// TestDistributedTPCHSortMergeJoin is the phase-3 in-process gate for the
+// distributed sort-merge join (docs/design/sort-merge-join.md §4): with
+// broadcast disabled and the SMJ threshold forced to 1, every eligible inner
+// equi-join runs as a sort_merge_join stage over the SAME exchange children
+// the hash join would use. Each query runs twice on the same coordinator —
+// hash-shuffle then SMJ — and must return identical rows. The
+// SortMergeJoinsPlanned counter proves the SMJ arm actually took the path.
+func TestDistributedTPCHSortMergeJoin(t *testing.T) {
+	ctx, coord := setupTPCHDistributed(t)
+	// Never broadcast: both arms take the shuffled-join DAG shape, so the
+	// comparison isolates the join operator.
+	coord.config.BroadcastBytesOverride = -1
+
+	for _, qn := range []int{3, 5, 10, 12, 14} {
+		q := tpch.TPCHQueries[qn]
+		t.Run(fmt.Sprintf("Q%02d_%s", qn, q.Name), func(t *testing.T) {
+			coord.config.SortMergeJoinBytes = 0
+			hashResult, err := coord.ExecuteSQL(ctx, q.SQL)
+			if err != nil {
+				t.Fatalf("hash arm: %v", err)
+			}
+			if hashResult.Error != "" {
+				t.Fatalf("hash arm error: %s", hashResult.Error)
+			}
+			want := mustRows(t, hashResult)
+
+			coord.config.SortMergeJoinBytes = 1
+			before := physical.SortMergeJoinsPlanned.Load()
+			smjResult, err := coord.ExecuteSQL(ctx, q.SQL)
+			if err != nil {
+				t.Fatalf("SMJ arm: %v", err)
+			}
+			if smjResult.Error != "" {
+				t.Fatalf("SMJ arm error: %s", smjResult.Error)
+			}
+			got := mustRows(t, smjResult)
+			if planned := physical.SortMergeJoinsPlanned.Load() - before; planned == 0 {
+				t.Fatal("SMJ arm planned zero sort-merge joins — the gate never fired")
+			} else {
+				t.Logf("Q%02d: %d sort-merge join(s) planned, %d rows", qn, planned, len(got))
+			}
+
+			w, g := canonRowsSMJ(want), canonRowsSMJ(got)
+			if len(w) != len(g) {
+				t.Fatalf("row count: SMJ %d vs hash %d", len(g), len(w))
+			}
+			for i := range w {
+				if w[i] != g[i] {
+					t.Fatalf("row %d differs:\n  hash %s\n  smj  %s", i, w[i], g[i])
+				}
+			}
+		})
+	}
+}
+
+// canonRowsSMJ renders rows order-independently with floats at 6 significant
+// digits (accumulation order differs between join algorithms).
+func canonRowsSMJ(rows []map[string]any) []string {
+	out := make([]string, 0, len(rows))
+	var sb strings.Builder
+	for _, r := range rows {
+		keys := make([]string, 0, len(r))
+		for k := range r {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		sb.Reset()
+		for _, k := range keys {
+			switch v := r[k].(type) {
+			case float64:
+				sb.WriteString(k + "=" + strconv.FormatFloat(v, 'g', 6, 64) + "|")
+			default:
+				fmt.Fprintf(&sb, "%s=%v|", k, v)
+			}
+		}
+		out = append(out, sb.String())
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -2030,6 +2030,19 @@ func (c *Coordinator) dispatchComputeStage(
 			}
 			t.Operators = ops
 		}
+		// Sort-merge join stages always route through the fragment runner —
+		// there is no legacy single-op execution path for them, so any
+		// ineligibility is a planner bug and fails loudly.
+		if stage.Type == physical.StageSortMergeJoin {
+			if t.Operators != nil {
+				return StageOutput{}, fmt.Errorf("stage %s: sort_merge_join stage already claimed by another migration", stage.ID)
+			}
+			ops, ferr := buildSortMergeJoinFragment(stage, &t, taskInputs, wireFused, sorts)
+			if ferr != nil {
+				return StageOutput{}, fmt.Errorf("stage %s: build sort-merge join fragment: %w", stage.ID, ferr)
+			}
+			t.Operators = ops
+		}
 		// Final/merge aggregate migration: dispatch via the fragment path
 		// when the stage has no fused sort/limit. The fragment runs:
 		//   [OpShuffleSource, OpHashAggregate(MergeMode), OpFilter? (HAVING),
@@ -2366,6 +2379,83 @@ func buildJoinFragment(
 	return ops, nil
 }
 
+// buildSortMergeJoinFragment translates a sort_merge_join stage's task into
+// a fragment pipeline:
+//
+//	[ShuffleSource(probe), OpSortMergeJoin(breaker; build from BuildFiles),
+//	 OpFilter?(residual), OpSort?(folded sort), OpUnpartitionedSink]
+//
+// The probe side streams from this task's partition of the left exchange;
+// the build side's partition files ride the op spec (BuildFiles) and are
+// drained by the worker's breaker construction — the same co-partitioned
+// input shape as buildJoinFragment, with the operator swapped. Fused
+// broadcast chains never attach to sort_merge_join stages (every fusion
+// pass gates on hash_join/broadcast_join), so wireFused must be empty.
+func buildSortMergeJoinFragment(
+	stage physical.Stage,
+	t *distributed.Task,
+	taskInputs map[string][]string,
+	wireFused []distributed.FusedJoinSpec,
+	sorts []distributed.SortKeySpec,
+) ([]distributed.OpSpec, error) {
+	if len(wireFused) > 0 {
+		return nil, fmt.Errorf("sort_merge_join stage carries %d fused joins; fusion passes must not target it", len(wireFused))
+	}
+	if t.BuildTableAlias == "" {
+		return nil, fmt.Errorf("BuildTableAlias required")
+	}
+	buildFiles, ok := taskInputs[t.BuildTableAlias]
+	if !ok {
+		return nil, fmt.Errorf("build alias %q missing from inputs", t.BuildTableAlias)
+	}
+	var probeAlias string
+	var probeFiles []string
+	for k, v := range taskInputs {
+		if k != t.BuildTableAlias {
+			probeAlias = k
+			probeFiles = v
+			break
+		}
+	}
+	if probeAlias == "" {
+		return nil, fmt.Errorf("no probe-side alias (only %q)", t.BuildTableAlias)
+	}
+
+	ops := make([]distributed.OpSpec, 0, 5)
+	ops = append(ops, distributed.OpSpec{
+		Type:        distributed.OpShuffleSource,
+		InputAlias:  probeAlias,
+		InputFiles:  probeFiles,
+		InputBucket: t.DataBucket,
+	})
+	ops = append(ops, distributed.OpSpec{
+		Type:                distributed.OpSortMergeJoin,
+		JoinType:            t.JoinType,
+		LeftKeys:            t.JoinLeftKeys,
+		RightKeys:           t.JoinRightKeys,
+		BuildAlias:          t.BuildTableAlias,
+		BuildFiles:          buildFiles,
+		BuildBucket:         t.DataBucket,
+		QualifyAllBuildCols: t.QualifyAllBuildCols,
+		OutputColumns:       append([]string(nil), t.Columns...),
+	})
+	if len(t.PostFilterExprs) > 0 {
+		ops = append(ops, distributed.OpSpec{
+			Type:       distributed.OpFilter,
+			Predicates: append([]string(nil), t.PostFilterExprs...),
+		})
+	}
+	if len(sorts) > 0 {
+		ops = append(ops, distributed.OpSpec{
+			Type:         distributed.OpSort,
+			SortKeySpecs: append([]distributed.SortKeySpec(nil), sorts...),
+			SortLimit:    stage.Limit,
+		})
+	}
+	ops = append(ops, distributed.OpSpec{Type: distributed.OpUnpartitionedSink})
+	return ops, nil
+}
+
 // buildAggregateFragment translates a final_aggregate / merge_aggregate
 // stage's task into a fragment Operators[] pipeline:
 //
@@ -2421,11 +2511,11 @@ func buildAggregateFragment(stage physical.Stage, t *distributed.Task, taskInput
 	// upstream hasn't pre-computed.
 	mergeMode := stage.Type == "final_aggregate" || stage.Type == "merge_aggregate"
 	ops = append(ops, distributed.OpSpec{
-		Type:         distributed.OpHashAggregate,
-		GroupByCols:  append([]string(nil), stage.GroupByCols...),
-		Aggregates:   append([]distributed.AggSpec(nil), aggs...),
-		GroupByAll:   stage.GroupByAll,
-		MergeMode:    mergeMode,
+		Type:        distributed.OpHashAggregate,
+		GroupByCols: append([]string(nil), stage.GroupByCols...),
+		Aggregates:  append([]distributed.AggSpec(nil), aggs...),
+		GroupByAll:  stage.GroupByAll,
+		MergeMode:   mergeMode,
 		// GroupByAll (DISTINCT) has no derived-input expressions to project and
 		// no AVG synthetics to fold — keep both off regardless of stage role.
 		FoldAvg:      stage.Type == "final_aggregate" && !stage.GroupByAll,
@@ -2961,7 +3051,7 @@ func estimateComputeTaskBytes(stage physical.Stage, inputs map[string]StageOutpu
 func buildTaskInputsForStage(stage physical.Stage, upstreams map[string]StageOutput, workerIdx, workerCount int) (map[string][]string, error) {
 	inputs := make(map[string][]string)
 	switch stage.Type {
-	case physical.StageHashJoin, physical.StageBroadcastJoin:
+	case physical.StageHashJoin, physical.StageBroadcastJoin, physical.StageSortMergeJoin:
 		expectedDeps := 2 + len(stage.FusedJoins)
 		if len(stage.Dependencies) != expectedDeps {
 			return nil, fmt.Errorf("join stage %s expects %d deps (2 primary + %d fused), got %d",

--- a/internal/coordinator/local_fastpath.go
+++ b/internal/coordinator/local_fastpath.go
@@ -91,6 +91,7 @@ func (c *Coordinator) tryLocalFastPath(ctx context.Context, queryID string, logi
 	// resident operator state, so a misestimate degrades to disk instead
 	// of coordinator OOM.
 	planner.MemoryBudget = 8 * threshold
+	planner.SortMergeJoinBytes = c.config.SortMergeJoinBytes
 	physPlan, err := planner.Plan(ctx, logicalPlan)
 	if err != nil {
 		c.logger.Warn("local fast path plan failed, routing to DAG",

--- a/internal/distributed/messages.go
+++ b/internal/distributed/messages.go
@@ -263,6 +263,7 @@ const (
 	OpFilter         OpType = "filter"          // FilterExprs predicate chain
 	OpHashJoinProbe  OpType = "hash_join_probe" // shuffle-side hash join: build from BuildFiles, probe upstream
 	OpBroadcastProbe OpType = "broadcast_probe" // broadcast hash join: small build replicated to every task
+	OpSortMergeJoin  OpType = "sort_merge_join" // big-vs-big inner join: both sides sort to runs, two-cursor merge (pipeline-breaker)
 
 	// Pipeline-breaker operators. Consume all input from the upstream chain,
 	// then emit results into the downstream chain. Splits the fragment into

--- a/internal/engine/exec/join.go
+++ b/internal/engine/exec/join.go
@@ -3015,10 +3015,19 @@ func (p *HashJoinProbe) outputSchema(leftSchema []parquet.Column) []parquet.Colu
 }
 
 func (p *HashJoinProbe) outputSchemaWithMapping(leftSchema []parquet.Column) ([]parquet.Column, []outColSource) {
+	return joinOutputSchemaWithMapping(p.join.JoinType, leftSchema, p.join.buildSchema,
+		p.join.BuildTableAlias, p.join.QualifyAllBuildCols, p.OutputFilter)
+}
+
+// joinOutputSchemaWithMapping computes a join's output schema — probe columns
+// first, then build columns with duplicate-name qualification — and the
+// per-output-column source mapping. Shared by HashJoinProbe and SortMergeJoin
+// so both emit identical schemas for the same join shape.
+func joinOutputSchemaWithMapping(joinType JoinType, leftSchema, buildSchema []parquet.Column, buildAlias string, qualifyAllBuildCols bool, outputFilter map[string]bool) ([]parquet.Column, []outColSource) {
 	var out []parquet.Column
 	var mapping []outColSource
 
-	if p.join.JoinType == RightJoin || p.join.JoinType == FullOuterJoin {
+	if joinType == RightJoin || joinType == FullOuterJoin {
 		for i, col := range leftSchema {
 			col.Nullable = true
 			out = append(out, col)
@@ -3036,19 +3045,19 @@ func (p *HashJoinProbe) outputSchemaWithMapping(leftSchema []parquet.Column) ([]
 		seen[col.Name] = true
 	}
 
-	for i, col := range p.join.buildSchema {
+	for i, col := range buildSchema {
 		isDup := seen[col.Name]
 		// Force qualification for self-join scenarios — the planner sets
 		// QualifyAllBuildCols when this build is one of two co-pathing
 		// scans of the same source table. Without it, the FIRST scan's
 		// column ships unqualified ("n_name") and downstream lookups for
 		// the qualified name ("n1.n_name") miss.
-		shouldQualify := (isDup || p.join.QualifyAllBuildCols) && p.join.BuildTableAlias != ""
+		shouldQualify := (isDup || qualifyAllBuildCols) && buildAlias != ""
 		switch {
 		case shouldQualify:
 			qualCol := col
-			qualCol.Name = p.join.BuildTableAlias + "." + col.Name
-			if p.join.JoinType == LeftJoin || p.join.JoinType == FullOuterJoin {
+			qualCol.Name = buildAlias + "." + col.Name
+			if joinType == LeftJoin || joinType == FullOuterJoin {
 				qualCol.Nullable = true
 			}
 			out = append(out, qualCol)
@@ -3056,7 +3065,7 @@ func (p *HashJoinProbe) outputSchemaWithMapping(leftSchema []parquet.Column) ([]
 		case isDup:
 			// Duplicate with no alias to disambiguate by — skip (backward compatible).
 		default:
-			if p.join.JoinType == LeftJoin || p.join.JoinType == FullOuterJoin {
+			if joinType == LeftJoin || joinType == FullOuterJoin {
 				col.Nullable = true
 			}
 			out = append(out, col)
@@ -3068,17 +3077,17 @@ func (p *HashJoinProbe) outputSchemaWithMapping(leftSchema []parquet.Column) ([]
 	// Apply output filter: skip columns not needed by downstream operators.
 	// This avoids allocating and gathering unneeded intermediate columns
 	// in multi-way join pipelines, reducing both CPU and memory pressure.
-	if len(p.OutputFilter) > 0 {
+	if len(outputFilter) > 0 {
 		var filteredSchema []parquet.Column
 		var filteredMapping []outColSource
 		for i, col := range out {
-			keep := p.OutputFilter[col.Name]
+			keep := outputFilter[col.Name]
 			// For qualified columns (e.g., "n2.n_name" from self-joins), also
 			// check if the unqualified base name is needed. Without this, the
 			// output filter would drop disambiguated self-join columns.
 			if !keep {
 				if dot := strings.IndexByte(col.Name, '.'); dot >= 0 {
-					keep = p.OutputFilter[col.Name[dot+1:]]
+					keep = outputFilter[col.Name[dot+1:]]
 				}
 			}
 			if keep {

--- a/internal/engine/exec/join.go
+++ b/internal/engine/exec/join.go
@@ -843,7 +843,11 @@ func (h *HashJoin) Build(ctx context.Context, source Source) error {
 				h.intIndex.CheckGrow()
 			} else {
 				if h.strIndex == nil {
-					h.strIndex = newStrHashTable(64)
+					// Seed to this batch's row count: the EnsureCapacity
+					// above skipped a nil strIndex, and a 64-bucket seed
+					// would let the first batch fill the table mid-loop
+					// (GetOrInsertNoGrow spins forever on a full table).
+					h.strIndex = newStrHashTable(batchRows)
 				}
 				if b.Sel != nil {
 					for _, si := range b.Sel {
@@ -1234,7 +1238,11 @@ func (h *HashJoin) insertKeyOnlyBatch(lk *localKeyBuild, b *batch.RecordBatch) {
 		lk.intIndex.CheckGrow()
 	} else {
 		if lk.strIndex == nil {
-			lk.strIndex = newStrHashTable(64)
+			// Seed to this batch's row count — the EnsureCapacity above
+			// skipped a nil strIndex, and a 64-bucket seed would let the
+			// first batch fill the table mid-loop (GetOrInsertNoGrow spins
+			// forever on a full table).
+			lk.strIndex = newStrHashTable(batchRows)
 		}
 		if b.Sel != nil {
 			for _, si := range b.Sel {
@@ -1626,7 +1634,13 @@ func (h *HashJoin) BuildFromRows(schema []parquet.Column, rows []map[string]any)
 	b.Detach() // prevent pooled batches from being recycled — build stores references
 	batchIdx := int32(len(h.buildBatches))
 	h.buildBatches = append(h.buildBatches, b)
+	// Pre-grow the index for this call's rows so PutNoGrow can't fill the
+	// table mid-loop — a full table turns its probe loop into an infinite
+	// spin. The int index is pre-sized by tryEnableIntKey only on the first
+	// call, and the string index was seeded at 64 buckets, so any call
+	// inserting more distinct keys than the remaining headroom hung here.
 	if h.useIntKey {
+		h.intIndex.EnsureCapacity(b.Len)
 		col := b.Columns[h.buildKeyIdx[0]]
 		for i := 0; i < b.Len; i++ {
 			key, ok := intKeyFromVector(col, i)
@@ -1639,8 +1653,9 @@ func (h *HashJoin) BuildFromRows(schema []parquet.Column, rows []map[string]any)
 		h.intIndex.CheckGrow()
 	} else {
 		if h.strIndex == nil {
-			h.strIndex = newStrHashTable(64)
+			h.strIndex = newStrHashTable(b.Len)
 		}
+		h.strIndex.EnsureCapacity(b.Len)
 		for i := 0; i < b.Len; i++ {
 			h.buildKeyFromBatch(b, i)
 			h.arenaAppendStr(buildRef{batchIdx: batchIdx, rowIdx: int32(i)})

--- a/internal/engine/exec/join_strindex_capacity_test.go
+++ b/internal/engine/exec/join_strindex_capacity_test.go
@@ -1,0 +1,119 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// Regression tests for the unguarded NoGrow-insert loops (found 2026-07-07 by
+// the SortMergeJoin equivalence test): strHashTable.PutNoGrow/GetOrInsertNoGrow
+// probe for an empty slot and never re-check the load factor, so a call site
+// that inserts more distinct keys than the table's remaining headroom without
+// EnsureCapacity spins forever once the table fills. Before the fix these
+// tests HUNG (10-minute test-binary timeout) rather than failing.
+
+// TestHashJoinBuildFromRows_ManyDistinctStringKeys: BuildFromRows seeded its
+// string index at 64 buckets and inserted every row before the deferred
+// CheckGrow — >64 distinct string keys in one call filled the table mid-loop.
+func TestHashJoinBuildFromRows_ManyDistinctStringKeys(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "k", Type: parquet.TypeString},
+		{Name: "v", Type: parquet.TypeInt64},
+	}
+	const n = 500 // well past the 64-bucket seed
+	rows := make([]map[string]any, n)
+	for i := range rows {
+		rows[i] = map[string]any{"k": fmt.Sprintf("key-%04d", i), "v": int64(i)}
+	}
+	hj := NewHashJoin(InnerJoin, []string{"k"}, []string{"k"})
+	hj.BuildFromRows(schema, rows)
+	// Repeat call: the int-index sibling hazard was capacity sized for the
+	// FIRST call only; a second call must extend it, not fill it.
+	rows2 := make([]map[string]any, n)
+	for i := range rows2 {
+		rows2[i] = map[string]any{"k": fmt.Sprintf("key2-%04d", i), "v": int64(n + i)}
+	}
+	hj.BuildFromRows(schema, rows2)
+
+	probeRows := []map[string]any{
+		{"k": "key-0007", "v": int64(-1)},
+		{"k": "key2-0499", "v": int64(-2)},
+		{"k": "absent", "v": int64(-3)},
+	}
+	sink := &CollectSink{}
+	pipe := &Pipeline{Source: NewSliceSource(schema, probeRows), Ops: []UnaryOperator{hj.Probe()}, Sink: sink}
+	if err := pipe.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(sink.Rows) != 2 {
+		t.Fatalf("expected 2 matches, got %d: %v", len(sink.Rows), sink.Rows)
+	}
+}
+
+// TestHashJoinBuildFromRows_ManyDistinctIntKeysRepeatCall: the int index is
+// pre-sized by tryEnableIntKey from the first call's BuildRowHint; a second
+// BuildFromRows call with fresh keys previously relied on post-loop CheckGrow
+// alone and could fill the table mid-loop.
+func TestHashJoinBuildFromRows_ManyDistinctIntKeysRepeatCall(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "k", Type: parquet.TypeInt64},
+		{Name: "v", Type: parquet.TypeInt64},
+	}
+	mkRows := func(base, n int) []map[string]any {
+		rows := make([]map[string]any, n)
+		for i := range rows {
+			rows[i] = map[string]any{"k": int64(base + i), "v": int64(i)}
+		}
+		return rows
+	}
+	hj := NewHashJoin(InnerJoin, []string{"k"}, []string{"k"})
+	hj.BuildFromRows(schema, mkRows(0, 100))
+	// 4× the first call: exceeds any headroom the first sizing left behind.
+	hj.BuildFromRows(schema, mkRows(100, 400))
+
+	probeRows := []map[string]any{{"k": int64(499), "v": int64(-1)}}
+	sink := &CollectSink{}
+	pipe := &Pipeline{Source: NewSliceSource(schema, probeRows), Ops: []UnaryOperator{hj.Probe()}, Sink: sink}
+	if err := pipe.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(sink.Rows) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(sink.Rows))
+	}
+}
+
+// TestHashJoinKeyOnlyBuild_ManyDistinctStringKeys: the semi/anti key-only
+// build paths (serial and per-worker parallel) created their string index at
+// 64 buckets AFTER the batch's EnsureCapacity guard had skipped the nil
+// index — a first batch with >64 distinct string keys filled it mid-loop.
+func TestHashJoinKeyOnlyBuild_ManyDistinctStringKeys(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "k", Type: parquet.TypeString},
+	}
+	const n = 2048 // one full batch of distinct keys through SliceSource
+	rows := make([]map[string]any, n)
+	for i := range rows {
+		rows[i] = map[string]any{"k": fmt.Sprintf("key-%05d", i)}
+	}
+	hj := NewHashJoin(SemiJoin, []string{"k"}, []string{"k"})
+	hj.SemiAntiKeyOnly = true
+	if err := hj.Build(context.Background(), NewSliceSource(schema, rows)); err != nil {
+		t.Fatal(err)
+	}
+
+	probeRows := []map[string]any{
+		{"k": "key-00042"},
+		{"k": "not-there"},
+	}
+	sink := &CollectSink{}
+	pipe := &Pipeline{Source: NewSliceSource(schema, probeRows), Ops: []UnaryOperator{hj.Probe()}, Sink: sink}
+	if err := pipe.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(sink.Rows) != 1 {
+		t.Fatalf("expected 1 semi-join match, got %d", len(sink.Rows))
+	}
+}

--- a/internal/engine/exec/sort_merge_join.go
+++ b/internal/engine/exec/sort_merge_join.go
@@ -1,0 +1,854 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/engine/exec/kernel"
+	"github.com/citc-tech/wadjet/internal/engine/memory"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// SortMergeJoin joins two large inputs by sorting both sides on the join keys
+// and streaming a two-cursor merge. Unlike HashJoin, neither side is held
+// resident: each side buffers under the shared tracker and self-spills sorted
+// columnar runs (Sort's external-merge machinery), so peak memory is
+// O(run buffer + one batch per merge cursor) regardless of input size.
+//
+// The build side (right, as in HashJoin) arrives via Build; the probe side
+// (left) arrives via Consume. Both are pipeline breakers here — inherent to
+// sort-based joins over unsorted input. After Finalize, Next streams joined
+// batches: probe columns first, then build columns, with the same
+// duplicate-name qualification and OutputFilter semantics as HashJoinProbe.
+//
+// v1 scope (docs/design/sort-merge-join.md): INNER equi-joins only, no
+// JoinFilter. Rows with a NULL in any join key are excluded at buffer time
+// (SQL equi-join semantics: NULL matches nothing — mirrors the hash paths,
+// where null keys produce no index entry). Not Cloneable: the breaker path
+// runs it single-consumer.
+type SortMergeJoin struct {
+	JoinType  JoinType // v1: InnerJoin only; validated in Init/Finalize
+	LeftKeys  []string // join key columns from left (probe) side
+	RightKeys []string // join key columns from right (build) side
+
+	// BuildTableAlias / QualifyAllBuildCols / OutputFilter carry
+	// HashJoinProbe's output-schema semantics — see joinOutputSchemaWithMapping.
+	BuildTableAlias     string
+	QualifyAllBuildCols bool
+	OutputFilter        map[string]bool
+
+	// Spill enables tracker accounting and spill-to-disk. When nil the
+	// operator buffers unbounded in memory (embedded/test paths), like Sort.
+	Spill *memory.SpillManager
+
+	mu        sync.Mutex
+	build     smjSide // right side
+	probe     smjSide // left side
+	buildDone bool
+	// finalized is set once Finalize begins; past that point the buffered
+	// batches are owned by the merge and there is nothing left to spill.
+	finalized bool
+
+	// AccountedOperator state — one registration owns both side states;
+	// see Sort for the contract.
+	accInstanceID       uint64
+	accState            atomic.Int32
+	unregisterAccounted func()
+
+	// Merge state, set up by Finalize and drained by Next.
+	outSchema  []parquet.Column
+	outMapping []outColSource
+	lstream    *smjStream
+	rstream    *smjStream
+	compare    []kernel.SortCompareKernel // per join key, resolved once
+
+	// Duplicate-group state: the build side's current key group, held as
+	// refs into merge-output batches (no copying). A batch the group still
+	// references after the cursor moves past it is pinned: its bytes are
+	// tracker-Reserved, so a pathologically hot key that drags a growing
+	// tail of batches fails loudly via Reserve instead of OOMing (the
+	// documented v1 bound). Groups contained in the live cursor batch —
+	// the overwhelmingly common case — reserve nothing.
+	group struct {
+		refs     []mergeRef
+		reserved int64
+	}
+	groupActive bool
+	groupPos    int // next group row to pair with the current probe row
+	// pendingRelease accumulates retired groups' reservations; released
+	// after the flush that materializes the pairs still referencing them.
+	pendingRelease int64
+
+	pending   []smjPair
+	exhausted bool
+	done      bool
+}
+
+// smjSide is one side's buffering/spill core: Sort's accumulate → self-spill
+// sorted runs pattern, parameterized by the side's join-key sort keys.
+type smjSide struct {
+	name       string // "probe" / "build", for error context
+	keys       []SortKey
+	schema     []parquet.Column
+	batches    []*batch.RecordBatch
+	totalRows  int
+	trackedMem int64
+	runFiles   []string
+}
+
+// smjPair pins one joined output row. The referenced batches are merge output
+// (fresh, unpooled), kept alive by the reference until the pending flush.
+type smjPair struct {
+	lb   *batch.RecordBatch
+	lrow uint32
+	rb   *batch.RecordBatch
+	rrow uint32
+}
+
+// smjStream is a row cursor over one side's fully merged sorted stream: the
+// side's spilled runs plus its in-memory remainder, collapsed by a runMerger.
+// cur==nil means exhausted.
+type smjStream struct {
+	merger *runMerger
+	runs   []string // run files to delete at teardown
+	keyIdx []int    // join-key column indices in the merged schema
+	cur    *batch.RecordBatch
+	row    int
+}
+
+func (s *smjStream) advance() error {
+	s.row++
+	if s.cur != nil && s.row < s.cur.Len {
+		return nil
+	}
+	b, err := s.merger.Next()
+	if err != nil {
+		return err
+	}
+	s.cur = b
+	s.row = 0
+	return nil
+}
+
+func (s *smjStream) close() {
+	if s.merger != nil {
+		s.merger.close()
+		s.merger = nil
+	}
+	removeRunFiles(s.runs)
+	s.runs = nil
+	s.cur = nil
+}
+
+// NewSortMergeJoin creates an inner sort-merge join. leftKeys are the probe
+// (left) side's join columns, rightKeys the build (right) side's, positionally
+// paired.
+func NewSortMergeJoin(leftKeys, rightKeys []string) *SortMergeJoin {
+	j := &SortMergeJoin{
+		JoinType:  InnerJoin,
+		LeftKeys:  leftKeys,
+		RightKeys: rightKeys,
+	}
+	j.probe = smjSide{name: "probe", keys: ascendingKeys(leftKeys)}
+	j.build = smjSide{name: "build", keys: ascendingKeys(rightKeys)}
+	return j
+}
+
+func ascendingKeys(cols []string) []SortKey {
+	keys := make([]SortKey, len(cols))
+	for i, c := range cols {
+		keys[i] = SortKey{Column: c, Order: Ascending}
+	}
+	return keys
+}
+
+// Init prepares the probe/merge state. It deliberately does NOT reset the
+// build side: Build runs before the probe pipeline starts (HashJoin's
+// contract), and pipeline Init would otherwise wipe it.
+func (j *SortMergeJoin) Init(_ context.Context) error {
+	if j.JoinType != InnerJoin {
+		return fmt.Errorf("sort-merge join: join type %d not supported (v1 is inner-only)", j.JoinType)
+	}
+	if len(j.LeftKeys) == 0 || len(j.LeftKeys) != len(j.RightKeys) {
+		return fmt.Errorf("sort-merge join: key count mismatch (%d left, %d right)", len(j.LeftKeys), len(j.RightKeys))
+	}
+	return nil
+}
+
+// Build drains the build-side (right) source, mirroring HashJoin.Build's
+// contract: inits and closes the source, reports row progress.
+func (j *SortMergeJoin) Build(ctx context.Context, source Source) error {
+	if err := source.Init(ctx); err != nil {
+		return fmt.Errorf("build source init: %w", err)
+	}
+	defer source.Close()
+
+	progress := ProgressReporterFromContext(ctx)
+	for {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("sort-merge join build cancelled: %w", err)
+		}
+		b, err := source.Next(ctx)
+		if err != nil {
+			return fmt.Errorf("build source next: %w", err)
+		}
+		if b == nil {
+			break
+		}
+		if progress != nil {
+			progress.AddRows(int64(b.ActiveLen()))
+		}
+		if err := j.consume(&j.build, b); err != nil {
+			return err
+		}
+		b.Release()
+	}
+	j.mu.Lock()
+	j.buildDone = true
+	j.mu.Unlock()
+	return nil
+}
+
+// Consume buffers a probe-side (left) batch.
+func (j *SortMergeJoin) Consume(_ context.Context, b *batch.RecordBatch) error {
+	return j.consume(&j.probe, b)
+}
+
+// consume buffers one batch into a side, excluding null-key rows via the
+// selection vector, tracking bytes, and self-spilling a sorted run under
+// SpillCheap pressure past the run floor — Sort.Consume's checklist.
+func (j *SortMergeJoin) consume(side *smjSide, b *batch.RecordBatch) error {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if side.schema == nil {
+		side.schema = b.Schema
+		// Register on the first buffered batch from either side (footprint
+		// exists from here on). One registration covers both sides.
+		if j.Spill != nil && j.unregisterAccounted == nil {
+			j.accInstanceID = memory.NextInstanceID()
+			j.accState.Store(int32(memory.OpActive))
+			j.unregisterAccounted = j.Spill.RegisterAccounted(j)
+		}
+	}
+
+	sel, err := nonNullKeySel(b, side)
+	if err != nil {
+		return err
+	}
+	if sel != nil && len(sel) == 0 {
+		return nil // every active row has a NULL join key — contributes nothing
+	}
+
+	b.Detach() // prevent pool recycle — pipeline calls Release() after Consume()
+	if sel != nil {
+		b.Sel = sel
+	} else if b.Sel != nil {
+		// Snapshot the selection vector — filter operators reuse their outSel
+		// scratch across calls; sinks that hold batches across calls would
+		// otherwise see clobbered Sel data (see BatchSink.Consume).
+		selCopy := make([]uint32, len(b.Sel))
+		copy(selCopy, b.Sel)
+		b.Sel = selCopy
+	}
+	side.batches = append(side.batches, b)
+	side.totalRows += b.ActiveLen()
+
+	if j.Spill != nil {
+		cost := b.MemBytes()
+		j.Spill.TrackBatch(cost)
+		side.trackedMem += cost
+		j.publishOwnedLocked()
+
+		if j.Spill.ShouldSpillFor(memory.SpillCheap) && side.trackedMem >= minSortRunBytes {
+			if _, err := j.flushSideLocked(side); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// nonNullKeySel returns a fresh selection vector of active rows whose join
+// keys are all non-null, or nil when no filtering is needed (no nulls in any
+// key column). Errors if a key column is missing from the batch.
+func nonNullKeySel(b *batch.RecordBatch, side *smjSide) ([]uint32, error) {
+	keyIdx := make([]int, len(side.keys))
+	anyNulls := false
+	for i, k := range side.keys {
+		idx := b.ColumnIndex(k.Column)
+		if idx < 0 {
+			return nil, fmt.Errorf("sort-merge join: %s-side key column %q not found", side.name, k.Column)
+		}
+		keyIdx[i] = idx
+		if b.Columns[idx].Nulls.HasNulls() {
+			anyNulls = true
+		}
+	}
+	if !anyNulls {
+		return nil, nil
+	}
+	rowOK := func(row int) bool {
+		for _, idx := range keyIdx {
+			if b.Columns[idx].Nulls.IsNull(row) {
+				return false
+			}
+		}
+		return true
+	}
+	sel := make([]uint32, 0, b.ActiveLen())
+	if b.Sel != nil {
+		for _, idx := range b.Sel {
+			if rowOK(int(idx)) {
+				sel = append(sel, idx)
+			}
+		}
+	} else {
+		for i := 0; i < b.Len; i++ {
+			if rowOK(i) {
+				sel = append(sel, uint32(i))
+			}
+		}
+	}
+	return sel, nil
+}
+
+// flushSideLocked drains a side's buffered batches into one sorted run file
+// and releases their tracking, returning the bytes freed. Caller holds j.mu.
+func (j *SortMergeJoin) flushSideLocked(side *smjSide) (int64, error) {
+	if len(side.batches) == 0 || side.trackedMem == 0 {
+		return 0, nil
+	}
+	path, err := sortBatchesToRun(j.Spill.SpillDir(), side.schema, side.batches, side.totalRows, side.keys, 0)
+	if err != nil {
+		return 0, err
+	}
+	if path != "" {
+		side.runFiles = append(side.runFiles, path)
+	}
+	side.batches = side.batches[:0]
+	side.totalRows = 0
+	freed := side.trackedMem
+	j.Spill.ReleaseTracking(freed)
+	side.trackedMem = 0
+	j.publishOwnedLocked()
+	return freed, nil
+}
+
+// publishOwnedLocked reports the combined side footprint. Caller holds j.mu.
+func (j *SortMergeJoin) publishOwnedLocked() {
+	if j.accInstanceID != 0 {
+		j.Spill.Tracker().PublishOwned(j.accInstanceID, j.probe.trackedMem+j.build.trackedMem)
+	}
+}
+
+// Finalize collapses each side into one sorted stream (spilled runs + the
+// in-memory remainder under a bounded-fan-in merger) and resolves the
+// cross-side comparison kernels. Nothing is materialized — Next streams the
+// merge one output batch at a time.
+func (j *SortMergeJoin) Finalize(_ context.Context) error {
+	j.mu.Lock()
+	if !j.buildDone {
+		j.mu.Unlock()
+		return fmt.Errorf("sort-merge join: build phase not complete")
+	}
+	j.finalized = true
+	j.mu.Unlock()
+	// Past this point the buffered batches belong to the merge; deregister so
+	// the relief registry stops considering us (Sort's pattern).
+	if j.unregisterAccounted != nil {
+		j.accState.Store(int32(memory.OpClosed))
+		j.unregisterAccounted()
+		j.unregisterAccounted = nil
+	}
+	if j.JoinType != InnerJoin {
+		return fmt.Errorf("sort-merge join: join type %d not supported (v1 is inner-only)", j.JoinType)
+	}
+
+	// An empty side means an empty inner join — tear down eagerly so the
+	// other side's runs and reservations don't wait for Close.
+	if j.probe.schema == nil || j.build.schema == nil {
+		j.mu.Lock()
+		j.teardownLocked()
+		j.mu.Unlock()
+		return nil
+	}
+
+	j.outSchema, j.outMapping = joinOutputSchemaWithMapping(j.JoinType, j.probe.schema, j.build.schema,
+		j.BuildTableAlias, j.QualifyAllBuildCols, j.OutputFilter)
+
+	if err := j.resolveCompareKernels(); err != nil {
+		j.mu.Lock()
+		j.teardownLocked()
+		j.mu.Unlock()
+		return err
+	}
+
+	ls, err := j.openStream(&j.probe)
+	if err != nil {
+		j.mu.Lock()
+		j.teardownLocked()
+		j.mu.Unlock()
+		return fmt.Errorf("sort-merge join: probe stream: %w", err)
+	}
+	j.lstream = ls
+	rs, err := j.openStream(&j.build)
+	if err != nil {
+		j.mu.Lock()
+		j.teardownLocked()
+		j.mu.Unlock()
+		return fmt.Errorf("sort-merge join: build stream: %w", err)
+	}
+	j.rstream = rs
+	return nil
+}
+
+// resolveCompareKernels resolves one typed kernel per key pair. Requires
+// identical key column types on both sides — the equi-join planner gate
+// guarantees this; anything else fails loudly here.
+func (j *SortMergeJoin) resolveCompareKernels() error {
+	j.compare = make([]kernel.SortCompareKernel, len(j.LeftKeys))
+	for i := range j.LeftKeys {
+		lIdx := schemaColumnIndex(j.probe.schema, j.LeftKeys[i])
+		rIdx := schemaColumnIndex(j.build.schema, j.RightKeys[i])
+		if lIdx < 0 || rIdx < 0 {
+			return fmt.Errorf("sort-merge join: key pair %q/%q not found in side schemas", j.LeftKeys[i], j.RightKeys[i])
+		}
+		lType, rType := j.probe.schema[lIdx].Type, j.build.schema[rIdx].Type
+		if lType != rType {
+			return fmt.Errorf("sort-merge join: key type mismatch for %q/%q (%d vs %d)", j.LeftKeys[i], j.RightKeys[i], lType, rType)
+		}
+		// Null-aware kernel is defensive only — null-key rows never enter
+		// the runs.
+		cmp := kernel.ResolveSortCompare(lType)
+		if cmp == nil {
+			return fmt.Errorf("sort-merge join: unsupported key type %d for %q", lType, j.LeftKeys[i])
+		}
+		j.compare[i] = cmp
+	}
+	return nil
+}
+
+func schemaColumnIndex(schema []parquet.Column, name string) int {
+	for i, col := range schema {
+		if col.Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+// openStream builds the side's merged sorted stream: pre-merged file runs
+// plus the sorted in-memory remainder as the last cursor (Sort's
+// finalizeExternalMerge shape, including its run-file error contract).
+func (j *SortMergeJoin) openStream(side *smjSide) (*smjStream, error) {
+	j.mu.Lock()
+	runs := side.runFiles
+	side.runFiles = nil
+	batches := side.batches
+	totalRows := side.totalRows
+	j.mu.Unlock()
+
+	var spillDir string
+	if j.Spill != nil {
+		spillDir = j.Spill.SpillDir()
+	}
+	runs, err := preMergeRuns(spillDir, side.schema, side.keys, runs, maxMergeFanIn-1, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	cursors := make([]*runCursor, 0, len(runs)+1)
+	for ord, p := range runs {
+		c, err := newFileRunCursor(p)
+		if err != nil {
+			for _, prev := range cursors {
+				prev.close()
+			}
+			removeRunFiles(runs)
+			return nil, err
+		}
+		c.ord = ord
+		cursors = append(cursors, c)
+	}
+	if len(batches) > 0 {
+		entries := buildSortEntries(batches, totalRows)
+		resolved := resolveSortKeysForBatches(side.keys, batches)
+		entries = selectSortedEntries(entries, sortEntriesLessFunc(resolved, batches), 0)
+		c, err := newMemRunCursor(side.schema, batches, entries)
+		if err != nil {
+			for _, prev := range cursors {
+				prev.close()
+			}
+			removeRunFiles(runs)
+			return nil, err
+		}
+		c.ord = len(runs)
+		cursors = append(cursors, c)
+	}
+
+	s := &smjStream{
+		merger: newRunMerger(side.schema, side.keys, cursors),
+		runs:   runs,
+		keyIdx: make([]int, len(side.keys)),
+	}
+	for i, k := range side.keys {
+		s.keyIdx[i] = schemaColumnIndex(side.schema, k.Column)
+	}
+	// Load the first batch.
+	b, err := s.merger.Next()
+	if err != nil {
+		s.close()
+		return nil, err
+	}
+	s.cur = b
+	return s, nil
+}
+
+// Next streams joined output batches (up to DefaultBatchSize rows each) from
+// the two-cursor merge, or (nil, nil) once both sides are exhausted. Merge
+// memory: one batch per live run cursor per side, the pinned duplicate-group
+// batches, and the pending flush window.
+func (j *SortMergeJoin) Next(_ context.Context) (*batch.RecordBatch, error) {
+	if j.done {
+		return nil, nil
+	}
+	if j.lstream == nil || j.rstream == nil {
+		// Empty-side finalize already tore down.
+		j.finishMerge()
+		return nil, nil
+	}
+
+	for !j.exhausted && len(j.pending) < batch.DefaultBatchSize {
+		if j.groupActive {
+			if err := j.stepGroup(); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		l, r := j.lstream, j.rstream
+		if l.cur == nil || r.cur == nil {
+			j.exhausted = true
+			break
+		}
+		cmp := j.compareLR()
+		switch {
+		case cmp < 0:
+			if err := l.advance(); err != nil {
+				return nil, err
+			}
+		case cmp > 0:
+			if err := r.advance(); err != nil {
+				return nil, err
+			}
+		default:
+			if err := j.collectGroup(); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if len(j.pending) > 0 {
+		return j.flushPending(), nil
+	}
+	j.finishMerge()
+	return nil, nil
+}
+
+// compareLR compares the probe cursor's current row against the build
+// cursor's, key by key.
+func (j *SortMergeJoin) compareLR() int {
+	l, r := j.lstream, j.rstream
+	for i, cmp := range j.compare {
+		if c := cmp(l.cur.Columns[l.keyIdx[i]], l.row, r.cur.Columns[r.keyIdx[i]], r.row); c != 0 {
+			return c
+		}
+	}
+	return 0
+}
+
+// keysEqual compares row (b1,r1) against (b2,r2) using keyIdx1/keyIdx2 for
+// the respective batches.
+func (j *SortMergeJoin) keysEqual(b1 *batch.RecordBatch, r1 int, keyIdx1 []int, b2 *batch.RecordBatch, r2 int, keyIdx2 []int) bool {
+	for i, cmp := range j.compare {
+		if cmp(b1.Columns[keyIdx1[i]], r1, b2.Columns[keyIdx2[i]], r2) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// collectGroup gathers every consecutive build-side row equal to the current
+// key into the group ref list. Each time the cursor moves INTO a new batch
+// while the group still references the previous one, the previous batch is
+// pinned (tracker-Reserved) — its lifetime is now the group's, not the
+// cursor's. Stream exhaustion pins nothing: the final batch was live cursor
+// memory a moment ago and stays bounded at one batch, the same untracked
+// envelope as any live cursor. The build cursor ends positioned on the first
+// row past the group.
+func (j *SortMergeJoin) collectGroup() error {
+	r := j.rstream
+	keyBatch, keyRow := r.cur, r.row
+	for {
+		j.group.refs = append(j.group.refs, mergeRef{b: r.cur, row: r.row})
+		prev := r.cur
+		if err := r.advance(); err != nil {
+			return err
+		}
+		if r.cur != nil && r.cur != prev {
+			if err := j.pinGroupBatch(prev); err != nil {
+				return err
+			}
+		}
+		if r.cur == nil || !j.keysEqual(r.cur, r.row, r.keyIdx, keyBatch, keyRow, r.keyIdx) {
+			break
+		}
+	}
+	j.groupActive = true
+	j.groupPos = 0
+	return nil
+}
+
+// pinGroupBatch reserves a group-referenced batch's bytes once the merge
+// cursor has moved past it. This is the loud v1 bound on per-key duplication:
+// a hot key whose group drags an ever-growing batch tail fails the query with
+// a clear error instead of OOMing the worker. The cursor transitions off a
+// batch exactly once, so each spanned batch is reserved exactly once.
+func (j *SortMergeJoin) pinGroupBatch(b *batch.RecordBatch) error {
+	if j.Spill == nil {
+		return nil
+	}
+	cost := b.MemBytes()
+	if err := j.Spill.Tracker().Reserve(cost); err != nil {
+		return fmt.Errorf("sort-merge join: build-side duplicate group for one key exceeds memory budget (%d rows buffered): %w", len(j.group.refs), err)
+	}
+	j.group.reserved += cost
+	return nil
+}
+
+// stepGroup emits pairs of the current probe row against the group, advancing
+// the probe cursor through every row that matches the group key, then retires
+// the group.
+func (j *SortMergeJoin) stepGroup() error {
+	l := j.lstream
+	key := j.group.refs[0]
+	if l.cur == nil || !j.keysEqual(l.cur, l.row, l.keyIdx, key.b, key.row, j.rstream.keyIdx) {
+		j.retireGroup()
+		return nil
+	}
+	for j.groupPos < len(j.group.refs) && len(j.pending) < batch.DefaultBatchSize {
+		ref := j.group.refs[j.groupPos]
+		j.pending = append(j.pending, smjPair{lb: l.cur, lrow: uint32(l.row), rb: ref.b, rrow: uint32(ref.row)})
+		j.groupPos++
+	}
+	if j.groupPos == len(j.group.refs) {
+		j.groupPos = 0
+		return l.advance()
+	}
+	return nil // pending is full; resume mid-group on the next call
+}
+
+// retireGroup drops the current group. Its reservation is released only after
+// the next flush — pending pairs may still reference the pinned batches.
+func (j *SortMergeJoin) retireGroup() {
+	j.pendingRelease += j.group.reserved
+	j.group.refs = j.group.refs[:0]
+	j.group.reserved = 0
+	j.groupActive = false
+	j.groupPos = 0
+}
+
+// flushPending materializes the pending pairs into one output batch using the
+// typed gather kernels (per-column hoisted type switch), then releases
+// retired-group reservations that no longer have pending references.
+func (j *SortMergeJoin) flushPending() *batch.RecordBatch {
+	n := len(j.pending)
+	// Per-flush batch lists + entries: consecutive pairs overwhelmingly share
+	// batches, so dedup by comparing against the last appended pointer.
+	var lBatches, rBatches []*batch.RecordBatch
+	lEntries := make([]sortEntry, n)
+	rEntries := make([]sortEntry, n)
+	for i, p := range j.pending {
+		if len(lBatches) == 0 || lBatches[len(lBatches)-1] != p.lb {
+			lBatches = append(lBatches, p.lb)
+		}
+		lEntries[i] = sortEntry{batchIdx: uint32(len(lBatches) - 1), rowIdx: p.lrow}
+		if len(rBatches) == 0 || rBatches[len(rBatches)-1] != p.rb {
+			rBatches = append(rBatches, p.rb)
+		}
+		rEntries[i] = sortEntry{batchIdx: uint32(len(rBatches) - 1), rowIdx: p.rrow}
+	}
+
+	out := batch.NewRecordBatch(j.outSchema, n)
+	for c, m := range j.outMapping {
+		if m.fromProbe {
+			gatherSortVector(out.Columns[c], m.srcIdx, lEntries, lBatches)
+		} else {
+			gatherSortVector(out.Columns[c], m.srcIdx, rEntries, rBatches)
+		}
+	}
+	j.pending = j.pending[:0]
+
+	if j.pendingRelease > 0 && j.Spill != nil {
+		j.Spill.Tracker().Release(j.pendingRelease)
+		j.pendingRelease = 0
+	}
+	return out
+}
+
+// finishMerge tears down the merge: closes cursors, deletes run scratch,
+// releases every reservation still held (in-memory remainders, group pins).
+func (j *SortMergeJoin) finishMerge() {
+	j.mu.Lock()
+	j.teardownLocked()
+	j.mu.Unlock()
+}
+
+// teardownLocked releases all merge and buffer state. Idempotent; caller
+// holds j.mu.
+func (j *SortMergeJoin) teardownLocked() {
+	if j.lstream != nil {
+		j.lstream.close()
+		j.lstream = nil
+	}
+	if j.rstream != nil {
+		j.rstream.close()
+		j.rstream = nil
+	}
+	for _, side := range []*smjSide{&j.probe, &j.build} {
+		removeRunFiles(side.runFiles)
+		side.runFiles = nil
+		side.batches = nil
+		side.totalRows = 0
+		if j.Spill != nil && side.trackedMem > 0 {
+			j.Spill.ReleaseTracking(side.trackedMem)
+			side.trackedMem = 0
+		}
+	}
+	if j.Spill != nil {
+		if j.group.reserved > 0 {
+			j.Spill.Tracker().Release(j.group.reserved)
+		}
+		if j.pendingRelease > 0 {
+			j.Spill.Tracker().Release(j.pendingRelease)
+		}
+	}
+	j.group.refs = nil
+	j.group.reserved = 0
+	j.pendingRelease = 0
+	j.pending = nil
+	j.groupActive = false
+	j.done = true
+}
+
+// Close releases buffered state, merge state, run scratch, and any tracker
+// reservation still held — see Sort.Close for why this matters (phantom
+// reservations outlive the query otherwise).
+func (j *SortMergeJoin) Close() error {
+	if j.unregisterAccounted != nil {
+		j.accState.Store(int32(memory.OpClosed))
+		j.unregisterAccounted()
+		j.unregisterAccounted = nil
+	}
+	j.mu.Lock()
+	j.teardownLocked()
+	j.mu.Unlock()
+	return nil
+}
+
+// Inspect implements memory.AccountedOperator.
+func (j *SortMergeJoin) Inspect() memory.OperatorFootprint {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	st := memory.OpState(j.accState.Load())
+	if st == memory.OpClosed {
+		return memory.OperatorFootprint{State: memory.OpClosed, InstanceID: j.accInstanceID, Name: "SortMergeJoin"}
+	}
+	owned := j.probe.trackedMem + j.build.trackedMem
+	return memory.OperatorFootprint{
+		OwnedBytes:     owned,
+		RetainedBytes:  owned,
+		SpillableBytes: j.spillableBytesLocked(),
+		State:          st,
+		InstanceID:     j.accInstanceID,
+		Name:           "SortMergeJoin",
+	}
+}
+
+// spillableBytesLocked: both sides are spillable pre-finalize (each drains
+// all-or-nothing to a sorted run); once finalize begins the buffers belong to
+// the merge cursors. Caller holds j.mu.
+func (j *SortMergeJoin) spillableBytesLocked() int64 {
+	if j.Spill == nil || j.finalized {
+		return 0
+	}
+	var total int64
+	if len(j.probe.batches) > 0 {
+		total += j.probe.trackedMem
+	}
+	if len(j.build.batches) > 0 {
+		total += j.build.trackedMem
+	}
+	return total
+}
+
+// EstimateRelief implements memory.AccountedOperator: what SpillSome(target)
+// would free — the larger buffered side, plus the smaller one when the larger
+// alone doesn't cover target.
+func (j *SortMergeJoin) EstimateRelief(target int64) int64 {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if target <= 0 || j.Spill == nil || j.finalized {
+		return 0
+	}
+	larger, smaller := j.sidesBySizeLocked()
+	lb, sb := sideSpillable(larger), sideSpillable(smaller)
+	if lb >= target {
+		return lb
+	}
+	return lb + sb
+}
+
+// SpillSome drains buffered batches to sorted runs, larger side first,
+// stopping once target is met. Implements memory.Spillable and
+// memory.AccountedOperator.
+func (j *SortMergeJoin) SpillSome(target int64) (int64, error) {
+	j.accState.Store(int32(memory.OpSpilling))
+	defer j.accState.CompareAndSwap(int32(memory.OpSpilling), int32(memory.OpActive))
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.Spill == nil || j.finalized {
+		return 0, nil
+	}
+	larger, smaller := j.sidesBySizeLocked()
+	freed, err := j.flushSideLocked(larger)
+	if err != nil {
+		return freed, err
+	}
+	if freed < target {
+		more, err := j.flushSideLocked(smaller)
+		freed += more
+		if err != nil {
+			return freed, err
+		}
+	}
+	return freed, nil
+}
+
+// sidesBySizeLocked orders the sides by buffered footprint, larger first.
+// Caller holds j.mu.
+func (j *SortMergeJoin) sidesBySizeLocked() (larger, smaller *smjSide) {
+	if j.build.trackedMem >= j.probe.trackedMem {
+		return &j.build, &j.probe
+	}
+	return &j.probe, &j.build
+}
+
+func sideSpillable(side *smjSide) int64 {
+	if len(side.batches) == 0 {
+		return 0
+	}
+	return side.trackedMem
+}

--- a/internal/engine/exec/sort_merge_join.go
+++ b/internal/engine/exec/sort_merge_join.go
@@ -90,13 +90,20 @@ type SortMergeJoin struct {
 // smjSide is one side's buffering/spill core: Sort's accumulate → self-spill
 // sorted runs pattern, parameterized by the side's join-key sort keys.
 type smjSide struct {
-	name       string // "probe" / "build", for error context
-	keys       []SortKey
-	schema     []parquet.Column
-	batches    []*batch.RecordBatch
-	totalRows  int
-	trackedMem int64
-	runFiles   []string
+	name string // "probe" / "build", for error context
+	keys []SortKey
+	// counterpart holds the OTHER side's key names, positionally paired.
+	// SQL may put the build-side column on the left of "=" ("JOIN t ON
+	// t.id = probe.id"), so a side's assigned key can belong to the other
+	// side; when the own name doesn't resolve against the first batch, the
+	// counterpart name is tried — symmetric adoption on both sides is
+	// exactly the pair swap HashJoin.FixKeyAssignment performs post-build.
+	counterpart []string
+	schema      []parquet.Column
+	batches     []*batch.RecordBatch
+	totalRows   int
+	trackedMem  int64
+	runFiles    []string
 }
 
 // smjPair pins one joined output row. The referenced batches are merge output
@@ -152,8 +159,8 @@ func NewSortMergeJoin(leftKeys, rightKeys []string) *SortMergeJoin {
 		LeftKeys:  leftKeys,
 		RightKeys: rightKeys,
 	}
-	j.probe = smjSide{name: "probe", keys: ascendingKeys(leftKeys)}
-	j.build = smjSide{name: "build", keys: ascendingKeys(rightKeys)}
+	j.probe = smjSide{name: "probe", keys: ascendingKeys(leftKeys), counterpart: rightKeys}
+	j.build = smjSide{name: "build", keys: ascendingKeys(rightKeys), counterpart: leftKeys}
 	return j
 }
 
@@ -224,6 +231,25 @@ func (j *SortMergeJoin) consume(side *smjSide, b *batch.RecordBatch) error {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	if side.schema == nil {
+		// Resolve the side's key names against the actual schema before
+		// anything sorts by them: the planner emits SQL-qualified names
+		// ("l.id") while batch columns may be bare, and join outputs carry
+		// qualified duplicates the other way around. Rewriting the sort keys
+		// to the schema's exact names here means every downstream exact-match
+		// resolution (run sorting, merge cursors, kernels) just works —
+		// without this, resolveSortKeysForBatches silently SKIPS an
+		// unresolvable key and the merge would run over unsorted runs.
+		for i := range side.keys {
+			idx := columnIndexFallback(b, side.keys[i].Column)
+			if idx < 0 && i < len(side.counterpart) {
+				// Swapped pair — see smjSide.counterpart.
+				idx = columnIndexFallback(b, side.counterpart[i])
+			}
+			if idx < 0 {
+				return fmt.Errorf("sort-merge join: %s-side key column %q not found", side.name, side.keys[i].Column)
+			}
+			side.keys[i].Column = b.Schema[idx].Name
+		}
 		side.schema = b.Schema
 		// Register on the first buffered batch from either side (footprint
 		// exists from here on). One registration covers both sides.
@@ -405,26 +431,28 @@ func (j *SortMergeJoin) Finalize(_ context.Context) error {
 	return nil
 }
 
-// resolveCompareKernels resolves one typed kernel per key pair. Requires
-// identical key column types on both sides — the equi-join planner gate
-// guarantees this; anything else fails loudly here.
+// resolveCompareKernels resolves one typed kernel per key pair, using the
+// consume-time-normalized side key names. Requires identical key column
+// types on both sides — the equi-join planner gate guarantees this;
+// anything else fails loudly here.
 func (j *SortMergeJoin) resolveCompareKernels() error {
-	j.compare = make([]kernel.SortCompareKernel, len(j.LeftKeys))
-	for i := range j.LeftKeys {
-		lIdx := schemaColumnIndex(j.probe.schema, j.LeftKeys[i])
-		rIdx := schemaColumnIndex(j.build.schema, j.RightKeys[i])
+	j.compare = make([]kernel.SortCompareKernel, len(j.probe.keys))
+	for i := range j.probe.keys {
+		lCol, rCol := j.probe.keys[i].Column, j.build.keys[i].Column
+		lIdx := schemaColumnIndex(j.probe.schema, lCol)
+		rIdx := schemaColumnIndex(j.build.schema, rCol)
 		if lIdx < 0 || rIdx < 0 {
-			return fmt.Errorf("sort-merge join: key pair %q/%q not found in side schemas", j.LeftKeys[i], j.RightKeys[i])
+			return fmt.Errorf("sort-merge join: key pair %q/%q not found in side schemas", lCol, rCol)
 		}
 		lType, rType := j.probe.schema[lIdx].Type, j.build.schema[rIdx].Type
 		if lType != rType {
-			return fmt.Errorf("sort-merge join: key type mismatch for %q/%q (%d vs %d)", j.LeftKeys[i], j.RightKeys[i], lType, rType)
+			return fmt.Errorf("sort-merge join: key type mismatch for %q/%q (%d vs %d)", lCol, rCol, lType, rType)
 		}
 		// Null-aware kernel is defensive only — null-key rows never enter
 		// the runs.
 		cmp := kernel.ResolveSortCompare(lType)
 		if cmp == nil {
-			return fmt.Errorf("sort-merge join: unsupported key type %d for %q", lType, j.LeftKeys[i])
+			return fmt.Errorf("sort-merge join: unsupported key type %d for %q", lType, lCol)
 		}
 		j.compare[i] = cmp
 	}

--- a/internal/engine/exec/sort_merge_join_bench_test.go
+++ b/internal/engine/exec/sort_merge_join_bench_test.go
@@ -1,0 +1,161 @@
+package exec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/engine/memory"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// benchCountSink counts joined rows without retaining batches.
+type benchCountSink struct{ rows int }
+
+func (s *benchCountSink) Init(context.Context) error { return nil }
+func (s *benchCountSink) Consume(_ context.Context, b *batch.RecordBatch) error {
+	s.rows += b.ActiveLen()
+	return nil
+}
+func (s *benchCountSink) Finalize(context.Context) error { return nil }
+func (s *benchCountSink) Close() error                   { return nil }
+
+// BenchmarkSortMergeJoinVsHash compares the full join lifecycle — build side
+// intake, probe intake, output drain — between HashJoin and SortMergeJoin at
+// an in-memory scale and at a spilled scale (tight budget: the hash join
+// grace-partitions, the SMJ writes sorted runs on both sides). This is the
+// design memo's honesty check: SMJ pays a sort on both sides, so it should
+// trail hash in-memory and earn its keep only via the memory profile — the
+// numbers quantify that trade at micro scale.
+func BenchmarkSortMergeJoinVsHash(b *testing.B) {
+	const buildN = 100_000
+	const probeN = 200_000
+	buildSchema := []parquet.Column{
+		{Name: "rk", Type: parquet.TypeInt64},
+		{Name: "rv", Type: parquet.TypeString},
+	}
+	probeSchema := []parquet.Column{
+		{Name: "k", Type: parquet.TypeInt64},
+		{Name: "amount", Type: parquet.TypeInt64},
+	}
+	buildRows := make([]map[string]any, buildN)
+	for i := range buildRows {
+		buildRows[i] = map[string]any{"rk": int64(i), "rv": "payload-string-of-modest-size"}
+	}
+	probeRows := make([]map[string]any, probeN)
+	for i := range probeRows {
+		probeRows[i] = map[string]any{"k": int64(i % buildN), "amount": int64(i)}
+	}
+
+	ctx := context.Background()
+	rowsToBatches := func(schema []parquet.Column, rows []map[string]any) []*batch.RecordBatch {
+		var out []*batch.RecordBatch
+		for i := 0; i < len(rows); i += batch.DefaultBatchSize {
+			end := i + batch.DefaultBatchSize
+			if end > len(rows) {
+				end = len(rows)
+			}
+			out = append(out, batch.FromRows(schema, rows[i:end]))
+		}
+		return out
+	}
+
+	// A bench-scale run floor: the production 64 MiB floor would keep this
+	// data set from ever writing a run.
+	oldFloor := minSortRunBytes
+	minSortRunBytes = 256 << 10
+	b.Cleanup(func() { minSortRunBytes = oldFloor })
+
+	const spillBudget = 1 << 20 // ~1 MiB vs ~5 MiB of data: both operators spill
+
+	runHash := func(b *testing.B, spill bool) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+			buildBatches := rowsToBatches(buildSchema, buildRows)
+			probeBatches := rowsToBatches(probeSchema, probeRows)
+			hj := NewHashJoin(InnerJoin, []string{"k"}, []string{"rk"})
+			if spill {
+				tracker := memory.NewTracker("bench-hash", spillBudget)
+				sm, err := memory.NewSpillManager(b.TempDir(), tracker)
+				if err != nil {
+					b.Fatal(err)
+				}
+				hj.MemTracker = tracker
+				hj.Spill = sm
+			}
+			b.StartTimer()
+
+			if err := hj.Build(ctx, NewBatchSource(buildBatches)); err != nil {
+				b.Fatal(err)
+			}
+			sink := &benchCountSink{}
+			pipe := &Pipeline{Source: NewBatchSource(probeBatches), Ops: []UnaryOperator{hj.Probe()}, Sink: sink}
+			if err := pipe.Run(ctx); err != nil {
+				b.Fatal(err)
+			}
+			if err := pipe.Close(); err != nil {
+				b.Fatal(err)
+			}
+			if sink.rows != probeN {
+				b.Fatalf("hash join produced %d rows, want %d", sink.rows, probeN)
+			}
+		}
+	}
+
+	runSMJ := func(b *testing.B, spill bool) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+			buildBatches := rowsToBatches(buildSchema, buildRows)
+			probeBatches := rowsToBatches(probeSchema, probeRows)
+			j := NewSortMergeJoin([]string{"k"}, []string{"rk"})
+			if spill {
+				tracker := memory.NewTracker("bench-smj", spillBudget)
+				sm, err := memory.NewSpillManager(b.TempDir(), tracker)
+				if err != nil {
+					b.Fatal(err)
+				}
+				j.Spill = sm
+			}
+			b.StartTimer()
+
+			if err := j.Init(ctx); err != nil {
+				b.Fatal(err)
+			}
+			if err := j.Build(ctx, NewBatchSource(buildBatches)); err != nil {
+				b.Fatal(err)
+			}
+			for _, pb := range probeBatches {
+				if err := j.Consume(ctx, pb); err != nil {
+					b.Fatal(err)
+				}
+			}
+			if err := j.Finalize(ctx); err != nil {
+				b.Fatal(err)
+			}
+			rows := 0
+			for {
+				ob, err := j.Next(ctx)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if ob == nil {
+					break
+				}
+				rows += ob.ActiveLen()
+			}
+			if err := j.Close(); err != nil {
+				b.Fatal(err)
+			}
+			if rows != probeN {
+				b.Fatalf("sort-merge join produced %d rows, want %d", rows, probeN)
+			}
+		}
+	}
+
+	b.Run("hash/inmem", func(b *testing.B) { runHash(b, false) })
+	b.Run("smj/inmem", func(b *testing.B) { runSMJ(b, false) })
+	b.Run("hash/spilled", func(b *testing.B) { runHash(b, true) })
+	b.Run("smj/spilled", func(b *testing.B) { runSMJ(b, true) })
+}

--- a/internal/engine/exec/sort_merge_join_test.go
+++ b/internal/engine/exec/sort_merge_join_test.go
@@ -584,6 +584,56 @@ func TestSortMergeJoin_QualificationAndOutputFilter(t *testing.T) {
 	assertSameRows(t, got, sink.Rows, []string{"name", "region"})
 }
 
+// TestSortMergeJoin_QualifiedAndSwappedKeyNames: the planner emits
+// SQL-qualified key names ("l.id") while batch columns are bare, and SQL may
+// put the build column on the left of "=" so the pair arrives side-swapped.
+// Consume must normalize both via columnIndexFallback + counterpart adoption
+// before anything sorts by them — an unresolved sort key is silently SKIPPED
+// by resolveSortKeysForBatches and the merge would run over UNSORTED runs
+// (wrong results, not an error).
+func TestSortMergeJoin_QualifiedAndSwappedKeyNames(t *testing.T) {
+	leftSchema := []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "lv", Type: parquet.TypeString},
+	}
+	rightSchema := []parquet.Column{
+		{Name: "rid", Type: parquet.TypeInt64},
+		{Name: "rv", Type: parquet.TypeString},
+	}
+	var leftRows, rightRows []map[string]any
+	// Reverse-ordered keys so unsorted runs would visibly break the merge.
+	for i := 500; i > 0; i-- {
+		leftRows = append(leftRows, map[string]any{"id": int64(i), "lv": fmt.Sprintf("l%d", i)})
+		rightRows = append(rightRows, map[string]any{"rid": int64(i), "rv": fmt.Sprintf("r%d", i)})
+	}
+
+	for _, tc := range []struct {
+		name                string
+		leftKeys, rightKeys []string
+	}{
+		{"qualified", []string{"smj_l.id"}, []string{"smj_r.rid"}},
+		{"swapped_pair", []string{"rid"}, []string{"id"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			j := NewSortMergeJoin(tc.leftKeys, tc.rightKeys)
+			got := runSMJ(t, j,
+				chunkBatches(t, rightSchema, rightRows, 64),
+				chunkBatches(t, leftSchema, leftRows, 64))
+			defer j.Close()
+
+			if len(got) != 500 {
+				t.Fatalf("expected 500 joined rows, got %d", len(got))
+			}
+			for _, r := range got {
+				id := r["id"].(int64)
+				if r["lv"] != fmt.Sprintf("l%d", id) || r["rv"] != fmt.Sprintf("r%d", id) {
+					t.Fatalf("mismatched pair: %v", r)
+				}
+			}
+		})
+	}
+}
+
 // TestSortMergeJoin_FinalizeBeforeBuild: Finalize without a completed build
 // phase must fail loudly, mirroring HashJoinProbe.Init's guard.
 func TestSortMergeJoin_FinalizeBeforeBuild(t *testing.T) {

--- a/internal/engine/exec/sort_merge_join_test.go
+++ b/internal/engine/exec/sort_merge_join_test.go
@@ -1,0 +1,869 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/engine/memory"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// chunkBatches splits rows into batches of chunk rows each.
+func chunkBatches(tb testing.TB, schema []parquet.Column, rows []map[string]any, chunk int) []*batch.RecordBatch {
+	tb.Helper()
+	var out []*batch.RecordBatch
+	for i := 0; i < len(rows); i += chunk {
+		end := i + chunk
+		if end > len(rows) {
+			end = len(rows)
+		}
+		out = append(out, batch.FromRows(schema, rows[i:end]))
+	}
+	return out
+}
+
+// runSMJ drives the operator through its full lifecycle — Build (right),
+// Consume (left), Finalize, drain — and returns the joined rows.
+func runSMJ(tb testing.TB, j *SortMergeJoin, rightBatches, leftBatches []*batch.RecordBatch) []map[string]any {
+	tb.Helper()
+	ctx := context.Background()
+	if err := j.Init(ctx); err != nil {
+		tb.Fatalf("Init: %v", err)
+	}
+	if err := j.Build(ctx, NewBatchSource(rightBatches)); err != nil {
+		tb.Fatalf("Build: %v", err)
+	}
+	for i, b := range leftBatches {
+		if err := j.Consume(ctx, b); err != nil {
+			tb.Fatalf("Consume batch %d: %v", i, err)
+		}
+	}
+	if err := j.Finalize(ctx); err != nil {
+		tb.Fatalf("Finalize: %v", err)
+	}
+	var rows []map[string]any
+	for {
+		b, err := j.Next(ctx)
+		if err != nil {
+			tb.Fatalf("Next: %v", err)
+		}
+		if b == nil {
+			return rows
+		}
+		rows = append(rows, b.ToRows()...)
+	}
+}
+
+// bruteInnerJoin computes the expected inner-join multiset with a plain
+// rendered-key map: an oracle independent of both operators' typed hash /
+// merge machinery. Rows with a NULL in any join key match nothing. Output
+// rows merge left columns with the right columns not shadowed by left names
+// (tests use distinct names unless exercising qualification, which uses the
+// HashJoin reference instead).
+func bruteInnerJoin(leftRows, rightRows []map[string]any, leftKeys, rightKeys []string) []map[string]any {
+	renderKey := func(row map[string]any, keys []string) (string, bool) {
+		var sb strings.Builder
+		for _, k := range keys {
+			v := row[k]
+			if v == nil {
+				return "", false
+			}
+			fmt.Fprintf(&sb, "%T:%v|", v, v)
+		}
+		return sb.String(), true
+	}
+	rightByKey := make(map[string][]map[string]any)
+	for _, r := range rightRows {
+		if key, ok := renderKey(r, rightKeys); ok {
+			rightByKey[key] = append(rightByKey[key], r)
+		}
+	}
+	var out []map[string]any
+	for _, l := range leftRows {
+		key, ok := renderKey(l, leftKeys)
+		if !ok {
+			continue
+		}
+		for _, r := range rightByKey[key] {
+			row := make(map[string]any, len(l)+len(r))
+			for k, v := range r {
+				row[k] = v
+			}
+			for k, v := range l {
+				row[k] = v
+			}
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
+// renderRows canonicalizes a row multiset for order-independent comparison.
+func renderRows(rows []map[string]any, cols []string) []string {
+	out := make([]string, len(rows))
+	var sb strings.Builder
+	for i, r := range rows {
+		sb.Reset()
+		for _, c := range cols {
+			fmt.Fprintf(&sb, "%s=%v|", c, r[c])
+		}
+		out[i] = sb.String()
+	}
+	sort.Strings(out)
+	return out
+}
+
+func assertSameRows(tb testing.TB, got, want []map[string]any, cols []string) {
+	tb.Helper()
+	g, w := renderRows(got, cols), renderRows(want, cols)
+	if len(g) != len(w) {
+		tb.Fatalf("row count: got %d want %d", len(g), len(w))
+	}
+	for i := range w {
+		if g[i] != w[i] {
+			tb.Fatalf("row %d (canonical order):\n  got  %s\n  want %s", i, g[i], w[i])
+		}
+	}
+}
+
+// newSMJSpillHarness attaches a SpillManager with the given budget and
+// lowers the run floor so unit-scale data exercises the spill path.
+func newSMJSpillHarness(tb testing.TB, j *SortMergeJoin, budget int64) *memory.Tracker {
+	tb.Helper()
+	forceTinyRuns(tb)
+	tracker := memory.NewTracker("smj-test", budget)
+	sm, err := memory.NewSpillManager(tb.TempDir(), tracker)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	j.Spill = sm
+	return tracker
+}
+
+// TestSortMergeJoin_InnerDupGroups: duplicate keys on BOTH sides within one
+// batch — every (left dup × right dup) pair must appear exactly once.
+func TestSortMergeJoin_InnerDupGroups(t *testing.T) {
+	leftSchema := []parquet.Column{
+		{Name: "k", Type: parquet.TypeInt64},
+		{Name: "lv", Type: parquet.TypeString},
+	}
+	rightSchema := []parquet.Column{
+		{Name: "rk", Type: parquet.TypeInt64},
+		{Name: "rv", Type: parquet.TypeString},
+	}
+	leftRows := []map[string]any{
+		{"k": int64(1), "lv": "l1a"},
+		{"k": int64(2), "lv": "l2a"},
+		{"k": int64(2), "lv": "l2b"},
+		{"k": int64(3), "lv": "l3a"},
+		{"k": int64(5), "lv": "l5a"}, // no right match
+	}
+	rightRows := []map[string]any{
+		{"rk": int64(1), "rv": "r1a"},
+		{"rk": int64(2), "rv": "r2a"},
+		{"rk": int64(2), "rv": "r2b"},
+		{"rk": int64(2), "rv": "r2c"},
+		{"rk": int64(4), "rv": "r4a"}, // no left match
+	}
+
+	j := NewSortMergeJoin([]string{"k"}, []string{"rk"})
+	got := runSMJ(t, j,
+		chunkBatches(t, rightSchema, rightRows, 100),
+		chunkBatches(t, leftSchema, leftRows, 100))
+	want := bruteInnerJoin(leftRows, rightRows, []string{"k"}, []string{"rk"})
+	if len(got) != 7 { // k=1: 1×1, k=2: 2×3, unmatched keys contribute nothing
+		t.Fatalf("row count: got %d want 7", len(got))
+	}
+	assertSameRows(t, got, want, []string{"k", "lv", "rk", "rv"})
+	if err := j.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestSortMergeJoin_MatchesHashJoin runs identical random data through
+// SortMergeJoin and the HashJoin build+probe pipeline and requires identical
+// row multisets — the operator-level equivalence the planner will rely on.
+func TestSortMergeJoin_MatchesHashJoin(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		keyType parquet.TypeID
+	}{
+		{"int64_keys", parquet.TypeInt64},
+		{"string_keys", parquet.TypeString},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			leftSchema := []parquet.Column{
+				{Name: "k", Type: tc.keyType},
+				{Name: "amount", Type: parquet.TypeFloat64},
+			}
+			rightSchema := []parquet.Column{
+				{Name: "rk", Type: tc.keyType},
+				{Name: "label", Type: parquet.TypeString},
+			}
+			rng := rand.New(rand.NewSource(99))
+			mkKey := func(n int) any {
+				if tc.keyType == parquet.TypeString {
+					return fmt.Sprintf("key-%03d", n)
+				}
+				return int64(n)
+			}
+			var leftRows, rightRows []map[string]any
+			for i := 0; i < 3000; i++ {
+				leftRows = append(leftRows, map[string]any{"k": mkKey(rng.Intn(400)), "amount": float64(i)})
+			}
+			for i := 0; i < 2000; i++ {
+				rightRows = append(rightRows, map[string]any{"rk": mkKey(rng.Intn(400)), "label": fmt.Sprintf("r%d", i)})
+			}
+
+			j := NewSortMergeJoin([]string{"k"}, []string{"rk"})
+			got := runSMJ(t, j,
+				chunkBatches(t, rightSchema, rightRows, 700),
+				chunkBatches(t, leftSchema, leftRows, 700))
+			defer j.Close()
+
+			hj := NewHashJoin(InnerJoin, []string{"k"}, []string{"rk"})
+			hj.BuildFromRows(rightSchema, rightRows)
+			sink := &CollectSink{}
+			pipe := &Pipeline{Source: NewSliceSource(leftSchema, leftRows), Ops: []UnaryOperator{hj.Probe()}, Sink: sink}
+			if err := pipe.Run(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+
+			assertSameRows(t, got, sink.Rows, []string{"k", "amount", "rk", "label"})
+		})
+	}
+}
+
+// TestSortMergeJoin_CrossBatchDupGroups: hot keys whose duplicate groups span
+// input batch boundaries AND merge-output batch boundaries (> DefaultBatchSize
+// rows), exercising group batch pinning and the mid-group pending-flush
+// resume path.
+func TestSortMergeJoin_CrossBatchDupGroups(t *testing.T) {
+	leftSchema := []parquet.Column{
+		{Name: "k", Type: parquet.TypeInt64},
+		{Name: "lv", Type: parquet.TypeInt64},
+	}
+	rightSchema := []parquet.Column{
+		{Name: "rk", Type: parquet.TypeInt64},
+		{Name: "rv", Type: parquet.TypeInt64},
+	}
+	var leftRows, rightRows []map[string]any
+	// Key 42: build-side group of 2500 (> DefaultBatchSize → spans merge
+	// batches), 3 probe rows. Key 7: probe-side run of 2200, 3 build rows.
+	// Key 9: 1:1. Keys 100/200: unmatched on either side.
+	for i := 0; i < 2500; i++ {
+		rightRows = append(rightRows, map[string]any{"rk": int64(42), "rv": int64(i)})
+	}
+	for i := 0; i < 3; i++ {
+		rightRows = append(rightRows, map[string]any{"rk": int64(7), "rv": int64(10000 + i)})
+		leftRows = append(leftRows, map[string]any{"k": int64(42), "lv": int64(20000 + i)})
+	}
+	for i := 0; i < 2200; i++ {
+		leftRows = append(leftRows, map[string]any{"k": int64(7), "lv": int64(i)})
+	}
+	leftRows = append(leftRows, map[string]any{"k": int64(9), "lv": int64(1)}, map[string]any{"k": int64(100), "lv": int64(2)})
+	rightRows = append(rightRows, map[string]any{"rk": int64(9), "rv": int64(1)}, map[string]any{"rk": int64(200), "rv": int64(2)})
+
+	j := NewSortMergeJoin([]string{"k"}, []string{"rk"})
+	got := runSMJ(t, j,
+		chunkBatches(t, rightSchema, rightRows, 512),
+		chunkBatches(t, leftSchema, leftRows, 512))
+	defer j.Close()
+
+	wantRows := 3*2500 + 2200*3 + 1
+	if len(got) != wantRows {
+		t.Fatalf("row count: got %d want %d", len(got), wantRows)
+	}
+	want := bruteInnerJoin(leftRows, rightRows, []string{"k"}, []string{"rk"})
+	assertSameRows(t, got, want, []string{"k", "lv", "rk", "rv"})
+}
+
+// TestSortMergeJoin_NullKeys: NULL join keys on either side match nothing
+// (SQL equi-join semantics) — including NULL-NULL pairs.
+func TestSortMergeJoin_NullKeys(t *testing.T) {
+	leftSchema := []parquet.Column{
+		{Name: "k", Type: parquet.TypeInt64, Nullable: true},
+		{Name: "lv", Type: parquet.TypeString},
+	}
+	rightSchema := []parquet.Column{
+		{Name: "rk", Type: parquet.TypeInt64, Nullable: true},
+		{Name: "rv", Type: parquet.TypeString},
+	}
+	leftRows := []map[string]any{
+		{"k": int64(1), "lv": "l1"},
+		{"k": nil, "lv": "lnull-a"},
+		{"k": int64(2), "lv": "l2"},
+		{"k": nil, "lv": "lnull-b"},
+	}
+	rightRows := []map[string]any{
+		{"rk": nil, "rv": "rnull"},
+		{"rk": int64(1), "rv": "r1"},
+		{"rk": int64(3), "rv": "r3"},
+	}
+
+	j := NewSortMergeJoin([]string{"k"}, []string{"rk"})
+	got := runSMJ(t, j,
+		chunkBatches(t, rightSchema, rightRows, 10),
+		chunkBatches(t, leftSchema, leftRows, 10))
+	defer j.Close()
+
+	if len(got) != 1 {
+		t.Fatalf("expected exactly the k=1 match, got %d rows: %v", len(got), got)
+	}
+	if got[0]["lv"] != "l1" || got[0]["rv"] != "r1" {
+		t.Fatalf("wrong match: %v", got[0])
+	}
+}
+
+// TestSortMergeJoin_EmptySides: inner join with any empty side is empty and
+// must tear down cleanly (no stranded run files or reservations).
+func TestSortMergeJoin_EmptySides(t *testing.T) {
+	schema := func(k, v string) []parquet.Column {
+		return []parquet.Column{
+			{Name: k, Type: parquet.TypeInt64},
+			{Name: v, Type: parquet.TypeString},
+		}
+	}
+	someRows := func(k, v string) []map[string]any {
+		return []map[string]any{
+			{k: int64(1), v: "a"},
+			{k: int64(2), v: "b"},
+		}
+	}
+	for _, tc := range []struct {
+		name        string
+		left, right []map[string]any
+	}{
+		{"both_empty", nil, nil},
+		{"probe_empty", nil, someRows("rk", "rv")},
+		{"build_empty", someRows("k", "lv"), nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			j := NewSortMergeJoin([]string{"k"}, []string{"rk"})
+			tracker := newSMJSpillHarness(t, j, 1<<30)
+			got := runSMJ(t, j,
+				chunkBatches(t, schema("rk", "rv"), tc.right, 10),
+				chunkBatches(t, schema("k", "lv"), tc.left, 10))
+			if len(got) != 0 {
+				t.Fatalf("expected empty join, got %d rows", len(got))
+			}
+			if err := j.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if used := tracker.Used(); used != 0 {
+				t.Fatalf("tracker should be fully released, still holds %d bytes", used)
+			}
+		})
+	}
+}
+
+// TestSortMergeJoin_ForcedSpillBothSides: a budget small enough that BOTH
+// sides self-spill sorted runs, with a hot key thrown in so group pinning
+// runs under a real tracker. Output must match the oracle; run scratch must
+// be deleted after the drain; the tracker must end at zero.
+func TestSortMergeJoin_ForcedSpillBothSides(t *testing.T) {
+	leftSchema := []parquet.Column{
+		{Name: "k", Type: parquet.TypeInt64},
+		{Name: "lv", Type: parquet.TypeInt64},
+	}
+	rightSchema := []parquet.Column{
+		{Name: "rk", Type: parquet.TypeInt64},
+		{Name: "rv", Type: parquet.TypeInt64},
+	}
+	rng := rand.New(rand.NewSource(5))
+	var leftRows, rightRows []map[string]any
+	for i := 0; i < 12000; i++ {
+		leftRows = append(leftRows, map[string]any{"k": int64(rng.Intn(4000)), "lv": int64(i)})
+	}
+	for i := 0; i < 12000; i++ {
+		rightRows = append(rightRows, map[string]any{"rk": int64(rng.Intn(4000)), "rv": int64(i)})
+	}
+	// Hot key: build group of 3000 spans merge batches → pinned batches are
+	// Reserved against the same tight budget.
+	for i := 0; i < 3000; i++ {
+		rightRows = append(rightRows, map[string]any{"rk": int64(9999), "rv": int64(i)})
+	}
+	leftRows = append(leftRows, map[string]any{"k": int64(9999), "lv": int64(-1)})
+
+	j := NewSortMergeJoin([]string{"k"}, []string{"rk"})
+	tracker := newSMJSpillHarness(t, j, 256<<10)
+
+	ctx := context.Background()
+	if err := j.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := j.Build(ctx, NewBatchSource(chunkBatches(t, rightSchema, rightRows, 2048))); err != nil {
+		t.Fatal(err)
+	}
+	if len(j.build.runFiles) == 0 {
+		t.Fatal("build side never spilled; budget/floor setup is wrong")
+	}
+	for _, b := range chunkBatches(t, leftSchema, leftRows, 2048) {
+		if err := j.Consume(ctx, b); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(j.probe.runFiles) == 0 {
+		t.Fatal("probe side never spilled; budget/floor setup is wrong")
+	}
+	probeRuns := append([]string(nil), j.probe.runFiles...)
+	buildRuns := append([]string(nil), j.build.runFiles...)
+
+	if err := j.Finalize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	var got []map[string]any
+	for {
+		b, err := j.Next(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if b == nil {
+			break
+		}
+		got = append(got, b.ToRows()...)
+	}
+
+	want := bruteInnerJoin(leftRows, rightRows, []string{"k"}, []string{"rk"})
+	assertSameRows(t, got, want, []string{"k", "lv", "rk", "rv"})
+
+	for _, p := range append(probeRuns, buildRuns...) {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("run file %s not cleaned up after drain", p)
+		}
+	}
+	if err := j.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if used := tracker.Used(); used != 0 {
+		t.Fatalf("tracker should be fully released after drain+Close, still holds %d bytes", used)
+	}
+}
+
+// TestSortMergeJoin_NestedPayload: ARRAY and ROW payload columns on both
+// sides ride the sorted-run spill format and the output gather, coming back
+// value-identical to the oracle.
+func TestSortMergeJoin_NestedPayload(t *testing.T) {
+	elem := parquet.Column{Name: "element", Type: parquet.TypeInt64}
+	leftSchema := []parquet.Column{
+		{Name: "k", Type: parquet.TypeInt64},
+		{Name: "tags", Type: parquet.TypeArray, ElementType: &elem, Nullable: true},
+	}
+	rightSchema := []parquet.Column{
+		{Name: "rk", Type: parquet.TypeInt64},
+		{Name: "rec", Type: parquet.TypeRow, Fields: []parquet.Column{
+			{Name: "a", Type: parquet.TypeInt64},
+			{Name: "b", Type: parquet.TypeString, Nullable: true},
+		}},
+	}
+	rng := rand.New(rand.NewSource(13))
+	var leftRows, rightRows []map[string]any
+	for i := 0; i < 1500; i++ {
+		var tags any
+		switch i % 4 {
+		case 0:
+			tags = nil
+		case 1:
+			tags = []any{}
+		default:
+			tags = []any{int64(i), int64(i % 9)}
+		}
+		leftRows = append(leftRows, map[string]any{"k": int64(rng.Intn(150)), "tags": tags})
+	}
+	for i := 0; i < 1500; i++ {
+		var b any
+		if i%5 == 0 {
+			b = nil
+		} else {
+			b = fmt.Sprintf("b%d", i)
+		}
+		rightRows = append(rightRows, map[string]any{
+			"rk":  int64(rng.Intn(150)),
+			"rec": map[string]any{"a": int64(i * 3), "b": b},
+		})
+	}
+
+	j := NewSortMergeJoin([]string{"k"}, []string{"rk"})
+	// Tight enough that both sides spill sorted runs, with headroom for the
+	// merge-phase group pins (~one merge batch of nested build rows).
+	tracker := newSMJSpillHarness(t, j, 64<<10)
+
+	ctx := context.Background()
+	if err := j.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := j.Build(ctx, NewBatchSource(chunkBatches(t, rightSchema, rightRows, 64))); err != nil {
+		t.Fatal(err)
+	}
+	for _, b := range chunkBatches(t, leftSchema, leftRows, 64) {
+		if err := j.Consume(ctx, b); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(j.build.runFiles) == 0 || len(j.probe.runFiles) == 0 {
+		t.Fatalf("nested payloads must ride the run format on both sides (probe %d runs, build %d runs)",
+			len(j.probe.runFiles), len(j.build.runFiles))
+	}
+	if err := j.Finalize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	var got []map[string]any
+	for {
+		b, err := j.Next(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if b == nil {
+			break
+		}
+		got = append(got, b.ToRows()...)
+	}
+
+	want := bruteInnerJoin(leftRows, rightRows, []string{"k"}, []string{"rk"})
+	assertSameRows(t, got, want, []string{"k", "tags", "rk", "rec"})
+	if err := j.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if used := tracker.Used(); used != 0 {
+		t.Fatalf("tracker should be fully released, still holds %d bytes", used)
+	}
+}
+
+// TestSortMergeJoin_QualificationAndOutputFilter: duplicate build column
+// names qualify under BuildTableAlias and OutputFilter prunes columns —
+// byte-for-byte the HashJoinProbe semantics (shared helper), verified against
+// the hash pipeline on identical data.
+func TestSortMergeJoin_QualificationAndOutputFilter(t *testing.T) {
+	leftSchema := []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "name", Type: parquet.TypeString},
+	}
+	rightSchema := []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64}, // collides with probe "id"
+		{Name: "region", Type: parquet.TypeString},
+	}
+	var leftRows, rightRows []map[string]any
+	for i := 0; i < 200; i++ {
+		leftRows = append(leftRows, map[string]any{"id": int64(i % 50), "name": fmt.Sprintf("n%d", i)})
+	}
+	for i := 0; i < 80; i++ {
+		rightRows = append(rightRows, map[string]any{"id": int64(i % 50), "region": fmt.Sprintf("g%d", i)})
+	}
+	filter := map[string]bool{"name": true, "region": true}
+
+	j := NewSortMergeJoin([]string{"id"}, []string{"id"})
+	j.BuildTableAlias = "r"
+	j.OutputFilter = filter
+	got := runSMJ(t, j,
+		chunkBatches(t, rightSchema, rightRows, 30),
+		chunkBatches(t, leftSchema, leftRows, 30))
+	defer j.Close()
+
+	for i, col := range j.outSchema {
+		if col.Name == "id" || strings.HasPrefix(col.Name, "r.") {
+			t.Fatalf("output column %d = %q; OutputFilter should have pruned ids", i, col.Name)
+		}
+	}
+
+	hj := NewHashJoin(InnerJoin, []string{"id"}, []string{"id"})
+	hj.BuildTableAlias = "r"
+	hj.BuildFromRows(rightSchema, rightRows)
+	probe := hj.Probe()
+	probe.OutputFilter = filter
+	sink := &CollectSink{}
+	pipe := &Pipeline{Source: NewSliceSource(leftSchema, leftRows), Ops: []UnaryOperator{probe}, Sink: sink}
+	if err := pipe.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	assertSameRows(t, got, sink.Rows, []string{"name", "region"})
+}
+
+// TestSortMergeJoin_FinalizeBeforeBuild: Finalize without a completed build
+// phase must fail loudly, mirroring HashJoinProbe.Init's guard.
+func TestSortMergeJoin_FinalizeBeforeBuild(t *testing.T) {
+	j := NewSortMergeJoin([]string{"k"}, []string{"rk"})
+	if err := j.Init(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := j.Finalize(context.Background()); err == nil {
+		t.Fatal("Finalize before Build should error")
+	}
+	if err := j.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// ---- Accounting truth-tests (mirroring Sort's contract) ----
+
+// TestSortMergeJoinAccounting_ReleaseOnDrainAndClose: bytes tracked during
+// consume are visible via Inspect/PublishOwned and fully released once the
+// merge drains — no phantom reservation survives the operator.
+func TestSortMergeJoinAccounting_ReleaseOnDrainAndClose(t *testing.T) {
+	leftSchema := []parquet.Column{{Name: "k", Type: parquet.TypeInt64}, {Name: "lv", Type: parquet.TypeInt64}}
+	rightSchema := []parquet.Column{{Name: "rk", Type: parquet.TypeInt64}, {Name: "rv", Type: parquet.TypeInt64}}
+	var leftRows, rightRows []map[string]any
+	for i := 0; i < 500; i++ {
+		leftRows = append(leftRows, map[string]any{"k": int64(i), "lv": int64(i)})
+		rightRows = append(rightRows, map[string]any{"rk": int64(i), "rv": int64(i)})
+	}
+
+	j := NewSortMergeJoin([]string{"k"}, []string{"rk"})
+	// Large budget: nothing spills; both sides stay buffered and tracked.
+	tracker := newSMJSpillHarness(t, j, 1<<30)
+
+	ctx := context.Background()
+	if err := j.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := j.Build(ctx, NewBatchSource(chunkBatches(t, rightSchema, rightRows, 100))); err != nil {
+		t.Fatal(err)
+	}
+	for _, b := range chunkBatches(t, leftSchema, leftRows, 100) {
+		if err := j.Consume(ctx, b); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	fp := j.Inspect()
+	if fp.OwnedBytes == 0 || fp.OwnedBytes != j.probe.trackedMem+j.build.trackedMem {
+		t.Fatalf("Inspect.OwnedBytes = %d, want %d (both sides)", fp.OwnedBytes, j.probe.trackedMem+j.build.trackedMem)
+	}
+	if fp.SpillableBytes != fp.OwnedBytes {
+		t.Fatalf("pre-finalize SpillableBytes = %d, want %d (both sides spillable)", fp.SpillableBytes, fp.OwnedBytes)
+	}
+	if got := tracker.OwnedFor(j.accInstanceID); got != fp.OwnedBytes {
+		t.Fatalf("PublishOwned reported %d, Inspect says %d", got, fp.OwnedBytes)
+	}
+	if tracker.Used() != fp.OwnedBytes {
+		t.Fatalf("tracker.Used = %d, want %d", tracker.Used(), fp.OwnedBytes)
+	}
+
+	if err := j.Finalize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	rows := 0
+	for {
+		b, err := j.Next(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if b == nil {
+			break
+		}
+		rows += b.ActiveLen()
+	}
+	if rows != 500 {
+		t.Fatalf("expected 500 joined rows, got %d", rows)
+	}
+	if used := tracker.Used(); used != 0 {
+		t.Fatalf("tracker should be fully released after drain, still holds %d bytes", used)
+	}
+	if fp := j.Inspect(); fp.State != memory.OpClosed || fp.OwnedBytes != 0 {
+		t.Fatalf("post-drain Inspect = %+v, want OpClosed with zero bytes", fp)
+	}
+	if err := j.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if used := tracker.Used(); used != 0 {
+		t.Fatalf("Close must not double-release or re-reserve, tracker at %d", used)
+	}
+}
+
+// TestSortMergeJoinAccounting_CloseWithoutFinalize: an early cancel (Close
+// with buffered state and spilled runs, no Finalize) releases every tracked
+// byte and deletes run scratch — Sort.Close's guarantee.
+func TestSortMergeJoinAccounting_CloseWithoutFinalize(t *testing.T) {
+	schemaL := []parquet.Column{{Name: "k", Type: parquet.TypeInt64}, {Name: "lv", Type: parquet.TypeInt64}}
+	schemaR := []parquet.Column{{Name: "rk", Type: parquet.TypeInt64}, {Name: "rv", Type: parquet.TypeInt64}}
+	var rowsL, rowsR []map[string]any
+	for i := 0; i < 4000; i++ {
+		rowsL = append(rowsL, map[string]any{"k": int64(i), "lv": int64(i)})
+		rowsR = append(rowsR, map[string]any{"rk": int64(i), "rv": int64(i)})
+	}
+	j := NewSortMergeJoin([]string{"k"}, []string{"rk"})
+	tracker := newSMJSpillHarness(t, j, 64<<10) // tight: some batches spill, some stay buffered
+
+	ctx := context.Background()
+	if err := j.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := j.Build(ctx, NewBatchSource(chunkBatches(t, schemaR, rowsR, 512))); err != nil {
+		t.Fatal(err)
+	}
+	for _, b := range chunkBatches(t, schemaL, rowsL, 512) {
+		if err := j.Consume(ctx, b); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runs := append(append([]string(nil), j.probe.runFiles...), j.build.runFiles...)
+	if len(runs) == 0 {
+		t.Fatal("expected spilled runs under the tight budget")
+	}
+
+	if err := j.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if used := tracker.Used(); used != 0 {
+		t.Fatalf("tracker should be fully released after Close, still holds %d bytes", used)
+	}
+	for _, p := range runs {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("run file %s not cleaned up by Close", p)
+		}
+	}
+	if fp := j.Inspect(); fp.State != memory.OpClosed || fp.OwnedBytes != 0 || fp.SpillableBytes != 0 {
+		t.Fatalf("closed Inspect = %+v, want OpClosed with zero bytes", fp)
+	}
+}
+
+// TestSortMergeJoinSpillSome_ReliefContract: EstimateRelief's claim is
+// delivered by SpillSome; the larger buffered side sheds first; a target the
+// larger side covers leaves the smaller side buffered; and the join still
+// produces correct output afterward.
+func TestSortMergeJoinSpillSome_ReliefContract(t *testing.T) {
+	schemaL := []parquet.Column{{Name: "k", Type: parquet.TypeInt64}, {Name: "lv", Type: parquet.TypeInt64}}
+	schemaR := []parquet.Column{{Name: "rk", Type: parquet.TypeInt64}, {Name: "rv", Type: parquet.TypeInt64}}
+	var rowsL, rowsR []map[string]any
+	for i := 0; i < 3000; i++ { // probe = the larger side
+		rowsL = append(rowsL, map[string]any{"k": int64(i % 500), "lv": int64(i)})
+	}
+	for i := 0; i < 500; i++ {
+		rowsR = append(rowsR, map[string]any{"rk": int64(i), "rv": int64(i)})
+	}
+	j := NewSortMergeJoin([]string{"k"}, []string{"rk"})
+	tracker := newSMJSpillHarness(t, j, 1<<30) // no self-spill; SpillSome is the only trigger
+
+	ctx := context.Background()
+	if err := j.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := j.Build(ctx, NewBatchSource(chunkBatches(t, schemaR, rowsR, 250))); err != nil {
+		t.Fatal(err)
+	}
+	for _, b := range chunkBatches(t, schemaL, rowsL, 250) {
+		if err := j.Consume(ctx, b); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if j.probe.trackedMem <= j.build.trackedMem {
+		t.Fatal("test setup: probe side must be the larger buffer")
+	}
+	largerBytes := j.probe.trackedMem
+
+	// A target the larger side covers: claim and delivery are larger-side-only.
+	claimed := j.EstimateRelief(1)
+	if claimed != largerBytes {
+		t.Fatalf("EstimateRelief(1) = %d, want larger side %d", claimed, largerBytes)
+	}
+	freed, err := j.SpillSome(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if freed != claimed {
+		t.Fatalf("SpillSome freed %d, EstimateRelief claimed %d", freed, claimed)
+	}
+	if len(j.probe.runFiles) == 0 || j.probe.trackedMem != 0 {
+		t.Fatal("larger (probe) side should have spilled to a run")
+	}
+	if len(j.build.runFiles) != 0 || j.build.trackedMem == 0 {
+		t.Fatal("smaller (build) side should still be buffered")
+	}
+
+	// A target beyond the remaining side: claim and delivery cover it too.
+	claimed = j.EstimateRelief(1 << 30)
+	if claimed != j.build.trackedMem {
+		t.Fatalf("EstimateRelief(big) = %d, want remaining build side %d", claimed, j.build.trackedMem)
+	}
+	freed, err = j.SpillSome(1 << 30)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if freed != claimed {
+		t.Fatalf("second SpillSome freed %d, claimed %d", freed, claimed)
+	}
+	if tracker.Used() != 0 {
+		t.Fatalf("all buffers spilled, tracker should be 0, at %d", tracker.Used())
+	}
+
+	if err := j.Finalize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	rows := 0
+	for {
+		b, err := j.Next(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if b == nil {
+			break
+		}
+		rows += b.ActiveLen()
+	}
+	if rows != 3000 { // every probe row matches exactly one build row
+		t.Fatalf("post-relief join produced %d rows, want 3000", rows)
+	}
+	if err := j.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if tracker.Used() != 0 {
+		t.Fatalf("tracker should end at 0, at %d", tracker.Used())
+	}
+}
+
+// TestSortMergeJoin_HotKeyGroupReserveFailsLoud: the documented v1 bound — a
+// single key whose build-side duplicate group outgrows the memory budget
+// fails the query with a clear error instead of OOMing.
+func TestSortMergeJoin_HotKeyGroupReserveFailsLoud(t *testing.T) {
+	schemaL := []parquet.Column{{Name: "k", Type: parquet.TypeInt64}, {Name: "lv", Type: parquet.TypeInt64}}
+	schemaR := []parquet.Column{{Name: "rk", Type: parquet.TypeInt64}, {Name: "rv", Type: parquet.TypeInt64}}
+	var rowsR []map[string]any
+	for i := 0; i < 30000; i++ { // one pathologically hot key
+		rowsR = append(rowsR, map[string]any{"rk": int64(1), "rv": int64(i)})
+	}
+	rowsL := []map[string]any{{"k": int64(1), "lv": int64(0)}}
+
+	j := NewSortMergeJoin([]string{"k"}, []string{"rk"})
+	newSMJSpillHarness(t, j, 64<<10)
+
+	ctx := context.Background()
+	if err := j.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := j.Build(ctx, NewBatchSource(chunkBatches(t, schemaR, rowsR, 2048))); err != nil {
+		t.Fatal(err)
+	}
+	for _, b := range chunkBatches(t, schemaL, rowsL, 2048) {
+		if err := j.Consume(ctx, b); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := j.Finalize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	var lastErr error
+	for {
+		b, err := j.Next(ctx)
+		if err != nil {
+			lastErr = err
+			break
+		}
+		if b == nil {
+			break
+		}
+	}
+	if lastErr == nil {
+		t.Fatal("expected the hot-key duplicate group to fail Reserve loudly")
+	}
+	if !strings.Contains(lastErr.Error(), "duplicate group") {
+		t.Fatalf("error should name the duplicate-group bound, got: %v", lastErr)
+	}
+	if err := j.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/planner/physical/distribution.go
+++ b/internal/planner/physical/distribution.go
@@ -174,7 +174,7 @@ func RequiredChildDistribution(stage Stage, slot int) RequiredDistribution {
 	case StageExchangeRepartition:
 		// Exchange-repartition accepts any input and re-partitions.
 		return RequiredDistribution{Kind: RequiredAny}
-	case StageHashJoin:
+	case StageHashJoin, StageSortMergeJoin:
 		switch slot {
 		case 0:
 			return RequiredDistribution{Kind: RequiredClusteredOn, Keys: stage.JoinLeftKeys}
@@ -291,7 +291,7 @@ func OutputDistribution(stage Stage, deps map[string]Distribution, workerCount i
 		return Distribution{Kind: DistBroadcast}
 	case StageExchangeGather:
 		return Distribution{Kind: DistSingleton}
-	case StageHashJoin, StageBroadcastJoin:
+	case StageHashJoin, StageBroadcastJoin, StageSortMergeJoin:
 		// The join inherits the probe (left) input's distribution — the
 		// join itself does not re-partition the joined output, it just
 		// pairs probe rows with matching build rows.
@@ -479,7 +479,7 @@ func AssertExchangeConsistency(stages []Stage) error {
 			// (single-input) is the only meaningful index — Phase 1 does
 			// not assert non-join multi-input requirements.
 			slot := 0
-			if consumer.Type == StageHashJoin || consumer.Type == StageBroadcastJoin {
+			if consumer.Type == StageHashJoin || consumer.Type == StageBroadcastJoin || consumer.Type == StageSortMergeJoin {
 				s := joinSlot(consumer, depID)
 				if s < 0 {
 					// Auxiliary dep (e.g. fused-join build). Skip — no

--- a/internal/planner/physical/ensure_distribution.go
+++ b/internal/planner/physical/ensure_distribution.go
@@ -180,7 +180,7 @@ type dependencySlot struct {
 
 func dependencySlots(s *Stage) []dependencySlot {
 	switch s.Type {
-	case StageHashJoin, StageBroadcastJoin:
+	case StageHashJoin, StageBroadcastJoin, StageSortMergeJoin:
 		return []dependencySlot{
 			{0, func(s *Stage) string { return s.LeftDepStage }, func(s *Stage, id string) { s.LeftDepStage = id }},
 			{1, func(s *Stage) string { return s.RightDepStage }, func(s *Stage, id string) { s.RightDepStage = id }},

--- a/internal/planner/physical/exchange.go
+++ b/internal/planner/physical/exchange.go
@@ -10,6 +10,11 @@ const (
 	StageSort          = "sort"
 	StageHashJoin      = "hash_join"
 	StageBroadcastJoin = "broadcast_join"
+	// StageSortMergeJoin is a hash-shuffled join executed as a sort-merge
+	// join (docs/design/sort-merge-join.md): identical exchange children and
+	// distribution properties to StageHashJoin — only the join operator
+	// differs. Emitted when the SortMergeJoinBytes gate passes.
+	StageSortMergeJoin = "sort_merge_join"
 	StageWindow        = "window"
 	StagePipeline      = "pipeline"
 

--- a/internal/planner/physical/native_dag_rewrite.go
+++ b/internal/planner/physical/native_dag_rewrite.go
@@ -25,7 +25,7 @@ import (
 func ValidateNativeDAGShape(stages []Stage) error {
 	for _, s := range stages {
 		switch s.Type {
-		case StageHashJoin, StageBroadcastJoin:
+		case StageHashJoin, StageBroadcastJoin, StageSortMergeJoin:
 			// A join with N FusedJoins has 2 + N dependencies: 2 for the
 			// primary join (probe + build) plus 1 build-dep per fused
 			// join. The worker's executeStageHashJoin consumes
@@ -107,7 +107,7 @@ func fuseSortIntoPredecessor(stages []Stage) []Stage {
 			continue
 		}
 		switch pred.Type {
-		case "hash_join", "broadcast_join", "aggregate", "final_aggregate":
+		case "hash_join", "broadcast_join", "sort_merge_join", "aggregate", "final_aggregate":
 		default:
 			continue
 		}

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -346,6 +346,16 @@ type Planner struct {
 	// planner's join-type logic.
 	BroadcastBytesThreshold int64
 
+	// SortMergeJoinBytes gates the sort-merge join path for big-vs-big inner
+	// equi-joins (docs/design/sort-merge-join.md). A join takes SMJ only when
+	// BOTH sides' estimated post-selectivity bytes reach this threshold —
+	// small builds keep the strictly-better hash/broadcast paths. Zero (the
+	// shipped default) disables SMJ entirely; the planner behaves exactly as
+	// before. Distributed callers should derive it from per-worker pool
+	// budget (the broadcast-threshold pattern) so "too big to sit resident"
+	// tracks cluster memory.
+	SortMergeJoinBytes int64
+
 	// DynamicFiltersEnabled gates the Trino-style dynamic-filter planner
 	// pass. When true, applyDynamicFilters annotates eligible hash_join
 	// build/probe leaf scans with Emit/Consume specs and adds the stat-dep
@@ -3674,43 +3684,9 @@ func (p *Planner) isBroadcastCandidate(joinNode *logical.Node) bool {
 	if len(joinNode.Children) < 2 {
 		return false
 	}
-	// Walk through Filter/Project/Limit wrappers to find the underlying Scan.
-	// Small dimension tables (e.g., region with r_name='EUROPE') are often
-	// wrapped in Filter nodes, but are still small enough to broadcast.
-	scan := findScanNode(joinNode.Children[1])
-	if scan == nil {
+	totalBytes, ok := p.estimateSubtreeBytes(joinNode.Children[1])
+	if !ok {
 		return false
-	}
-	// Estimate size from file count
-	manifest, err := p.catalog.GetManifest(context.Background(), scan.TableName)
-	if err != nil {
-		return false
-	}
-	var totalBytes, totalRows int64
-	for _, part := range manifest.Partitions {
-		for _, f := range part.Files {
-			totalBytes += f.SizeBytes
-			totalRows += f.NumRows
-		}
-	}
-	// Apply filter selectivity to the build-side bytes estimate. Q17's
-	// `part WHERE p_brand=... AND p_container=...` filters 2M rows to
-	// ~13K, dropping the build size from 200 MB raw to ~1.5 MB — well
-	// below the broadcast threshold. Without this scaling, the raw
-	// 200 MB exceeds the threshold and Q17 falls through to a
-	// hash-shuffle that pays exchange-repartition for BOTH lineitem
-	// (60M rows ≈ 6 GB at SF10) and part.
-	//
-	// Source of selectivity: RelStatsOf walks the build subtree applying
-	// histogram-driven predicate selectivity (CBO Phase 3 work). For
-	// tables without HLL/histogram, the existing 0.33/0.1 heuristic
-	// still applies so the scaling is at-worst-conservative.
-	if totalRows > 0 {
-		stats := logical.RelStatsOf(joinNode.Children[1])
-		if stats.Rows > 0 && stats.Rows < float64(totalRows) {
-			scale := stats.Rows / float64(totalRows)
-			totalBytes = int64(float64(totalBytes) * scale)
-		}
 	}
 	// Broadcast threshold: defaults to 100 MB (legacy behavior). Distributed
 	// callers override via BroadcastBytesThreshold to adapt the decision to
@@ -3724,6 +3700,50 @@ func (p *Planner) isBroadcastCandidate(joinNode *logical.Node) bool {
 		return false // broadcast disabled
 	}
 	return totalBytes <= threshold
+}
+
+// estimateSubtreeBytes estimates a join input's post-selectivity size by
+// walking through Filter/Project/Limit wrappers to the underlying Scan and
+// scaling the table's manifest bytes by the subtree's estimated selectivity.
+// Returns ok=false when the subtree has no scan root (e.g. another join) or
+// the manifest is unavailable — callers must treat "unknown" conservatively.
+func (p *Planner) estimateSubtreeBytes(n *logical.Node) (int64, bool) {
+	scan := findScanNode(n)
+	if scan == nil {
+		return 0, false
+	}
+	// Estimate size from file count
+	manifest, err := p.catalog.GetManifest(context.Background(), scan.TableName)
+	if err != nil {
+		return 0, false
+	}
+	var totalBytes, totalRows int64
+	for _, part := range manifest.Partitions {
+		for _, f := range part.Files {
+			totalBytes += f.SizeBytes
+			totalRows += f.NumRows
+		}
+	}
+	// Apply filter selectivity to the bytes estimate. Q17's
+	// `part WHERE p_brand=... AND p_container=...` filters 2M rows to
+	// ~13K, dropping the build size from 200 MB raw to ~1.5 MB — well
+	// below the broadcast threshold. Without this scaling, the raw
+	// 200 MB exceeds the threshold and Q17 falls through to a
+	// hash-shuffle that pays exchange-repartition for BOTH lineitem
+	// (60M rows ≈ 6 GB at SF10) and part.
+	//
+	// Source of selectivity: RelStatsOf walks the subtree applying
+	// histogram-driven predicate selectivity (CBO Phase 3 work). For
+	// tables without HLL/histogram, the existing 0.33/0.1 heuristic
+	// still applies so the scaling is at-worst-conservative.
+	if totalRows > 0 {
+		stats := logical.RelStatsOf(n)
+		if stats.Rows > 0 && stats.Rows < float64(totalRows) {
+			scale := stats.Rows / float64(totalRows)
+			totalBytes = int64(float64(totalBytes) * scale)
+		}
+	}
+	return totalBytes, true
 }
 
 // findScanNode walks through pass-through nodes (Filter, Project, Limit)
@@ -3873,6 +3893,15 @@ func (p *Planner) buildJoin(ctx context.Context, node *logical.Node) (exec.Sourc
 		// probe-side and right keys are build-side. This avoids the expensive
 		// post-build FixKeyAssignment hash table rebuild.
 		fixJoinKeyOrder(leftKeys, rightKeys, node.Children[1])
+	}
+
+	// Big-vs-big inner equi-joins route to sort-merge join when BOTH sides'
+	// estimated bytes reach SortMergeJoinBytes (0 = disabled, the shipped
+	// default — this branch is dormant unless the deploy opts in). Small
+	// builds keep the strictly-better hash path below, unchanged.
+	if joinType == exec.InnerJoin && node.JoinFilter == "" && len(leftKeys) > 0 &&
+		p.shouldSortMergeJoin(node) {
+		return p.buildSortMergeJoin(ctx, node, leftKeys, rightKeys)
 	}
 
 	hj := exec.NewHashJoin(joinType, leftKeys, rightKeys)

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -2422,7 +2422,7 @@ func LargeBuildScans(stages []Stage, probeAlias string, thresholdBytes int64) []
 func CountJoinStages(stages []Stage) int {
 	n := 0
 	for _, s := range stages {
-		if s.Type == "hash_join" || s.Type == "broadcast_join" {
+		if s.Type == "hash_join" || s.Type == "broadcast_join" || s.Type == StageSortMergeJoin {
 			n++
 		}
 		n += len(s.FusedJoins)
@@ -2686,7 +2686,7 @@ func markCoPathingSelfJoinBuilds(stages []Stage) {
 	var joinScans []joinScan
 	for i := range stages {
 		s := &stages[i]
-		if s.Type != StageHashJoin && s.Type != StageBroadcastJoin {
+		if s.Type != StageHashJoin && s.Type != StageBroadcastJoin && s.Type != StageSortMergeJoin {
 			continue
 		}
 		buildDep := s.RightDepStage
@@ -3363,6 +3363,18 @@ func (p *Planner) walkStages(node *logical.Node, stages *[]Stage, parentID *stri
 			for i, key := range rightKeys {
 				rightKeys[i] = resolveShuffleKey(key, node.Children[1])
 			}
+		}
+
+		// Big-vs-big inner equi-joins upgrade the shuffled hash join to a
+		// sort-merge join when the SortMergeJoinBytes gate passes (same gate
+		// as the local buildJoin path). The exchange children below are
+		// IDENTICAL — co-partitioning is all SMJ needs — so only the stage
+		// type changes. Broadcast candidates keep the strictly-better
+		// broadcast path.
+		if joinType == StageHashJoin && jt == "inner" && node.JoinFilter == "" &&
+			len(leftKeys) > 0 && p.shouldSortMergeJoin(node) {
+			joinType = StageSortMergeJoin
+			SortMergeJoinsPlanned.Add(1)
 		}
 
 		// Insert shuffle stages for non-broadcast joins when distributed

--- a/internal/planner/physical/sort_merge_join.go
+++ b/internal/planner/physical/sort_merge_join.go
@@ -1,0 +1,159 @@
+package physical
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/engine/exec"
+	"github.com/citc-tech/wadjet/internal/planner/logical"
+)
+
+// SortMergeJoinsPlanned counts joins routed through the sort-merge path,
+// process-wide. Observability: the TPC-H forced-on gate test uses it to
+// prove the route fired (and, on the default config, that it stayed
+// dormant); ops dashboards can sample it the same way.
+var SortMergeJoinsPlanned atomic.Int64
+
+// shouldSortMergeJoin decides whether an inner equi-join takes the
+// sort-merge path (docs/design/sort-merge-join.md §3.4): both sides'
+// estimated post-selectivity bytes must reach SortMergeJoinBytes. An
+// unknown estimate (no scan root — e.g. a join-on-join input — or a missing
+// manifest) keeps the hash path: SMJ is an opt-in for provably-big sides,
+// never a default for uncertainty.
+func (p *Planner) shouldSortMergeJoin(node *logical.Node) bool {
+	if p.SortMergeJoinBytes <= 0 || len(node.Children) < 2 {
+		return false
+	}
+	buildBytes, ok := p.estimateSubtreeBytes(node.Children[1])
+	if !ok || buildBytes < p.SortMergeJoinBytes {
+		return false
+	}
+	probeBytes, ok := p.estimateSubtreeBytes(node.Children[0])
+	if !ok || probeBytes < p.SortMergeJoinBytes {
+		return false
+	}
+	return true
+}
+
+// buildSortMergeJoin constructs the local sort-merge join: the build (right)
+// side drains into the operator in a goroutine — overlapping with probe-side
+// preparation AND probe-side consumption, since the two side buffers are
+// independent — and the probe (left) side runs as a child pipeline inside
+// the returned source adapter. Mirrors buildJoin's hash wiring for alias,
+// spill, and output-filter semantics.
+func (p *Planner) buildSortMergeJoin(ctx context.Context, node *logical.Node, leftKeys, rightKeys []string) (exec.Source, []exec.UnaryOperator, exec.Sink, error) {
+	SortMergeJoinsPlanned.Add(1)
+	j := exec.NewSortMergeJoin(leftKeys, rightKeys)
+
+	// Set build-side table alias for column disambiguation in self-joins
+	if alias := findScanAlias(node.Children[1]); alias != "" {
+		j.BuildTableAlias = alias
+	}
+	if sm := p.getSpillManager(); sm != nil {
+		j.Spill = sm
+	}
+	// Push output filter into the join to avoid materializing intermediate
+	// columns not needed by upstream operators (HashJoinProbe.OutputFilter
+	// parity — the shared schema helper applies it identically).
+	if len(node.NeededColumns) > 0 {
+		filter := make(map[string]bool, len(node.NeededColumns))
+		for _, col := range node.NeededColumns {
+			filter[col] = true
+		}
+		j.OutputFilter = filter
+	}
+
+	rightSource, rightOps, _, err := p.buildPipeline(ctx, node.Children[1])
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("building sort-merge join right side: %w", err)
+	}
+	buildSource := &pipelineSource{source: rightSource, ops: rightOps}
+
+	buildDone := make(chan struct{})
+	var buildErr error
+	go func() {
+		defer close(buildDone)
+		if err := j.Build(ctx, buildSource); err != nil {
+			buildErr = fmt.Errorf("sort-merge join build side: %w", err)
+		}
+	}()
+
+	leftSource, leftOps, _, err := p.buildPipeline(ctx, node.Children[0])
+	if err != nil {
+		<-buildDone // prevent goroutine leak
+		return nil, nil, nil, fmt.Errorf("building sort-merge join left side: %w", err)
+	}
+
+	return &smjSourceAdapter{
+		childSource: leftSource,
+		childOps:    leftOps,
+		join:        j,
+		barrier:     buildDone,
+		buildErr:    &buildErr,
+	}, nil, &exec.CollectSink{}, nil
+}
+
+// smjProbeSink feeds the probe pipeline into the join while deferring
+// Finalize: the pipeline's own Finalize call would race the build goroutine
+// (SortMergeJoin.Finalize requires the build phase complete and starts the
+// merge). The adapter finalizes after the build barrier instead.
+type smjProbeSink struct {
+	*exec.SortMergeJoin
+}
+
+func (s smjProbeSink) Finalize(context.Context) error { return nil }
+
+// smjSourceAdapter wraps the probe child pipeline + sort-merge join into a
+// Source (the sortSourceAdapter pattern): the first Next runs the probe
+// pipeline into the join — concurrently with the build goroutine — waits for
+// the build barrier, finalizes the merge, and streams joined batches.
+type smjSourceAdapter struct {
+	childSource exec.Source
+	childOps    []exec.UnaryOperator
+	join        *exec.SortMergeJoin
+	barrier     <-chan struct{}
+	buildErr    *error
+	initialized bool
+}
+
+func (s *smjSourceAdapter) Init(ctx context.Context) error {
+	return nil
+}
+
+func (s *smjSourceAdapter) Next(ctx context.Context) (*batch.RecordBatch, error) {
+	if !s.initialized {
+		s.initialized = true
+		pipe := &exec.Pipeline{
+			Source:  s.childSource,
+			Ops:     s.childOps,
+			Sink:    smjProbeSink{s.join},
+			Workers: innerPipelineWorkers(s.childSource),
+		}
+		if err := pipe.Run(ctx); err != nil {
+			<-s.barrier // the build goroutine owns join state; let it finish
+			return nil, err
+		}
+		<-s.barrier
+		if *s.buildErr != nil {
+			return nil, *s.buildErr
+		}
+		if err := s.join.Finalize(ctx); err != nil {
+			return nil, err
+		}
+	}
+	return s.join.Next(ctx)
+}
+
+func (s *smjSourceAdapter) Close() error {
+	s.join.Close()
+	return s.childSource.Close()
+}
+
+func (s *smjSourceAdapter) RowsScanned() int64 {
+	if sp, ok := s.childSource.(exec.ScanStatsProvider); ok {
+		return sp.RowsScanned()
+	}
+	return 0
+}

--- a/internal/planner/physical/sort_merge_join_test.go
+++ b/internal/planner/physical/sort_merge_join_test.go
@@ -1,0 +1,186 @@
+package physical
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/planner/logical"
+	plansql "github.com/citc-tech/wadjet/internal/planner/sql"
+	"github.com/citc-tech/wadjet/internal/storage/catalog"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// setupJoinTables creates two joinable tables (l: id/val, r: rid/rval) with
+// enough rows that any positive byte threshold sees both sides as "big".
+func setupJoinTables(t *testing.T) *catalog.Catalog {
+	t.Helper()
+	ctx := context.Background()
+	store := objstore.NewMemStore()
+	cat := catalog.NewWithStore(store, "test")
+	if err := cat.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	writeTable := func(name string, cols []parquet.Column, rows []map[string]any) {
+		schema := parquet.Schema{Columns: cols}
+		if err := cat.CreateTable(ctx, name, schema, nil); err != nil {
+			t.Fatal(err)
+		}
+		var buf bytes.Buffer
+		cfg := parquet.DefaultWriterConfig()
+		cfg.Compression = parquet.CompressionNone
+		w, err := parquet.NewWriter(&buf, schema, cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := w.WriteRows(rows); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		data := buf.Bytes()
+		path := fmt.Sprintf("tables/%s/chunk_0000.parquet", name)
+		if _, err := store.Put(ctx, "test", path, bytes.NewReader(data), int64(len(data)), ""); err != nil {
+			t.Fatal(err)
+		}
+		if err := cat.AddFiles(ctx, name, map[string]string{}, "tables/"+name+"/", []catalog.FileEntry{{
+			Path:      path,
+			SizeBytes: int64(len(data)),
+			NumRows:   int64(len(rows)),
+		}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	lRows := make([]map[string]any, 300)
+	for i := range lRows {
+		lRows[i] = map[string]any{"id": int64(i), "val": fmt.Sprintf("l%d", i)}
+	}
+	writeTable("smj_l", []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "val", Type: parquet.TypeString},
+	}, lRows)
+
+	rRows := make([]map[string]any, 200)
+	for i := range rRows {
+		rRows[i] = map[string]any{"rid": int64(i), "rval": fmt.Sprintf("r%d", i)}
+	}
+	writeTable("smj_r", []parquet.Column{
+		{Name: "rid", Type: parquet.TypeInt64},
+		{Name: "rval", Type: parquet.TypeString},
+	}, rRows)
+
+	return cat
+}
+
+// planSQL runs SQL through parse → logical → optimize → physical Plan with
+// the given SMJ threshold and returns the physical plan.
+func planSQL(t *testing.T, cat *catalog.Catalog, sql string, smjBytes int64) *PhysicalPlan {
+	t.Helper()
+	ctx := context.Background()
+	parsed, err := plansql.Parse(sql)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	selectInfo, err := plansql.ExtractSelect(parsed)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	logicalPlan, err := logical.BuildFromSelect(selectInfo)
+	if err != nil {
+		t.Fatalf("logical plan: %v", err)
+	}
+	scanAnnotator := func(plan *logical.Node) {
+		NewPlanner(cat).AnnotateScanColumns(ctx, plan)
+	}
+	scanAnnotator(logicalPlan)
+	logicalPlan = logical.Optimize(logicalPlan, scanAnnotator)
+
+	planner := NewPlanner(cat)
+	planner.SortMergeJoinBytes = smjBytes
+	plan, err := planner.Plan(ctx, logicalPlan)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	return plan
+}
+
+// TestSortMergeJoinGate_RoutesBigInnerJoin: with the threshold forced to 1,
+// an inner equi-join over two scan-rooted sides plans as a sort-merge join
+// and produces the same rows the hash path would.
+func TestSortMergeJoinGate_RoutesBigInnerJoin(t *testing.T) {
+	cat := setupJoinTables(t)
+	sql := "SELECT id, val, rval FROM smj_l JOIN smj_r ON smj_l.id = smj_r.rid"
+
+	plan := planSQL(t, cat, sql, 1)
+	if _, ok := plan.Pipeline.Source.(*smjSourceAdapter); !ok {
+		t.Fatalf("expected smjSourceAdapter source under forced threshold, got %T", plan.Pipeline.Source)
+	}
+	if err := plan.Pipeline.Run(context.Background()); err != nil {
+		t.Fatalf("running SMJ plan: %v", err)
+	}
+	sink := plan.Pipeline.Sink.(interface{ ToRows() []map[string]any })
+	rows := sink.ToRows()
+	if len(rows) != 200 { // ids 0..199 match; 200..299 unmatched
+		t.Fatalf("expected 200 joined rows, got %d", len(rows))
+	}
+	for _, r := range rows {
+		if r["val"] == nil || r["rval"] == nil {
+			t.Fatalf("row missing side columns: %v", r)
+		}
+	}
+}
+
+// TestSortMergeJoinGate_DormantByDefault: the zero-value threshold leaves the
+// join on the hash path — the gate must be unreachable without opt-in.
+func TestSortMergeJoinGate_DormantByDefault(t *testing.T) {
+	cat := setupJoinTables(t)
+	sql := "SELECT id, val, rval FROM smj_l JOIN smj_r ON smj_l.id = smj_r.rid"
+
+	before := SortMergeJoinsPlanned.Load()
+	plan := planSQL(t, cat, sql, 0)
+	if _, ok := plan.Pipeline.Source.(*smjSourceAdapter); ok {
+		t.Fatal("SMJ planned with threshold 0 — the gate must be dormant by default")
+	}
+	if got := SortMergeJoinsPlanned.Load(); got != before {
+		t.Fatalf("SortMergeJoinsPlanned moved %d→%d on the default config", before, got)
+	}
+	if err := plan.Pipeline.Run(context.Background()); err != nil {
+		t.Fatalf("running hash plan: %v", err)
+	}
+}
+
+// TestSortMergeJoinGate_SkipsNonInner: outer joins keep the hash path even
+// under a forced threshold (v1 is inner-only).
+func TestSortMergeJoinGate_SkipsNonInner(t *testing.T) {
+	cat := setupJoinTables(t)
+	sql := "SELECT id, val, rval FROM smj_l LEFT JOIN smj_r ON smj_l.id = smj_r.rid"
+
+	plan := planSQL(t, cat, sql, 1)
+	if _, ok := plan.Pipeline.Source.(*smjSourceAdapter); ok {
+		t.Fatal("LEFT JOIN must not take the sort-merge path in v1")
+	}
+	if err := plan.Pipeline.Run(context.Background()); err != nil {
+		t.Fatalf("running plan: %v", err)
+	}
+	sink := plan.Pipeline.Sink.(interface{ ToRows() []map[string]any })
+	if rows := sink.ToRows(); len(rows) != 300 {
+		t.Fatalf("LEFT JOIN expected 300 rows, got %d", len(rows))
+	}
+}
+
+// TestSortMergeJoinGate_SkipsSmallSides: a threshold above both sides'
+// estimated bytes keeps the hash path — SMJ is for provably-big sides only.
+func TestSortMergeJoinGate_SkipsSmallSides(t *testing.T) {
+	cat := setupJoinTables(t)
+	sql := "SELECT id, val, rval FROM smj_l JOIN smj_r ON smj_l.id = smj_r.rid"
+
+	plan := planSQL(t, cat, sql, 1<<40)
+	if _, ok := plan.Pipeline.Source.(*smjSourceAdapter); ok {
+		t.Fatal("tiny sides must not take the sort-merge path")
+	}
+}

--- a/internal/planner/physical/sort_merge_join_test.go
+++ b/internal/planner/physical/sort_merge_join_test.go
@@ -184,3 +184,90 @@ func TestSortMergeJoinGate_SkipsSmallSides(t *testing.T) {
 		t.Fatal("tiny sides must not take the sort-merge path")
 	}
 }
+
+// planDistributedSQL runs SQL through parse → logical → optimize →
+// PlanDistributed with the given SMJ threshold and worker count.
+func planDistributedSQL(t *testing.T, cat *catalog.Catalog, sql string, smjBytes int64, workers int) []Stage {
+	t.Helper()
+	ctx := context.Background()
+	parsed, err := plansql.Parse(sql)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	selectInfo, err := plansql.ExtractSelect(parsed)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	logicalPlan, err := logical.BuildFromSelect(selectInfo)
+	if err != nil {
+		t.Fatalf("logical plan: %v", err)
+	}
+	scanAnnotator := func(plan *logical.Node) {
+		NewPlanner(cat).AnnotateScanColumns(ctx, plan)
+	}
+	scanAnnotator(logicalPlan)
+	logicalPlan = logical.Optimize(logicalPlan, scanAnnotator)
+
+	planner := NewPlanner(cat)
+	planner.WorkerCount = workers
+	planner.BroadcastBytesThreshold = -1 // never broadcast: force the shuffled-join path
+	planner.SortMergeJoinBytes = smjBytes
+	stages, err := planner.PlanDistributed(ctx, logicalPlan)
+	if err != nil {
+		t.Fatalf("plan distributed: %v", err)
+	}
+	return stages
+}
+
+// TestSortMergeJoinStage_EmittedWithExchangeChildren: under a forced
+// threshold, the distributed planner emits a sort_merge_join stage whose
+// dependencies are the SAME exchange-repartition children a hash_join would
+// get — co-partitioning is the only exchange requirement.
+func TestSortMergeJoinStage_EmittedWithExchangeChildren(t *testing.T) {
+	cat := setupJoinTables(t)
+	sql := "SELECT id, val, rval FROM smj_l JOIN smj_r ON smj_l.id = smj_r.rid"
+
+	stages := planDistributedSQL(t, cat, sql, 1, 3)
+	byID := make(map[string]Stage, len(stages))
+	var smj *Stage
+	for i := range stages {
+		byID[stages[i].ID] = stages[i]
+		if stages[i].Type == StageSortMergeJoin {
+			smj = &stages[i]
+		}
+		if stages[i].Type == StageHashJoin {
+			t.Fatalf("hash_join stage %s emitted alongside the forced sort-merge gate", stages[i].ID)
+		}
+	}
+	if smj == nil {
+		t.Fatalf("no sort_merge_join stage emitted; stages: %v", stageTypes(stages))
+	}
+	left, ok := byID[smj.LeftDepStage]
+	if !ok || left.Type != StageExchangeRepartition {
+		t.Fatalf("left dep %q should be an exchange-repartition stage, got %+v", smj.LeftDepStage, left.Type)
+	}
+	right, ok := byID[smj.RightDepStage]
+	if !ok || right.Type != StageExchangeRepartition {
+		t.Fatalf("right dep %q should be an exchange-repartition stage, got %+v", smj.RightDepStage, right.Type)
+	}
+	if left.Exchange == nil || right.Exchange == nil || left.Exchange.Count != right.Exchange.Count {
+		t.Fatalf("exchange children must co-partition: left %+v right %+v", left.Exchange, right.Exchange)
+	}
+	if len(smj.Dependencies) != 2 {
+		t.Fatalf("sort_merge_join stage has %d dependencies, want 2", len(smj.Dependencies))
+	}
+}
+
+// TestSortMergeJoinStage_DormantByDefault: with the zero-value threshold the
+// distributed plan is the hash_join shape, byte-identical to before.
+func TestSortMergeJoinStage_DormantByDefault(t *testing.T) {
+	cat := setupJoinTables(t)
+	sql := "SELECT id, val, rval FROM smj_l JOIN smj_r ON smj_l.id = smj_r.rid"
+
+	stages := planDistributedSQL(t, cat, sql, 0, 3)
+	for _, s := range stages {
+		if s.Type == StageSortMergeJoin {
+			t.Fatal("sort_merge_join stage emitted with threshold 0 — the gate must be dormant by default")
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -54,6 +54,7 @@ type Config struct {
 	ShutdownTimeout    time.Duration            // graceful shutdown drain timeout (default 30s)
 	QueryLimits        *config.QueryLimits      // global cost-based query limits (nil = unlimited)
 	RoleLimits         map[string]*config.QueryLimits // per-role overrides (nil = use global)
+	SortMergeJoinBytes int64                    // local sort-merge-join gate (0 = disabled)
 }
 
 // Server is the Wadjet HTTP API server.
@@ -132,7 +133,9 @@ func (s *Server) Mux() chi.Router {
 // per-query mutable state (scanCounter, scanCache, cteCache) so it must not be
 // shared across concurrent requests.
 func (s *Server) newPlanner() *physical.Planner {
-	return physical.NewPlanner(s.catalog)
+	p := physical.NewPlanner(s.catalog)
+	p.SortMergeJoinBytes = s.config.SortMergeJoinBytes
+	return p
 }
 
 // Start starts the HTTP server.

--- a/internal/worker/executor_fragment.go
+++ b/internal/worker/executor_fragment.go
@@ -1053,7 +1053,7 @@ func (e *Executor) runFragmentWithBreakers(ctx context.Context, task distributed
 
 	breakers := make([]*fragmentBreaker, len(breakerIdxs))
 	for i, idx := range breakerIdxs {
-		fb, err := e.buildFragmentBreaker(ctx, middle[idx])
+		fb, err := e.buildFragmentBreaker(ctx, task, middle[idx])
 		if err != nil {
 			return fmt.Errorf("fragment task %s: build breaker %d (%s): %w", task.ID, i, middle[idx].Type, err)
 		}
@@ -1274,7 +1274,7 @@ func drainThroughBreaker(ctx context.Context, src exec.Source, xform func(*batch
 // buildFragmentBreaker dispatches per-OpType breaker construction. Returns a
 // fully-initialised SinkSource plus the optional pre/drain/post hooks the
 // breaker needs.
-func (e *Executor) buildFragmentBreaker(ctx context.Context, spec distributed.OpSpec) (*fragmentBreaker, error) {
+func (e *Executor) buildFragmentBreaker(ctx context.Context, task distributed.Task, spec distributed.OpSpec) (*fragmentBreaker, error) {
 	switch spec.Type {
 	case distributed.OpHashAggregate:
 		hashAgg, err := e.buildFragmentHashAggregate(spec)
@@ -1342,9 +1342,100 @@ func (e *Executor) buildFragmentBreaker(ctx context.Context, spec distributed.Op
 		}
 		return fb, nil
 
+	case distributed.OpSortMergeJoin:
+		return e.buildFragmentSortMergeJoin(ctx, task, spec)
+
 	default:
 		return nil, fmt.Errorf("unsupported breaker op %q", spec.Type)
 	}
+}
+
+// smjBreakerOp wraps SortMergeJoin for the fragment breaker path: the
+// consume-phase Pipeline.Run finalizes its sink itself, and the SMJ build
+// side drains in a concurrent goroutine — Finalize must wait for the build
+// barrier before starting the merge.
+type smjBreakerOp struct {
+	*exec.SortMergeJoin
+	barrier  <-chan struct{}
+	buildErr *error
+}
+
+func (s *smjBreakerOp) Finalize(ctx context.Context) error {
+	<-s.barrier
+	if *s.buildErr != nil {
+		return *s.buildErr
+	}
+	return s.SortMergeJoin.Finalize(ctx)
+}
+
+// buildFragmentSortMergeJoin constructs the sort-merge join breaker: the
+// build side's co-partitioned shuffle files (spec.BuildFiles) drain into the
+// operator in a goroutine — overlapping the probe-side consume phase, since
+// the two side buffers are independent — and the probe side arrives via the
+// breaker's Consume. Inner-only in v1; the planner gate guarantees it.
+func (e *Executor) buildFragmentSortMergeJoin(ctx context.Context, task distributed.Task, spec distributed.OpSpec) (*fragmentBreaker, error) {
+	if len(spec.LeftKeys) == 0 || len(spec.RightKeys) == 0 {
+		return nil, fmt.Errorf("sort_merge_join: LeftKeys and RightKeys required")
+	}
+	if jt := mapJoinTypeString(spec.JoinType); jt != exec.InnerJoin {
+		return nil, fmt.Errorf("sort_merge_join: join type %q not supported (v1 is inner-only)", spec.JoinType)
+	}
+
+	j := exec.NewSortMergeJoin(spec.LeftKeys, spec.RightKeys)
+	j.BuildTableAlias = spec.BuildAlias
+	j.QualifyAllBuildCols = spec.QualifyAllBuildCols
+	if len(spec.OutputColumns) > 0 {
+		filter := make(map[string]bool, len(spec.OutputColumns))
+		for _, c := range spec.OutputColumns {
+			filter[c] = true
+		}
+		j.OutputFilter = filter
+	}
+	if e.sharedSpill != nil {
+		j.Spill = e.sharedSpill
+	}
+
+	// Build source: this task's partition of the build-side exchange. Empty
+	// BuildFiles is the legitimate "upstream produced nothing for this
+	// partition" case — Build over an empty source completes immediately and
+	// the inner join emits nothing.
+	var buildSrc exec.Source
+	if len(spec.BuildFiles) == 0 {
+		buildSrc = exec.NewBatchSource(nil)
+	} else {
+		bucket := spec.BuildBucket
+		if bucket == "" {
+			bucket = task.DataBucket
+		}
+		if bucket == "" {
+			bucket = task.ResultBucket
+		}
+		src, err := e.sourceForAlias(task.QueryID, bucket, spec.BuildAlias, spec.BuildFiles)
+		if err != nil {
+			return nil, fmt.Errorf("sort_merge_join build source: %w", err)
+		}
+		buildSrc = src
+	}
+
+	buildDone := make(chan struct{})
+	var buildErr error
+	go func() {
+		defer close(buildDone)
+		if err := j.Build(ctx, buildSrc); err != nil {
+			buildErr = fmt.Errorf("sort_merge_join build side: %w", err)
+		}
+	}()
+
+	return &fragmentBreaker{
+		Op:    &smjBreakerOp{SortMergeJoin: j, barrier: buildDone, buildErr: &buildErr},
+		Label: "sort_merge_join",
+		Cleanup: func() {
+			// The build goroutine owns join state until the barrier closes;
+			// closing under it would release tracker bytes it is still adding.
+			<-buildDone
+			j.Close()
+		},
+	}, nil
 }
 
 // buildFragmentSort constructs an exec.Sort from an OpSpec. Converts each
@@ -1509,7 +1600,7 @@ func isFragmentSinkOp(t distributed.OpType) bool {
 }
 
 func isFragmentBreakerOp(t distributed.OpType) bool {
-	return t == distributed.OpHashAggregate || t == distributed.OpSort
+	return t == distributed.OpHashAggregate || t == distributed.OpSort || t == distributed.OpSortMergeJoin
 }
 
 func (e *Executor) buildFragmentSource(task distributed.Task, spec distributed.OpSpec) (exec.Source, error) {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -1265,7 +1265,7 @@ func (w *Worker) executeIncomingTask(ctx context.Context, task distributed.Task,
 		shouldGC = true
 	case distributed.TaskTypeStage:
 		switch task.StageType {
-		case "hash_join", "broadcast_join", "aggregate", "final_aggregate", "sort", "merge_sort", "window":
+		case "hash_join", "broadcast_join", "sort_merge_join", "aggregate", "final_aggregate", "sort", "merge_sort", "window":
 			shouldGC = true
 		}
 	}

--- a/wadjet/wadjet.go
+++ b/wadjet/wadjet.go
@@ -36,6 +36,7 @@ type DB struct {
 	authProvider       *auth.Provider    // nil = no auth enforcement
 	alertScheduler     *alerts.Scheduler // non-nil when EnableAlerts is set
 	alertSchedulerStop context.CancelFunc
+	sortMergeJoinBytes int64
 }
 
 // Config holds configuration for creating a DB instance.
@@ -43,10 +44,14 @@ type Config struct {
 	Store        objstore.Store
 	Bucket       string
 	Logger       *slog.Logger
-	MetaKV       catalog.MetaKV  // optional: NATS KV for production, nil = in-memory
-	MemoryBudget int64           // per-query memory budget in bytes (0 = unlimited)
-	SpillDir     string          // directory for spill-to-disk files (empty = os temp dir)
-	AuthProvider *auth.Provider  // optional: enables ABAC enforcement at query level
+	MetaKV       catalog.MetaKV // optional: NATS KV for production, nil = in-memory
+	MemoryBudget int64          // per-query memory budget in bytes (0 = unlimited)
+	SpillDir     string         // directory for spill-to-disk files (empty = os temp dir)
+	AuthProvider *auth.Provider // optional: enables ABAC enforcement at query level
+	// SortMergeJoinBytes routes inner equi-joins whose sides BOTH exceed this
+	// estimated size through the sort-merge join instead of the hash join
+	// (docs/design/sort-merge-join.md). 0 = disabled (default).
+	SortMergeJoinBytes int64
 	// EnableAlerts turns on the CREATE ALERT scheduler in embedded mode.
 	// When true, Open() creates a Scheduler that evaluates alerts on cadence.
 	EnableAlerts bool
@@ -69,13 +74,14 @@ func Open(ctx context.Context, cfg Config) (*DB, error) {
 	}
 
 	db := &DB{
-		store:        cfg.Store,
-		catalog:      cat,
-		bucket:       cfg.Bucket,
-		memoryBudget: cfg.MemoryBudget,
-		spillDir:     cfg.SpillDir,
-		logger:       cfg.Logger,
-		authProvider: cfg.AuthProvider,
+		store:              cfg.Store,
+		catalog:            cat,
+		bucket:             cfg.Bucket,
+		memoryBudget:       cfg.MemoryBudget,
+		spillDir:           cfg.SpillDir,
+		logger:             cfg.Logger,
+		authProvider:       cfg.AuthProvider,
+		sortMergeJoinBytes: cfg.SortMergeJoinBytes,
 	}
 
 	if cfg.EnableAlerts {
@@ -147,6 +153,7 @@ func (db *DB) newPlanner() *physical.Planner {
 	p := physical.NewPlanner(db.catalog)
 	p.MemoryBudget = db.memoryBudget
 	p.SpillDir = db.spillDir
+	p.SortMergeJoinBytes = db.sortMergeJoinBytes
 	return p
 }
 


### PR DESCRIPTION
Implements docs/design/sort-merge-join.md (committed as the first commit): a sort-merge join for the both-sides-large inner equi-join class, land-dark per the memory-accounting-overhaul rollout pattern — `--sort-merge-join-bytes` defaults to 0 = disabled, and plans/dispatch are byte-identical until a deploy opts in.

## Why

A shuffled hash join holds one side resident as a hash table; at SF100 that resident build is what pins worker concurrency (`max_concurrent`) and burns grace-partition respill churn under pressure. SMJ streams both sides in key order: resident memory is O(run buffer + one batch per merge cursor) regardless of input size. Micro-bench at spilled scale: **2.4× faster than the grace hash path with 6× fewer bytes allocated**; in-memory it trails hash 2× (the sort tax) — which is why the gate only routes joins whose sides are both provably big.

## Commits (reviewable in order)

1. `docs(exec)` — design memo (grounded against main 9dbf16e; approved design)
2. `fix(exec)` — **pre-existing infinite loop**: three hash-join sites ran `PutNoGrow`/`GetOrInsertNoGrow` insert loops without `EnsureCapacity`; a full table spins its probe loop forever. Found because the SMJ equivalence test (400 distinct string keys through `BuildFromRows`) hung a 10-minute test binary. Regression tests included.
3. `feat(exec)` — the `SortMergeJoin` operator: per-side Sort-style buffer/self-spill cores reusing `sortBatchesToRun`/`runMerger`/`spillBatchWriter` verbatim (no new spill formats), two-cursor advance-lesser merge, duplicate groups as refs into merge batches with a loud-Reserve bound on hot keys, output schema shared with `HashJoinProbe` via extracted `joinOutputSchemaWithMapping`. AccountedOperator contract mirrors Sort.
4. `feat(exec)` — key-name normalization per side (`columnIndexFallback` + counterpart-adoption swap = the `FixKeyAssignment` analog; an unresolved sort key would silently produce unsorted runs)
5. `feat(planner)` — local `buildJoin` gate: inner equi-join, no JoinFilter, BOTH sides ≥ threshold via `estimateSubtreeBytes` (extracted from `isBroadcastCandidate`, mirrored onto the probe child); `smjSourceAdapter` runs the probe pipeline with build overlapped in a goroutine
6. `feat(coordinator)` — distributed execution: `walkStages` upgrades hash_join → sort_merge_join with **identical exchange children**; `StageSortMergeJoin` rides every distribution-property/pass site `StageHashJoin` does; worker runs `OpSortMergeJoin` as a fragment breaker (build side drains concurrently, Finalize gated on the build barrier). Also adds `--broadcast-bytes` (needed to exercise shuffled joins at small SF; doubles as the A/B surface)
7. `build(tpch)` — benchmark deploy plumbing (env knob + terraform var)

## Gates run

- **SF0.01 forced-on (threshold=1), local**: all 22 TPC-H queries row-identical to the hash baseline; 19 SMJ joins planned; per-query dormancy asserted on default config
- **tpch-harness --mode=local**, both flag states under `--broadcast-bytes=-1`: 22/22 row_count + row_checksum identical (~190 SMJ task dispatches forced-on; sole exception Q14's checksum = last-ULP accumulation noise, value-verified equal at 6 significant digits)
- **Race arms**: exec/worker packages `-race`; harness forced-on with a race-built binary — zero DATA RACE across coord/worker logs
- **SF10 + SF100 same-window A/B deploys** (production shape, broadcast untouched, threshold 256 MiB): row-identical 22/22 at both scales, zero reaps/stalls. SF100: 5 SMJ stages (Q03/Q05/Q14/Q18/Q21), Q18 at parity (−0.9%), suite +2.8% ≈ same-window noise. SF10's lone SMJ query (Q18) paid the sort tax (+37%) — expected with no memory pressure to relieve, and why the knob stays dormant until the admission-relaxation payoff step (explicitly out of scope here, memo §3.6)
- Full exec/planner/coordinator/worker suites + default TPC-H green throughout

Side effect of the A/B: fresh SF100 baseline at `results/20260707-231136` (52.9 m per-query sum) and a regenerated rgmeta catalog snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZaEw6PKU9Lq8cGJu3KM6K