### PR TITLE
feat(worker): late-mat phase 4 — serialize view columns through shuffle writers

### DIFF
--- a/internal/engine/exec/join.go
+++ b/internal/engine/exec/join.go
@@ -668,6 +668,25 @@ func hashBuildBytes(b *batch.RecordBatch) int64 {
 	return b.MemBytes() + int64(b.Len)*40
 }
 
+// warmBuildNullBitmaps forces Bitmap.HasNulls memoization on every stored
+// build column at build completion — the last single-threaded point. View
+// output batches share these vectors as bases across concurrently-consumed
+// batches (morsel-parallel sinks, per-partition append bursts), and
+// HasNulls' lazy first-call write would otherwise race between consumers.
+func (h *HashJoin) warmBuildNullBitmaps() {
+	for _, b := range h.buildBatches {
+		if b == nil {
+			continue // partition-on-arrival: spilled partitions leave nil slots
+		}
+		for _, col := range b.Columns {
+			if col == nil {
+				continue
+			}
+			_ = col.Nulls.HasNulls()
+		}
+	}
+}
+
 // Build consumes all rows from the build (right) side into the columnar hash table.
 // Uses parallel workers when the build side is large enough to benefit from
 // concurrent hash table construction with per-worker local tables.
@@ -1025,6 +1044,7 @@ func (h *HashJoin) Build(ctx context.Context, source Source) error {
 	// the per-batch tracking loop. Charge them to the memory tracker.
 	h.reconcileHashMemory()
 
+	h.warmBuildNullBitmaps()
 	h.buildDone = true
 	return nil
 }
@@ -1671,6 +1691,7 @@ func (h *HashJoin) BuildFromRows(schema []parquet.Column, rows []map[string]any)
 		h.arenaMatched = make([]bool, len(h.arena))
 	}
 	h.buildBloom()
+	h.warmBuildNullBitmaps()
 	h.buildDone = true
 }
 

--- a/internal/engine/exec/join_partition_arrival.go
+++ b/internal/engine/exec/join_partition_arrival.go
@@ -168,6 +168,7 @@ func (h *HashJoin) buildPartitioned(ctx context.Context, source Source) error {
 	h.buildBloom()
 	h.reconcileHashMemory()
 
+	h.warmBuildNullBitmaps()
 	h.buildDone = true
 	return nil
 }

--- a/internal/engine/exec/join_spill.go
+++ b/internal/engine/exec/join_spill.go
@@ -1011,6 +1011,7 @@ func (h *HashJoin) buildTempJoinFromBatches(buildBatches []*batch.RecordBatch) (
 		tmpJoin.arenaMatched = make([]bool, len(tmpJoin.arena))
 	}
 	tmpJoin.buildBloom()
+	tmpJoin.warmBuildNullBitmaps()
 	tmpJoin.buildDone = true
 	return tmpJoin, nil
 }

--- a/internal/engine/exec/late_mat.go
+++ b/internal/engine/exec/late_mat.go
@@ -20,6 +20,10 @@ var (
 	// LateMatFlattens counts FlattenViews calls made on behalf of consumers
 	// that don't accept views — each one is a deferred gather finally paid.
 	LateMatFlattens atomic.Int64
+	// LateMatViewColumnsSerialized counts view columns serialized straight
+	// through their indirection by the shuffle writers (no flatten copy at
+	// all) — the phase-4 engagement marker.
+	LateMatViewColumnsSerialized atomic.Int64
 )
 
 // ViewAware marks an operator or sink that can consume batches containing

