### PR TITLE
feat(coordinator): dynamic-filter observability

### DIFF
--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -1153,6 +1153,10 @@ func (c *Coordinator) dispatchPipelineStage(
 		// without having to re-walk the plan.
 		if len(stage.ConsumeDynamicFilters) > 0 {
 			out.DynamicFilters = dynamicFilterSpecsFromBuildStats(stage.ConsumeDynamicFilters, inputs)
+			c.logger.Info("dynamic_filter: consume specs attached to pass-through scan output",
+				"stage_id", stage.ID,
+				"requested", len(stage.ConsumeDynamicFilters),
+				"attached", len(out.DynamicFilters))
 		}
 		return out, nil
 	}
@@ -1546,7 +1550,9 @@ func (c *Coordinator) dispatchScanFilterStage(
 	c.logger.Info("dispatchScanFilterStage",
 		"stage_id", stage.ID, "files", len(stage.ScanFiles),
 		"tasks", actualTasks, "filters", len(stage.FilterExprs),
-		"shard_count", shardCount)
+		"shard_count", shardCount,
+		"df_emits", len(stage.EmitDynamicFilters),
+		"df_consumes", len(stage.ConsumeDynamicFilters))
 
 	// Fragment dispatch: when the planner's fuseScanShuffle pass absorbed a
 	// downstream exchange-repartition into this scan, emit a 2-op (or 3-op
