### PR TITLE
refactor(planner): structure-independent join column resolution (bushy CBO Phase A)

### DIFF
--- a/docs/design/bushy-join-cbo.md
+++ b/docs/design/bushy-join-cbo.md
@@ -1,6 +1,7 @@
 # Bushy join enumeration for the CBO
 
-Status: DRAFT for review — 2026-07-09
+Status: Phase A (Layer A resolution refactor) LANDED on branch
+feat/bushy-cbo-phase-a — 2026-07-09. Layer B (enumeration) not started.
 Prior art: left-deep DP reorder (`internal/planner/logical/optimizer.go:2863`),
 bushy attempt deferred 2026-05-26 (commit 80c2f46, wrong rows on
 Q02/Q07/Q08/Q09/Q21 at SF0.01).
@@ -203,6 +204,18 @@ marker proving the treatment engaged).
   be *rescued* by FixKeyAssignment/counterpart adoption firing. Phase A's
   WARN tripwire across TPC-H + harness will surface any such case before
   the safety nets are demoted.
+  **CONFIRMED (Phase A, 2026-07-09): Q02's decorrelated scalar-subquery join
+  is exactly such a case** — after decorrelation, BOTH children contain
+  partsupp and supplier scans, so bare `s_suppkey`/`ps_suppkey` are owned by
+  both sides and plan-time assignment (old membership test AND new ownership
+  test) correctly stays conservative; the runtime repair fixes it, as the
+  long-standing comment in FixKeyAssignment records. Root cause: the flat
+  JoinCond string loses the query-block scope of each column reference. The
+  architectural fix is the decorrelator emitting side-assigned keys
+  (LeftKeys/RightKeys on the Node instead of a re-parsed string) — deferred,
+  tracked as a Phase B+ follow-on. Until then the tripwire gate reads: NO
+  repair other than the known Q02 pair, and the bushy unit suite asserts
+  ZERO repairs on bushy shapes.
 - **Memory**: a bushy build is a join output, so build size = intermediate
   cardinality, not base-table size. Spill machinery (grace partition-on-
   arrival) already covers oversized builds; `estimateSubtreeStats` (Layer A

--- a/docs/design/bushy-join-cbo.md
+++ b/docs/design/bushy-join-cbo.md
@@ -1,0 +1,209 @@
+# Bushy join enumeration for the CBO
+
+Status: DRAFT for review — 2026-07-09
+Prior art: left-deep DP reorder (`internal/planner/logical/optimizer.go:2863`),
+bushy attempt deferred 2026-05-26 (commit 80c2f46, wrong rows on
+Q02/Q07/Q08/Q09/Q21 at SF0.01).
+
+## 1. Problem
+
+`dpJoinReorder` enumerates only left-deep trees: every join's build side is a
+single base relation, so plans are one spine
+`((((lineitem ⋈ orders) ⋈ customer) ⋈ nation) ⋈ region)`. A bushy plan may
+join two intermediates — e.g. `(customer ⋈ orders ⋈ lineitem) ⋈
+(supplier ⋈ nation ⋈ region)` — pre-collapsing dimension chains into one
+small build instead of streaming the fact spine through several separate
+probes. Trino enumerates bushy shapes; the roadmap names bushy CBO as the
+residual join-order gap (Q05/Q07/Q09 class).
+
+SF100 anchors (baseline results/20260709-175846, 48.5m suite): Q05 2m45,
+Q07 2m42, Q09 3m01, Q02 1m18, Q08 1m39.
+
+The May attempt proved the enumeration itself is not the hard part. Bushy
+plans produced **wrong rows** because the physical layer's column resolution
+assumes left-deep nesting. This memo is therefore two designs in one:
+
+- **Layer A (the enabler, most of the work): structure-independent column
+  resolution** — make join-key and alias resolution correct for arbitrary
+  tree shapes, as a zero-behavior-change refactor gated on existing plans.
+- **Layer B (small): bushy DP enumeration** behind a dormant flag, activated
+  only after Layer A holds.
+
+## 2. Why the May attempt broke — verified failure map (grounded 2026-07-09 vs main 93e137f)
+
+A logical `NodeJoin` carries `JoinCond` as a raw SQL string. Conversion to
+physical build/probe keys is a 4-step guessing pipeline, and every step
+assumes the build side (`Children[1]`) is a single base scan:
+
+| Step | Location | Left-deep assumption | Bushy failure |
+|---|---|---|---|
+| `parseJoinKeys` | physical/plan.go:4810 | positional split on `=`; side assignment deferred entirely to later repair | none by itself, but all repairs downstream inherit its guesses |
+| `fixJoinKeyOrder` | physical/plan.go:4842 | each equality has exactly one column resident in the build subtree; swap fires only on `leftInBuild && !rightInBuild` | multi-table build → both sides resident → no/false swap |
+| `collectPlanColumns` | physical/plan.go:4864 | unions ALL scans under `Children[1]` (special-cases only semi/anti) | inner-join build leaks several tables' columns into the membership set |
+| `findScanAlias` → `BuildTableAlias` | physical/plan.go:6978, 3481, 3928 | one scan under the build | returns the first scan's alias in DFS order; all other build tables' aliases are lost |
+| `joinOutputSchemaWithMapping` | exec/join.go:3190 | one `buildAlias` valid for every build column | stamps the wrong alias onto other tables' columns (e.g. region cols shipped as `n2.r_regionkey`) |
+| `markCoPathingSelfJoinBuilds` | physical/plan.go:2678 | build dep chain reaches a `StageScan` within 3 Exchange hops | build dep = join stage → walk bails → Q07-class self-join qualification silently disabled |
+| `columnIndexFallback` | exec/aggregate.go:693 | unqualified suffix match unique in schema | multi-table build → ambiguous → −1 → zero/wrong rows |
+| `FixKeyAssignment` / SMJ counterpart | exec/join.go:1707, sort_merge_join.go:230 | runtime swap on the same asymmetric-membership rule | same blind spot as `fixJoinKeyOrder`, now against the real schema |
+| `resolveShuffleKey` | physical/plan.go:3073 | walks single-child chains only | breaks at a 2-child build; Project aliases inside a bushy build unresolved for shuffle keys |
+| `findScanRowEstimate` | physical/plan.go:6870 | first scan represents the build | mis-sized arena; wrong semi/anti swap threshold |
+
+Two facts make Layer A tractable rather than a rewrite:
+
+1. **The dataflow layer already runs bushy trees.** `buildJoin` recursively
+   builds `Children[1]` pipelines, `walkStages` records per-child leaf stages
+   and wires a join-stage build dependency generically (plan.go:3322-3345 —
+   nested-join support is explicitly claimed there), and
+   `ValidateNativeDAGShape` checks dependency counts only. Semi/anti
+   subtrees-as-leaves ALREADY put join subtrees on the build side in
+   production. Only the *naming* layer is wrong.
+2. **The logical optimizer already knows the truth.** At reorder time it has
+   per-relation column sets (`collectSubtreeColumns`) and the edge list — it
+   knows exactly which relation owns each key. The information is discarded
+   into a flat SQL string and then re-guessed downstream. The fix is to stop
+   discarding it.
+
+The strict-columns binder (PRs #151-#153, physical/validate.go) was assessed
+as a resolution source and rejected: it runs pre-plan on the SQL AST, keeps
+nothing (returns only pass/fail), and deliberately goes lossy on ambiguous
+scopes. Its per-alias column-set idea is the right shape, but the resolver
+must live where the tree is, in the planner.
+
+## 3. Design
+
+### 3.1 The invariant (Layer A)
+
+> **Every column in a join-output schema has exactly one stable, unique name,
+> derived from its ORIGIN scan (alias-qualified where needed), independent of
+> join-tree shape. Plan-time join/shuffle keys are emitted in exactly that
+> naming, with sides already assigned. Runtime name repair becomes a safety
+> net, not a resolution mechanism.**
+
+Three changes carry the invariant:
+
+**(a) Origin-aware output naming in the executor.**
+`joinOutputSchemaWithMapping` stops stamping the single `BuildTableAlias`
+onto every build column. Instead: a build column that already carries a
+qualifier (because the build subtree is itself a join that qualified it)
+keeps its name verbatim; only bare columns from a scan-shaped build get the
+build alias. Qualification remains conditional exactly as today (`isDup ||
+qualifyAllBuildCols`) so left-deep output schemas are byte-identical —
+this is a strict generalization, not a rename.
+
+**(b) A subtree output-naming resolver in the physical planner.**
+New helper `subtreeOutputName(node, col) → qualified name` (and its
+companion `subtreeOwnsColumn`) that computes, for any logical subtree, the
+name a column will carry in that subtree's OUTPUT schema — recursing through
+joins with the same qualification rule as (a), through Projects/CTE aliases
+(subsuming `resolveShuffleKey`'s single-child walk), and through semi/anti
+probe-only visibility (subsuming the special case in
+`collectPlanColumnsRec`). This is the one place tree-shape knowledge lives.
+
+**(c) Plan-time key resolution replaces guessing.**
+`buildJoin` and `walkStages` resolve each parsed equality against
+`subtreeOwnsColumn(Children[0])` / `(Children[1])`:
+side assignment is decided by ownership (error loudly on
+both-sides/neither-side instead of silently keeping positional order), and
+the emitted key strings are the exact `subtreeOutputName` of each side.
+`fixJoinKeyOrder` is deleted from these paths. Runtime `FixKeyAssignment`,
+`columnIndexFallback` fallback tiers, and SMJ counterpart adoption stay as
+safety nets, with a WARN log when they actually fire (they should not, on
+any plan — the log is the regression tripwire).
+
+**(d) Structure-independent co-pathing qualification.**
+`markCoPathingSelfJoinBuilds`'s build-chain walk continues through join
+stages (collecting ALL underlying scan tables of the build subtree, not
+bailing at the first non-scan), so self-join qualification engages for bushy
+builds. With (a), qualifying "all build cols" is per-origin correct.
+
+**(e) Structure-independent build estimate.**
+The `findScanRowEstimate(Children[1])` uses (arena sizing, semi/anti swap
+threshold plan.go:3946) switch to `estimateSubtreeStats` — which already
+exists and handles join subtrees.
+
+Layer A changes NO plan shapes. Gate: golden snapshots
+(`testdata/ensure_distribution/qNN.golden`), `TestTPCHSelfJoinAliases`,
+TPC-H SF0.01 22/22, harness `--mode=local` — all must pass unchanged.
+New tests: a plan-shape-independent resolution suite that constructs bushy
+logical trees directly (bypassing the reorderer) and asserts key/alias
+resolution + row correctness on self-join and multi-dimension shapes — this
+is the test bed that would have caught the May failure at unit level.
+
+### 3.2 Bushy enumeration (Layer B)
+
+Extend `dpJoinReorder` with the standard subset-partition transition:
+
+```
+for each connected subset S (by increasing popcount):
+  dp[S] = min over ( existing left-deep extension,          — unchanged
+                     partitions (S1, S2) of S, S1 ∪ S2 = S, both dp-reachable,
+                     edges(S1, S2) non-empty:
+                       dp[S1].cost + dp[S2].cost + hashJoinCost(probe, build) )
+```
+
+- Probe/build orientation per pair chosen by estimated rows (larger side
+  probes), matching the existing 2-way rule.
+- Join condition = conjunction of all edges crossing the (S1, S2) cut, each
+  equality emitted side-assigned via the ownership map (Layer A c) — the
+  optimizer writes truth, not a string to be re-guessed.
+- **Tie-break prefers left-deep**: with Selinger floored at max(L,R), FK→PK
+  chains cost identically bushy or left-deep (observed in the May attempt);
+  requiring strict cost improvement for a bushy partition minimizes plan
+  churn and keeps goldens stable except where bushy genuinely wins.
+- Complexity: subset-partition DP is O(3^N). Bushy enumeration only for
+  N ≤ 10 (3^10 ≈ 59K transitions, negligible); 11-16 relations keep
+  left-deep DP; >16 keep greedy. TPC-H maxes at N=8 (Q08).
+- Cross-join penalty, `hasEmptyJoinCond` greedy fallback, and CTE-ref bail
+  are unchanged.
+
+Flag: `--bushy-join-reorder` (bool, **default off** v1) plumbed like
+`--late-materialization`: wadjet.Config + coordinator.Config + server.Config,
+env `WADJET_BUSHY_JOIN_REORDER` for the bench harness. Off = today's
+behavior bit-for-bit. Observability: `BushyJoinsPlanned` counter + one Info
+log per query naming the partition chosen (mirrors SortMergeJoinsPlanned /
+DynamicFiltersPlanned — the same-window A/B discipline requires a mechanism
+marker proving the treatment engaged).
+
+### 3.3 Scope exclusions (v1)
+
+- Semi/anti joins stay leaf relations (current `flattenJoinChain` handling).
+  Reordering them into bushy positions is a follow-on.
+- Outer joins: never reordered (unchanged).
+- No cost-model changes. Bushy inherits Selinger + HLL/histogram inputs
+  as-is; if estimates are wrong, left-deep is equally exposed today.
+
+## 4. Phases and gates
+
+1. **Phase A — resolution refactor** (no flag; zero behavior change).
+   Gates: all existing plan snapshots byte-identical, TPC-H SF0.01 22/22,
+   full planner/exec/coordinator/worker suites, harness `--mode=local`,
+   new bushy-tree resolution unit suite green, FixKeyAssignment WARN
+   tripwire silent across the whole TPC-H run.
+2. **Phase B — enumeration behind dormant flag.**
+   Gates: flag-off = plans byte-identical (dormancy assert on the counter);
+   flag-on forced SF0.01 22/22 row-identical vs flag-off; plan dumps for
+   Q05/Q07/Q08/Q09 inspected — expected shapes: dimension-chain pre-joins
+   (supplier⋈nation⋈region class); harness `--mode=local` both arms.
+3. **Phase C — distributed validation + perf.** SF10 pair, then SF100
+   same-window pair (deploy approval per run). Success = target-band wins
+   (Q05/Q07/Q09) with no per-query regression beyond the ±15% noise
+   envelope, counter proving bushy plans actually fired. Default flip is a
+   separate decision after the pair, per the morsel/late-mat precedent.
+
+## 5. Risks
+
+- **Plan-space risk**: bushy opens shapes where cardinality-estimate error
+  does more damage (a bad bushy pick materializes a large intermediate as a
+  build). Mitigations: strict-improvement tie-break (§3.2), HLL/histogram
+  stats already landed, dormant flag + A/B before flip.
+- **Golden churn**: Phase B flag-on will change snapshots for queries where
+  bushy wins — deliberate, reviewed per query in plan dumps, not bulk
+  `-update`.
+- **Hidden name-repair dependencies**: some correct left-deep plan may today
+  be *rescued* by FixKeyAssignment/counterpart adoption firing. Phase A's
+  WARN tripwire across TPC-H + harness will surface any such case before
+  the safety nets are demoted.
+- **Memory**: a bushy build is a join output, so build size = intermediate
+  cardinality, not base-table size. Spill machinery (grace partition-on-
+  arrival) already covers oversized builds; `estimateSubtreeStats` (Layer A
+  e) keeps admission estimates honest.

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -1980,6 +1980,7 @@ func (c *Coordinator) dispatchComputeStage(
 				JoinRightKeys:   append([]string(nil), fj.JoinRightKeys...),
 				BuildFiles:      flattenStageFiles(buildOut),
 				BuildTableAlias: fj.BuildTableAlias,
+				BuildColOrigins: fj.BuildColOrigins,
 				JoinFilter:      fj.JoinFilter,
 				FilterExprs:     append([]string(nil), fj.FilterExprs...),
 			})
@@ -1995,6 +1996,7 @@ func (c *Coordinator) dispatchComputeStage(
 			JoinRightKeys:       stage.JoinRightKeys,
 			BuildTableAlias:     stage.BuildTableAlias,
 			QualifyAllBuildCols: stage.QualifyAllBuildCols,
+			BuildColOrigins:     stage.BuildColOrigins,
 			JoinFilter:          stage.JoinFilter,
 			FusedJoins:          wireFused,
 			GroupByCols:         stage.GroupByCols,
@@ -2377,6 +2379,7 @@ func buildJoinFragment(
 			LeftKeys:        fj.JoinLeftKeys,
 			RightKeys:       fj.JoinRightKeys,
 			BuildAlias:      fj.BuildTableAlias,
+			BuildColOrigins: fj.BuildColOrigins,
 			BuildFiles:      fj.BuildFiles,
 			BuildBucket:     t.DataBucket,
 			JoinFilter:      fj.JoinFilter,
@@ -2399,6 +2402,7 @@ func buildJoinFragment(
 		BuildRowHint:        t.BuildRowHint,
 		SemiAntiKeyOnly:     t.SemiAntiKeyOnly,
 		QualifyAllBuildCols: t.QualifyAllBuildCols,
+		BuildColOrigins:     t.BuildColOrigins,
 		OutputColumns:       append([]string(nil), t.Columns...),
 		LateMaterialize:     lateMat,
 	})
@@ -2480,6 +2484,7 @@ func buildSortMergeJoinFragment(
 		BuildFiles:          buildFiles,
 		BuildBucket:         t.DataBucket,
 		QualifyAllBuildCols: t.QualifyAllBuildCols,
+		BuildColOrigins:     t.BuildColOrigins,
 		OutputColumns:       append([]string(nil), t.Columns...),
 	})
 	if len(t.PostFilterExprs) > 0 {

--- a/internal/distributed/messages.go
+++ b/internal/distributed/messages.go
@@ -119,8 +119,13 @@ type Task struct {
 	// build-side columns under their qualified name even when no probe-side
 	// column has the same base name. Set by the planner for self-join scenarios
 	// (Q07's two scans of nation that co-path into the same join chain).
-	QualifyAllBuildCols bool   `json:"qualify_all_build_cols,omitempty"`
-	JoinFilter          string `json:"join_filter,omitempty"` // semi/anti join inequality filter expression
+	QualifyAllBuildCols bool `json:"qualify_all_build_cols,omitempty"`
+	// BuildColOrigins maps bare build-column names (lowercased) to their
+	// owning scan alias. Set only for multi-table build subtrees (bushy
+	// shapes); the executor qualifies duplicate build columns with the
+	// owning alias instead of BuildTableAlias.
+	BuildColOrigins map[string]string `json:"build_col_origins,omitempty"`
+	JoinFilter      string            `json:"join_filter,omitempty"` // semi/anti join inequality filter expression
 
 	// Fused join: additional broadcast joins absorbed into a single task.
 	// The worker builds hash tables for each fused join, then chains probes
@@ -312,8 +317,9 @@ type OpSpec struct {
 	JoinFilter          string   `json:"join_filter,omitempty"`
 	BuildRowHint        int64    `json:"build_row_hint,omitempty"`
 	SemiAntiKeyOnly     bool     `json:"semi_anti_key_only,omitempty"`
-	QualifyAllBuildCols bool     `json:"qualify_all_build_cols,omitempty"`
-	OutputColumns       []string `json:"output_columns,omitempty"` // OutputFilter for primary probe
+	QualifyAllBuildCols bool              `json:"qualify_all_build_cols,omitempty"`
+	BuildColOrigins     map[string]string `json:"build_col_origins,omitempty"` // bare build col → owning scan alias (multi-table builds only)
+	OutputColumns       []string          `json:"output_columns,omitempty"`    // OutputFilter for primary probe
 	LateMaterialize     bool     `json:"late_materialize,omitempty"` // emit view-column join output (deferred gather)
 
 	// OpExchangeSender (sink).
@@ -425,13 +431,14 @@ type WindowColSpec struct {
 // The worker builds the hash table from BuildFiles, then probes each batch
 // through this join before passing it to the next fused join (or output).
 type FusedJoinSpec struct {
-	JoinType        string   `json:"join_type"`
-	JoinLeftKeys    []string `json:"join_left_keys"`  // keys from the probe stream
-	JoinRightKeys   []string `json:"join_right_keys"` // keys in build files
-	BuildFiles      []string `json:"build_files"`     // build-side files (broadcast)
-	BuildTableAlias string   `json:"build_table_alias,omitempty"`
-	JoinFilter      string   `json:"join_filter,omitempty"`
-	FilterExprs     []string `json:"filter_exprs,omitempty"` // post-join filters for this step
+	JoinType        string            `json:"join_type"`
+	JoinLeftKeys    []string          `json:"join_left_keys"`  // keys from the probe stream
+	JoinRightKeys   []string          `json:"join_right_keys"` // keys in build files
+	BuildFiles      []string          `json:"build_files"`     // build-side files (broadcast)
+	BuildTableAlias string            `json:"build_table_alias,omitempty"`
+	BuildColOrigins map[string]string `json:"build_col_origins,omitempty"` // bare build col → owning scan alias (multi-table builds only)
+	JoinFilter      string            `json:"join_filter,omitempty"`
+	FilterExprs     []string          `json:"filter_exprs,omitempty"` // post-join filters for this step
 }
 
 // ResultNotification is sent by workers when a task completes.

--- a/internal/engine/exec/join.go
+++ b/internal/engine/exec/join.go
@@ -1707,13 +1707,23 @@ func (h *HashJoin) BuildRows() int64 {
 	return h.buildRows
 }
 
+// KeyAssignmentRepairs counts runtime probe/build key swaps performed by
+// FixKeyAssignment after a build completed — cases where PLAN-TIME side
+// assignment (assignJoinKeySides) got a pair wrong and the runtime safety
+// net rescued it. Tripwire observability: the TPC-H suites assert this
+// stays 0; a nonzero count means a plan shape leaked through the planner's
+// ownership resolution (rebuild cost + a hazard for partitioned builds).
+var KeyAssignmentRepairs atomic.Int64
+
 // FixKeyAssignment corrects misassigned join keys after the build phase.
 // SQL may place the build-side column on the left of "=" (e.g., JOIN t ON t.id = src.id),
 // causing parseJoinKeys to assign it as a left/probe key. This detects and swaps
 // misassigned pairs by checking which keys exist in the build schema.
-func (h *HashJoin) FixKeyAssignment() {
+// It returns true when any pair was swapped, so callers can surface the
+// repair (it should never fire on planner-produced plans).
+func (h *HashJoin) FixKeyAssignment() bool {
 	if h.buildSchema == nil || len(h.LeftKeys) == 0 {
-		return
+		return false
 	}
 	buildCols := make(map[string]bool, len(h.buildSchema))
 	for _, col := range h.buildSchema {
@@ -1730,6 +1740,9 @@ func (h *HashJoin) FixKeyAssignment() {
 			needsRebuild = true
 			h.probeResolved.Store(false) // force re-resolution of probe key indices
 		}
+	}
+	if needsRebuild {
+		KeyAssignmentRepairs.Add(1)
 	}
 
 	// Rebuild hash index if keys were swapped
@@ -1752,7 +1765,7 @@ func (h *HashJoin) FixKeyAssignment() {
 		if h.spillState != nil {
 			for _, b := range h.buildBatches {
 				if b == nil {
-					return
+					return true
 				}
 			}
 		}
@@ -1829,6 +1842,7 @@ func (h *HashJoin) FixKeyAssignment() {
 		h.bloom = nil
 		h.buildBloom()
 	}
+	return needsRebuild
 }
 
 // Probe is a UnaryOperator that probes the hash table for each input batch.

--- a/internal/engine/exec/join.go
+++ b/internal/engine/exec/join.go
@@ -85,6 +85,13 @@ type HashJoin struct {
 	// columnIndexFallback path that breaks Q07).
 	QualifyAllBuildCols bool
 
+	// BuildColOrigins maps each bare build-column name (lowercased) to the
+	// scan alias that owns it. Set by the planner only when the build side
+	// spans multiple tables (bushy join subtrees); nil for single-scan
+	// builds. Duplicate qualification then uses the owning alias instead of
+	// the single BuildTableAlias, which is ambiguous for multi-table builds.
+	BuildColOrigins map[string]string
+
 	// Pre-resolved column indices and reusable key buffer for typed serialization.
 	// Avoids fmt.Sprint + GetValue boxing on every row.
 	keyBuf        []byte
@@ -3180,14 +3187,14 @@ func (p *HashJoinProbe) outputSchema(leftSchema []parquet.Column) []parquet.Colu
 
 func (p *HashJoinProbe) outputSchemaWithMapping(leftSchema []parquet.Column) ([]parquet.Column, []outColSource) {
 	return joinOutputSchemaWithMapping(p.join.JoinType, leftSchema, p.join.buildSchema,
-		p.join.BuildTableAlias, p.join.QualifyAllBuildCols, p.OutputFilter)
+		p.join.BuildTableAlias, p.join.BuildColOrigins, p.join.QualifyAllBuildCols, p.OutputFilter)
 }
 
 // joinOutputSchemaWithMapping computes a join's output schema — probe columns
 // first, then build columns with duplicate-name qualification — and the
 // per-output-column source mapping. Shared by HashJoinProbe and SortMergeJoin
 // so both emit identical schemas for the same join shape.
-func joinOutputSchemaWithMapping(joinType JoinType, leftSchema, buildSchema []parquet.Column, buildAlias string, qualifyAllBuildCols bool, outputFilter map[string]bool) ([]parquet.Column, []outColSource) {
+func joinOutputSchemaWithMapping(joinType JoinType, leftSchema, buildSchema []parquet.Column, buildAlias string, buildColOrigins map[string]string, qualifyAllBuildCols bool, outputFilter map[string]bool) ([]parquet.Column, []outColSource) {
 	var out []parquet.Column
 	var mapping []outColSource
 
@@ -3211,16 +3218,36 @@ func joinOutputSchemaWithMapping(joinType JoinType, leftSchema, buildSchema []pa
 
 	for i, col := range buildSchema {
 		isDup := seen[col.Name]
+		// A build column that already carries a qualifier was named by a
+		// nested join INSIDE the build subtree (bushy shapes). The name is
+		// already unique and stable — re-qualifying would double-qualify
+		// ("s.n2.n_name") and dropping it would lose the column. Emit verbatim.
+		if strings.IndexByte(col.Name, '.') >= 0 {
+			if joinType == LeftJoin || joinType == FullOuterJoin {
+				col.Nullable = true
+			}
+			out = append(out, col)
+			mapping = append(mapping, outColSource{fromProbe: false, srcIdx: i})
+			seen[col.Name] = true
+			continue
+		}
+		// Qualification alias: the column's OWNING scan when the planner
+		// provided per-column origins (multi-table build subtrees), else the
+		// build side's single table alias.
+		alias := buildAlias
+		if origin := buildColOrigins[strings.ToLower(col.Name)]; origin != "" {
+			alias = origin
+		}
 		// Force qualification for self-join scenarios — the planner sets
 		// QualifyAllBuildCols when this build is one of two co-pathing
 		// scans of the same source table. Without it, the FIRST scan's
 		// column ships unqualified ("n_name") and downstream lookups for
 		// the qualified name ("n1.n_name") miss.
-		shouldQualify := (isDup || qualifyAllBuildCols) && buildAlias != ""
+		shouldQualify := (isDup || qualifyAllBuildCols) && alias != ""
 		switch {
 		case shouldQualify:
 			qualCol := col
-			qualCol.Name = buildAlias + "." + col.Name
+			qualCol.Name = alias + "." + col.Name
 			if joinType == LeftJoin || joinType == FullOuterJoin {
 				qualCol.Nullable = true
 			}

--- a/internal/engine/exec/sort_merge_join.go
+++ b/internal/engine/exec/sort_merge_join.go
@@ -34,9 +34,11 @@ type SortMergeJoin struct {
 	LeftKeys  []string // join key columns from left (probe) side
 	RightKeys []string // join key columns from right (build) side
 
-	// BuildTableAlias / QualifyAllBuildCols / OutputFilter carry
-	// HashJoinProbe's output-schema semantics — see joinOutputSchemaWithMapping.
+	// BuildTableAlias / BuildColOrigins / QualifyAllBuildCols / OutputFilter
+	// carry HashJoinProbe's output-schema semantics — see
+	// joinOutputSchemaWithMapping.
 	BuildTableAlias     string
+	BuildColOrigins     map[string]string
 	QualifyAllBuildCols bool
 	OutputFilter        map[string]bool
 
@@ -404,7 +406,7 @@ func (j *SortMergeJoin) Finalize(_ context.Context) error {
 	}
 
 	j.outSchema, j.outMapping = joinOutputSchemaWithMapping(j.JoinType, j.probe.schema, j.build.schema,
-		j.BuildTableAlias, j.QualifyAllBuildCols, j.OutputFilter)
+		j.BuildTableAlias, j.BuildColOrigins, j.QualifyAllBuildCols, j.OutputFilter)
 
 	if err := j.resolveCompareKernels(); err != nil {
 		j.mu.Lock()

--- a/internal/engine/exec/sort_merge_join.go
+++ b/internal/engine/exec/sort_merge_join.go
@@ -29,6 +29,11 @@ import (
 // (SQL equi-join semantics: NULL matches nothing — mirrors the hash paths,
 // where null keys produce no index entry). Not Cloneable: the breaker path
 // runs it single-consumer.
+// SMJCounterpartAdoptions counts key resolutions that only succeeded by
+// adopting the OTHER side's key name (swapped pair) — the sort-merge analog
+// of KeyAssignmentRepairs. Tripwire: should stay 0 on planner-produced plans.
+var SMJCounterpartAdoptions atomic.Int64
+
 type SortMergeJoin struct {
 	JoinType  JoinType // v1: InnerJoin only; validated in Init/Finalize
 	LeftKeys  []string // join key columns from left (probe) side
@@ -245,8 +250,13 @@ func (j *SortMergeJoin) consume(side *smjSide, b *batch.RecordBatch) error {
 		for i := range side.keys {
 			idx := columnIndexFallback(b, side.keys[i].Column)
 			if idx < 0 && i < len(side.counterpart) {
-				// Swapped pair — see smjSide.counterpart.
+				// Swapped pair — see smjSide.counterpart. Adoption is the
+				// SMJ analog of FixKeyAssignment: count it as a tripwire
+				// (plan-time side assignment should make this unreachable).
 				idx = columnIndexFallback(b, side.counterpart[i])
+				if idx >= 0 {
+					SMJCounterpartAdoptions.Add(1)
+				}
 			}
 			if idx < 0 {
 				return fmt.Errorf("sort-merge join: %s-side key column %q not found", side.name, side.keys[i].Column)

--- a/internal/planner/physical/bushy_join_test.go
+++ b/internal/planner/physical/bushy_join_test.go
@@ -1,0 +1,362 @@
+package physical
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/exec"
+	"github.com/citc-tech/wadjet/internal/planner/logical"
+	"github.com/citc-tech/wadjet/internal/storage/catalog"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// The bushy suite constructs logical join trees with a JOIN SUBTREE ON THE
+// BUILD SIDE — the exact shape bushy join enumeration (Layer B of
+// docs/design/bushy-join-cbo.md) will emit — and executes them against
+// in-memory fixtures. It exists because the May 2026 bushy attempt produced
+// wrong rows at SF0.01: these tests pin the resolution layer at unit level
+// so the failure class is caught without a benchmark run.
+
+// setupBushyTables builds a mini star schema: a fact table and a dimension
+// chain (supplier → nation → region), with nation designed for self-joins.
+func setupBushyTables(t *testing.T) *catalog.Catalog {
+	t.Helper()
+	ctx := context.Background()
+	store := objstore.NewMemStore()
+	cat := catalog.NewWithStore(store, "test")
+	if err := cat.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	writeTable := func(name string, cols []parquet.Column, rows []map[string]any) {
+		schema := parquet.Schema{Columns: cols}
+		if err := cat.CreateTable(ctx, name, schema, nil); err != nil {
+			t.Fatal(err)
+		}
+		var buf bytes.Buffer
+		cfg := parquet.DefaultWriterConfig()
+		cfg.Compression = parquet.CompressionNone
+		w, err := parquet.NewWriter(&buf, schema, cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := w.WriteRows(rows); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		data := buf.Bytes()
+		path := fmt.Sprintf("tables/%s/chunk_0000.parquet", name)
+		if _, err := store.Put(ctx, "test", path, bytes.NewReader(data), int64(len(data)), ""); err != nil {
+			t.Fatal(err)
+		}
+		if err := cat.AddFiles(ctx, name, map[string]string{}, "tables/"+name+"/", []catalog.FileEntry{{
+			Path:      path,
+			SizeBytes: int64(len(data)),
+			NumRows:   int64(len(rows)),
+		}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// 4 regions; 12 nations (3 per region); 40 suppliers (round-robin
+	// nations); 200 fact rows (round-robin suppliers).
+	regionRows := make([]map[string]any, 4)
+	for i := range regionRows {
+		regionRows[i] = map[string]any{"r_rk": int64(i), "r_name": fmt.Sprintf("region%d", i)}
+	}
+	writeTable("b_region", []parquet.Column{
+		{Name: "r_rk", Type: parquet.TypeInt64},
+		{Name: "r_name", Type: parquet.TypeString},
+	}, regionRows)
+
+	nationRows := make([]map[string]any, 12)
+	for i := range nationRows {
+		nationRows[i] = map[string]any{"n_nk": int64(i), "n_name": fmt.Sprintf("nation%d", i), "n_rk": int64(i % 4)}
+	}
+	writeTable("b_nation", []parquet.Column{
+		{Name: "n_nk", Type: parquet.TypeInt64},
+		{Name: "n_name", Type: parquet.TypeString},
+		{Name: "n_rk", Type: parquet.TypeInt64},
+	}, nationRows)
+
+	supplierRows := make([]map[string]any, 40)
+	for i := range supplierRows {
+		supplierRows[i] = map[string]any{"s_sk": int64(i), "s_name": fmt.Sprintf("supp%d", i), "s_nk": int64(i % 12)}
+	}
+	writeTable("b_supplier", []parquet.Column{
+		{Name: "s_sk", Type: parquet.TypeInt64},
+		{Name: "s_name", Type: parquet.TypeString},
+		{Name: "s_nk", Type: parquet.TypeInt64},
+	}, supplierRows)
+
+	factRows := make([]map[string]any, 200)
+	for i := range factRows {
+		factRows[i] = map[string]any{"l_ok": int64(i), "l_sk": int64(i % 40), "l_qty": int64(i % 7)}
+	}
+	writeTable("b_fact", []parquet.Column{
+		{Name: "l_ok", Type: parquet.TypeInt64},
+		{Name: "l_sk", Type: parquet.TypeInt64},
+		{Name: "l_qty", Type: parquet.TypeInt64},
+	}, factRows)
+
+	return cat
+}
+
+func bushyScan(table, alias string) *logical.Node {
+	return &logical.Node{Type: logical.NodeScan, TableName: table, TableAlias: alias}
+}
+
+func bushyJoin(jt, cond string, left, right *logical.Node) *logical.Node {
+	return &logical.Node{
+		Type:     logical.NodeJoin,
+		JoinType: jt,
+		JoinCond: cond,
+		Children: []*logical.Node{left, right},
+	}
+}
+
+// planTree runs a hand-built logical tree through scan annotation and the
+// local physical planner — bypassing the optimizer's (left-deep) join
+// reorder, exactly as a bushy-enumerating reorder would hand its output on.
+func planTree(t *testing.T, cat *catalog.Catalog, root *logical.Node) *PhysicalPlan {
+	t.Helper()
+	ctx := context.Background()
+	planner := NewPlanner(cat)
+	planner.AnnotateScanColumns(ctx, root)
+	plan, err := planner.Plan(ctx, root)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	return plan
+}
+
+func runPlanRows(t *testing.T, plan *PhysicalPlan) []map[string]any {
+	t.Helper()
+	if err := plan.Pipeline.Run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	sink, ok := plan.Pipeline.Sink.(interface{ ToRows() []map[string]any })
+	if !ok {
+		t.Fatalf("sink %T does not expose rows", plan.Pipeline.Sink)
+	}
+	return sink.ToRows()
+}
+
+// rowKeySet flattens rows to sorted "col=val|col=val" strings over the given
+// columns for order-independent multiset comparison.
+func rowKeySet(t *testing.T, rows []map[string]any, cols ...string) []string {
+	t.Helper()
+	keys := make([]string, 0, len(rows))
+	for _, r := range rows {
+		s := ""
+		for _, c := range cols {
+			v, ok := r[c]
+			if !ok {
+				t.Fatalf("row missing column %q: %v", c, r)
+			}
+			s += fmt.Sprintf("%s=%v|", c, v)
+		}
+		keys = append(keys, s)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// TestBushyBuild_DimensionChain joins the fact table against a BUSHY build:
+// supplier ⋈ (nation ⋈ region). The equivalent left-deep SQL is ground
+// truth. The runtime key-repair tripwires must not fire — plan-time
+// ownership resolution has to get every pair right on the first try.
+func TestBushyBuild_DimensionChain(t *testing.T) {
+	cat := setupBushyTables(t)
+
+	repairsBefore := exec.KeyAssignmentRepairs.Load()
+
+	bushy := bushyJoin("inner", "l_sk = s_sk",
+		bushyScan("b_fact", ""),
+		bushyJoin("inner", "s_nk = n_nk",
+			bushyScan("b_supplier", ""),
+			bushyJoin("inner", "n_rk = r_rk",
+				bushyScan("b_nation", ""),
+				bushyScan("b_region", ""))))
+
+	rows := runPlanRows(t, planTree(t, cat, bushy))
+	if len(rows) != 200 {
+		t.Fatalf("bushy plan returned %d rows, want 200", len(rows))
+	}
+
+	ldPlan := planSQL(t, cat,
+		"SELECT l_ok, s_name, n_name, r_name FROM b_fact "+
+			"JOIN b_supplier ON l_sk = s_sk "+
+			"JOIN b_nation ON s_nk = n_nk "+
+			"JOIN b_region ON n_rk = r_rk", 0)
+	ldRows := runPlanRows(t, ldPlan)
+
+	got := rowKeySet(t, rows, "l_ok", "s_name", "n_name", "r_name")
+	want := rowKeySet(t, ldRows, "l_ok", "s_name", "n_name", "r_name")
+	if len(got) != len(want) {
+		t.Fatalf("row count mismatch: bushy %d vs left-deep %d", len(got), len(want))
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("row %d differs:\nbushy:     %s\nleft-deep: %s", i, got[i], want[i])
+		}
+	}
+
+	if d := exec.KeyAssignmentRepairs.Load() - repairsBefore; d != 0 {
+		t.Fatalf("runtime key repair fired %d time(s) — plan-time side assignment missed pairs", d)
+	}
+}
+
+// TestBushyBuild_ReversedKeysInCondition is the same shape with every join
+// condition written build-side-first ("s_sk = l_sk"). parseJoinKeys assigns
+// positionally, so every pair needs a plan-time swap — against a MULTI-TABLE
+// build subtree that the old membership test could not resolve.
+func TestBushyBuild_ReversedKeysInCondition(t *testing.T) {
+	cat := setupBushyTables(t)
+
+	repairsBefore := exec.KeyAssignmentRepairs.Load()
+
+	bushy := bushyJoin("inner", "s_sk = l_sk",
+		bushyScan("b_fact", ""),
+		bushyJoin("inner", "n_nk = s_nk",
+			bushyScan("b_supplier", ""),
+			bushyJoin("inner", "r_rk = n_rk",
+				bushyScan("b_nation", ""),
+				bushyScan("b_region", ""))))
+
+	rows := runPlanRows(t, planTree(t, cat, bushy))
+	if len(rows) != 200 {
+		t.Fatalf("bushy plan with reversed conditions returned %d rows, want 200", len(rows))
+	}
+	if d := exec.KeyAssignmentRepairs.Load() - repairsBefore; d != 0 {
+		t.Fatalf("runtime key repair fired %d time(s)", d)
+	}
+}
+
+// TestBushyBuild_SelfJoinOriginQualification puts a SECOND nation scan (n2)
+// inside the build subtree BEHIND region, so the build's first-DFS scan
+// alias is b_region — the single BuildTableAlias is wrong for n2's columns.
+// The duplicate n_name/n_nk/n_rk columns must qualify under their OWNING
+// alias (n2.*) via BuildColOrigins, not under b_region.*.
+func TestBushyBuild_SelfJoinOriginQualification(t *testing.T) {
+	cat := setupBushyTables(t)
+
+	// Probe: fact ⋈ supplier ⋈ nation n1 (left-deep spine, bare n_name).
+	// Build: region ⋈ nation n2 (region FIRST — findScanAlias returns it).
+	probe := bushyJoin("inner", "s_nk = n1.n_nk",
+		bushyJoin("inner", "l_sk = s_sk",
+			bushyScan("b_fact", ""),
+			bushyScan("b_supplier", "")),
+		bushyScan("b_nation", "n1"))
+	build := bushyJoin("inner", "r_rk = n2.n_rk",
+		bushyScan("b_region", ""),
+		bushyScan("b_nation", "n2"))
+	root := bushyJoin("inner", "n1.n_rk = n2.n_rk", probe, build)
+
+	rows := runPlanRows(t, planTree(t, cat, root))
+	if len(rows) == 0 {
+		t.Fatal("self-join bushy plan returned 0 rows")
+	}
+	// Every nation (n1) pairs with the 3 nations (n2) of its region:
+	// 200 fact rows × 3 = 600.
+	if len(rows) != 600 {
+		t.Fatalf("self-join bushy plan returned %d rows, want 600", len(rows))
+	}
+	// The build's duplicate nation columns must be reachable under the n2
+	// alias — b_region.* qualification (the old single-alias stamp) or a
+	// dropped column would break this.
+	sample := rows[0]
+	if _, ok := sample["n2.n_name"]; !ok {
+		cols := make([]string, 0, len(sample))
+		for k := range sample {
+			cols = append(cols, k)
+		}
+		sort.Strings(cols)
+		t.Fatalf("build-side self-join column not qualified by owning alias; output columns: %v", cols)
+	}
+	// Probe-side n1 copy stays bare (probe columns keep their names).
+	if _, ok := sample["n_name"]; !ok {
+		t.Fatal("probe-side nation column lost its bare name")
+	}
+	// Correctness: each row's n1 and n2 nations must share a region.
+	for _, r := range rows[:10] {
+		if r["n_rk"] != r["n2.n_rk"] {
+			t.Fatalf("joined nations differ in region: %v vs %v", r["n_rk"], r["n2.n_rk"])
+		}
+	}
+}
+
+// TestBushyBuild_DistributedStageShape runs a bushy tree through walkStages
+// and asserts the DAG wiring the executor depends on: the parent join's
+// build dependency is itself a join stage, BuildColOrigins is set (the build
+// spans multiple tables), and the stage list passes DAG-shape validation.
+func TestBushyBuild_DistributedStageShape(t *testing.T) {
+	cat := setupBushyTables(t)
+	ctx := context.Background()
+
+	bushy := bushyJoin("inner", "l_sk = s_sk",
+		bushyScan("b_fact", ""),
+		bushyJoin("inner", "s_nk = n_nk",
+			bushyScan("b_supplier", ""),
+			bushyScan("b_nation", "")))
+
+	planner := NewPlanner(cat)
+	planner.WorkerCount = 3
+	planner.AnnotateScanColumns(ctx, bushy)
+	stages, err := planner.PlanDistributed(ctx, bushy)
+	if err != nil {
+		t.Fatalf("PlanDistributed: %v", err)
+	}
+
+	stageByID := make(map[string]*Stage, len(stages))
+	for i := range stages {
+		stageByID[stages[i].ID] = &stages[i]
+	}
+	isJoinType := func(s *Stage) bool {
+		return s.Type == StageHashJoin || s.Type == StageBroadcastJoin || s.Type == StageSortMergeJoin
+	}
+
+	// Find the parent join: a join stage whose build dep chain (through
+	// exchanges) reaches another join stage.
+	var parent *Stage
+	for i := range stages {
+		s := &stages[i]
+		if !isJoinType(s) || s.RightDepStage == "" {
+			continue
+		}
+		cur := stageByID[s.RightDepStage]
+		for hop := 0; cur != nil && !isJoinType(cur) && hop < 3; hop++ {
+			if len(cur.Dependencies) == 0 {
+				cur = nil
+				break
+			}
+			cur = stageByID[cur.Dependencies[0]]
+		}
+		if cur != nil && isJoinType(cur) {
+			parent = s
+			break
+		}
+	}
+	if parent == nil {
+		types := make([]string, len(stages))
+		for i, s := range stages {
+			types[i] = s.ID + ":" + s.Type
+		}
+		t.Fatalf("no join stage with a join-shaped build dependency; stages: %v", types)
+	}
+	if parent.BuildColOrigins == nil {
+		t.Fatal("parent join over a multi-table build must carry BuildColOrigins")
+	}
+	if got := parent.BuildColOrigins["s_name"]; got != "b_supplier" {
+		t.Fatalf("BuildColOrigins[s_name] = %q, want b_supplier", got)
+	}
+	if got := parent.BuildColOrigins["n_name"]; got != "b_nation" {
+		t.Fatalf("BuildColOrigins[n_name] = %q, want b_nation", got)
+	}
+}

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -70,6 +70,12 @@ type Stage struct {
 	LeftDepStage    string // stage providing probe (left) side
 	RightDepStage   string // stage providing build (right) side
 	BuildTableAlias string // build-side table alias for column disambiguation in self-joins
+	// BuildColOrigins maps each bare build-output column (lowercased) to the
+	// scan alias that owns it. Only set when the build subtree spans multiple
+	// tables (bushy shapes) — nil for single-scan builds, where
+	// BuildTableAlias is already exact. The join executor qualifies duplicate
+	// build columns with the OWNING alias instead of BuildTableAlias.
+	BuildColOrigins map[string]string
 	JoinFilter      string // semi/anti join inequality filter (e.g., "l2.l_suppkey != l1.l_suppkey")
 
 	// Fused broadcast joins absorbed into this stage (avoids separate
@@ -239,6 +245,7 @@ type FusedJoinSpec struct {
 	JoinRightKeys   []string
 	BuildDepStage   string // stage providing build-side data
 	BuildTableAlias string
+	BuildColOrigins map[string]string // bare build col → owning scan alias (multi-table builds only)
 	JoinFilter      string
 	FilterExprs     []string
 }
@@ -2962,6 +2969,7 @@ func fuseJoinStages(stages []Stage) []Stage {
 			JoinRightKeys:   s.JoinRightKeys,
 			BuildDepStage:   s.RightDepStage,
 			BuildTableAlias: s.BuildTableAlias,
+			BuildColOrigins: s.BuildColOrigins,
 			JoinFilter:      s.JoinFilter,
 			FilterExprs:     s.FilterExprs,
 		}
@@ -3349,15 +3357,19 @@ func (p *Planner) walkStages(node *logical.Node, stages *[]Stage, parentID *stri
 
 		// Extract join keys from condition (cross joins have no ON clause)
 		var leftKeys, rightKeys []string
+		var buildNaming *subtreeNaming
+		if len(node.Children) >= 2 {
+			buildNaming = subtreeNamingOf(node.Children[1])
+		}
 		if jt != "cross" {
 			leftKeys, rightKeys = parseJoinKeys(node.JoinCond)
 			// parseJoinKeys assigns left/right based on position in the "="
 			// expression, not based on which child subtree owns the column.
 			// Fix the assignment so leftKeys are from the probe (left) child
 			// and rightKeys are from the build (right) child.
-			if len(node.Children) >= 2 {
+			if buildNaming != nil {
 				assignJoinKeySides(leftKeys, rightKeys,
-					subtreeNamingOf(node.Children[0]), subtreeNamingOf(node.Children[1]))
+					subtreeNamingOf(node.Children[0]), buildNaming)
 			}
 		}
 
@@ -3482,6 +3494,10 @@ func (p *Planner) walkStages(node *logical.Node, stages *[]Stage, parentID *stri
 			if alias := findScanAlias(node.Children[1]); alias != "" {
 				stage.BuildTableAlias = alias
 			}
+			// Multi-table build subtrees additionally carry per-column origin
+			// aliases so the executor qualifies each duplicate with its OWNING
+			// scan, not the (arbitrary) first one. Nil for single-scan builds.
+			stage.BuildColOrigins = buildNaming.buildColOrigins()
 		}
 		// Propagate semi/anti join inequality filters
 		if node.JoinFilter != "" {
@@ -3930,6 +3946,9 @@ func (p *Planner) buildJoin(ctx context.Context, node *logical.Node) (exec.Sourc
 	if alias := findScanAlias(node.Children[1]); alias != "" {
 		hj.BuildTableAlias = alias
 	}
+	// Multi-table build subtrees carry per-column origin aliases so each
+	// duplicate qualifies under its OWNING scan (nil for single-scan builds).
+	hj.BuildColOrigins = subtreeNamingOf(node.Children[1]).buildColOrigins()
 
 	// Grace Hash Join spill-to-disk: prevents OOM on large build sides (e.g.
 	// SF100 orders table at 150M rows). The shared MemTracker means multi-join
@@ -3968,10 +3987,11 @@ func (p *Planner) buildJoin(ctx context.Context, node *logical.Node) (exec.Sourc
 		hj.RightKeys = rightKeys
 		assignJoinKeySides(leftKeys, rightKeys,
 			subtreeNamingOf(node.Children[0]), subtreeNamingOf(node.Children[1]))
-		// Update build-side alias after swap
+		// Update build-side alias + origins after swap
 		if alias := findScanAlias(node.Children[1]); alias != "" {
 			hj.BuildTableAlias = alias
 		}
+		hj.BuildColOrigins = subtreeNamingOf(node.Children[1]).buildColOrigins()
 	}
 
 	// For semi/anti joins without a filter, enable key-only build:

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -2691,6 +2691,17 @@ func markCoPathingSelfJoinBuilds(stages []Stage) {
 	// For each join stage, walk its build-side dep chain (transitively
 	// through any Exchange wrappers) to the underlying scan and record
 	// (joinIdx, scanTableName).
+	//
+	// The walk deliberately does NOT branch into both sides of a join stage
+	// encountered mid-chain (bushy builds). An attempted extension that did
+	// (2026-07-09) surfaced same-table scans from Q02/Q20's decorrelated
+	// subquery chains and force-qualified joins whose downstream consumers
+	// reference bare names — 0 rows. Bushy self-join collisions are instead
+	// qualified at the join where the collision occurs, via isDup +
+	// BuildColOrigins in joinOutputSchemaWithMapping. If a bushy shape ever
+	// needs Q07-style cross-chain force-qualification, decide it from the
+	// LOGICAL tree's exact output visibility (subtreeNaming), not from a
+	// stage-DAG walk.
 	type joinScan struct {
 		joinIdx   int
 		joinID    string
@@ -3077,12 +3088,16 @@ func sumFusedBytes(stages []Stage, specs []FusedJoinSpec) int64 {
 // resolveShuffleKey resolves a join key name through any Project alias nodes
 // in the child subtree. For example, a CTE with `l_suppkey AS supplier_no`
 // creates a Project that renames the column — the shuffle key `supplier_no`
-// must be mapped back to `l_suppkey` so the executor can find it in the data.
+// must be mapped back to `l_suppkey` so the executor can find it in the data
+// (distributed walkStages treats ordinary Projects as passthrough, so the
+// physical columns keep their original names).
+//
+// Join nodes recurse into their output-visible children: both sides for
+// inner/outer joins, probe side only for semi/anti. First resolution wins.
 func resolveShuffleKey(key string, child *logical.Node) string {
 	if child == nil {
 		return key
 	}
-	// Walk down through pass-through nodes looking for a Project with an alias.
 	for n := child; n != nil; {
 		if n.Type == logical.NodeProject {
 			for _, proj := range n.Projections {
@@ -3090,6 +3105,16 @@ func resolveShuffleKey(key string, child *logical.Node) string {
 					return proj.Column
 				}
 			}
+		}
+		if n.Type == logical.NodeJoin && len(n.Children) == 2 {
+			if resolved := resolveShuffleKey(key, n.Children[0]); resolved != key {
+				return resolved
+			}
+			jt := strings.ToLower(n.JoinType)
+			if jt != "semi" && jt != "anti" {
+				return resolveShuffleKey(key, n.Children[1])
+			}
+			return key
 		}
 		// Continue down to single-child nodes (Filter, Sort, Limit, Project, Aggregate)
 		if len(n.Children) == 1 {

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"runtime"
 	"strconv"
@@ -4108,7 +4109,10 @@ func (p *Planner) buildJoin(ctx context.Context, node *logical.Node) (exec.Sourc
 			return
 		}
 		if deferBuild || useReverseBloom {
-			hj.FixKeyAssignment()
+			if hj.FixKeyAssignment() {
+				slog.Warn("join key repair fired at runtime — plan-time side assignment missed a pair",
+					"left_keys", hj.LeftKeys, "right_keys", hj.RightKeys)
+			}
 			if joinType == exec.SemiJoin || joinType == exec.AntiJoin {
 				hj.PruneBuildColumns(keepCols)
 			}
@@ -4199,7 +4203,11 @@ func (p *Planner) buildJoin(ctx context.Context, node *logical.Node) (exec.Sourc
 	// (left of "=" → leftKey, right → rightKey), but the SQL may put the
 	// build-side column on the left (e.g., "JOIN t ON t.id = probe.id").
 	// After building, we know the build schema; swap any misassigned pairs.
-	hj.FixKeyAssignment()
+	// A repair firing here means plan-time assignJoinKeySides missed a pair.
+	if hj.FixKeyAssignment() {
+		slog.Warn("join key repair fired at runtime — plan-time side assignment missed a pair",
+			"left_keys", hj.LeftKeys, "right_keys", hj.RightKeys)
+	}
 
 	// SemiAntiFilter already set above (pre-goroutine).
 

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -1684,7 +1684,7 @@ func (p *Planner) PlanDistributed(ctx context.Context, node *logical.Node) ([]St
 	if len(node.CTEs) > 0 {
 		p.ctes = node.CTEs
 	}
-	// Ensure scan nodes have column metadata — needed by fixJoinKeyOrder
+	// Ensure scan nodes have column metadata — needed by assignJoinKeySides
 	// to assign shuffle keys to the correct child side.
 	p.AnnotateScanColumns(ctx, node)
 	stages := p.generateStages(node)
@@ -3356,7 +3356,8 @@ func (p *Planner) walkStages(node *logical.Node, stages *[]Stage, parentID *stri
 			// Fix the assignment so leftKeys are from the probe (left) child
 			// and rightKeys are from the build (right) child.
 			if len(node.Children) >= 2 {
-				fixJoinKeyOrder(leftKeys, rightKeys, node.Children[1])
+				assignJoinKeySides(leftKeys, rightKeys,
+					subtreeNamingOf(node.Children[0]), subtreeNamingOf(node.Children[1]))
 			}
 		}
 
@@ -3907,10 +3908,11 @@ func (p *Planner) buildJoin(ctx context.Context, node *logical.Node) (exec.Sourc
 		if len(leftKeys) == 0 {
 			return nil, nil, nil, fmt.Errorf("could not extract join keys from: %s", node.JoinCond)
 		}
-		// Fix key assignment using plan-level column info: ensure left keys are
-		// probe-side and right keys are build-side. This avoids the expensive
+		// Fix key assignment using plan-level column ownership: ensure left keys
+		// are probe-side and right keys are build-side. This avoids the expensive
 		// post-build FixKeyAssignment hash table rebuild.
-		fixJoinKeyOrder(leftKeys, rightKeys, node.Children[1])
+		assignJoinKeySides(leftKeys, rightKeys,
+			subtreeNamingOf(node.Children[0]), subtreeNamingOf(node.Children[1]))
 	}
 
 	// Big-vs-big inner equi-joins route to sort-merge join when BOTH sides'
@@ -3964,7 +3966,8 @@ func (p *Planner) buildJoin(ctx context.Context, node *logical.Node) (exec.Sourc
 		leftKeys, rightKeys = rightKeys, leftKeys
 		hj.LeftKeys = leftKeys
 		hj.RightKeys = rightKeys
-		fixJoinKeyOrder(leftKeys, rightKeys, node.Children[1])
+		assignJoinKeySides(leftKeys, rightKeys,
+			subtreeNamingOf(node.Children[0]), subtreeNamingOf(node.Children[1]))
 		// Update build-side alias after swap
 		if alias := findScanAlias(node.Children[1]); alias != "" {
 			hj.BuildTableAlias = alias
@@ -4829,69 +4832,6 @@ func parseJoinKeys(cond string) (leftKeys, rightKeys []string) {
 		rightKeys = append(rightKeys, right)
 	}
 	return
-}
-
-// fixJoinKeyOrder ensures left keys are probe-side and right keys are build-side
-// by checking against the build subtree's available columns from the plan.
-// This avoids the expensive post-build FixKeyAssignment hash table rebuild
-// which was 31% of Q09's time at SF10.
-//
-// Build columns are unqualified (from the table scan), but join keys may now
-// preserve qualifiers (post Q07 fix). Strip the qualifier on lookup so a key
-// like "n1.n_nationkey" matches the build's unqualified "n_nationkey".
-func fixJoinKeyOrder(leftKeys, rightKeys []string, buildNode *logical.Node) {
-	buildCols := collectPlanColumns(buildNode)
-	if len(buildCols) == 0 {
-		return
-	}
-	stripQual := func(k string) string {
-		if dot := strings.Index(k, "."); dot >= 0 {
-			return k[dot+1:]
-		}
-		return k
-	}
-	for i := range leftKeys {
-		leftInBuild := buildCols[leftKeys[i]] || buildCols[stripQual(leftKeys[i])]
-		rightInBuild := buildCols[rightKeys[i]] || buildCols[stripQual(rightKeys[i])]
-		if leftInBuild && !rightInBuild {
-			leftKeys[i], rightKeys[i] = rightKeys[i], leftKeys[i]
-		}
-	}
-}
-
-// collectPlanColumns returns all column names available from scan nodes
-// in the logical plan subtree (lowercased).
-func collectPlanColumns(n *logical.Node) map[string]bool {
-	if n == nil {
-		return nil
-	}
-	result := make(map[string]bool)
-	collectPlanColumnsRec(n, result)
-	return result
-}
-
-func collectPlanColumnsRec(n *logical.Node, result map[string]bool) {
-	if n == nil {
-		return
-	}
-	if n.Type == logical.NodeScan {
-		for _, col := range n.ScanColumns {
-			result[strings.ToLower(col)] = true
-		}
-	}
-	// Semi/anti joins only output probe-side (child[0]) columns.
-	// Skip build side so fixJoinKeyOrder doesn't see build-only columns
-	// as available from this subtree.
-	if n.Type == logical.NodeJoin && len(n.Children) == 2 {
-		jt := strings.ToLower(n.JoinType)
-		if jt == "semi" || jt == "anti" {
-			collectPlanColumnsRec(n.Children[0], result)
-			return
-		}
-	}
-	for _, child := range n.Children {
-		collectPlanColumnsRec(child, result)
-	}
 }
 
 func (p *Planner) buildFilter(ctx context.Context, node *logical.Node) (exec.Source, []exec.UnaryOperator, exec.Sink, error) {

--- a/internal/planner/physical/sort_merge_join.go
+++ b/internal/planner/physical/sort_merge_join.go
@@ -51,6 +51,9 @@ func (p *Planner) buildSortMergeJoin(ctx context.Context, node *logical.Node, le
 	if alias := findScanAlias(node.Children[1]); alias != "" {
 		j.BuildTableAlias = alias
 	}
+	// Multi-table build subtrees carry per-column origin aliases so each
+	// duplicate qualifies under its OWNING scan (nil for single-scan builds).
+	j.BuildColOrigins = subtreeNamingOf(node.Children[1]).buildColOrigins()
 	if sm := p.getSpillManager(); sm != nil {
 		j.Spill = sm
 	}

--- a/internal/planner/physical/subtree_naming.go
+++ b/internal/planner/physical/subtree_naming.go
@@ -1,0 +1,171 @@
+package physical
+
+import (
+	"strings"
+
+	"github.com/citc-tech/wadjet/internal/planner/logical"
+)
+
+// subtreeNaming captures structure-independent column-provenance facts about
+// a logical subtree: which scan aliases it contains, which columns each alias
+// provides, which projection/aggregate output names it exposes, and —
+// mirroring the join executor's output-naming rule — which scan alias owns
+// each bare column name in the subtree's OUTPUT schema.
+//
+// It replaces the flat scan-column union (collectPlanColumns) that join-key
+// side assignment used to rely on. The union could not distinguish
+// alias-qualified self-join keys (n1.x vs n2.x both collapsed to x) and
+// broke down entirely when a join's build side spans multiple tables — the
+// failure that blocked bushy join plans (see docs/design/bushy-join-cbo.md).
+type subtreeNaming struct {
+	// aliasCols maps a scan alias (lowercased; TableAlias falling back to
+	// TableName) to that scan's column set (lowercased). Only scans visible
+	// in the subtree's output are included: a semi/anti join's build side
+	// contributes nothing.
+	aliasCols map[string]map[string]bool
+	// outputNames holds projection aliases and aggregate output columns
+	// (lowercased) exposed by the subtree (e.g. supplier_no from
+	// `l_suppkey AS supplier_no`, total_revenue from a CTE aggregate).
+	// These are owned names without scan provenance.
+	outputNames map[string]bool
+	// origins maps each bare column name (lowercased) to the alias
+	// (verbatim case) whose copy of the column stays UNQUALIFIED in the
+	// subtree's output schema. Mirrors joinOutputSchemaWithMapping:
+	// probe-side columns keep their names and duplicate build-side columns
+	// get qualified, so the probe-most scan owns the bare name.
+	origins map[string]string
+}
+
+// subtreeNamingOf computes the naming facts for a logical subtree.
+func subtreeNamingOf(n *logical.Node) *subtreeNaming {
+	s := &subtreeNaming{
+		aliasCols:   make(map[string]map[string]bool),
+		outputNames: make(map[string]bool),
+		origins:     make(map[string]string),
+	}
+	s.collect(n)
+	return s
+}
+
+func (s *subtreeNaming) collect(n *logical.Node) {
+	if n == nil {
+		return
+	}
+	switch n.Type {
+	case logical.NodeScan:
+		alias := n.TableAlias
+		if alias == "" {
+			alias = n.TableName
+		}
+		key := strings.ToLower(alias)
+		cols := s.aliasCols[key]
+		if cols == nil {
+			cols = make(map[string]bool, len(n.ScanColumns))
+			s.aliasCols[key] = cols
+		}
+		for _, col := range n.ScanColumns {
+			lc := strings.ToLower(col)
+			cols[lc] = true
+			// First writer wins: children are visited probe-before-build,
+			// so the probe-most scan owns the bare output name.
+			if _, ok := s.origins[lc]; !ok {
+				s.origins[lc] = alias
+			}
+		}
+		return
+	case logical.NodeJoin:
+		s.collect(n.Children[0])
+		// Semi/anti joins output only probe-side columns; the build side is
+		// invisible above the join.
+		jt := strings.ToLower(n.JoinType)
+		if jt == "semi" || jt == "anti" {
+			return
+		}
+		for _, child := range n.Children[1:] {
+			s.collect(child)
+		}
+		return
+	case logical.NodeProject:
+		for _, proj := range n.Projections {
+			if proj.Alias != "" {
+				s.outputNames[strings.ToLower(proj.Alias)] = true
+			}
+		}
+	case logical.NodeAggregate:
+		for _, agg := range n.AggExprs {
+			if agg.OutputCol != "" {
+				s.outputNames[strings.ToLower(agg.OutputCol)] = true
+			}
+		}
+	}
+	for _, child := range n.Children {
+		s.collect(child)
+	}
+}
+
+// ownsKey reports whether a join-key reference resolves to a column this
+// subtree exposes. Alias-qualified keys ("n2.n_nationkey") are owned only
+// when the qualifier is one of the subtree's scan aliases and the column
+// belongs to that scan — a self-join's other copy does NOT own them.
+// Bare keys are owned when any scan in the subtree provides the column or
+// the subtree exposes it as a projection/aggregate output name.
+// Expression keys (anything that isn't a plain column reference) resolve to
+// not-owned, matching the previous membership test's behavior.
+func (s *subtreeNaming) ownsKey(key string) bool {
+	k := strings.ToLower(strings.TrimSpace(key))
+	if dot := strings.IndexByte(k, '.'); dot >= 0 {
+		if cols, ok := s.aliasCols[k[:dot]]; ok {
+			return cols[k[dot+1:]]
+		}
+		return false
+	}
+	if s.outputNames[k] {
+		return true
+	}
+	for _, cols := range s.aliasCols {
+		if cols[k] {
+			return true
+		}
+	}
+	return false
+}
+
+// buildColOrigins returns the bare-column → origin-alias map the join
+// executor needs to qualify duplicate build columns with the OWNING scan's
+// alias when the build side spans multiple tables. Single-alias subtrees
+// return nil: the join's single BuildTableAlias is already exact, and nil
+// keeps every current left-deep plan byte-identical.
+func (s *subtreeNaming) buildColOrigins() map[string]string {
+	if len(s.aliasCols) <= 1 {
+		return nil
+	}
+	return s.origins
+}
+
+// assignJoinKeySides ensures leftKeys reference the probe (left) child and
+// rightKeys the build (right) child, deciding by column OWNERSHIP in each
+// child subtree rather than textual position in the join condition.
+//
+// Decision rule, per key pair: a key exclusively owned by the build side
+// must sit in rightKeys. When ownership is symmetric or unresolvable
+// (shared column names, expression keys), the pair keeps its positional
+// order — exactly the previous fixJoinKeyOrder outcome — and the runtime
+// safety net (FixKeyAssignment) remains the last resort.
+func assignJoinKeySides(leftKeys, rightKeys []string, probe, build *subtreeNaming) {
+	for i := range leftKeys {
+		lProbe, lBuild := probe.ownsKey(leftKeys[i]), build.ownsKey(leftKeys[i])
+		rProbe, rBuild := probe.ownsKey(rightKeys[i]), build.ownsKey(rightKeys[i])
+		lExclBuild := lBuild && !lProbe
+		rExclBuild := rBuild && !rProbe
+		switch {
+		case lExclBuild && !rExclBuild:
+			leftKeys[i], rightKeys[i] = rightKeys[i], leftKeys[i]
+		case rExclBuild && !lExclBuild:
+			// Correctly assigned.
+		case lBuild && !rBuild:
+			// Partial information (e.g. right side is an expression):
+			// mirror the previous membership rule.
+			leftKeys[i], rightKeys[i] = rightKeys[i], leftKeys[i]
+		}
+	}
+}

--- a/internal/planner/physical/subtree_naming_test.go
+++ b/internal/planner/physical/subtree_naming_test.go
@@ -1,0 +1,258 @@
+package physical
+
+import (
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/planner/logical"
+)
+
+func scanNode(table, alias string, cols ...string) *logical.Node {
+	return &logical.Node{
+		Type:        logical.NodeScan,
+		TableName:   table,
+		TableAlias:  alias,
+		ScanColumns: cols,
+	}
+}
+
+func joinNode(jt string, left, right *logical.Node, cond string) *logical.Node {
+	return &logical.Node{
+		Type:     logical.NodeJoin,
+		JoinType: jt,
+		JoinCond: cond,
+		Children: []*logical.Node{left, right},
+	}
+}
+
+func TestSubtreeNamingScanOwnership(t *testing.T) {
+	s := subtreeNamingOf(scanNode("nation", "n1", "n_nationkey", "n_name"))
+
+	tests := []struct {
+		key  string
+		want bool
+	}{
+		{"n_nationkey", true},
+		{"n1.n_nationkey", true},
+		{"N1.N_NATIONKEY", true}, // case-insensitive
+		{"n2.n_nationkey", false},
+		{"nation.n_nationkey", false}, // alias overrides table name
+		{"r_regionkey", false},
+		{"n1.r_regionkey", false},
+		{"extract(year from o_orderdate)", false}, // expression key
+	}
+	for _, tt := range tests {
+		if got := s.ownsKey(tt.key); got != tt.want {
+			t.Errorf("ownsKey(%q) = %v, want %v", tt.key, got, tt.want)
+		}
+	}
+}
+
+func TestSubtreeNamingTableNameFallback(t *testing.T) {
+	s := subtreeNamingOf(scanNode("region", "", "r_regionkey", "r_name"))
+	if !s.ownsKey("region.r_regionkey") {
+		t.Error("unaliased scan should own table-qualified key")
+	}
+	if !s.ownsKey("r_name") {
+		t.Error("unaliased scan should own bare key")
+	}
+}
+
+func TestSubtreeNamingSemiAntiBuildInvisible(t *testing.T) {
+	// orders SEMI JOIN lineitem — lineitem columns are not in the output.
+	semi := joinNode("semi",
+		scanNode("orders", "", "o_orderkey", "o_custkey"),
+		scanNode("lineitem", "", "l_orderkey", "l_suppkey"),
+		"o_orderkey = l_orderkey")
+	s := subtreeNamingOf(semi)
+	if !s.ownsKey("o_custkey") {
+		t.Error("semi join must own probe columns")
+	}
+	if s.ownsKey("l_suppkey") {
+		t.Error("semi join must NOT own build-only columns")
+	}
+	if s.ownsKey("lineitem.l_orderkey") {
+		t.Error("semi join must NOT own qualified build columns")
+	}
+}
+
+func TestSubtreeNamingInnerJoinBothSidesVisible(t *testing.T) {
+	inner := joinNode("inner",
+		scanNode("nation", "n2", "n_nationkey", "n_name"),
+		scanNode("region", "", "r_regionkey", "r_name"),
+		"n_regionkey = r_regionkey")
+	s := subtreeNamingOf(inner)
+	for _, key := range []string{"n2.n_name", "r_name", "n_nationkey", "r_regionkey"} {
+		if !s.ownsKey(key) {
+			t.Errorf("inner join subtree should own %q", key)
+		}
+	}
+	if s.ownsKey("n1.n_name") {
+		t.Error("must not own the other self-join copy's qualified key")
+	}
+}
+
+func TestSubtreeNamingProjectAndAggregateOutputs(t *testing.T) {
+	agg := &logical.Node{
+		Type:     logical.NodeAggregate,
+		GroupBy:  []string{"l_suppkey"},
+		AggExprs: []logical.AggExpr{{Func: "sum", InputCol: "l_extendedprice", OutputCol: "total_revenue"}},
+		Children: []*logical.Node{scanNode("lineitem", "", "l_suppkey", "l_extendedprice")},
+	}
+	proj := &logical.Node{
+		Type:        logical.NodeProject,
+		Projections: []logical.Projection{{Column: "l_suppkey", Alias: "supplier_no"}},
+		Children:    []*logical.Node{agg},
+	}
+	s := subtreeNamingOf(proj)
+	if !s.ownsKey("total_revenue") {
+		t.Error("aggregate output name should be owned")
+	}
+	if !s.ownsKey("supplier_no") {
+		t.Error("projection alias should be owned")
+	}
+	if !s.ownsKey("l_suppkey") {
+		t.Error("underlying scan column should remain owned")
+	}
+}
+
+func TestSubtreeNamingBuildColOrigins(t *testing.T) {
+	// Single-alias build: nil origins (BuildTableAlias suffices; keeps
+	// left-deep plans byte-identical).
+	single := subtreeNamingOf(scanNode("nation", "n2", "n_nationkey", "n_name"))
+	if single.buildColOrigins() != nil {
+		t.Fatal("single-alias subtree must return nil origins")
+	}
+
+	// Multi-table build: each bare column maps to its owning scan alias.
+	bushy := joinNode("inner",
+		scanNode("supplier", "", "s_suppkey", "s_nationkey"),
+		joinNode("inner",
+			scanNode("nation", "n2", "n_nationkey", "n_name"),
+			scanNode("region", "", "r_regionkey", "r_name"),
+			"n_regionkey = r_regionkey"),
+		"s_nationkey = n_nationkey")
+	origins := subtreeNamingOf(bushy).buildColOrigins()
+	if origins == nil {
+		t.Fatal("multi-alias subtree must return origins")
+	}
+	want := map[string]string{
+		"s_suppkey":   "supplier",
+		"n_name":      "n2",
+		"r_regionkey": "region",
+	}
+	for col, alias := range want {
+		if origins[col] != alias {
+			t.Errorf("origins[%q] = %q, want %q", col, origins[col], alias)
+		}
+	}
+}
+
+func TestSubtreeNamingOriginsProbePriority(t *testing.T) {
+	// Self-join inside one subtree: the probe-most copy owns the bare name.
+	selfJoin := joinNode("inner",
+		scanNode("nation", "n1", "n_nationkey", "n_name"),
+		scanNode("nation", "n2", "n_nationkey", "n_name"),
+		"n1.n_nationkey = n2.n_nationkey")
+	s := subtreeNamingOf(selfJoin)
+	if got := s.origins["n_name"]; got != "n1" {
+		t.Errorf("probe-most scan should own bare name: got %q, want n1", got)
+	}
+}
+
+func TestAssignJoinKeySides(t *testing.T) {
+	probeChain := joinNode("inner",
+		joinNode("inner",
+			scanNode("customer", "", "c_custkey", "c_nationkey"),
+			scanNode("orders", "", "o_orderkey", "o_custkey"),
+			"c_custkey = o_custkey"),
+		scanNode("nation", "n1", "n_nationkey", "n_name"),
+		"c_nationkey = n1.n_nationkey")
+
+	tests := []struct {
+		name       string
+		leftKeys   []string
+		rightKeys  []string
+		build      *logical.Node
+		wantLeft   []string
+		wantRight  []string
+	}{
+		{
+			name:      "correct order kept",
+			leftKeys:  []string{"o_orderkey"},
+			rightKeys: []string{"l_orderkey"},
+			build:     scanNode("lineitem", "", "l_orderkey", "l_suppkey"),
+			wantLeft:  []string{"o_orderkey"},
+			wantRight: []string{"l_orderkey"},
+		},
+		{
+			name:      "reversed bare keys swapped",
+			leftKeys:  []string{"l_orderkey"},
+			rightKeys: []string{"o_orderkey"},
+			build:     scanNode("lineitem", "", "l_orderkey", "l_suppkey"),
+			wantLeft:  []string{"o_orderkey"},
+			wantRight: []string{"l_orderkey"},
+		},
+		{
+			name:      "self-join qualified keys kept",
+			leftKeys:  []string{"n1.n_nationkey"},
+			rightKeys: []string{"n2.n_nationkey"},
+			build:     scanNode("nation", "n2", "n_nationkey", "n_name"),
+			wantLeft:  []string{"n1.n_nationkey"},
+			wantRight: []string{"n2.n_nationkey"},
+		},
+		{
+			name:      "reversed self-join qualified keys swapped",
+			leftKeys:  []string{"n2.n_nationkey"},
+			rightKeys: []string{"n1.n_nationkey"},
+			build:     scanNode("nation", "n2", "n_nationkey", "n_name"),
+			wantLeft:  []string{"n1.n_nationkey"},
+			wantRight: []string{"n2.n_nationkey"},
+		},
+		{
+			name:      "expression left key with build-owned right kept",
+			leftKeys:  []string{"substring(c_phone from 1 for 2)"},
+			rightKeys: []string{"l_orderkey"},
+			build:     scanNode("lineitem", "", "l_orderkey"),
+			wantLeft:  []string{"substring(c_phone from 1 for 2)"},
+			wantRight: []string{"l_orderkey"},
+		},
+		{
+			name:      "build-owned left with expression right swapped",
+			leftKeys:  []string{"l_orderkey"},
+			rightKeys: []string{"substring(c_phone from 1 for 2)"},
+			build:     scanNode("lineitem", "", "l_orderkey"),
+			wantLeft:  []string{"substring(c_phone from 1 for 2)"},
+			wantRight: []string{"l_orderkey"},
+		},
+		{
+			// Probe chain owns n_nationkey too (via n1), so the build's
+			// copy is not exclusive — but the probe-side key IS exclusive
+			// to the probe. The reversed pair must still swap.
+			name:      "reversed keys with bushy multi-table build swapped",
+			leftKeys:  []string{"n_nationkey"},
+			rightKeys: []string{"c_nationkey"},
+			build: joinNode("inner",
+				scanNode("nation", "n2", "n_nationkey", "n_regionkey"),
+				scanNode("region", "", "r_regionkey", "r_name"),
+				"n_regionkey = r_regionkey"),
+			wantLeft:  []string{"c_nationkey"},
+			wantRight: []string{"n_nationkey"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			probe := subtreeNamingOf(probeChain)
+			build := subtreeNamingOf(tt.build)
+			left := append([]string(nil), tt.leftKeys...)
+			right := append([]string(nil), tt.rightKeys...)
+			assignJoinKeySides(left, right, probe, build)
+			for i := range left {
+				if left[i] != tt.wantLeft[i] || right[i] != tt.wantRight[i] {
+					t.Errorf("pair %d = (%q, %q), want (%q, %q)",
+						i, left[i], right[i], tt.wantLeft[i], tt.wantRight[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/worker/executor_fragment.go
+++ b/internal/worker/executor_fragment.go
@@ -1744,7 +1744,10 @@ func (e *Executor) buildFragmentJoinProbe(ctx context.Context, task distributed.
 		if err := hj.Build(ctx, src); err != nil {
 			return nil, fmt.Errorf("building hash table: %w", err)
 		}
-		hj.FixKeyAssignment()
+		if hj.FixKeyAssignment() {
+			slog.Warn("join key repair fired at runtime — plan-time side assignment missed a pair",
+				"left_keys", hj.LeftKeys, "right_keys", hj.RightKeys)
+		}
 		return hj, nil
 	}
 

--- a/internal/worker/executor_fragment.go
+++ b/internal/worker/executor_fragment.go
@@ -1391,6 +1391,7 @@ func (e *Executor) buildFragmentSortMergeJoin(ctx context.Context, task distribu
 	j := exec.NewSortMergeJoin(spec.LeftKeys, spec.RightKeys)
 	j.BuildTableAlias = spec.BuildAlias
 	j.QualifyAllBuildCols = spec.QualifyAllBuildCols
+	j.BuildColOrigins = spec.BuildColOrigins
 	if len(spec.OutputColumns) > 0 {
 		filter := make(map[string]bool, len(spec.OutputColumns))
 		for _, c := range spec.OutputColumns {
@@ -1717,6 +1718,7 @@ func (e *Executor) buildFragmentJoinProbe(ctx context.Context, task distributed.
 		hj := exec.NewHashJoin(mapJoinTypeString(spec.JoinType), spec.LeftKeys, spec.RightKeys)
 		hj.BuildTableAlias = spec.BuildAlias
 		hj.QualifyAllBuildCols = spec.QualifyAllBuildCols
+		hj.BuildColOrigins = spec.BuildColOrigins
 		if spec.BuildRowHint > 0 {
 			hj.BuildRowHint = spec.BuildRowHint
 		}


### PR DESCRIPTION
## Summary

Phase A of the bushy-CBO plan (design memo: `docs/design/bushy-join-cbo.md`). The May 2026 bushy join-enumeration attempt produced wrong rows on Q02/Q07/Q08/Q09/Q21 because the physical layer resolves join keys and build aliases by guessing against a "build side = one base scan" assumption. This PR makes that resolution structure-independent — a zero-behavior-change refactor gated on byte-identical plans — so bushy enumeration (Phase B, dormant flag) can land on a correct foundation.

## What changed

- **`subtreeNaming` resolver** (`internal/planner/physical/subtree_naming.go`): per-alias column sets, semi/anti probe-only visibility, projection/aggregate output names, and per-column origin aliases for any logical subtree. `assignJoinKeySides` replaces `fixJoinKeyOrder`/`collectPlanColumns` — side assignment now distinguishes alias-qualified self-join keys and multi-table builds by ownership, not flat membership.
- **`BuildColOrigins`** end-to-end (planner → Stage/FusedJoinSpec → Task/OpSpec → hash + sort-merge + fused executors): duplicate build columns qualify under their **owning** scan's alias instead of the first-DFS `BuildTableAlias`, and pre-qualified columns from nested joins emit verbatim (no double-qualification, no drops). Nil for single-scan builds — left-deep output schemas are unchanged.
- **`resolveShuffleKey`** resolves Project/CTE aliases through join subtrees (output-visible children only).
- **Tripwires**: `exec.KeyAssignmentRepairs` / `exec.SMJCounterpartAdoptions` counters + WARN when a runtime key repair fires — plan-time resolution is supposed to keep these silent.
- **Bushy unit suite** (`bushy_join_test.go`): constructs the exact tree shapes Phase B will emit and executes them against MemStore fixtures — dimension-chain parity vs left-deep SQL, reversed-condition assignment, self-join origin qualification (verified to fail under the old single-alias stamping), distributed stage shape.

## Gates

- Distribution snapshot goldens: **byte-identical**
- TPC-H SF0.01: 22/22 (plus late-mat-forced and SMJ-forced variants)
- `tpch-harness --mode=local`: **row-identical** to a main-built binary across all 22 queries + micros
- Full `./internal/...` suite green
- Tripwire: silent except Q02's **pre-existing** scalar-subquery repair (documented in the memo §5 — the flat JoinCond loses query-block scope after decorrelation; runtime repair has always carried it; decorrelator-emitted side-assigned keys tracked as a follow-on)

## Explicitly not in this PR

- No bushy enumeration (Phase B: `--bushy-join-reorder`, default off)
- No plan shape changes of any kind
- `markCoPathingSelfJoinBuilds` deliberately keeps its single-path walk — the branching extension broke Q02/Q20 (rationale documented in-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UgXRArvN16VitPkxV55g8S