--- a/internal/worker/executor_fragment.go
+++ b/internal/worker/executor_fragment.go
@@ -1858,7 +1858,6 @@ type fragmentExchangeSink struct {
 }
 
 func (s *fragmentExchangeSink) consume(ctx context.Context, b *batch.RecordBatch) error {
-	exec.FlattenForConsumer(b, s) // serializes typed storage: views must resolve here
 	s.initMu.Lock()
 	if s.sink == nil {
 		sink := newPartitionedShuffleSink(s.spillDir, s.shuffleKeys, s.numParts, b.Schema)
@@ -1900,7 +1899,6 @@ type fragmentUnpartitionedSink struct {
 }
 
 func (s *fragmentUnpartitionedSink) consume(ctx context.Context, b *batch.RecordBatch) error {
-	exec.FlattenForConsumer(b, s) // serializes typed storage: views must resolve here
 	return s.sink.Consume(ctx, b)
 }
 
@@ -1928,7 +1926,6 @@ type fragmentGatherSink struct {
 }
 
 func (s *fragmentGatherSink) consume(ctx context.Context, b *batch.RecordBatch) error {
-	exec.FlattenForConsumer(b, s) // serializes typed storage: views must resolve here
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if !s.finished {

--- a/internal/worker/partitioned_shuffle_sink.go
+++ b/internal/worker/partitioned_shuffle_sink.go
@@ -112,6 +112,12 @@ func newPartitionedShuffleSink(spillDir string, keys []string, numParts int, sch
 	}
 }
 
+// AcceptsViews: Consume normalizes view columns itself (key and own-null
+// columns flatten single-threaded before the per-partition fan-out; the
+// rest serialize through appendBatchRowsBulk's row translation, copy-free),
+// so the pipeline's defensive flatten is unnecessary.
+func (s *partitionedShuffleSink) AcceptsViews() bool { return true }
+
 // Init creates the per-partition spill files.
 func (s *partitionedShuffleSink) Init(_ context.Context) error {
 	if s.spillDir == "" {
@@ -165,6 +171,27 @@ func (s *partitionedShuffleSink) Consume(_ context.Context, b *batch.RecordBatch
 		return s.keyErr
 	}
 
+	if b.HasViews() {
+		// Normalize views single-threaded, before the per-partition goroutine
+		// fan-out: the hash pass below reads key columns positionally, and
+		// own-null views (outer-join fill) can't ride appendBatchRowsBulk's
+		// per-column row translation — flattening either inside the burst
+		// goroutines would race on the shared vectors. Remaining views defer
+		// nulls to their base and serialize through the translation, copy-free.
+		for _, ki := range s.keyIdxs {
+			if b.Columns[ki].IsView() {
+				b.FlattenColumn(ki)
+				exec.LateMatFlattens.Add(1)
+			}
+		}
+		for _, col := range b.Columns {
+			if col.IsView() && col.Nulls.HasNulls() {
+				col.Flatten()
+				exec.LateMatFlattens.Add(1)
+			}
+		}
+	}
+
 	// Vectorized partition assignment: one pass per key column over the
 	// active rows, mixing into a per-row hash accumulator. Pre-2026-04-30
 	// this code did `fnv.New64a()` per row → 1M heap allocations of the
@@ -214,6 +241,11 @@ func (s *partitionedShuffleSink) Consume(_ context.Context, b *batch.RecordBatch
 	// batches.
 	for _, col := range b.Columns {
 		_ = col.Nulls.HasNulls()
+		if col.Base != nil {
+			// View columns read their base's bitmap in the per-partition
+			// appends — warm that memoization too.
+			_ = col.Base.Nulls.HasNulls()
+		}
 	}
 
 	// Small consumes skip the goroutine fan-out below: with ~24 partitions a
@@ -324,19 +356,37 @@ func (s *partitionedShuffleSink) appendRowsBulkLocked(p int, b *batch.RecordBatc
 // types only — the switch (like growBatchTo) has no Array/Map/Row/Vector
 // arms. Shared by the partition writers and the unpartitioned stage sink's
 // chunk-coalescing accumulator.
-func appendBatchRowsBulk(dst *batch.RecordBatch, b *batch.RecordBatch, rows []int) int {
+func appendBatchRowsBulk(dst *batch.RecordBatch, b *batch.RecordBatch, srcRows []int) int {
 	start := dst.Len
-	end := start + len(rows)
+	end := start + len(srcRows)
 
 	// Pre-grow all column storage to fit `end` rows in one allocation per
 	// column (versus one append-of-one per row in the old code).
 	growBatchTo(dst, end)
 
 	bytesAdded := 0
-	nRows := len(rows)
+	nRows := len(srcRows)
 
+	var viewRows []int // lazy scratch for view-column row translation
 	for ci, srcCol := range b.Columns {
 		dstCol := dst.Columns[ci]
+		rows := srcRows
+		if srcCol.Base != nil {
+			// View column (own-null views were normalized by the caller's
+			// single-threaded Consume): translate the row list through the
+			// view's indices so every typed arm below reads the base
+			// directly — one copy, straight into the accumulator, instead
+			// of a flatten copy followed by this copy.
+			if viewRows == nil {
+				viewRows = make([]int, nRows)
+			}
+			for i, r := range srcRows {
+				viewRows[i] = int(srcCol.Indices[r])
+			}
+			srcCol = srcCol.Base
+			rows = viewRows
+			exec.LateMatViewColumnsSerialized.Add(1)
+		}
 		hasNulls := srcCol.Nulls.HasNulls()
 		switch dstCol.Type {
 		case parquet.TypeBool:

--- a/internal/worker/shuffle_format.go
+++ b/internal/worker/shuffle_format.go
@@ -10,6 +10,7 @@ import (
 	"unsafe"
 
 	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/engine/exec"
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
 )
 
@@ -37,11 +38,12 @@ var shuffleMagic = [4]byte{'W', 'S', 'H', 'F'}
 
 // shuffleWriter writes RecordBatch chunks in columnar binary format.
 type shuffleWriter struct {
-	w         io.Writer
-	schema    []parquet.Column
-	numChunks uint32
-	buf       []byte // reusable scratch buffer
-	gatherBuf []byte // reusable buffer for gathering selected rows
+	w              io.Writer
+	schema         []parquet.Column
+	numChunks      uint32
+	buf            []byte   // reusable scratch buffer
+	gatherBuf      []byte   // reusable buffer for gathering selected rows
+	viewSelScratch []uint32 // reusable composed selection for view columns
 }
 
 func newShuffleWriter(w io.Writer, schema []parquet.Column) *shuffleWriter {
@@ -109,6 +111,15 @@ func (sw *shuffleWriter) writeHeader() error {
 
 // writeChunk writes a batch of selected rows as a columnar chunk.
 // sel contains the row indices to write; if nil, writes all rows.
+//
+// View (dictionary) columns serialize straight through their indirection:
+// the writer already gathers rows via sel, so a view without an own-null
+// override is just its base with the selection composed through Indices —
+// the final copy the view deferred simply becomes this encode, with no
+// flatten in between. Own-null views (outer-join fill) can't ride the
+// composition because their null bits override the base's; those columns
+// flatten in place (every caller serializes a batch under its own lock, so
+// the in-place mutation is single-threaded).
 func (sw *shuffleWriter) writeChunk(cols []*batch.Vector, sel []uint32, numRows int) error {
 	sw.numChunks++
 
@@ -120,11 +131,39 @@ func (sw *shuffleWriter) writeChunk(cols []*batch.Vector, sel []uint32, numRows 
 
 	for ci := range sw.schema {
 		vec := cols[ci]
-		if err := sw.writeColumnData(vec, sel, numRows, sw.schema[ci].Type); err != nil {
+		colSel := sel
+		if vec.Base != nil {
+			if vec.Nulls.HasNulls() {
+				vec.Flatten()
+				exec.LateMatFlattens.Add(1)
+			} else {
+				colSel = sw.composeViewSel(vec.Indices, sel, numRows)
+				vec = vec.Base
+				exec.LateMatViewColumnsSerialized.Add(1)
+			}
+		}
+		if err := sw.writeColumnData(vec, colSel, numRows, sw.schema[ci].Type); err != nil {
 			return fmt.Errorf("writing column %d (%s): %w", ci, sw.schema[ci].Name, err)
 		}
 	}
 	return nil
+}
+
+// composeViewSel resolves a view column's effective selection against its
+// base: with no caller selection the view's index array IS the selection;
+// otherwise compose element-wise into a reusable scratch.
+func (sw *shuffleWriter) composeViewSel(indices, sel []uint32, numRows int) []uint32 {
+	if sel == nil {
+		return indices[:numRows]
+	}
+	if cap(sw.viewSelScratch) < len(sel) {
+		sw.viewSelScratch = make([]uint32, len(sel))
+	}
+	out := sw.viewSelScratch[:len(sel)]
+	for i, si := range sel {
+		out[i] = indices[si]
+	}
+	return out
 }
 
 func (sw *shuffleWriter) writeColumnData(vec *batch.Vector, sel []uint32, numRows int, typ parquet.TypeID) error {

--- a/internal/worker/shuffle_views_test.go
+++ b/internal/worker/shuffle_views_test.go
@@ -1,0 +1,209 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/engine/exec"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+var viewTestSchema = []parquet.Column{
+	{Name: "k", Type: parquet.TypeInt64, Nullable: true},
+	{Name: "name", Type: parquet.TypeString, Nullable: true},
+	{Name: "price", Type: parquet.TypeFloat64, Nullable: true},
+}
+
+// viewTestBatches builds an owned base batch and a view batch over it with
+// permuted + duplicated indices (the join-output shape). The price column
+// carries an own-null override (outer-join fill) to exercise the flatten
+// fallback; k and name are pure views.
+func viewTestBatches(tb testing.TB) (base, viewBatch *batch.RecordBatch) {
+	tb.Helper()
+	base = batch.NewRecordBatch(viewTestSchema, 4)
+	for i := range 4 {
+		base.Columns[0].Int64Data[i] = int64((i + 1) * 100)
+		base.Columns[1].BytesData.Set(i, fmt.Appendf(nil, "row%d", i))
+		base.Columns[2].Float64Data[i] = float64(i) + 0.5
+	}
+	base.Columns[1].Nulls.SetNull(2) // base null rides through views
+
+	indices := []uint32{3, 0, 0, 2, 1, 3}
+	kv := batch.NewViewVector(base.Columns[0], indices)
+	nv := batch.NewViewVector(base.Columns[1], indices)
+	pv := batch.NewViewVector(base.Columns[2], indices)
+	pv.Nulls.SetNull(1) // own-null override on one row
+	pv.Nulls.SetNull(4)
+	viewBatch = &batch.RecordBatch{
+		Columns: []*batch.Vector{kv, nv, pv},
+		Schema:  viewTestSchema,
+		Len:     len(indices),
+	}
+	return base, viewBatch
+}
+
+// eagerClone materializes an independent owned copy of a (possibly view)
+// batch for the control arm.
+func eagerClone(tb testing.TB, b *batch.RecordBatch) *batch.RecordBatch {
+	tb.Helper()
+	out := batch.NewRecordBatch(b.Schema, b.Len)
+	for ci := range b.Columns {
+		for i := 0; i < b.Len; i++ {
+			out.Columns[ci].CopyValueFrom(i, b.Columns[ci], i)
+		}
+	}
+	return out
+}
+
+func TestShuffleWriteChunkViewColumns(t *testing.T) {
+	_, viewBatch := viewTestBatches(t)
+	control := eagerClone(t, viewBatch)
+
+	writeArm := func(b *batch.RecordBatch) []*batch.RecordBatch {
+		var buf bytes.Buffer
+		sw := newShuffleWriter(&buf, viewTestSchema)
+		if err := sw.writeHeader(); err != nil {
+			t.Fatal(err)
+		}
+		// One chunk with a selection (incl. a duplicated view row), one dense.
+		if err := sw.writeChunk(b.Columns, []uint32{5, 1, 3}, 3); err != nil {
+			t.Fatal(err)
+		}
+		if err := sw.writeChunk(b.Columns, nil, b.Len); err != nil {
+			t.Fatal(err)
+		}
+		data := buf.Bytes()
+		data[4] = byte(sw.numChunks)
+		batches, err := shuffleReadBatches(data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return batches
+	}
+
+	serializedBefore := exec.LateMatViewColumnsSerialized.Load()
+	got := writeArm(viewBatch)
+	if exec.LateMatViewColumnsSerialized.Load() == serializedBefore {
+		t.Fatal("no view column serialized through its indirection")
+	}
+	// The own-null price column had to flatten (its null bits override the
+	// base's); the pure view columns must NOT have been flattened.
+	if viewBatch.Columns[2].IsView() {
+		t.Fatal("own-null view column was not flattened by writeChunk")
+	}
+	if !viewBatch.Columns[0].IsView() || !viewBatch.Columns[1].IsView() {
+		t.Fatal("pure view column was flattened — indirect serialize did not engage")
+	}
+
+	want := writeArm(control)
+	if len(got) != len(want) {
+		t.Fatalf("chunk count: got %d want %d", len(got), len(want))
+	}
+	for i := range want {
+		w, g := want[i].ToRows(), got[i].ToRows()
+		if !reflect.DeepEqual(w, g) {
+			t.Fatalf("chunk %d differs:\nwant %v\ngot  %v", i, w, g)
+		}
+	}
+}
+
+func TestPartitionedShuffleSinkViewBatch(t *testing.T) {
+	runArm := func(b *batch.RecordBatch) map[int][]map[string]any {
+		dir := t.TempDir()
+		s := newPartitionedShuffleSink(dir, []string{"k"}, 3, viewTestSchema)
+		if err := s.Init(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Consume(context.Background(), b); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Finalize(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		defer s.Close()
+		out := make(map[int][]map[string]any)
+		for p := range 3 {
+			data, err := os.ReadFile(filepath.Join(dir, fmt.Sprintf("part-%04d.wshf", p)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(data) == 0 {
+				continue
+			}
+			batches, err := shuffleReadBatches(data)
+			if err != nil {
+				t.Fatalf("partition %d: %v", p, err)
+			}
+			for _, ob := range batches {
+				out[p] = append(out[p], ob.ToRows()...)
+			}
+		}
+		return out
+	}
+
+	_, viewBatch := viewTestBatches(t)
+	control := eagerClone(t, viewBatch)
+
+	serializedBefore := exec.LateMatViewColumnsSerialized.Load()
+	got := runArm(viewBatch)
+	if exec.LateMatViewColumnsSerialized.Load() == serializedBefore {
+		t.Fatal("partitioned sink never serialized a view column through translation")
+	}
+	// The key column must have been flattened (hash pass reads it
+	// positionally); the name column must have stayed a view.
+	if viewBatch.Columns[0].IsView() {
+		t.Fatal("key view column was not flattened before hashing")
+	}
+	if !viewBatch.Columns[1].IsView() {
+		t.Fatal("non-key pure view column was flattened — translation did not engage")
+	}
+
+	want := runArm(control)
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("partition contents differ:\nwant %v\ngot  %v", want, got)
+	}
+}
+
+func TestUnpartitionedStageSinkViewBatch(t *testing.T) {
+	runArm := func(b *batch.RecordBatch) []map[string]any {
+		dir := t.TempDir()
+		s := newUnpartitionedStageSink(dir, "viewtest")
+		if err := s.Init(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Consume(context.Background(), b); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Finalize(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		defer s.Close()
+		data, err := os.ReadFile(filepath.Join(dir, "stage-viewtest.wshf"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		batches, err := shuffleReadBatches(data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var rows []map[string]any
+		for _, ob := range batches {
+			rows = append(rows, ob.ToRows()...)
+		}
+		return rows
+	}
+
+	_, viewBatch := viewTestBatches(t)
+	control := eagerClone(t, viewBatch)
+	got := runArm(viewBatch)
+	want := runArm(control)
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("stage file contents differ:\nwant %v\ngot  %v", want, got)
+	}
+}

--- a/internal/worker/unpartitioned_stage_sink.go
+++ b/internal/worker/unpartitioned_stage_sink.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/citc-tech/wadjet/internal/engine/batch"
 	"github.com/citc-tech/wadjet/internal/engine/diskio"
+	"github.com/citc-tech/wadjet/internal/engine/exec"
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
 )
 
@@ -116,6 +117,12 @@ func newUnpartitionedStageSink(spillDir, taskID string) *unpartitionedStageSink 
 	return s
 }
 
+// AcceptsViews: Consume flattens own-null view columns under its lock and
+// the rest serialize through their indirection (writeChunk sel composition /
+// appendBatchRowsBulk row translation) — the pipeline's defensive flatten
+// would just add the copy this sink exists to skip.
+func (s *unpartitionedStageSink) AcceptsViews() bool { return true }
+
 // Init creates the spill file. Schema is discovered lazily on first Consume,
 // so empty stages don't pay for a file open.
 func (s *unpartitionedStageSink) Init(_ context.Context) error {
@@ -153,6 +160,17 @@ func (s *unpartitionedStageSink) Consume(_ context.Context, b *batch.RecordBatch
 	defer s.mu.Unlock()
 	if s.closed {
 		return fmt.Errorf("unpartitionedStageSink: Consume after Close")
+	}
+	// Own-null view columns (outer-join fill) can't ride writeChunk's sel
+	// composition or appendBatchRowsBulk's row translation — flatten them
+	// here under the lock. Other views serialize through their indirection.
+	if b.HasViews() {
+		for _, col := range b.Columns {
+			if col.IsView() && col.Nulls.HasNulls() {
+				col.Flatten()
+				exec.LateMatFlattens.Add(1)
+			}
+		}
 	}
 	if s.writer == nil {
 		s.writer = newShuffleWriter(s.bufFile, b.Schema)

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -1331,7 +1331,8 @@ func (w *Worker) executeIncomingTask(ctx context.Context, task distributed.Task,
 	// Zero-valued attrs are omitted so flag-off logs are byte-identical.
 	if emitted := exec.LateMatBatchesEmitted.Load(); emitted > 0 {
 		logAttrsEnd = append(logAttrsEnd, "late_mat_batches", emitted,
-			"late_mat_flattens", exec.LateMatFlattens.Load())
+			"late_mat_flattens", exec.LateMatFlattens.Load(),
+			"late_mat_serialized_cols", exec.LateMatViewColumnsSerialized.Load())
 	}
 	w.logger.Info("task completed", logAttrsEnd...)
 }


### PR DESCRIPTION
## What

Phase 4 of `docs/design/late-materialization.md` (follows #200): distributed fragment sinks stop flattening view batches — the serialization primitives read through the view indirection, so the final copy a view deferred becomes the encode itself.

Two mechanisms, both reusing the existing typed kernels unchanged:
- **`writeChunk`**: a view column without an own-null override is just its base with the selection composed through `Indices` (a dense chunk reuses the index array with zero allocation). Covers the unpartitioned legacy path, the gather-reply sink, and every other `writeChunk` caller.
- **`appendBatchRowsBulk`**: per-column row-list translation through `Indices` — one copy straight from the base into the partition accumulator instead of flatten-then-copy. Covers the exchange (repartition) sink and the unpartitioned coalescing path.

Own-null views (outer-join fill) can't ride either trick and flatten at the sinks' single-threaded points; the exchange sink also flattens its shuffle-key columns, mirroring the probe's keys-only rule from #200.

## Concurrency

`Bitmap.HasNulls()` memoizes on first call, and view bases are shared across concurrently-consumed batches (morsel-parallel sinks, per-partition append bursts). Build batches now warm their bitmaps at build completion — the last single-threaded point — on all four build paths (nil partition slots guarded), and the partitioned sink's prewarm loop covers view bases per Consume. View tests run under `-race`.

## Evidence

`tpch-harness --mode=local` forced arm: `late_mat_serialized_cols=37` in worker logs — 37 view columns crossed the serialization boundary with **no flatten copy at all** (before this PR each was a `late_mat_flattens` event), while 45 flattens remain at consumers that genuinely read column storage.

## Gates

- New worker tests: chunk round-trip with view columns (sel composition, dup indices, own-null fallback), partitioned-sink per-partition parity view-arm vs eager-arm, unpartitioned coalescing parity — all also under `-race`
- Full worker/engine/wadjet suites
- SF0.01 default (dormant) + forced-on 22/22
- `tpch-harness --mode=local` PASS both arms

## Next (queued)

Phase 5: SF10 + SF100 same-window pairs with the counters proving engagement, then the default-on decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZaEw6PKU9Lq8cGJu3KM6K