@@ -1557,6 +1563,19 @@ func (c *Coordinator) dispatchScanFilterStage(
 	// on a single-op task, but that hit the worker's CollectSink memory blow-
 	// up on Q05 SF10; the fragment path uses runStageScanPartitionedStreaming.
 	fuseShuffle := stage.Exchange != nil && len(stage.Exchange.Keys) > 0 && stage.Exchange.Count > 0
+	// Probe-side consume specs are identical for every task — materialize
+	// once and log the attach outcome. attached < requested means the
+	// build side produced no eligible partials for some FilterID and that
+	// consume silently degraded to scan-without-filter (correct but worth
+	// seeing in an A/B run).
+	var consumeSpecs []distributed.DynamicFilterSpec
+	if len(stage.ConsumeDynamicFilters) > 0 {
+		consumeSpecs = dynamicFilterSpecsFromBuildStats(stage.ConsumeDynamicFilters, inputs)
+		c.logger.Info("dynamic_filter: consume specs attached to probe scan",
+			"stage_id", stage.ID,
+			"requested", len(stage.ConsumeDynamicFilters),
+			"attached", len(consumeSpecs))
+	}
 	tasks := make([]distributed.Task, 0, actualTasks)
 	for shardIdx, files := range fileSets {
 		t := distributed.Task{
@@ -1601,8 +1620,8 @@ func (c *Coordinator) dispatchScanFilterStage(
 		// Probe-side: coordinator-merged stats from the upstream build-scan.
 		// dynamicFilterSpecsFromBuildStats walks ConsumeDynamicFilters and
 		// pulls the matching BuildStats out of inputs[SourceStageID].
-		if len(stage.ConsumeDynamicFilters) > 0 {
-			scanOp.DynamicFilters = dynamicFilterSpecsFromBuildStats(stage.ConsumeDynamicFilters, inputs)
+		if len(consumeSpecs) > 0 {
+			scanOp.DynamicFilters = consumeSpecs
 		}
 		t.Operators = append(t.Operators, scanOp)
 		if len(stage.FilterExprs) > 0 {
@@ -1740,6 +1759,17 @@ func (c *Coordinator) dispatchScanFilterStage(
 				}
 			}
 		}
+		staged := 0
+		for _, stats := range merged {
+			if stats != nil && stats.StagedKey != "" {
+				staged++
+			}
+		}
+		c.logger.Info("dynamic_filter: build partials merged",
+			"stage_id", stage.ID,
+			"partial_refs", len(allRefs),
+			"merged_filters", len(merged),
+			"staged_to_s3", staged)
 		buildStats = merged
 	}
 

--- a/internal/planner/physical/dynamic_filter.go
+++ b/internal/planner/physical/dynamic_filter.go
@@ -1,6 +1,8 @@
 package physical
 
 import (
+	"sync/atomic"
+
 	"context"
 	"fmt"
 	"strings"
@@ -46,6 +48,13 @@ const dynamicFilterMinBloomBits = 1024
 //
 // Safe to call multiple times — already-annotated stages are detected by
 // the presence of EmitDynamicFilters/ConsumeDynamicFilters and skipped.
+// DynamicFiltersPlanned counts join annotations the dynamic-filter pass
+// produced, process-wide. Observability: A/B runs use it (via the
+// coordinator's dispatch logs) to prove the pass actually fired — the
+// 2026-07-08 revisit pair was unverifiable without it, exactly the failure
+// mode SortMergeJoinsPlanned exists to prevent.
+var DynamicFiltersPlanned atomic.Int64
+
 func (p *Planner) applyDynamicFilters(ctx context.Context, stages []Stage) []Stage {
 	if !p.DynamicFiltersEnabled {
 		return stages
@@ -145,6 +154,7 @@ func (p *Planner) applyDynamicFilters(ctx context.Context, stages []Stage) []Sta
 			KeyType:   buildKeyType,
 			BloomBits: bloomBits,
 		})
+		DynamicFiltersPlanned.Add(1)
 		probeLeaf.ConsumeDynamicFilters = append(probeLeaf.ConsumeDynamicFilters, DynamicFilterConsume{
 			FilterID:      filterID,
 			SourceStageID: buildLeaf.ID,

--- a/internal/planner/physical/dynamic_filter_test.go
+++ b/internal/planner/physical/dynamic_filter_test.go
@@ -106,3 +106,51 @@ func TestDynamicFilterPassDisabled(t *testing.T) {
 		}
 	}
 }
+
+// TestDynamicFilterPass_AnnotatesShuffledJoin: a shuffled single-int-key
+// inner join gets Emit/Consume annotations and bumps DynamicFiltersPlanned —
+// the observability contract A/B runs rely on to prove the pass fired
+// (the 2026-07-08 revisit pair was unverifiable without it).
+func TestDynamicFilterPass_AnnotatesShuffledJoin(t *testing.T) {
+	cat := setupJoinTables(t)
+	ctx := context.Background()
+	parsed, err := plansql.Parse("SELECT id, val, rval FROM smj_l JOIN smj_r ON id = rid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	selectInfo, err := plansql.ExtractSelect(parsed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logicalPlan, err := logical.BuildFromSelect(selectInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scanAnnotator := func(plan *logical.Node) {
+		NewPlanner(cat).AnnotateScanColumns(ctx, plan)
+	}
+	scanAnnotator(logicalPlan)
+	logicalPlan = logical.Optimize(logicalPlan, scanAnnotator)
+
+	planner := NewPlanner(cat)
+	planner.WorkerCount = 3
+	planner.BroadcastBytesThreshold = -1 // force the shuffled hash join
+	planner.DynamicFiltersEnabled = true
+
+	before := DynamicFiltersPlanned.Load()
+	stages, err := planner.PlanDistributed(ctx, logicalPlan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := DynamicFiltersPlanned.Load() - before; got == 0 {
+		t.Fatal("DynamicFiltersPlanned did not move — the pass never annotated")
+	}
+	emits, consumes := 0, 0
+	for _, s := range stages {
+		emits += len(s.EmitDynamicFilters)
+		consumes += len(s.ConsumeDynamicFilters)
+	}
+	if emits == 0 || consumes == 0 {
+		t.Fatalf("expected emit+consume annotations, got emits=%d consumes=%d", emits, consumes)
+	}
+}


### PR DESCRIPTION
Makes dynamic-filter activity provable from run output: a `DynamicFiltersPlanned` counter (the `SortMergeJoinsPlanned` pattern) plus coordinator Info logs for partial-merge results, consume-spec attach (requested vs attached — shortfall = silent degradation), and emit/consume counts on scan dispatch. Also hoists consume-spec materialization out of the per-task loop.

Context: the 2026-07-08 SF100 revisit A/B showed −2.8% suite (Q18 −10%, Q04 −20%, Q12 +17%) but was unverifiable because the entire path was log-free. This unblocks the confirming pair before any default-on decision.

Also documented: qualified join-key names ("t.col") silently disqualify a join from the pass (catalog lookup wants bare names). TPC-H is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZaEw6PKU9Lq8cGJu3KM6K