### PR TITLE
feat(exec): late materialization — view-column join output with chain composition

### DIFF
--- a/benchmarks/tpch/bench_test.go
+++ b/benchmarks/tpch/bench_test.go
@@ -340,6 +340,11 @@ func setupTPCHStreaming(tb testing.TB, sf ScaleFactor) *wadjet.DB {
 	db, err := wadjet.Open(ctx, wadjet.Config{
 		Store:  store,
 		Bucket: "tpch",
+		// Local A/B knob for the flag-gated view-column join output —
+		// mirrors the tpch-bench env so `WADJET_LATE_MATERIALIZATION=1
+		// TPCH_SCALE=1 go test -run TestTPCHQueriesLarge` is a same-process
+		// treatment arm.
+		LateMaterialization: os.Getenv("WADJET_LATE_MATERIALIZATION") == "1",
 	})
 	if err != nil {
 		tb.Fatal(err)

--- a/benchmarks/tpch/late_mat_test.go
+++ b/benchmarks/tpch/late_mat_test.go
@@ -1,0 +1,120 @@
+package tpch
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/exec"
+	"github.com/citc-tech/wadjet/internal/planner/physical"
+	"github.com/citc-tech/wadjet/internal/storage/ingest"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/wadjet"
+)
+
+// TestTPCHQueriesLateMaterializationForced is the phase-2 gate from
+// docs/design/late-materialization.md §8: with --late-materialization on,
+// every inner/left hash-join probe emits view-column output, and all 22
+// queries must return rows IDENTICAL to the default configuration — unlike
+// the SMJ gate, no accumulation-order tolerance applies anywhere, because
+// the deferred gather produces the same values in the same order as the
+// eager one.
+//
+// Engagement is asserted through both counters (the dynamic-filter lesson):
+// LateMatJoinsPlanned proves the planner stamped probes, and
+// LateMatBatchesEmitted proves probes actually emitted views at runtime.
+func TestTPCHQueriesLateMaterializationForced(t *testing.T) {
+	ctx := context.Background()
+
+	// Two independent DBs, each loaded from the deterministic generator: a
+	// DB's catalog metadata is in-memory per instance, so sharing one store
+	// between two Opens leaves the second catalog empty.
+	openAndLoad := func(lateMat bool) *wadjet.DB {
+		db, err := wadjet.Open(ctx, wadjet.Config{
+			Store:               objstore.NewMemStore(),
+			Bucket:              "tpch",
+			LateMaterialization: lateMat,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		data := Generate(SF001)
+		for tableName, schema := range AllTables {
+			if err := db.CreateTable(ctx, tableName, schema, nil); err != nil {
+				t.Fatalf("creating table %s: %v", tableName, err)
+			}
+			rows := data[tableName]
+			if len(rows) == 0 {
+				continue
+			}
+			ing := db.NewIngester(tableName, schema, nil, ingest.Config{
+				MaxBufferRows: len(rows) + 1,
+				RowGroupSize:  max(100, len(rows)/4),
+			})
+			if err := ing.Ingest(ctx, rows); err != nil {
+				t.Fatalf("ingesting %s: %v", tableName, err)
+			}
+			if err := ing.FlushAll(ctx); err != nil {
+				t.Fatalf("flushing %s: %v", tableName, err)
+			}
+		}
+		return db
+	}
+
+	baseline := openAndLoad(false)
+	defer baseline.Close()
+	forced := openAndLoad(true)
+	defer forced.Close()
+
+	queryNums := make([]int, 0, len(TPCHQueries))
+	for n := range TPCHQueries {
+		queryNums = append(queryNums, n)
+	}
+	sort.Ints(queryNums)
+
+	plannedBefore := physical.LateMatJoinsPlanned.Load()
+	emittedBefore := exec.LateMatBatchesEmitted.Load()
+	for _, qNum := range queryNums {
+		q := TPCHQueries[qNum]
+		t.Run(fmt.Sprintf("Q%02d_%s", qNum, q.Name), func(t *testing.T) {
+			baseCount := physical.LateMatJoinsPlanned.Load()
+			baseEmitted := exec.LateMatBatchesEmitted.Load()
+			want, err := baseline.Query(ctx, q.SQL)
+			if err != nil {
+				t.Fatalf("baseline Q%d failed: %v", qNum, err)
+			}
+			if got := physical.LateMatJoinsPlanned.Load(); got != baseCount {
+				t.Fatalf("dormancy broken: default config planned %d late-mat joins", got-baseCount)
+			}
+			if got := exec.LateMatBatchesEmitted.Load(); got != baseEmitted {
+				t.Fatalf("dormancy broken: default config emitted %d view batches", got-baseEmitted)
+			}
+
+			got, err := forced.Query(ctx, q.SQL)
+			if err != nil {
+				t.Fatalf("late-mat Q%d failed: %v", qNum, err)
+			}
+
+			w, g := canonicalRows(want.Rows), canonicalRows(got.Rows)
+			if len(w) != len(g) {
+				t.Fatalf("Q%d row count: late-mat %d vs baseline %d", qNum, len(g), len(w))
+			}
+			for i := range w {
+				if w[i] != g[i] {
+					t.Fatalf("Q%d row %d differs:\n  baseline %s\n  late-mat %s", qNum, i, w[i], g[i])
+				}
+			}
+		})
+	}
+	if planned := physical.LateMatJoinsPlanned.Load() - plannedBefore; planned == 0 {
+		t.Fatal("forced flag planned zero late-mat joins — the gate never fired and this test proved nothing")
+	} else {
+		t.Logf("late-mat joins planned across the suite: %d", planned)
+	}
+	if emitted := exec.LateMatBatchesEmitted.Load() - emittedBefore; emitted == 0 {
+		t.Fatal("zero view batches emitted — planner stamped probes but runtime never engaged")
+	} else {
+		t.Logf("view batches emitted across the suite: %d (flattens: %d)", emitted, exec.LateMatFlattens.Load())
+	}
+}

--- a/cmd/tpch-bench/main.go
+++ b/cmd/tpch-bench/main.go
@@ -343,6 +343,10 @@ func setupDistributed(ctx context.Context, logger *slog.Logger, endpoint, region
 		// equi-joins whose sides BOTH exceed this many estimated bytes run
 		// as sort-merge joins. 0/unset = disabled (hash/broadcast as before).
 		SortMergeJoinBytes: envInt64("WADJET_SORT_MERGE_JOIN_BYTES"),
+		// Late materialization (docs/design/late-materialization.md):
+		// inner/left join output rides view columns, gather deferred to
+		// first touch. Unset = off.
+		LateMaterialization: os.Getenv("WADJET_LATE_MATERIALIZATION") == "1" || strings.EqualFold(os.Getenv("WADJET_LATE_MATERIALIZATION"), "true"),
 		// Broadcast threshold override: <0 = never broadcast. 0/unset =
 		// cluster-derived default.
 		BroadcastBytesOverride: envInt64("WADJET_BROADCAST_BYTES"),

--- a/cmd/wadjet/main.go
+++ b/cmd/wadjet/main.go
@@ -97,6 +97,7 @@ var (
 	coordDataPlane        string
 	localFastPathBytes    int64
 	sortMergeJoinBytes    int64
+	lateMaterialization   bool
 	broadcastBytes        int64
 	streamingExchange     bool
 	peerExchangeAddr      string
@@ -156,6 +157,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&coordDataPlane, "coord-data-plane", "", "Coord's data-plane host:port (worker only; defaults to coord-host + 9091)")
 	rootCmd.PersistentFlags().Int64Var(&broadcastBytes, "broadcast-bytes", 0, "Override the broadcast-join threshold: joins whose estimated build side is under this many bytes replicate the build to every worker. 0 = derive from worker pool budget (default), <0 = never broadcast (every join takes the hash-shuffle/sort-merge path; benchmarking/debugging surface).")
 	rootCmd.PersistentFlags().Int64Var(&sortMergeJoinBytes, "sort-merge-join-bytes", 0, "Inner equi-joins whose sides BOTH exceed this estimated size run as sort-merge joins (both sides sort to spill-friendly runs and stream a merge) instead of hash joins, bounding join memory at merge-cursor state instead of a resident build table. Applies to both the local single-process paths and the distributed stage DAG (the join stage swaps operator; its exchange children are identical). 0 = disabled (default). See docs/design/sort-merge-join.md.")
+	rootCmd.PersistentFlags().BoolVar(&lateMaterialization, "late-materialization", false, "Emit inner/left hash-join output as view (dictionary) columns over the probe input and build batches, deferring the column gather to the first consumer that needs owned storage. Cuts join-output copies and allocation in multi-join pipelines. Applies to the local single-process paths and to distributed worker fragments (rides the join-probe op spec). Default off. See docs/design/late-materialization.md.")
 	rootCmd.PersistentFlags().Int64Var(&localFastPathBytes, "local-fastpath-bytes", coordinator.DefaultLocalFastPathBytes, "Queries whose post-pruning catalog scan bytes stay under this threshold execute in-process on the coordinator (skipping the distributed stage DAG and its per-stage object-store round trips). 0 = disabled.")
 	rootCmd.PersistentFlags().BoolVar(&streamingExchange, "streaming-exchange", true, "Streaming exchange: consumers fetch stage outputs from the producing workers' local disk over gRPC with async S3 upload; every failure falls through to the durable S3 path. Default true (validated 2026-07-02: SF10 −10%, SF100 −23% suite wall, row-identical, zero fault-tolerance events); --streaming-exchange=false restores synchronous S3-only shuffle. See docs/design/streaming-exchange.md.")
 	rootCmd.PersistentFlags().StringVar(&peerExchangeAddr, "peer-exchange-addr", ":0", "Peer-exchange (FetchShuffle) listen address. Default :0 picks a free port (the address reaches peers via heartbeats, and a fixed default would collide when multiple workers share a host); pin it when firewalls need a known port.")
@@ -883,6 +885,7 @@ func runStandalone(ctx context.Context, store objstore.Store, logger *slog.Logge
 		LocalFastPathBytes:     localFastPathBytes,
 		BroadcastBytesOverride: broadcastBytes,
 		SortMergeJoinBytes:     sortMergeJoinBytes,
+		LateMaterialization:    lateMaterialization,
 		StreamingExchange:      streamingExchange,
 	}, cat, nc, js, logger)
 
@@ -964,6 +967,7 @@ func runStandalone(ctx context.Context, store objstore.Store, logger *slog.Logge
 		Coordinator:        coord,
 		Metrics:            m,
 		SortMergeJoinBytes: sortMergeJoinBytes,
+		LateMaterialization: lateMaterialization,
 	}
 
 	var cfgMgr *config.Manager
@@ -1181,6 +1185,7 @@ func runCoordinator(ctx context.Context, store objstore.Store, logger *slog.Logg
 		LocalFastPathBytes:     localFastPathBytes,
 		BroadcastBytesOverride: broadcastBytes,
 		SortMergeJoinBytes:     sortMergeJoinBytes,
+		LateMaterialization:    lateMaterialization,
 		StreamingExchange:      streamingExchange,
 	}, cat, nc, js, logger)
 
@@ -1252,6 +1257,7 @@ func runCoordinator(ctx context.Context, store objstore.Store, logger *slog.Logg
 		DLQ:                dlq,
 		Metrics:            m,
 		SortMergeJoinBytes: sortMergeJoinBytes,
+		LateMaterialization: lateMaterialization,
 	}
 
 	var cfgMgr *config.Manager

--- a/docs/design/late-materialization.md
+++ b/docs/design/late-materialization.md
@@ -1,0 +1,214 @@
+# Late materialization: view vectors for join output
+
+Status: DRAFT — awaiting review. Grounded against main a76c083, 2026-07-08.
+
+## 1. Problem and evidence
+
+Every hash-join probe batch is fully materialized today: match pairs are
+collected as references, then every output column is gathered (copied) into a
+freshly allocated batch (`join.go:2141-2148`). In a fused multi-join pipeline
+(Q05/Q07/Q08/Q09 shapes — `buildPipeline` appends successive probes into one
+`[]UnaryOperator`, plan.go:4190; distributed fragments carry consecutive
+`OpHashJoinProbe` specs, executor_fragment.go:1656), a column that merely
+passes through k joins on its way to the aggregate is copied k times, and rows
+eliminated by a later probe or residual filter are copied and then thrown away.
+
+Fresh evidence (SF1 CPU profile, 2026-07-08, main a76c083; query phase =
+~64.7s of samples after excluding datagen/ingest):
+
+- `HashJoinProbe.Execute` cum 7.15s = **11.0% of query-phase CPU** — the
+  largest single operator, ahead of `HashAggregate.Consume` (5.03s).
+- Of that, **~4.9s (~7.5% of query phase) is pure output materialization**:
+  `gatherVector` on probe columns 2.40s, `gatherBuildVector` 1.18s,
+  single-build fast-path gather 0.09s, output-batch alloc + `memclr` ~1.2s.
+  Matching itself (hash lookups, pair collection) is the minority of probe
+  time.
+- GC is a first-order cost in the same profile (`gcDrain` 20s of 120s total).
+  Join output is a top allocation site (fresh vectors per output batch, up to
+  16×2048 rows); deferring materialization removes most of those bytes.
+
+The roadmap's "~13% memmove" figure (2026-05-22 block profile) is documented
+nowhere and predates morsel/streaming-exchange/CBO; this profile replaces it
+as the payoff basis. Note the honest bound: late materialization does not
+eliminate the final copy — a column touched downstream is still gathered once.
+The save is (k−1) intermediate copies per passed-through column, all copies
+for rows later eliminated, and the allocation/GC bytes of intermediate
+batches.
+
+## 2. Verified current state (anchors)
+
+- Match pairs are already references: `matchPair{probeRow int32, ref
+  buildRef{batchIdx,rowIdx}, matched bool}` (join.go:1885, :32). The gather
+  into a fresh pooled batch (join.go:2085-2148) is the only materialization
+  step. `countingSortPairs` (join.go:1438) orders pairs by build batch for
+  gather locality.
+- Semi/anti joins already late-materialize: they return the *input* batch
+  with `in.Sel` set (join.go:2695-2705) — zero copy. This design extends the
+  same idea to joins that must emit build columns, which `Sel` cannot express
+  (one batch-level `Sel` cannot address two source batches, and build columns
+  need one entry per *pair*, not per probe row).
+- Build batches are columnar, `Detach()`ed, retained in `h.buildBatches`, and
+  freed only in `HashJoin.Close()` after the probe pipeline fully drains
+  (join.go:2982-2996; broadcast builds refcounted via `broadcastJoinCache`).
+  `buildRef` addressing already survives `consolidateBuild`'s ref rewrite
+  because refs are minted at probe time, post-consolidation (join.go:1425).
+- There is no view/dictionary vector anywhere: `batch.Vector` is owned typed
+  storage (vector.go:225-246); every consumer reads `Int64Data[row]` etc.
+  directly. The expression compiler is row-indexed on concrete vectors
+  (expr.go:116,163-165) and its `EvalVec` path additionally requires dense
+  rows. Filter kernels read raw columns (filter.go:407).
+- Pipeline ownership: after each op, `prev.Release()` recycles the input
+  batch (pipeline.go:100-101). A reference into the probe input would dangle
+  without an explicit pinning contract (build batches already have one).
+- Retaining consumers: Sort (`Detach`+append, sort.go:91-92), Window
+  (window.go:129-130), CollectSink/BatchSink (pipeline.go:594), the deferred
+  join / reverse-bloom bridges (plan.go:4218, :4087). Serializing sinks all
+  gather rows anyway: shuffle `writeChunk(cols, sel, n)`
+  (shuffle_format.go:110-148), `gatherReplySink` (gather_reply_sink.go:75),
+  `partitionedShuffleSink` (partitioned_shuffle_sink.go:142).
+- Column pruning through joins already exists (`OutputFilter` from
+  `NeededColumns`, join.go:1902-1912, plan.go:4183) — late materialization is
+  orthogonal: it defers the *row* copy of the columns that survive pruning.
+- Adjacent prior art: PR #192 `BuildStoreCols` arrival projection returns a
+  view RecordBatch sharing vectors (join.go:1517-1556) — the share-and-detach
+  pattern this design generalizes.
+
+## 3. Design: view (dictionary) vectors
+
+New optional form on `batch.Vector` — the standard columnar-engine primitive
+(DuckDB slice vectors, Velox/Arrow dictionary vectors):
+
+```go
+type Vector struct {
+    ...
+    // View form: when Base != nil this vector owns no typed storage;
+    // logical row i is Base row Indices[i]. Nulls (if allocated) is the
+    // view's own bitmap and overrides Base (outer-join null-fill);
+    // otherwise nullness comes from Base through Indices.
+    Base    *Vector
+    Indices []uint32
+}
+```
+
+- `Flatten()` materializes a view into owned storage — implementation-wise it
+  IS `gatherVector(dst, Base, Indices)` (sort.go:530), the exact copy we do
+  today, moved to first touch. All 22 types incl. nested come along for free.
+- `RecordBatch.FlattenViews()` flattens all view columns;
+  `FlattenColumn(i)` flattens one (column-granular laziness).
+- Composition: gathering *from* a view emits a new view over the same Base
+  with `newIndices[i] = old.Indices[rows[i]]` — uint32 arithmetic, no data
+  copy. This is what makes k-join chains one-copy-per-column.
+- All probe-side view columns of one output batch share a single backing
+  `Indices` slice (the pair probe rows); build-side views share another. Two
+  uint32 arrays per output batch replace one full copy per column.
+- `MemBytes()` of a view counts indices + own bitmap only. Base bytes are
+  accounted by their owner (build tracker / probe pin — §4). No charge is
+  ever added to shared broadcast-cache vectors (2026-06 stall incident).
+- Escape safety: a view has nil typed slices, so any non-aware code that
+  reads `Int64Data[row]` fails loud (index panic), not silently wrong.
+
+### Join output under the flag
+
+`HashJoinProbe.Execute` (inner + left in v1; see §7):
+
+- Probe columns: view over `in.Columns[srcIdx]` with the shared probe-row
+  indices. If `in` itself carries views (chained probe), compose.
+- Build columns: view over `buildBatches[0].Columns[srcIdx]` when the build
+  is single-batch (the common case post-`consolidateBuild`); multi-batch
+  builds keep today's `gatherBuildVector` copy (a view has one Base).
+- Left-join unmatched rows: view with own null bitmap set on unmatched pair
+  positions; `Flatten` composes own-nulls over base-nulls — exactly
+  `gatherBuildVector`'s matched branch (join.go:3155).
+- Right/full-outer probe-phase output may also use views, but the
+  `FlushUnmatched`/`FlushMatched` emission paths (join.go:2821-2961) stay
+  eager — they run post-probe against build refs and are small.
+- Semi/anti/right-semi/right-anti: unchanged (already optimal or build-only).
+
+## 4. Ownership and lifetime
+
+Rule: **views never survive the pipeline's per-batch cycle.** The push
+pipeline drives one batch through the whole op chain before the next
+(pipeline.go:92-115), so views over probe input i are dead (flattened,
+composed away, or serialized) before batch i+1 enters.
+
+- The probe pins its input: on emitting view output, `in.Detach()` and hold
+  it as `pinnedProbe`, releasing the *previous* pinned input at the start of
+  the next `Execute` and at `Close`. Bounded at one batch per join. The
+  pinned batch's `MemBytes` is reserved on the join's tracker while held.
+- Build bases need nothing new: `HashJoin.Close()` after pipeline drain is
+  the existing guarantee; broadcast refcounts already cover shared builds.
+- Every retaining or serializing consumer flattens on entry: Sort, Window,
+  CollectSink/BatchSink, spill writers, the join bridges — one
+  `b.FlattenViews()` call guarded by a cheap `HasViews()` check. The
+  pipeline additionally flattens defensively before any sink not declared
+  view-aware, so correctness never depends on remembering a call site.
+
+## 5. Consumer matrix (what flattens, what stays lazy)
+
+| Consumer | v1 behavior |
+|---|---|
+| Chained HashJoinProbe | Compose (the headline win). Key columns needed for hashing are flattened individually (one column) or read through indices in the inline probes — start with flatten-key-column, measure, then teach `inlineIntProbe` indirection if it shows. |
+| Filter family | Flatten only the filtered column(s); `Sel` manipulation itself is view-compatible (Limit needs nothing). |
+| Project / expr | Flatten columns referenced by expressions; `DirectCopy` of a view passes the view through. `VecEval` path keeps its existing `Compact()` behavior. |
+| HashAggregate | `FlattenViews()` on `Consume` — by then the upstream win is banked; teaching the agg fast paths indirection is a measured follow-on, not v1. |
+| Sort / Window / TopN | `FlattenViews()` on `Consume` (they retain batches; pinning bases would defeat the memory win). |
+| Shuffle / gather / collect sinks | v1: `FlattenViews()` before serialize. v1.5: `writeChunk` already gathers rows via `Sel` — reading through view indices there makes the final copy free for distributed fragments ending in an exchange. |
+| Spill paths | Probe-side grace partitioning happens before views exist (input is concrete); spill writers flatten like other serializers. |
+
+## 6. Distributed interplay
+
+Nothing crosses the wire: views are an intra-fragment representation, always
+resolved at the fragment's serializing sink. `.wshf` format, exchange
+protocol, and stage materialization are untouched. Broadcast-cached builds as
+view bases are safe under the existing refcount (views die with the probe
+pipeline that holds the cache reference). The local fast path and worker
+fragment path share `HashJoinProbe`, so both get the feature from one
+implementation.
+
+## 7. What v1 does NOT do
+
+- No view output from Sort/Window/aggregate/scan — joins only.
+- No expression/kernel indirection — flatten-on-touch everywhere except probe
+  chains and (v1.5) shuffle serialization.
+- No multi-base views: multi-batch builds keep the eager gather.
+- No view spilling: any batch that reaches a spill/retain point flattens.
+- Right/full-outer flush paths stay eager.
+
+## 8. Observability, gates, rollout
+
+Dyn-filter lesson applied from day 1: the feature must prove it engaged.
+
+- Counters: `LateMatBatchesEmitted`, `LateMatViewColumns`,
+  `LateMatBytesDeferred` (bytes NOT copied at emit), `LateMatFlattens`
+  (where views got materialized, labeled by consumer). Logged per query at
+  Info alongside `SortMergeJoinsPlanned`-style reporting.
+- Flag: `--late-materialization` (bool), default off until gates pass; this
+  is engine-local (no protocol change), so the endgame is default-on, unlike
+  SMJ's dormant-until-payoff posture.
+- Gates, in order:
+  1. `batch` package unit tests: view round-trip for all 22 types, nested,
+     null composition, Flatten/Compact/ToRows/RowAt/CopyValueFrom, MemBytes.
+  2. Full exec suite + `-race`; SF0.01 22/22 forced-on.
+  3. `cmd/tpch-harness --mode=local` both arms (hard rule for any
+     coordinator/distribution-adjacent change).
+  4. SF1 profile pair: expect `gatherVector`-in-probe and join-output alloc
+     bytes to drop and `LateMatBytesDeferred` ≫ 0; wall may be flat at SF1
+     (no-revert-on-serial-clog — CPU/alloc is the signal).
+  5. Deploy-gated SF10 + SF100 same-window pairs (user approval per deploy);
+     per the A/B method note, attribute per-query deltas only with the
+     counters proving engagement, and treat ±15%/query as noise floor.
+
+## 9. Phases
+
+1. **Batch primitive**: view form on `Vector`, `Flatten`/`FlattenViews`/
+   `FlattenColumn`/`HasViews`, MemBytes, generic-accessor audit
+   (`GetValue`/`RowAt`/`Compact`/`CopyValueFrom` view-aware or guarded),
+   exhaustive tests. Zero behavior change.
+2. **Join emission + defensive flatten**: flag-gated view output from
+   `HashJoinProbe` (inner+left), probe-input pinning lifecycle, flatten
+   calls at every retain/serialize/expr touch point, counters. Gates 1-3.
+3. **Composition**: chained-probe index composition + key-column handling;
+   Filter/Project column-granular flatten. Gate 4 (SF1 profile pair).
+4. **v1.5 shuffle indirection**: view-aware `writeChunk` so fragment-final
+   copies disappear. Re-run gates 2-4.
+5. **Activation**: SF10 + SF100 same-window pairs; flip default on evidence.

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -77,6 +77,11 @@ type Config struct {
 	// the distributed stage DAG alike (the join stage swaps operator; its
 	// exchange children are identical). 0 = disabled (default, dormant).
 	SortMergeJoinBytes int64
+	// LateMaterialization emits inner/left hash-join output as view
+	// (dictionary) columns with the gather deferred to first touch
+	// (docs/design/late-materialization.md), on the local fast path and in
+	// worker fragments alike (rides the join-probe OpSpec). Off by default.
+	LateMaterialization bool
 	// StreamingExchange annotates dispatched tasks with peer-location
 	// hints (Task.InputLocations) and per-query fetch tokens so consumers
 	// stream stage outputs from the producing workers' local disk instead
@@ -742,6 +747,7 @@ func (c *Coordinator) ExecuteSQL(ctx context.Context, sql string) (*SQLResult, e
 		planner.BroadcastBytesThreshold = c.config.BroadcastBytesOverride
 	}
 	planner.SortMergeJoinBytes = c.config.SortMergeJoinBytes
+	planner.LateMaterialization = c.config.LateMaterialization
 	planner.DynamicFiltersEnabled = c.config.DynamicFilters
 	physStages, err := planner.PlanDistributed(ctx, logicalPlan)
 	if err != nil {
@@ -2435,6 +2441,7 @@ func (c *Coordinator) SubmitSQL(ctx context.Context, sql string) (queryID string
 		planner.BroadcastBytesThreshold = c.config.BroadcastBytesOverride
 	}
 	planner.SortMergeJoinBytes = c.config.SortMergeJoinBytes
+	planner.LateMaterialization = c.config.LateMaterialization
 	planner.DynamicFiltersEnabled = c.config.DynamicFilters
 	physStages, err := planner.PlanDistributed(ctx, logicalPlan)
 	if err != nil {

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -2054,7 +2054,7 @@ func (c *Coordinator) dispatchComputeStage(
 			} else {
 				sinkOp = distributed.OpSpec{Type: distributed.OpUnpartitionedSink}
 			}
-			ops, ferr := buildJoinFragment(stage, &t, taskInputs, wireFused, sorts, sinkOp)
+			ops, ferr := buildJoinFragment(stage, &t, taskInputs, wireFused, sorts, sinkOp, c.config.LateMaterialization)
 			if ferr != nil {
 				return StageOutput{}, fmt.Errorf("stage %s: build join fragment: %w", stage.ID, ferr)
 			}
@@ -2331,6 +2331,7 @@ func buildJoinFragment(
 	wireFused []distributed.FusedJoinSpec,
 	sorts []distributed.SortKeySpec,
 	terminalSink distributed.OpSpec,
+	lateMat bool,
 ) ([]distributed.OpSpec, error) {
 	if t.BuildTableAlias == "" {
 		return nil, fmt.Errorf("BuildTableAlias required")
@@ -2361,14 +2362,15 @@ func buildJoinFragment(
 	})
 	for _, fj := range wireFused {
 		ops = append(ops, distributed.OpSpec{
-			Type:        distributed.OpBroadcastProbe,
-			JoinType:    fj.JoinType,
-			LeftKeys:    fj.JoinLeftKeys,
-			RightKeys:   fj.JoinRightKeys,
-			BuildAlias:  fj.BuildTableAlias,
-			BuildFiles:  fj.BuildFiles,
-			BuildBucket: t.DataBucket,
-			JoinFilter:  fj.JoinFilter,
+			Type:            distributed.OpBroadcastProbe,
+			JoinType:        fj.JoinType,
+			LeftKeys:        fj.JoinLeftKeys,
+			RightKeys:       fj.JoinRightKeys,
+			BuildAlias:      fj.BuildTableAlias,
+			BuildFiles:      fj.BuildFiles,
+			BuildBucket:     t.DataBucket,
+			JoinFilter:      fj.JoinFilter,
+			LateMaterialize: lateMat,
 		})
 	}
 	primaryType := distributed.OpHashJoinProbe
@@ -2388,6 +2390,7 @@ func buildJoinFragment(
 		SemiAntiKeyOnly:     t.SemiAntiKeyOnly,
 		QualifyAllBuildCols: t.QualifyAllBuildCols,
 		OutputColumns:       append([]string(nil), t.Columns...),
+		LateMaterialize:     lateMat,
 	})
 	// Residual post-join filters (semi/anti residual or compute-stage
 	// HAVING-equivalent) compile to an OpFilter applied AFTER the probe and

--- a/internal/coordinator/local_fastpath.go
+++ b/internal/coordinator/local_fastpath.go
@@ -92,6 +92,7 @@ func (c *Coordinator) tryLocalFastPath(ctx context.Context, queryID string, logi
 	// of coordinator OOM.
 	planner.MemoryBudget = 8 * threshold
 	planner.SortMergeJoinBytes = c.config.SortMergeJoinBytes
+	planner.LateMaterialization = c.config.LateMaterialization
 	physPlan, err := planner.Plan(ctx, logicalPlan)
 	if err != nil {
 		c.logger.Warn("local fast path plan failed, routing to DAG",

--- a/internal/distributed/messages.go
+++ b/internal/distributed/messages.go
@@ -314,6 +314,7 @@ type OpSpec struct {
 	SemiAntiKeyOnly     bool     `json:"semi_anti_key_only,omitempty"`
 	QualifyAllBuildCols bool     `json:"qualify_all_build_cols,omitempty"`
 	OutputColumns       []string `json:"output_columns,omitempty"` // OutputFilter for primary probe
+	LateMaterialize     bool     `json:"late_materialize,omitempty"` // emit view-column join output (deferred gather)
 
 	// OpExchangeSender (sink).
 	ShuffleKeys   []string `json:"shuffle_keys,omitempty"`

--- a/internal/engine/batch/batch.go
+++ b/internal/engine/batch/batch.go
@@ -34,6 +34,14 @@ func NewRecordBatch(schema []parquet.Column, numRows int) *RecordBatch {
 	}
 }
 
+// NewColumnVector creates a single Vector from a Column definition with
+// numRows pre-allocated rows, recursively initializing nested type children —
+// the per-column equivalent of NewRecordBatch for callers that materialize
+// some columns of a batch while emitting others as views.
+func NewColumnVector(col parquet.Column, numRows int) *Vector {
+	return newVectorFromColumn(col, numRows)
+}
+
 // newVectorFromColumn creates a Vector from a Column definition, recursively
 // initializing nested type children.
 func newVectorFromColumn(col parquet.Column, numRows int) *Vector {

--- a/internal/engine/batch/batch.go
+++ b/internal/engine/batch/batch.go
@@ -145,6 +145,10 @@ func (b *RecordBatch) Reset(numRows int) {
 // the first reused row read back the prior batch's data concatenated with
 // the new value, and child arenas grew monotonically per reuse cycle.
 func resetVectorForReuse(col *Vector, numRows int) {
+	// Views must never survive into a pooled reuse cycle; drop the
+	// indirection so the batch is a plain (empty) owned batch again.
+	col.Base = nil
+	col.Indices = nil
 	col.Len = numRows
 	col.Nulls.ResetNonNull(numRows)
 	switch col.Type {
@@ -170,6 +174,8 @@ func resetVectorForReuse(col *Vector, numRows int) {
 // truncateVectorStorage re-slices a vector's element storage to zero length
 // (capacity retained for reuse). Recurses into nested children.
 func truncateVectorStorage(v *Vector) {
+	v.Base = nil
+	v.Indices = nil
 	v.Len = 0
 	v.BoolData = v.BoolData[:0]
 	v.Int32Data = v.Int32Data[:0]

--- a/internal/engine/batch/vector.go
+++ b/internal/engine/batch/vector.go
@@ -243,6 +243,18 @@ type Vector struct {
 	Child      *Vector   // ARRAY: flat vector of all element values
 	Children   []*Vector // ROW: one vector per field (same length as parent)
 	FieldNames []string  // ROW: names of child fields
+
+	// View (dictionary) form: when Base != nil this vector owns no typed
+	// storage — logical row i is Base row Indices[i]. Nulls is the view's OWN
+	// override bitmap (a null bit marks the row null regardless of Base; a
+	// valid bit defers to Base's nullness through Indices). Base is always an
+	// owned vector: NewViewVector composes indices when handed a view base, so
+	// views never chain. Views are read-only and understood only by the
+	// view-aware accessors (GetValue, CopyValueFrom-as-source, Flatten,
+	// MemBytes); typed hot-path accessors (GetInt64, Int64Data[i], ...) fail
+	// loud on a view because the typed slices are nil. See view.go.
+	Base    *Vector
+	Indices []uint32
 }
 
 // NewVector creates a new vector of the given type and length.
@@ -298,6 +310,11 @@ func NewVectorWithScale(typ TypeID, length int, scale int) *Vector {
 func (v *Vector) EnsureLen(n int) {
 	if n <= v.Len {
 		return
+	}
+	if v.Base != nil {
+		// Views are read-only; growing one for in-place writes is always a
+		// caller bug. Fail loud rather than writing into nil typed slices.
+		panic("batch: EnsureLen on a view vector — Flatten() first")
 	}
 	v.Nulls.EnsureLen(n)
 	switch v.Type {
@@ -459,6 +476,11 @@ func NewMapVector(length int, keyType, valueType TypeID) *Vector {
 func (v *Vector) GetValue(i int) any {
 	if v.Nulls.IsNullFast(i) {
 		return nil
+	}
+	if v.Base != nil {
+		// View: own-null already checked above; defer to base through the
+		// index (base applies its own null bitmap).
+		return v.Base.GetValue(int(v.Indices[i]))
 	}
 	// Hot types first as if-chain for better branch prediction
 	switch v.Type {
@@ -916,6 +938,13 @@ func (v *Vector) memBytes(depth int) int64 {
 	if v == nil || depth > memBytesMaxDepth {
 		return 0
 	}
+	if v.Base != nil {
+		// View: indices + own bitmap. Base storage is accounted by its
+		// owner (build tracker / pinned probe input), never double-charged
+		// here — the same rule that keeps shared broadcast-cache vectors
+		// single-owner.
+		return int64(len(v.Nulls.Words()))*8 + int64(len(v.Indices))*4
+	}
 	// Null bitmap: stored as []uint64 words, one bit per row.
 	size := int64(len(v.Nulls.Words())) * 8 // 8 = sizeof(uint64) word
 
@@ -1128,6 +1157,14 @@ func NewVectorLike(src *Vector) *Vector {
 // no boxing, no string round-trips — recursive for nested types. dst's
 // nested structure must match src's (build it with NewVectorLike).
 func (v *Vector) AppendFrom(src *Vector, si int) {
+	if src.Base != nil {
+		// View source: mirror CopyValueFrom's redirect.
+		if src.Nulls.IsNullFast(si) {
+			appendToVector(v, nil)
+			return
+		}
+		src, si = src.Base, int(src.Indices[si])
+	}
 	idx := v.Len
 	v.Len++
 	v.Nulls = v.Nulls.Grow(v.Len)
@@ -1234,6 +1271,15 @@ func (v *Vector) AppendFrom(src *Vector, si int) {
 // (NewVectorLike); ROW children handle both — indexed writes when
 // pre-allocated, appends when built lazily.
 func (v *Vector) CopyValueFrom(di int, src *Vector, si int) {
+	if src.Base != nil {
+		// View source: an own-null row becomes a null write (its index value
+		// is meaningless); otherwise copy from the base row it references.
+		if src.Nulls.IsNullFast(si) {
+			v.WriteNullAt(di)
+			return
+		}
+		src, si = src.Base, int(src.Indices[si])
+	}
 	isNull := src.Nulls.IsNull(si)
 	if isNull {
 		v.Nulls.SetNull(di)

--- a/internal/engine/batch/view.go
+++ b/internal/engine/batch/view.go
@@ -1,0 +1,259 @@
+package batch
+
+// View (dictionary) vectors — the late-materialization primitive.
+//
+// A view vector holds no typed storage: logical row i resolves to Base row
+// Indices[i]. Creating a view over N rows costs one uint32 slice + one null
+// bitmap instead of copying every column value; Flatten performs the exact
+// gather that eager materialization would have done, moved to first touch.
+// Gathering FROM a view composes index arrays (see NewViewVector), so a
+// column passing through a chain of joins is copied once, at its final
+// consumer, instead of once per join.
+//
+// Ownership contract: a view does NOT keep Base alive — whoever mints the
+// view must guarantee Base's storage outlives it (the hash join pins its
+// probe input and already owns its build batches). Views are read-only;
+// writers must Flatten first. See docs/design/late-materialization.md.
+
+// NewViewVector creates a view over base addressing rows through indices.
+// The indices slice is adopted, not copied — callers must not mutate it
+// afterwards. If base is itself a view, the indirection is composed away
+// (newIndices[i] = base.Indices[indices[i]], own-nulls folded), so Base on
+// the returned vector is always an owned vector.
+//
+// The view starts all-valid: row i's nullness defers to base through
+// indices. Callers that need null-injection (outer-join fill) mark rows
+// with v.Nulls.SetNull(i); those rows' index values are ignored.
+func NewViewVector(base *Vector, indices []uint32) *Vector {
+	v := &Vector{
+		Type:  base.Type,
+		Len:   len(indices),
+		Nulls: NewBitmap(len(indices)),
+	}
+	if base.Base != nil {
+		// Compose: fold the base view's indirection and own-nulls into this
+		// view so Base is always owned and reads are single-hop.
+		composed := make([]uint32, len(indices))
+		for i, x := range indices {
+			composed[i] = base.Indices[x]
+			if base.Nulls.IsNullFast(int(x)) {
+				v.Nulls.SetNull(i)
+			}
+		}
+		indices = composed
+		base = base.Base
+	}
+	v.Base = base
+	v.Indices = indices
+	// Mirror metadata that generic code inspects without touching storage.
+	v.VectorDim = base.VectorDim
+	v.DecimalData.Scale = base.DecimalData.Scale
+	v.FieldNames = base.FieldNames
+	return v
+}
+
+// IsView reports whether the vector is a view (owns no typed storage).
+func (v *Vector) IsView() bool {
+	return v.Base != nil
+}
+
+// Flatten materializes a view in place: owned storage is allocated, values
+// are gathered from Base through Indices (own-null rows become nulls), and
+// the view fields are cleared. Aliases of the *Vector see the flattened
+// form. No-op on owned vectors.
+func (v *Vector) Flatten() {
+	base := v.Base
+	if base == nil {
+		return
+	}
+	n := len(v.Indices)
+	idx := v.Indices
+	own := v.Nulls
+	ownNulls := own.HasNulls()
+	baseNulls := base.Nulls.HasNulls()
+	flat := newOwnedLike(base, n)
+	// Typed kernels for the flat-storage types (per the no-per-row-type-switch
+	// rule); nested and VECTOR shapes take the generic per-value copier.
+	switch base.Type {
+	case TypeBool:
+		if !ownNulls && !baseNulls {
+			for di, si := range idx {
+				flat.BoolData[di] = base.BoolData[si]
+			}
+		} else {
+			for di, si := range idx {
+				if (ownNulls && own.IsNullFast(di)) || (baseNulls && base.Nulls.IsNullFast(int(si))) {
+					flat.Nulls.SetNull(di)
+					continue
+				}
+				flat.BoolData[di] = base.BoolData[si]
+			}
+		}
+	case TypeInt32, TypePort, TypeProtocol, TypeDate:
+		if !ownNulls && !baseNulls {
+			for di, si := range idx {
+				flat.Int32Data[di] = base.Int32Data[si]
+			}
+		} else {
+			for di, si := range idx {
+				if (ownNulls && own.IsNullFast(di)) || (baseNulls && base.Nulls.IsNullFast(int(si))) {
+					flat.Nulls.SetNull(di)
+					continue
+				}
+				flat.Int32Data[di] = base.Int32Data[si]
+			}
+		}
+	case TypeInt64, TypeTimestamp, TypeIPv4, TypeMAC, TypeDuration:
+		if !ownNulls && !baseNulls {
+			for di, si := range idx {
+				flat.Int64Data[di] = base.Int64Data[si]
+			}
+		} else {
+			for di, si := range idx {
+				if (ownNulls && own.IsNullFast(di)) || (baseNulls && base.Nulls.IsNullFast(int(si))) {
+					flat.Nulls.SetNull(di)
+					continue
+				}
+				flat.Int64Data[di] = base.Int64Data[si]
+			}
+		}
+	case TypeFloat32:
+		if !ownNulls && !baseNulls {
+			for di, si := range idx {
+				flat.Float32Data[di] = base.Float32Data[si]
+			}
+		} else {
+			for di, si := range idx {
+				if (ownNulls && own.IsNullFast(di)) || (baseNulls && base.Nulls.IsNullFast(int(si))) {
+					flat.Nulls.SetNull(di)
+					continue
+				}
+				flat.Float32Data[di] = base.Float32Data[si]
+			}
+		}
+	case TypeFloat64:
+		if !ownNulls && !baseNulls {
+			for di, si := range idx {
+				flat.Float64Data[di] = base.Float64Data[si]
+			}
+		} else {
+			for di, si := range idx {
+				if (ownNulls && own.IsNullFast(di)) || (baseNulls && base.Nulls.IsNullFast(int(si))) {
+					flat.Nulls.SetNull(di)
+					continue
+				}
+				flat.Float64Data[di] = base.Float64Data[si]
+			}
+		}
+	case TypeDecimal:
+		if !ownNulls && !baseNulls {
+			for di, si := range idx {
+				flat.DecimalData.Data[di] = base.DecimalData.Data[si]
+			}
+		} else {
+			for di, si := range idx {
+				if (ownNulls && own.IsNullFast(di)) || (baseNulls && base.Nulls.IsNullFast(int(si))) {
+					flat.Nulls.SetNull(di)
+					continue
+				}
+				flat.DecimalData.Data[di] = base.DecimalData.Data[si]
+			}
+		}
+	case TypeString, TypeBytes, TypeIPv6, TypeCIDR, TypeUUID:
+		// Pre-size the destination arena to avoid growslice per SetFrom.
+		srcOff := base.BytesData.Offsets
+		totalBytes := 0
+		for _, si := range idx {
+			totalBytes += int(srcOff[si+1] - srcOff[si])
+		}
+		flat.BytesData.PreAllocBytes(totalBytes)
+		for di, si := range idx {
+			if (ownNulls && own.IsNullFast(di)) || (baseNulls && base.Nulls.IsNullFast(int(si))) {
+				flat.Nulls.SetNull(di)
+				flat.BytesData.Set(di, nil)
+				continue
+			}
+			flat.BytesData.SetFrom(di, &base.BytesData, int(si))
+		}
+	default:
+		// ARRAY/MAP/ROW/VECTOR: nested-aware per-value copy.
+		for di, si := range idx {
+			if ownNulls && own.IsNullFast(di) {
+				flat.WriteNullAt(di)
+			} else {
+				flat.CopyValueFrom(di, base, int(si))
+			}
+		}
+	}
+	v.Base = nil
+	v.Indices = nil
+	v.Len = n
+	v.Nulls = flat.Nulls
+	v.BoolData = flat.BoolData
+	v.Int32Data = flat.Int32Data
+	v.Int64Data = flat.Int64Data
+	v.Float32Data = flat.Float32Data
+	v.Float64Data = flat.Float64Data
+	v.BytesData = flat.BytesData
+	v.DecimalData = flat.DecimalData
+	v.VectorDim = flat.VectorDim
+	v.Offsets = flat.Offsets
+	v.Child = flat.Child
+	v.Children = flat.Children
+	v.FieldNames = flat.FieldNames
+}
+
+// newOwnedLike allocates an owned vector of src's type and nested structure
+// with n pre-allocated rows, ready for sequential CopyValueFrom/WriteNullAt
+// writes at positions 0..n-1. ROW children are pre-allocated at n rows so
+// null rows advance through the indexed-write path (an append-built child
+// would misalign if the first rows were nulls written before the child
+// existed); ARRAY/MAP element storage stays append-built, which is what
+// CopyValueFrom expects.
+func newOwnedLike(src *Vector, n int) *Vector {
+	v := NewVectorWithScale(src.Type, n, src.DecimalData.Scale)
+	switch src.Type {
+	case TypeVector:
+		v.VectorDim = src.VectorDim
+		if src.VectorDim > 0 {
+			v.Float32Data = make([]float32, n*src.VectorDim)
+		}
+	case TypeArray, TypeMap:
+		if src.Child != nil {
+			v.Child = NewVectorLike(src.Child)
+		}
+	case TypeRow:
+		v.Children = make([]*Vector, len(src.Children))
+		for j, ch := range src.Children {
+			v.Children[j] = newOwnedLike(ch, n)
+		}
+		v.FieldNames = append([]string(nil), src.FieldNames...)
+	}
+	return v
+}
+
+// HasViews reports whether any column of the batch is a view vector.
+func (b *RecordBatch) HasViews() bool {
+	for _, col := range b.Columns {
+		if col.Base != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// FlattenViews materializes every view column in place. Call before
+// retaining a batch past the pipeline's per-batch cycle (Sort/Window/sink
+// Consume) or handing it to code that reads typed storage directly.
+func (b *RecordBatch) FlattenViews() {
+	for _, col := range b.Columns {
+		col.Flatten()
+	}
+}
+
+// FlattenColumn materializes a single column if it is a view. Use for
+// column-granular consumers (a filter touching one column) so the remaining
+// columns stay lazy.
+func (b *RecordBatch) FlattenColumn(i int) {
+	b.Columns[i].Flatten()
+}

--- a/internal/engine/batch/view_test.go
+++ b/internal/engine/batch/view_test.go
@@ -1,0 +1,395 @@
+package batch
+
+import (
+	"math"
+	"reflect"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// buildVec constructs an owned vector from boxed values (nil = null) using
+// the public SetValue path, so expected results can be derived with GetValue.
+func buildVec(tb testing.TB, typ TypeID, scale int, vals []any) *Vector {
+	tb.Helper()
+	v := NewVectorWithScale(typ, len(vals), scale)
+	for i, val := range vals {
+		v.SetValue(i, val)
+	}
+	return v
+}
+
+// checkViewValues verifies the view resolves to the expected boxed values
+// both before Flatten (view-aware GetValue) and after (owned storage).
+func checkViewValues(tb testing.TB, view *Vector, want []any) {
+	tb.Helper()
+	if !view.IsView() {
+		tb.Fatalf("expected a view vector")
+	}
+	if view.Len != len(want) {
+		tb.Fatalf("view Len = %d, want %d", view.Len, len(want))
+	}
+	for i, w := range want {
+		got := view.GetValue(i)
+		if !reflect.DeepEqual(got, w) {
+			tb.Fatalf("pre-flatten GetValue(%d) = %#v, want %#v", i, got, w)
+		}
+	}
+	view.Flatten()
+	if view.IsView() {
+		tb.Fatalf("Flatten left the vector a view")
+	}
+	if view.Len != len(want) {
+		tb.Fatalf("flattened Len = %d, want %d", view.Len, len(want))
+	}
+	for i, w := range want {
+		got := view.GetValue(i)
+		if !reflect.DeepEqual(got, w) {
+			tb.Fatalf("post-flatten GetValue(%d) = %#v, want %#v", i, got, w)
+		}
+	}
+}
+
+func TestViewFlattenAllFlatTypes(t *testing.T) {
+	cases := []struct {
+		name  string
+		typ   TypeID
+		scale int
+		vals  []any
+	}{
+		{"bool", TypeBool, 0, []any{true, nil, false, true}},
+		{"int32", TypeInt32, 0, []any{int32(1), int32(-7), nil, int32(2048)}},
+		{"int64", TypeInt64, 0, []any{int64(1), nil, int64(-9e15), int64(42)}},
+		{"float32", TypeFloat32, 0, []any{float32(1.5), nil, float32(-0.25), float32(0)}},
+		{"float64", TypeFloat64, 0, []any{1.5, nil, -2.75, 0.0}},
+		{"string", TypeString, 0, []any{"alpha", "", nil, "a longer string value"}},
+		{"bytes", TypeBytes, 0, []any{[]byte{1, 2, 3}, []byte{}, nil, []byte{0xff}}},
+		{"timestamp", TypeTimestamp, 0, []any{int64(1700000000000), nil, int64(0), int64(-1)}},
+		{"ipv4", TypeIPv4, 0, []any{"10.0.0.1", nil, "255.255.255.255", "0.0.0.0"}},
+		{"ipv6", TypeIPv6, 0, []any{"::1", nil, "fe80::1", "2001:db8::ff"}},
+		{"cidr", TypeCIDR, 0, []any{"10.0.0.0/8", nil, "192.168.1.0/24", "::/0"}},
+		{"mac", TypeMAC, 0, []any{"aa:bb:cc:dd:ee:ff", nil, "00:00:00:00:00:01", "ff:ff:ff:ff:ff:ff"}},
+		{"port", TypePort, 0, []any{int32(443), nil, int32(0), int32(65535)}},
+		{"protocol", TypeProtocol, 0, []any{int32(6), int32(17), nil, int32(1)}},
+		{"duration", TypeDuration, 0, []any{int64(1000), nil, int64(-5), int64(0)}},
+		{"uuid", TypeUUID, 0, []any{"01234567-89ab-cdef-0123-456789abcdef", nil, "ffffffff-ffff-ffff-ffff-ffffffffffff", "00000000-0000-0000-0000-000000000000"}},
+		{"date", TypeDate, 0, []any{"2026-07-08", nil, "1970-01-01", "1999-12-31"}},
+		{"decimal", TypeDecimal, 2, []any{"123.45", nil, "-0.01", "0.00"}},
+	}
+	// Indices exercise permutation, duplication (1:N join expansion) and
+	// repeats of null source rows.
+	indices := []uint32{3, 0, 0, 2, 1, 3}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			base := buildVec(t, tc.typ, tc.scale, tc.vals)
+			want := make([]any, len(indices))
+			for i, si := range indices {
+				want[i] = base.GetValue(int(si))
+			}
+			view := NewViewVector(base, append([]uint32(nil), indices...))
+			checkViewValues(t, view, want)
+		})
+	}
+}
+
+func TestViewFlattenNested(t *testing.T) {
+	t.Run("array", func(t *testing.T) {
+		base := NewArrayVector(3, TypeInt64)
+		base.SetValue(0, []any{int64(1), int64(2)})
+		base.SetValue(1, nil)
+		base.SetValue(2, []any{int64(7)})
+		indices := []uint32{2, 0, 1, 0}
+		want := make([]any, len(indices))
+		for i, si := range indices {
+			want[i] = base.GetValue(int(si))
+		}
+		view := NewViewVector(base, indices)
+		checkViewValues(t, view, want)
+	})
+	t.Run("row", func(t *testing.T) {
+		base := NewRowVector(3, []string{"a", "b"}, []TypeID{TypeInt64, TypeString})
+		base.SetValue(0, map[string]any{"a": int64(1), "b": "x"})
+		base.SetValue(1, nil)
+		base.SetValue(2, map[string]any{"a": int64(3), "b": ""})
+		indices := []uint32{1, 2, 0, 2}
+		want := make([]any, len(indices))
+		for i, si := range indices {
+			want[i] = base.GetValue(int(si))
+		}
+		view := NewViewVector(base, indices)
+		checkViewValues(t, view, want)
+	})
+	t.Run("row_null_first", func(t *testing.T) {
+		// First flattened rows are null: ROW children must advance their
+		// variable-length bookkeeping (the pre-allocated-children guarantee
+		// in newOwnedLike) or later string rows read back shifted.
+		base := NewRowVector(2, []string{"s"}, []TypeID{TypeString})
+		base.SetValue(0, nil)
+		base.SetValue(1, map[string]any{"s": "tail"})
+		indices := []uint32{0, 0, 1}
+		want := []any{base.GetValue(0), base.GetValue(0), base.GetValue(1)}
+		view := NewViewVector(base, indices)
+		checkViewValues(t, view, want)
+	})
+	t.Run("map", func(t *testing.T) {
+		base := NewMapVector(2, TypeString, TypeInt64)
+		base.SetValue(0, []any{map[string]any{"key": "k1", "value": int64(1)}})
+		base.SetValue(1, []any{map[string]any{"key": "k2", "value": int64(2)}, map[string]any{"key": "k3", "value": int64(3)}})
+		indices := []uint32{1, 0}
+		want := []any{base.GetValue(1), base.GetValue(0)}
+		view := NewViewVector(base, indices)
+		checkViewValues(t, view, want)
+	})
+	t.Run("vector", func(t *testing.T) {
+		base := NewVectorVector(3, 2)
+		base.SetVector(0, []float32{1, 2})
+		base.SetVector(1, []float32{3, 4})
+		base.SetVector(2, []float32{5, 6})
+		indices := []uint32{2, 2, 0}
+		want := []any{base.GetValue(2), base.GetValue(2), base.GetValue(0)}
+		view := NewViewVector(base, indices)
+		checkViewValues(t, view, want)
+	})
+}
+
+func TestViewOwnNullOverride(t *testing.T) {
+	// Outer-join null-fill: own-null rows are null regardless of the (
+	// meaningless) index value, for both flat and variable-length types.
+	base := buildVec(t, TypeString, 0, []any{"a", "b", "c"})
+	view := NewViewVector(base, []uint32{0, 1, 2, 0})
+	view.Nulls.SetNull(1)
+	view.Nulls.SetNull(3)
+	want := []any{"a", nil, "c", nil}
+	checkViewValues(t, view, want)
+
+	ints := buildVec(t, TypeInt64, 0, []any{int64(10), int64(20)})
+	iview := NewViewVector(ints, []uint32{1, 0})
+	iview.Nulls.SetNull(0)
+	checkViewValues(t, iview, []any{nil, int64(10)})
+}
+
+func TestViewComposition(t *testing.T) {
+	// A view over a view composes indices and folds own-nulls; Base is
+	// always the owned vector.
+	base := buildVec(t, TypeInt64, 0, []any{int64(0), int64(10), int64(20), int64(30)})
+	v1 := NewViewVector(base, []uint32{3, 2, 1, 0})
+	v1.Nulls.SetNull(2) // logical row 2 of v1 (base row 1) nulled
+	v2 := NewViewVector(v1, []uint32{2, 0, 1, 2})
+	if v2.Base != base {
+		t.Fatalf("composition did not collapse to the owned base")
+	}
+	want := []any{nil, int64(30), int64(20), nil}
+	checkViewValues(t, v2, want)
+}
+
+func TestViewFloat64NaN(t *testing.T) {
+	base := NewVector(TypeFloat64, 2)
+	base.Float64Data[0] = math.NaN()
+	base.Float64Data[1] = 1.0
+	view := NewViewVector(base, []uint32{0, 1, 0})
+	view.Flatten()
+	if !math.IsNaN(view.Float64Data[0]) || !math.IsNaN(view.Float64Data[2]) {
+		t.Fatalf("NaN not preserved through flatten: %v", view.Float64Data)
+	}
+	if view.Float64Data[1] != 1.0 {
+		t.Fatalf("Float64Data[1] = %v, want 1.0", view.Float64Data[1])
+	}
+}
+
+func TestViewFlattenCopiesStorage(t *testing.T) {
+	// Flatten must produce an independent copy: mutating the base afterwards
+	// must not change flattened values (the whole point of materialization).
+	base := buildVec(t, TypeString, 0, []any{"one", "two"})
+	view := NewViewVector(base, []uint32{1, 0})
+	view.Flatten()
+	base.BytesData.Reset()
+	base.BytesData.Set(0, []byte("XXX"))
+	base.BytesData.Set(1, []byte("YYY"))
+	if got, _ := view.GetString(0); got != "two" {
+		t.Fatalf("flattened value aliases base storage: got %q", got)
+	}
+}
+
+func TestViewEmptyAndSingle(t *testing.T) {
+	base := buildVec(t, TypeInt64, 0, []any{int64(5)})
+	empty := NewViewVector(base, []uint32{})
+	checkViewValues(t, empty, []any{})
+	single := NewViewVector(base, []uint32{0})
+	checkViewValues(t, single, []any{int64(5)})
+}
+
+func TestViewMemBytes(t *testing.T) {
+	base := buildVec(t, TypeInt64, 0, make([]any, 1000))
+	for i := range 1000 {
+		base.SetValue(i, int64(i))
+	}
+	view := NewViewVector(base, make([]uint32, 500))
+	got := view.MemBytes()
+	// 500 uint32 indices + 500-bit own bitmap (8 words) — and crucially NOT
+	// the base's 8000 data bytes (single-owner accounting).
+	want := int64(500*4 + 8*8)
+	if got != want {
+		t.Fatalf("view MemBytes = %d, want %d", got, want)
+	}
+}
+
+func TestViewEnsureLenPanics(t *testing.T) {
+	base := buildVec(t, TypeInt64, 0, []any{int64(1)})
+	view := NewViewVector(base, []uint32{0})
+	defer func() {
+		if recover() == nil {
+			t.Fatalf("EnsureLen on a view did not panic")
+		}
+	}()
+	view.EnsureLen(10)
+}
+
+func TestViewCopyValueFromViewSource(t *testing.T) {
+	// Generic per-value copy (Compact, spill writers, accumulator adopt)
+	// must read through a view source, honoring own-null overrides.
+	base := buildVec(t, TypeString, 0, []any{"a", "b", "c"})
+	view := NewViewVector(base, []uint32{2, 1, 0})
+	view.Nulls.SetNull(1)
+	dst := NewVector(TypeString, 3)
+	for i := range 3 {
+		dst.CopyValueFrom(i, view, i)
+	}
+	want := []any{"c", nil, "a"}
+	for i, w := range want {
+		if got := dst.GetValue(i); !reflect.DeepEqual(got, w) {
+			t.Fatalf("dst[%d] = %#v, want %#v", i, got, w)
+		}
+	}
+}
+
+func TestViewAppendFromViewSource(t *testing.T) {
+	base := buildVec(t, TypeInt64, 0, []any{int64(7), int64(8)})
+	view := NewViewVector(base, []uint32{1, 0})
+	view.Nulls.SetNull(0)
+	dst := NewVectorLike(base)
+	dst.AppendFrom(view, 0)
+	dst.AppendFrom(view, 1)
+	if got := dst.GetValue(0); got != nil {
+		t.Fatalf("dst[0] = %#v, want nil", got)
+	}
+	if got := dst.GetValue(1); got != int64(7) {
+		t.Fatalf("dst[1] = %#v, want 7", got)
+	}
+}
+
+func TestBatchHasViewsFlattenViews(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "k", Type: parquet.TypeInt64},
+		{Name: "s", Type: parquet.TypeString},
+	}
+	owned := NewRecordBatch(schema, 2)
+	owned.Columns[0].SetValue(0, int64(1))
+	owned.Columns[0].SetValue(1, int64(2))
+	owned.Columns[1].SetValue(0, "x")
+	owned.Columns[1].SetValue(1, "y")
+	if owned.HasViews() {
+		t.Fatalf("owned batch reports views")
+	}
+
+	b := &RecordBatch{
+		Columns: []*Vector{
+			NewViewVector(owned.Columns[0], []uint32{1, 0}),
+			NewViewVector(owned.Columns[1], []uint32{1, 0}),
+		},
+		Schema: schema,
+		Len:    2,
+	}
+	if !b.HasViews() {
+		t.Fatalf("view batch does not report views")
+	}
+	b.FlattenColumn(0)
+	if b.Columns[0].IsView() || !b.Columns[1].IsView() {
+		t.Fatalf("FlattenColumn touched the wrong column")
+	}
+	b.FlattenViews()
+	if b.HasViews() {
+		t.Fatalf("FlattenViews left views behind")
+	}
+	if got, _ := b.Columns[0].GetInt64(0); got != 2 {
+		t.Fatalf("flattened k[0] = %d, want 2", got)
+	}
+	if got, _ := b.Columns[1].GetString(1); got != "x" {
+		t.Fatalf("flattened s[1] = %q, want x", got)
+	}
+}
+
+func TestBatchCompactWithViewColumn(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "k", Type: parquet.TypeInt64},
+		{Name: "v", Type: parquet.TypeString},
+	}
+	owned := NewRecordBatch(schema, 3)
+	for i := range 3 {
+		owned.Columns[0].SetValue(i, int64(i*10))
+	}
+	owned.Columns[1].SetValue(0, "a")
+	owned.Columns[1].SetValue(1, "b")
+	owned.Columns[1].SetValue(2, "c")
+
+	b := &RecordBatch{
+		Columns: []*Vector{
+			NewViewVector(owned.Columns[0], []uint32{2, 1, 0}),
+			NewViewVector(owned.Columns[1], []uint32{2, 1, 0}),
+		},
+		Schema: schema,
+		Len:    3,
+		Sel:    []uint32{0, 2},
+	}
+	out := b.Compact()
+	if out.Len != 2 {
+		t.Fatalf("compact Len = %d, want 2", out.Len)
+	}
+	if got := out.Columns[0].GetValue(0); got != int64(20) {
+		t.Fatalf("compact k[0] = %#v, want 20", got)
+	}
+	if got := out.Columns[1].GetValue(1); got != "a" {
+		t.Fatalf("compact v[1] = %#v, want a", got)
+	}
+}
+
+func TestBatchResetClearsViews(t *testing.T) {
+	schema := []parquet.Column{{Name: "k", Type: parquet.TypeInt64}}
+	owned := NewRecordBatch(schema, 2)
+	owned.Columns[0].SetValue(0, int64(1))
+	owned.Columns[0].SetValue(1, int64(2))
+
+	b := NewRecordBatch(schema, 2)
+	b.Columns[0] = NewViewVector(owned.Columns[0], []uint32{1, 0})
+	b.Reset(2)
+	if b.HasViews() {
+		t.Fatalf("Reset left a view column — pooled reuse would read stale indirection")
+	}
+}
+
+func TestViewRowAtAndToRows(t *testing.T) {
+	schema := []parquet.Column{
+		{Name: "k", Type: parquet.TypeInt64},
+		{Name: "s", Type: parquet.TypeString},
+	}
+	owned := NewRecordBatch(schema, 2)
+	owned.Columns[0].SetValue(0, int64(1))
+	owned.Columns[0].SetValue(1, int64(2))
+	owned.Columns[1].SetValue(0, "x")
+	owned.Columns[1].SetValue(1, "y")
+	b := &RecordBatch{
+		Columns: []*Vector{
+			NewViewVector(owned.Columns[0], []uint32{1, 0}),
+			NewViewVector(owned.Columns[1], []uint32{1, 0}),
+		},
+		Schema: schema,
+		Len:    2,
+	}
+	row := b.RowAt(0)
+	if row["k"] != int64(2) || row["s"] != "y" {
+		t.Fatalf("RowAt(0) = %#v", row)
+	}
+	rows := b.ToRows()
+	if len(rows) != 2 || rows[1]["k"] != int64(1) || rows[1]["s"] != "x" {
+		t.Fatalf("ToRows = %#v", rows)
+	}
+}

--- a/internal/engine/exec/aggregate.go
+++ b/internal/engine/exec/aggregate.go
@@ -577,6 +577,9 @@ func (h *HashAggregate) Init(_ context.Context) error {
 func (h *HashAggregate) Consume(_ context.Context, b *batch.RecordBatch) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	// Reads typed column storage directly and is fed outside the pipeline
+	// loops by the worker's multi-breaker runner — flatten at the boundary.
+	FlattenForConsumer(b, nil)
 
 	// Save schema from first batch for spill recovery
 	if h.inputSchema == nil {

--- a/internal/engine/exec/batch_collector.go
+++ b/internal/engine/exec/batch_collector.go
@@ -46,7 +46,8 @@ func (c *SpillableBatchCollector) Consume(_ context.Context, b *batch.RecordBatc
 	if c.schema == nil {
 		c.schema = b.Schema
 	}
-	b.Detach() // prevent pool recycle — pipeline calls Release() after Consume()
+	FlattenForConsumer(b, nil) // retained past the batch cycle: views must not survive
+	b.Detach()                 // prevent pool recycle — pipeline calls Release() after Consume()
 	// Snapshot the selection vector — filter operators reuse their outSel
 	// scratch across calls (see BatchSink.Consume).
 	if b.Sel != nil {

--- a/internal/engine/exec/join.go
+++ b/internal/engine/exec/join.go
@@ -672,6 +672,10 @@ func hashBuildBytes(b *batch.RecordBatch) int64 {
 // Uses parallel workers when the build side is large enough to benefit from
 // concurrent hash table construction with per-worker local tables.
 func (h *HashJoin) Build(ctx context.Context, source Source) error {
+	// Build pulls directly from a Source (no pipeline loop in between) and
+	// stores or key-reads what it pulls — arriving view batches must be
+	// materialized at this boundary.
+	source = &flattenSource{inner: source}
 	if err := source.Init(ctx); err != nil {
 		return fmt.Errorf("build source init: %w", err)
 	}
@@ -1909,6 +1913,14 @@ type HashJoinProbe struct {
 	// in multi-way join pipelines.
 	OutputFilter map[string]bool
 
+	// LateMaterialize emits inner/left join output as view (dictionary)
+	// columns over the probe input and build batches instead of gathering
+	// copies — the deferred gather happens at the first consumer that needs
+	// owned storage (see flattenForConsumer). The probe input is Detach()ed
+	// when views reference it so pool recycling can't mutate the shared
+	// vectors; GC reclaims it once the views die. Off by default.
+	LateMaterialize bool
+
 	// outPool caches output batches for reuse. Created on first Execute
 	// when the output schema is known. Eliminates per-batch allocation
 	// in multi-way join pipelines where intermediate batches are released
@@ -2079,6 +2091,14 @@ func (p *HashJoinProbe) Execute(ctx context.Context, in *batch.RecordBatch) (*ba
 		countingSortPairs(pairs, len(p.join.buildBatches), &p.sortBuf)
 	}
 
+	// Late materialization: emit view columns instead of gathered copies.
+	// Inner and left joins only in v1 — right/full-outer probe output could
+	// also ride views, but their FlushUnmatched/FlushMatched emission paths
+	// stay eager, so they are excluded until measured separately.
+	if p.LateMaterialize && (h.JoinType == InnerJoin || h.JoinType == LeftJoin) {
+		return p.emitViewOutput(in, outSchema, mapping, pairs), nil
+	}
+
 	// Build output batch using precomputed column source mapping.
 	// Two-pool strategy: standard pool for ≤DefaultBatchSize (common case,
 	// cache-friendly), large pool for oversized 1:N outputs (avoids fresh alloc).
@@ -2150,6 +2170,88 @@ func (p *HashJoinProbe) Execute(ctx context.Context, in *batch.RecordBatch) (*ba
 	}
 
 	return out, nil
+}
+
+// emitViewOutput builds the join output as view (dictionary) columns: probe
+// columns reference the input batch through the pair probe rows, build
+// columns reference the (single) build batch through the pair build rows.
+// The only per-row work is filling two shared uint32 index slices — the
+// value gather is deferred to the first consumer that needs owned storage.
+// Multi-batch builds (consolidation skipped: spilling, >2M rows, >30%
+// budget) keep the eager gather for build columns, since a view has one
+// base; the output is then mixed view/owned, which is fine — views are
+// per-column.
+func (p *HashJoinProbe) emitViewOutput(in *batch.RecordBatch, outSchema []parquet.Column, mapping []outColSource, pairs []matchPair) *batch.RecordBatch {
+	n := len(pairs)
+	h := p.join
+	allMatched := h.JoinType != LeftJoin && h.JoinType != FullOuterJoin
+	singleBuild := len(h.buildBatches) == 1
+
+	// Index slices are freshly allocated per output batch — views escape
+	// downstream, so reusing a scratch buffer here would let batch i+1
+	// corrupt any batch-i view a consumer failed to flatten. Two O(n)
+	// uint32 slices replace one full copy per output column.
+	var probeIdx, buildIdx []uint32
+	hasProbeCols, hasBuildCols := false, false
+	for _, m := range mapping {
+		if m.fromProbe {
+			hasProbeCols = true
+		} else {
+			hasBuildCols = true
+		}
+	}
+	if hasProbeCols {
+		probeIdx = make([]uint32, n)
+		for i, pair := range pairs {
+			probeIdx[i] = uint32(pair.probeRow)
+		}
+	}
+	if hasBuildCols && singleBuild {
+		buildIdx = make([]uint32, n)
+		for i, pair := range pairs {
+			buildIdx[i] = uint32(pair.ref.rowIdx)
+		}
+	}
+
+	cols := make([]*batch.Vector, len(mapping))
+	viewCols := 0
+	for outColIdx, m := range mapping {
+		switch {
+		case m.fromProbe:
+			cols[outColIdx] = batch.NewViewVector(in.Columns[m.srcIdx], probeIdx)
+			viewCols++
+		case singleBuild:
+			v := batch.NewViewVector(h.buildBatches[0].Columns[m.srcIdx], buildIdx)
+			if !allMatched {
+				// Left-join null-fill: unmatched pairs carry a zero buildRef
+				// whose index value is meaningless — the view's own null bit
+				// masks it (Flatten and all view-aware readers honor it).
+				for i, pair := range pairs {
+					if !pair.matched {
+						v.Nulls.SetNull(i)
+					}
+				}
+			}
+			cols[outColIdx] = v
+			viewCols++
+		default:
+			dst := batch.NewColumnVector(outSchema[outColIdx], n)
+			gatherBuildVector(dst, m.srcIdx, pairs, h.buildBatches, allMatched)
+			cols[outColIdx] = dst
+		}
+	}
+
+	if hasProbeCols {
+		// Views reference the input's vectors: sever it from its pool so a
+		// recycle can't truncate the shared arenas mid-flight. GC reclaims
+		// it through the views' Base pointers once they die (the pipeline
+		// flattens before every non-view-aware consumer).
+		in.Detach()
+	}
+
+	LateMatBatchesEmitted.Add(1)
+	LateMatViewColumns.Add(int64(viewCols))
+	return &batch.RecordBatch{Columns: cols, Schema: outSchema, Len: n}
 }
 
 // inlineIntProbe is the fast probe path for single int key inner joins.
@@ -3000,6 +3102,7 @@ func (h *HashJoin) Close() error {
 func (p *HashJoinProbe) Clone() UnaryOperator {
 	c := p.join.Probe()
 	c.OutputFilter = p.OutputFilter
+	c.LateMaterialize = p.LateMaterialize
 	return c
 }
 

--- a/internal/engine/exec/join.go
+++ b/internal/engine/exec/join.go
@@ -1982,7 +1982,47 @@ func (p *HashJoinProbe) markKeyMatched(in *batch.RecordBatch, row int) {
 	}
 }
 
+// AcceptsViews marks the probe view-aware: Execute self-manages view input
+// via prepareViewInput — key columns (the only probe-side columns the probe
+// reads positionally) are flattened individually, pass-through columns stay
+// lazy and compose in emitViewOutput, and the paths that read or persist
+// arbitrary columns flatten everything. This is what makes a fused join
+// chain one-copy-per-column: join N's output views compose over join N-1's
+// bases instead of materializing between probes.
+func (p *HashJoinProbe) AcceptsViews() bool { return true }
+
+// prepareViewInput materializes exactly as much of a view-carrying input
+// batch as this probe's execution path will read.
+func (p *HashJoinProbe) prepareViewInput(in *batch.RecordBatch) {
+	h := p.join
+	// Paths that touch arbitrary probe columns must see owned storage:
+	// cross join gathers every column; SemiAntiFilter evaluates a compiled
+	// expression over unresolved column sets; grace partitioning writes
+	// whole probe rows to spill files; right/full outer take the eager
+	// gather path (they never emit views); inner/left without the flag
+	// likewise gather eagerly.
+	lazyKeys := h.SemiAntiFilter == nil &&
+		!(h.spillState != nil && len(h.spillState.spilledParts) > 0) &&
+		((p.LateMaterialize && (h.JoinType == InnerJoin || h.JoinType == LeftJoin)) ||
+			h.JoinType == SemiJoin || h.JoinType == AntiJoin ||
+			h.JoinType == RightSemiJoin || h.JoinType == RightAntiJoin)
+	if !lazyKeys {
+		FlattenForConsumer(in, nil)
+		return
+	}
+	h.resolveProbeKeyIdx(in)
+	for _, idx := range h.probeKeyIdx {
+		if idx >= 0 && in.Columns[idx].IsView() {
+			in.FlattenColumn(idx)
+			LateMatFlattens.Add(1)
+		}
+	}
+}
+
 func (p *HashJoinProbe) Execute(ctx context.Context, in *batch.RecordBatch) (*batch.RecordBatch, error) {
+	if in.HasViews() {
+		p.prepareViewInput(in)
+	}
 	if p.join.JoinType == CrossJoin {
 		outSchema := p.outputSchema(in.Schema)
 		return p.executeCrossJoin(in, outSchema)

--- a/internal/engine/exec/join_spill.go
+++ b/internal/engine/exec/join_spill.go
@@ -1309,6 +1309,7 @@ func (p *HashJoinProbe) openNextSpillPartition(ctx context.Context) error {
 	}
 	probe := tmpJoin.Probe()
 	probe.OutputFilter = p.join.spillOutputFilter
+	probe.LateMaterialize = p.LateMaterialize
 	if err := probe.Init(ctx); err != nil {
 		return fmt.Errorf("initialising probe for spilled partition %d: %w", partID, err)
 	}

--- a/internal/engine/exec/late_mat.go
+++ b/internal/engine/exec/late_mat.go
@@ -1,0 +1,64 @@
+package exec
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+)
+
+// Late-materialization runtime counters. Process-wide, monotonic — they exist
+// so every A/B arm can PROVE the treatment engaged (the dynamic-filter lesson:
+// a silent feature that never fires reads as a wash). Zero while the flag is
+// off is the dormancy assertion; >0 under the flag is the engagement marker.
+var (
+	// LateMatBatchesEmitted counts join-probe output batches emitted in view
+	// (reference) form instead of eagerly gathered.
+	LateMatBatchesEmitted atomic.Int64
+	// LateMatViewColumns counts view columns across those batches.
+	LateMatViewColumns atomic.Int64
+	// LateMatFlattens counts FlattenViews calls made on behalf of consumers
+	// that don't accept views — each one is a deferred gather finally paid.
+	LateMatFlattens atomic.Int64
+)
+
+// ViewAware marks an operator or sink that can consume batches containing
+// view (dictionary) columns directly — composing or reading through the
+// indirection — so the pipeline skips the defensive flatten in front of it.
+type ViewAware interface {
+	AcceptsViews() bool
+}
+
+// FlattenForConsumer materializes any view columns before handing the batch
+// to a consumer that hasn't declared view-awareness. This is the structural
+// correctness guarantee: no operator or sink ever sees a view unless it
+// opted in, so a missed call site degrades to an eager copy, never to
+// reading nil typed slices. Exported because manual operator-chain loops
+// exist outside this package (physical.pipelineSource, the worker fragment
+// runner) and must apply the same guard the Pipeline loops do.
+func FlattenForConsumer(b *batch.RecordBatch, consumer any) {
+	if b == nil || !b.HasViews() {
+		return
+	}
+	if va, ok := consumer.(ViewAware); ok && va.AcceptsViews() {
+		return
+	}
+	b.FlattenViews()
+	LateMatFlattens.Add(1)
+}
+
+// flattenSource wraps a Source so every pulled batch is view-free. It guards
+// consumers that pull directly from a Source outside any pipeline loop —
+// HashJoin.Build and its partition-on-arrival / key-only variants, which
+// retain or read typed storage from what they pull.
+type flattenSource struct {
+	inner Source
+}
+
+func (f *flattenSource) Init(ctx context.Context) error { return f.inner.Init(ctx) }
+func (f *flattenSource) Close() error                   { return f.inner.Close() }
+func (f *flattenSource) Next(ctx context.Context) (*batch.RecordBatch, error) {
+	b, err := f.inner.Next(ctx)
+	FlattenForConsumer(b, nil)
+	return b, err
+}

--- a/internal/engine/exec/late_mat_test.go
+++ b/internal/engine/exec/late_mat_test.go
@@ -1,0 +1,229 @@
+package exec
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+var lateMatBuildSchema = []parquet.Column{
+	{Name: "o_orderkey", Type: parquet.TypeInt64},
+	{Name: "o_comment", Type: parquet.TypeString},
+}
+
+var lateMatProbeSchema = []parquet.Column{
+	{Name: "l_orderkey", Type: parquet.TypeInt64},
+	{Name: "l_price", Type: parquet.TypeFloat64},
+	{Name: "l_ship", Type: parquet.TypeString},
+}
+
+func lateMatBuildRows() []map[string]any {
+	return []map[string]any{
+		{"o_orderkey": int64(1), "o_comment": "one"},
+		{"o_orderkey": int64(2), "o_comment": "two"},
+		{"o_orderkey": int64(3), "o_comment": ""},
+	}
+}
+
+func lateMatProbeRows() []map[string]any {
+	return []map[string]any{
+		{"l_orderkey": int64(2), "l_price": 20.5, "l_ship": "AIR"},
+		{"l_orderkey": int64(9), "l_price": 90.0, "l_ship": "RAIL"}, // no match
+		{"l_orderkey": int64(1), "l_price": 10.0, "l_ship": ""},
+		{"l_orderkey": int64(2), "l_price": 21.0, "l_ship": "SHIP"}, // dup key: 1:N with row 0
+	}
+}
+
+// runLateMatJoin builds the join once per invocation and probes a fresh
+// batch, returning the output rows. With lateMat the output must arrive as
+// views and match the eager rows exactly after FlattenViews.
+func runLateMatJoin(t *testing.T, joinType JoinType, lateMat bool) []map[string]any {
+	t.Helper()
+	hj := NewHashJoin(joinType, []string{"l_orderkey"}, []string{"o_orderkey"})
+	if err := hj.Build(context.Background(), NewSliceSource(lateMatBuildSchema, lateMatBuildRows())); err != nil {
+		t.Fatal(err)
+	}
+	hj.FixKeyAssignment()
+	probe := hj.Probe()
+	probe.LateMaterialize = lateMat
+	if err := probe.Init(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	out, err := probe.Execute(context.Background(), batch.FromRows(lateMatProbeSchema, lateMatProbeRows()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out == nil {
+		t.Fatal("expected output batch")
+	}
+	if lateMat {
+		if !out.HasViews() {
+			t.Fatal("late-mat output has no view columns")
+		}
+		out.FlattenViews()
+		if out.HasViews() {
+			t.Fatal("FlattenViews left views")
+		}
+	} else if out.HasViews() {
+		t.Fatal("eager output unexpectedly contains views")
+	}
+	return out.ToRows()
+}
+
+func TestLateMatInnerJoinParity(t *testing.T) {
+	before := LateMatBatchesEmitted.Load()
+	eager := runLateMatJoin(t, InnerJoin, false)
+	if LateMatBatchesEmitted.Load() != before {
+		t.Fatal("dormancy violated: counter moved with flag off")
+	}
+	lazy := runLateMatJoin(t, InnerJoin, true)
+	if LateMatBatchesEmitted.Load() == before {
+		t.Fatal("engagement marker did not move with flag on")
+	}
+	if !reflect.DeepEqual(eager, lazy) {
+		t.Fatalf("inner join parity broken:\neager=%v\nlazy =%v", eager, lazy)
+	}
+	if len(lazy) != 3 {
+		t.Fatalf("expected 3 inner rows, got %d", len(lazy))
+	}
+}
+
+func TestLateMatLeftJoinParity(t *testing.T) {
+	eager := runLateMatJoin(t, LeftJoin, false)
+	lazy := runLateMatJoin(t, LeftJoin, true)
+	if !reflect.DeepEqual(eager, lazy) {
+		t.Fatalf("left join parity broken:\neager=%v\nlazy =%v", eager, lazy)
+	}
+	if len(lazy) != 4 {
+		t.Fatalf("expected 4 left rows, got %d", len(lazy))
+	}
+	// The unmatched probe row must carry NULL build columns via the view's
+	// own null bitmap.
+	var sawUnmatched bool
+	for _, r := range lazy {
+		if r["l_orderkey"] == int64(9) {
+			sawUnmatched = true
+			if r["o_orderkey"] != nil || r["o_comment"] != nil {
+				t.Fatalf("unmatched row build cols not null: %v", r)
+			}
+		}
+	}
+	if !sawUnmatched {
+		t.Fatal("unmatched probe row missing from left join output")
+	}
+}
+
+func TestLateMatSemiAntiUnaffected(t *testing.T) {
+	// Semi/anti already return the input with a selection vector; the flag
+	// must not change that path (no views, no counter movement).
+	for _, jt := range []JoinType{SemiJoin, AntiJoin} {
+		hj := NewHashJoin(jt, []string{"l_orderkey"}, []string{"o_orderkey"})
+		if err := hj.Build(context.Background(), NewSliceSource(lateMatBuildSchema, lateMatBuildRows())); err != nil {
+			t.Fatal(err)
+		}
+		hj.FixKeyAssignment()
+		probe := hj.Probe()
+		probe.LateMaterialize = true
+		if err := probe.Init(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		before := LateMatBatchesEmitted.Load()
+		in := batch.FromRows(lateMatProbeSchema, lateMatProbeRows())
+		out, err := probe.Execute(context.Background(), in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out != nil && out.HasViews() {
+			t.Fatalf("%v emitted views", jt)
+		}
+		if LateMatBatchesEmitted.Load() != before {
+			t.Fatalf("%v moved the late-mat counter", jt)
+		}
+	}
+}
+
+// TestLateMatPipelineFlattensForSink runs a probe inside a Pipeline whose
+// sink is not view-aware: the defensive flatten must hand the sink an owned
+// batch, and the flatten counter must record the deferred gather.
+func TestLateMatPipelineFlattensForSink(t *testing.T) {
+	hj := NewHashJoin(InnerJoin, []string{"l_orderkey"}, []string{"o_orderkey"})
+	if err := hj.Build(context.Background(), NewSliceSource(lateMatBuildSchema, lateMatBuildRows())); err != nil {
+		t.Fatal(err)
+	}
+	hj.FixKeyAssignment()
+	probe := hj.Probe()
+	probe.LateMaterialize = true
+
+	sink := &CollectSink{}
+	pl := &Pipeline{
+		Source: NewSliceSource(lateMatProbeSchema, lateMatProbeRows()),
+		Ops:    []UnaryOperator{probe},
+		Sink:   sink,
+	}
+	flattensBefore := LateMatFlattens.Load()
+	if err := pl.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if LateMatFlattens.Load() == flattensBefore {
+		t.Fatal("pipeline did not flatten for the non-view-aware sink")
+	}
+	for _, b := range sink.Batches() {
+		if b.HasViews() {
+			t.Fatal("sink retained a batch with live views")
+		}
+	}
+	rows := sink.ToRows()
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 rows through pipeline, got %d", len(rows))
+	}
+}
+
+// TestLateMatProbeInputDetached verifies the probe severs its input from the
+// pool when views reference it — a pooled recycle would truncate the shared
+// arenas out from under the views.
+func TestLateMatProbeInputDetached(t *testing.T) {
+	hj := NewHashJoin(InnerJoin, []string{"l_orderkey"}, []string{"o_orderkey"})
+	if err := hj.Build(context.Background(), NewSliceSource(lateMatBuildSchema, lateMatBuildRows())); err != nil {
+		t.Fatal(err)
+	}
+	hj.FixKeyAssignment()
+	probe := hj.Probe()
+	probe.LateMaterialize = true
+	if err := probe.Init(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	pool := batch.NewBatchPool(lateMatProbeSchema, batch.DefaultBatchSize)
+	in := pool.Get()
+	for i, r := range lateMatProbeRows() {
+		for j, col := range lateMatProbeSchema {
+			in.Columns[j].SetValue(i, r[col.Name])
+		}
+	}
+	in.Len = len(lateMatProbeRows())
+	for _, c := range in.Columns {
+		c.Len = in.Len
+	}
+
+	out, err := probe.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !out.HasViews() {
+		t.Fatal("expected view output")
+	}
+	// The pipeline would call in.Release() here; after Detach it must be a
+	// no-op — the pool must NOT hand the batch out again while views live.
+	in.Release()
+	recycled := pool.Get()
+	if recycled == in {
+		t.Fatal("probe input recycled into the pool while views reference it")
+	}
+	out.FlattenViews()
+	if got := out.ToRows(); len(got) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(got))
+	}
+}

--- a/internal/engine/exec/late_mat_test.go
+++ b/internal/engine/exec/late_mat_test.go
@@ -227,3 +227,103 @@ func TestLateMatProbeInputDetached(t *testing.T) {
 		t.Fatalf("expected 3 rows, got %d", len(got))
 	}
 }
+
+// TestLateMatChainComposition drives a two-join chain probe-by-probe and
+// asserts the phase-3 property: join 2's pass-through view columns compose
+// straight back to the ORIGINAL scan batch's vectors (one copy per column,
+// paid at the final flatten), while only the column join 2 reads (its probe
+// key) is materialized in between.
+func TestLateMatChainComposition(t *testing.T) {
+	lineSchema := []parquet.Column{
+		{Name: "l_orderkey", Type: parquet.TypeInt64},
+		{Name: "l_price", Type: parquet.TypeFloat64},
+		{Name: "l_comment", Type: parquet.TypeString},
+	}
+	ordersSchema := []parquet.Column{
+		{Name: "o_orderkey", Type: parquet.TypeInt64},
+		{Name: "o_custkey", Type: parquet.TypeInt64},
+	}
+	custSchema := []parquet.Column{
+		{Name: "c_custkey", Type: parquet.TypeInt64},
+		{Name: "c_name", Type: parquet.TypeString},
+	}
+	lineRows := []map[string]any{
+		{"l_orderkey": int64(1), "l_price": 10.0, "l_comment": "a"},
+		{"l_orderkey": int64(2), "l_price": 20.0, "l_comment": "b"},
+		{"l_orderkey": int64(1), "l_price": 11.0, "l_comment": "c"},
+		{"l_orderkey": int64(3), "l_price": 30.0, "l_comment": "d"}, // no order match
+	}
+	orderRows := []map[string]any{
+		{"o_orderkey": int64(1), "o_custkey": int64(100)},
+		{"o_orderkey": int64(2), "o_custkey": int64(200)},
+	}
+	custRows := []map[string]any{
+		{"c_custkey": int64(100), "c_name": "alice"},
+		{"c_custkey": int64(200), "c_name": "bob"},
+	}
+
+	runChain := func(lateMat bool) ([]map[string]any, *batch.RecordBatch, *batch.RecordBatch, *batch.RecordBatch) {
+		hj1 := NewHashJoin(InnerJoin, []string{"l_orderkey"}, []string{"o_orderkey"})
+		if err := hj1.Build(context.Background(), NewSliceSource(ordersSchema, orderRows)); err != nil {
+			t.Fatal(err)
+		}
+		hj1.FixKeyAssignment()
+		p1 := hj1.Probe()
+		p1.LateMaterialize = lateMat
+
+		hj2 := NewHashJoin(InnerJoin, []string{"o_custkey"}, []string{"c_custkey"})
+		if err := hj2.Build(context.Background(), NewSliceSource(custSchema, custRows)); err != nil {
+			t.Fatal(err)
+		}
+		hj2.FixKeyAssignment()
+		p2 := hj2.Probe()
+		p2.LateMaterialize = lateMat
+
+		in := batch.FromRows(lineSchema, lineRows)
+		out1, err := p1.Execute(context.Background(), in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		out2, err := p2.Execute(context.Background(), out1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		out2.FlattenViews()
+		return out2.ToRows(), in, out1, out2
+	}
+
+	eager, _, _, _ := runChain(false)
+
+	flattensBefore := LateMatFlattens.Load()
+	lazy, in, out1, out2 := runChain(true)
+	_ = out2
+	if !reflect.DeepEqual(eager, lazy) {
+		t.Fatalf("chain parity broken:\neager=%v\nlazy =%v", eager, lazy)
+	}
+	if len(lazy) != 3 {
+		t.Fatalf("expected 3 chained rows, got %d", len(lazy))
+	}
+
+	// Probe 2 must have flattened out1's o_custkey (its key) and nothing else.
+	custKeyIdx := out1.ColumnIndex("o_custkey")
+	priceIdx := out1.ColumnIndex("l_price")
+	if out1.Columns[custKeyIdx].IsView() {
+		t.Fatal("probe 2 did not flatten its key column")
+	}
+	if !out1.Columns[priceIdx].IsView() {
+		t.Fatal("probe 2 flattened a pass-through column — composition lost")
+	}
+	// LateMatFlattens: exactly 1 — probe 2's key column. The final
+	// FlattenViews above is a direct batch call, not a counted consumer
+	// flatten, and no pass-through column may have been materialized.
+	if got := LateMatFlattens.Load() - flattensBefore; got != 1 {
+		t.Fatalf("expected exactly 1 flatten event (probe-2 key), got %d", got)
+	}
+	// The composed pass-through view must reference the ORIGINAL input's
+	// vector, not join 1's output — that identity IS the one-copy property.
+	// (out2 was flattened for row comparison; re-run the composition check
+	// against a fresh probe on the still-lazy out1.)
+	if out1.Columns[priceIdx].Base != in.Columns[in.ColumnIndex("l_price")] {
+		t.Fatal("pass-through view does not compose back to the original batch")
+	}
+}

--- a/internal/engine/exec/limit.go
+++ b/internal/engine/exec/limit.go
@@ -26,6 +26,10 @@ func (l *Limit) Init(_ context.Context) error {
 	return nil
 }
 
+// AcceptsViews: Limit manipulates only the selection vector and row counts —
+// it never reads column storage, so view columns pass through untouched.
+func (l *Limit) AcceptsViews() bool { return true }
+
 func (l *Limit) Execute(_ context.Context, in *batch.RecordBatch) (*batch.RecordBatch, error) {
 	if l.passed.Load() >= l.Max {
 		return nil, nil

--- a/internal/engine/exec/pipeline.go
+++ b/internal/engine/exec/pipeline.go
@@ -91,6 +91,7 @@ func (p *Pipeline) runSerial(ctx context.Context) error {
 		exhausted := false
 		for _, op := range p.Ops {
 			prev := b
+			FlattenForConsumer(b, op)
 			b, err = op.Execute(ctx, b)
 			if err != nil {
 				return fmt.Errorf("operator execute: %w", err)
@@ -109,6 +110,7 @@ func (p *Pipeline) runSerial(ctx context.Context) error {
 		}
 
 		if b != nil {
+			FlattenForConsumer(b, p.Sink)
 			if err := p.Sink.Consume(ctx, b); err != nil {
 				return fmt.Errorf("sink consume: %w", err)
 			}
@@ -148,6 +150,7 @@ func (p *Pipeline) flushSpilledOps(ctx context.Context, ops []UnaryOperator) err
 			}
 			for _, rop := range remainingOps {
 				prev := b
+				FlattenForConsumer(b, rop)
 				b, err = rop.Execute(ctx, b)
 				if err != nil {
 					return fmt.Errorf("operator execute (flush): %w", err)
@@ -160,6 +163,7 @@ func (p *Pipeline) flushSpilledOps(ctx context.Context, ops []UnaryOperator) err
 				}
 			}
 			if b != nil {
+				FlattenForConsumer(b, p.Sink)
 				if err := p.Sink.Consume(ctx, b); err != nil {
 					return fmt.Errorf("sink consume (flush): %w", err)
 				}
@@ -191,6 +195,7 @@ func (p *Pipeline) runParallel(ctx context.Context) error {
 		exhausted := false
 		for _, op := range p.Ops {
 			prev := b
+			FlattenForConsumer(b, op)
 			b, err = op.Execute(ctx, b)
 			if err != nil {
 				return fmt.Errorf("operator execute: %w", err)
@@ -206,6 +211,7 @@ func (p *Pipeline) runParallel(ctx context.Context) error {
 			}
 		}
 		if b != nil {
+			FlattenForConsumer(b, p.Sink)
 			if err := p.Sink.Consume(ctx, b); err != nil {
 				return fmt.Errorf("sink consume: %w", err)
 			}
@@ -328,6 +334,7 @@ func (p *Pipeline) runParallel(ctx context.Context) error {
 				exhausted := false
 				for _, op := range ops {
 					prev := b
+					FlattenForConsumer(b, op)
 					b, err = op.Execute(workerCtx, b)
 					if err != nil {
 						firstErr.CompareAndSwap(nil, fmt.Errorf("operator execute: %w", err))
@@ -346,6 +353,7 @@ func (p *Pipeline) runParallel(ctx context.Context) error {
 				}
 
 				if b != nil {
+					FlattenForConsumer(b, sink)
 					if err := sink.Consume(workerCtx, b); err != nil {
 						firstErr.CompareAndSwap(nil, fmt.Errorf("sink consume: %w", err))
 						cancel()
@@ -526,6 +534,7 @@ func (s *BatchSink) Init(_ context.Context) error {
 
 func (s *BatchSink) Consume(_ context.Context, b *batch.RecordBatch) error {
 	s.mu.Lock()
+	FlattenForConsumer(b, nil) // retained past the batch cycle: views must not survive
 	b.Detach()
 	// Snapshot the selection vector. Many UnaryOperators (KernelFilter,
 	// AndFilter, OrFilter, the comparison/expression filters) reuse a
@@ -591,7 +600,8 @@ func (s *CollectSink) Consume(_ context.Context, b *batch.RecordBatch) error {
 	if s.schema == nil {
 		s.schema = b.Schema
 	}
-	b.Detach() // prevent pool recycle — pipeline calls Release() after Consume()
+	FlattenForConsumer(b, nil) // retained past the batch cycle: views must not survive
+	b.Detach()                 // prevent pool recycle — pipeline calls Release() after Consume()
 	// Snapshot the selection vector — see BatchSink.Consume for the full
 	// rationale. Filter operators reuse outSel across calls; sinks that
 	// hold batches across calls would otherwise see clobbered Sel data.

--- a/internal/engine/exec/sort.go
+++ b/internal/engine/exec/sort.go
@@ -88,7 +88,8 @@ func (s *Sort) Consume(_ context.Context, b *batch.RecordBatch) error {
 			s.unregisterAccounted = s.Spill.RegisterAccounted(s)
 		}
 	}
-	b.Detach() // prevent pool recycle — pipeline calls Release() after Consume()
+	FlattenForConsumer(b, nil) // retained past the batch cycle: views must not survive
+	b.Detach()                 // prevent pool recycle — pipeline calls Release() after Consume()
 	s.batches = append(s.batches, b)
 	s.totalRows += b.ActiveLen()
 

--- a/internal/engine/exec/sort_merge_join.go
+++ b/internal/engine/exec/sort_merge_join.go
@@ -230,6 +230,7 @@ func (j *SortMergeJoin) Consume(_ context.Context, b *batch.RecordBatch) error {
 func (j *SortMergeJoin) consume(side *smjSide, b *batch.RecordBatch) error {
 	j.mu.Lock()
 	defer j.mu.Unlock()
+	FlattenForConsumer(b, nil) // retained past the batch cycle: views must not survive
 	if side.schema == nil {
 		// Resolve the side's key names against the actual schema before
 		// anything sorts by them: the planner emits SQL-qualified names

--- a/internal/engine/exec/window.go
+++ b/internal/engine/exec/window.go
@@ -126,7 +126,8 @@ func (w *Window) Consume(_ context.Context, b *batch.RecordBatch) error {
 	if w.schema == nil {
 		w.schema = b.Schema
 	}
-	b.Detach() // prevent pool recycle — pipeline calls Release() after Consume()
+	FlattenForConsumer(b, nil) // retained past the batch cycle: views must not survive
+	b.Detach()                 // prevent pool recycle — pipeline calls Release() after Consume()
 	w.batches = append(w.batches, b)
 	w.totalRows += b.ActiveLen()
 

--- a/internal/planner/physical/late_mat.go
+++ b/internal/planner/physical/late_mat.go
@@ -1,0 +1,24 @@
+package physical
+
+import (
+	"sync/atomic"
+
+	"github.com/citc-tech/wadjet/internal/engine/exec"
+)
+
+// LateMatJoinsPlanned counts local-pipeline hash-join probes planned with
+// late materialization enabled. Observability-first, mirroring
+// SortMergeJoinsPlanned: dormancy tests assert it stays zero with the flag
+// off, and A/B arms use it (with exec.LateMatBatchesEmitted) to prove the
+// treatment engaged rather than inferring from wall-clock deltas.
+var LateMatJoinsPlanned atomic.Int64
+
+// applyLateMaterialization stamps a planned probe with the planner's
+// late-materialization setting and records the engagement marker.
+func (p *Planner) applyLateMaterialization(probe *exec.HashJoinProbe) {
+	if !p.LateMaterialization {
+		return
+	}
+	probe.LateMaterialize = true
+	LateMatJoinsPlanned.Add(1)
+}

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -356,6 +356,12 @@ type Planner struct {
 	// tracks cluster memory.
 	SortMergeJoinBytes int64
 
+	// LateMaterialization emits inner/left hash-join output as view
+	// (dictionary) columns over the probe input and build batches; the
+	// gather is deferred to the first consumer needing owned storage
+	// (docs/design/late-materialization.md). Off by default.
+	LateMaterialization bool
+
 	// DynamicFiltersEnabled gates the Trino-style dynamic-filter planner
 	// pass. When true, applyDynamicFilters annotates eligible hash_join
 	// build/probe leaf scans with Emit/Consume specs and adds the stat-dep
@@ -4076,6 +4082,7 @@ func (p *Planner) buildJoin(ctx context.Context, node *logical.Node) (exec.Sourc
 		// from its join key values, inject as filter on build-side scan, then
 		// signal the build goroutine to start with the filtered scan.
 		probe := hj.Probe()
+		p.applyLateMaterialization(probe)
 		if len(node.NeededColumns) > 0 {
 			filter := make(map[string]bool, len(node.NeededColumns))
 			for _, col := range node.NeededColumns {
@@ -4106,6 +4113,7 @@ func (p *Planner) buildJoin(ctx context.Context, node *logical.Node) (exec.Sourc
 		// filtered batches, waits for the build barrier, then replays them
 		// through the deferred probe operators.
 		probe := hj.Probe()
+		p.applyLateMaterialization(probe)
 		if len(node.NeededColumns) > 0 {
 			filter := make(map[string]bool, len(node.NeededColumns))
 			for _, col := range node.NeededColumns {
@@ -4176,6 +4184,7 @@ func (p *Planner) buildJoin(ctx context.Context, node *logical.Node) (exec.Sourc
 		attachDynamicFilterToScanSource(leftSource, ranges)
 	}
 	probe := hj.Probe()
+	p.applyLateMaterialization(probe)
 	// Push output filter into the probe to avoid materializing intermediate
 	// columns not needed by upstream operators. In multi-way joins, this
 	// eliminates allocation and gather work for columns that would otherwise
@@ -4771,6 +4780,7 @@ func (ps *pipelineSource) Next(ctx context.Context) (*batch.RecordBatch, error) 
 			return b, err
 		}
 		for _, op := range ps.ops {
+			exec.FlattenForConsumer(b, op)
 			b, err = op.Execute(ctx, b)
 			if err != nil {
 				return nil, err

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -55,6 +55,7 @@ type Config struct {
 	QueryLimits        *config.QueryLimits      // global cost-based query limits (nil = unlimited)
 	RoleLimits         map[string]*config.QueryLimits // per-role overrides (nil = use global)
 	SortMergeJoinBytes int64                    // local sort-merge-join gate (0 = disabled)
+	LateMaterialization bool                    // view-column join output, deferred gather (default off)
 }
 
 // Server is the Wadjet HTTP API server.
@@ -135,6 +136,7 @@ func (s *Server) Mux() chi.Router {
 func (s *Server) newPlanner() *physical.Planner {
 	p := physical.NewPlanner(s.catalog)
 	p.SortMergeJoinBytes = s.config.SortMergeJoinBytes
+	p.LateMaterialization = s.config.LateMaterialization
 	return p
 }
 

--- a/internal/worker/executor_fragment.go
+++ b/internal/worker/executor_fragment.go
@@ -401,6 +401,7 @@ func (e *Executor) runFragmentLinear(ctx context.Context, task distributed.Task,
 			cur := b
 			var err error
 			for _, op := range ops {
+				exec.FlattenForConsumer(cur, op)
 				cur, err = op.Execute(gctx, cur)
 				if err != nil {
 					return fmt.Errorf("unary exec: %w", err)
@@ -556,6 +557,7 @@ func (e *Executor) runFragmentLinearParallel(ctx context.Context, task distribut
 	if warmup != nil {
 		cur := warmup
 		for _, op := range ops {
+			exec.FlattenForConsumer(cur, op)
 			cur, err = op.Execute(ctx, cur)
 			if err != nil {
 				return fmt.Errorf("fragment task %s: unary exec: %w", task.ID, err)
@@ -616,6 +618,7 @@ func (e *Executor) runFragmentLinearParallel(ctx context.Context, task distribut
 			cur := b
 			var err error
 			for _, op := range chain {
+				exec.FlattenForConsumer(cur, op)
 				cur, err = op.Execute(ctx, cur)
 				if err != nil {
 					return nil, fmt.Errorf("unary exec: %w", err)
@@ -754,6 +757,7 @@ func (e *Executor) runBreakerConsumeParallel(ctx context.Context, task distribut
 		cur := b
 		var err error
 		for _, op := range chain {
+			exec.FlattenForConsumer(cur, op)
 			cur, err = op.Execute(ctx, cur)
 			if err != nil {
 				return nil, fmt.Errorf("unary exec: %w", err)
@@ -994,6 +998,7 @@ func drainFlushableOps(ctx context.Context, ops []exec.UnaryOperator, snapshotSe
 			}
 			cur := b
 			for _, dop := range downstream {
+				exec.FlattenForConsumer(cur, dop)
 				cur, err = dop.Execute(ctx, cur)
 				if err != nil {
 					return err
@@ -1180,6 +1185,7 @@ func (e *Executor) runFragmentWithBreakers(ctx context.Context, task distributed
 			}
 		}
 		for _, op := range finalOps {
+			exec.FlattenForConsumer(cur, op)
 			cur, err = op.Execute(ctx, cur)
 			if err != nil {
 				return fmt.Errorf("fragment task %s: post-breaker exec: %w", task.ID, err)
@@ -1250,6 +1256,7 @@ func drainThroughBreaker(ctx context.Context, src exec.Source, xform func(*batch
 			}
 		}
 		for _, op := range ops {
+			exec.FlattenForConsumer(cur, op)
 			cur, err = op.Execute(ctx, cur)
 			if err != nil {
 				return err
@@ -1761,6 +1768,7 @@ func (e *Executor) buildFragmentJoinProbe(ctx context.Context, task distributed.
 	}
 
 	probe := hj.Probe()
+	probe.LateMaterialize = spec.LateMaterialize
 	if len(spec.OutputColumns) > 0 {
 		filter := make(map[string]bool, len(spec.OutputColumns))
 		for _, c := range spec.OutputColumns {
@@ -1850,6 +1858,7 @@ type fragmentExchangeSink struct {
 }
 
 func (s *fragmentExchangeSink) consume(ctx context.Context, b *batch.RecordBatch) error {
+	exec.FlattenForConsumer(b, s) // serializes typed storage: views must resolve here
 	s.initMu.Lock()
 	if s.sink == nil {
 		sink := newPartitionedShuffleSink(s.spillDir, s.shuffleKeys, s.numParts, b.Schema)
@@ -1891,6 +1900,7 @@ type fragmentUnpartitionedSink struct {
 }
 
 func (s *fragmentUnpartitionedSink) consume(ctx context.Context, b *batch.RecordBatch) error {
+	exec.FlattenForConsumer(b, s) // serializes typed storage: views must resolve here
 	return s.sink.Consume(ctx, b)
 }
 
@@ -1918,6 +1928,7 @@ type fragmentGatherSink struct {
 }
 
 func (s *fragmentGatherSink) consume(ctx context.Context, b *batch.RecordBatch) error {
+	exec.FlattenForConsumer(b, s) // serializes typed storage: views must resolve here
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if !s.finished {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -1325,6 +1325,14 @@ func (w *Worker) executeIncomingTask(ctx context.Context, task distributed.Task,
 	if result.Error != "" {
 		logAttrsEnd = append(logAttrsEnd, "error", result.Error)
 	}
+	// Late-materialization engagement marker (cumulative per process,
+	// monotonic): lets an A/B arm prove from worker logs that view batches
+	// were actually emitted, instead of inferring from wall-clock deltas.
+	// Zero-valued attrs are omitted so flag-off logs are byte-identical.
+	if emitted := exec.LateMatBatchesEmitted.Load(); emitted > 0 {
+		logAttrsEnd = append(logAttrsEnd, "late_mat_batches", emitted,
+			"late_mat_flattens", exec.LateMatFlattens.Load())
+	}
 	w.logger.Info("task completed", logAttrsEnd...)
 }
 

--- a/wadjet/wadjet.go
+++ b/wadjet/wadjet.go
@@ -37,6 +37,7 @@ type DB struct {
 	alertScheduler     *alerts.Scheduler // non-nil when EnableAlerts is set
 	alertSchedulerStop context.CancelFunc
 	sortMergeJoinBytes int64
+	lateMaterialization bool
 }
 
 // Config holds configuration for creating a DB instance.
@@ -52,6 +53,10 @@ type Config struct {
 	// estimated size through the sort-merge join instead of the hash join
 	// (docs/design/sort-merge-join.md). 0 = disabled (default).
 	SortMergeJoinBytes int64
+	// LateMaterialization emits inner/left hash-join output as view
+	// (dictionary) columns with the gather deferred to first touch
+	// (docs/design/late-materialization.md). Off by default.
+	LateMaterialization bool
 	// EnableAlerts turns on the CREATE ALERT scheduler in embedded mode.
 	// When true, Open() creates a Scheduler that evaluates alerts on cadence.
 	EnableAlerts bool
@@ -82,6 +87,7 @@ func Open(ctx context.Context, cfg Config) (*DB, error) {
 		logger:             cfg.Logger,
 		authProvider:       cfg.AuthProvider,
 		sortMergeJoinBytes: cfg.SortMergeJoinBytes,
+		lateMaterialization: cfg.LateMaterialization,
 	}
 
 	if cfg.EnableAlerts {
@@ -154,6 +160,7 @@ func (db *DB) newPlanner() *physical.Planner {
 	p.MemoryBudget = db.memoryBudget
 	p.SpillDir = db.spillDir
 	p.SortMergeJoinBytes = db.sortMergeJoinBytes
+	p.LateMaterialization = db.lateMaterialization
 	return p
 }
 


### PR DESCRIPTION
## What

Implements phases 1–3 of `docs/design/late-materialization.md` (memo included in this PR):

1. **View (dictionary) vector primitive** (`batch`): `Vector` gains an optional `Base + Indices` form with an own-null override bitmap. `Flatten()` is literally today's gather moved to first touch (typed kernels, bytes arena pre-sized); `NewViewVector` composes view-over-view so views never chain. Generic accessors are view-aware; typed hot-path accessors fail loud (nil slices). Zero behavior change.
2. **Flag-gated emission** (`--late-materialization`, default off): inner/left `HashJoinProbe` emits view columns over the probe input and single-batch build — two shared uint32 index slices instead of one copy per column. `FlattenForConsumer` guards every batch-drive loop and retaining/serializing boundary, so a missed site degrades to an eager copy, never to wrong results. The flag rides the join-probe OpSpec, so the coordinator controls workers — no worker flag.
3. **Chain composition**: the probe is view-aware — it flattens only its key columns; pass-through columns compose index arrays through fused join chains. A column crossing k joins is copied once, at its final consumer; rows eliminated by later probes are never copied.

## Observability (the dynamic-filter lesson)

`physical.LateMatJoinsPlanned`, `exec.LateMatBatchesEmitted/ViewColumns/Flattens`, and a cumulative `late_mat_batches` attr on worker task-completed logs — every future A/B arm can prove engagement from logs instead of inferring from wall deltas.

## Evidence

- Fresh SF1 profile (main a76c083): join-output materialization = **~7.5% of query-phase CPU**, the #1 operator cost (the roadmap's undocumented "~13% memmove" claim replaced with measured data).
- SF1 pair on this branch: wall flat (64.1s vs 64.4s), probe-side `gatherVector` eliminated, probe `memmove` halved; deferred cost lands in `Vector.Flatten` at consumers as designed. Single-hop flattens dominate at SF1 — the chain/GC payoff is the SF10/SF100 question (deploy-gated, not in this PR).

## Gates

- `batch`/`exec` unit tests incl. all-22-types view round-trip, `-race` clean
- Forced-on SF0.01: 22/22 row-identical (strict, no tolerance), 63 joins planned, 168 view batches emitted
- Default SF0.01: pass, counters frozen (dormancy)
- `tpch-harness --mode=local`: PASS both arms; forced arm worker logs show `late_mat_batches=47`
- Full `./internal/...` + `./wadjet` suites
- Chain-composition test pins pointer identity to the original batch + exactly one intermediate flatten

## Not in this PR (queued)

- Phase 4: view-aware shuffle `writeChunk` (serialize through indices — free final gather for distributed fragments)
- Phase 5: SF10/SF100 same-window pairs, then default-on decision
- Noted follow-up: a panic during `HashJoin.buildPartitioned` deadlocks in the deferred accounting `Inspect` (pre-existing; panics in build present as hangs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZaEw6PKU9Lq8cGJu3KM6K