### PR TITLE
fix(planner): composite broadcast eligibility + probe-side-only join fusion

### DIFF
--- a/internal/planner/physical/fusion_byte_budget_test.go
+++ b/internal/planner/physical/fusion_byte_budget_test.go
@@ -24,7 +24,7 @@ func TestFuseJoinStages_SkipsLargeBuilds(t *testing.T) {
 			{
 				ID: "join-outer", Type: "broadcast_join",
 				Dependencies: []string{"scan-probe", "join-leaf"},
-				LeftDepStage: "scan-probe", RightDepStage: "join-leaf",
+				LeftDepStage: "join-leaf", RightDepStage: "scan-probe", // candidate feeds the PROBE side (fusion requirement since 2026-07-09)
 				JoinLeftKeys: []string{"k"}, JoinRightKeys: []string{"k"},
 			},
 			// Leaf broadcast join (candidate for fusion)
@@ -110,7 +110,7 @@ func TestFuseJoinStages_BuildBytesViaExchangeReplicate(t *testing.T) {
 			{
 				ID: "join-outer", Type: "broadcast_join",
 				Dependencies: []string{"scan-probe", "join-leaf"},
-				LeftDepStage: "scan-probe", RightDepStage: "join-leaf",
+				LeftDepStage: "join-leaf", RightDepStage: "scan-probe", // candidate feeds the PROBE side (fusion requirement since 2026-07-09)
 				JoinLeftKeys: []string{"k"}, JoinRightKeys: []string{"k"},
 			},
 			{

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -2941,6 +2941,15 @@ func fuseJoinStages(stages []Stage) []Stage {
 		if consumer.Type != "hash_join" && consumer.Type != "broadcast_join" {
 			continue
 		}
+		// The candidate's output must feed the consumer's PROBE side.
+		// Fusion replays the absorbed join as a broadcast-probe step on the
+		// consumer's probe STREAM — valid only when the absorbed output IS
+		// that stream. A candidate feeding the consumer's BUILD side (bushy
+		// composite builds) would replay its probe steps against the wrong
+		// stream: Q07/Q08-class chains returned 0 rows (2026-07-09).
+		if consumer.LeftDepStage != s.ID {
+			continue
+		}
 
 		// Cumulative byte budget: cap total cache amplification across the
 		// fused chain. Required because each probe-split shard loads every
@@ -3776,9 +3785,21 @@ func (p *Planner) isBroadcastCandidate(joinNode *logical.Node) bool {
 // scaling the table's manifest bytes by the subtree's estimated selectivity.
 // Returns ok=false when the subtree has no scan root (e.g. another join) or
 // the manifest is unavailable — callers must treat "unknown" conservatively.
+//
+// Under BushyJoinReorder, join-shaped subtrees (composite build sides) are
+// estimated too: output bytes ≈ estimated output rows × the combined
+// per-row width of the join's visible inputs. Without this, a 25-row
+// nation ⋈ region pre-join is "unknown" → never broadcast-eligible → the
+// whole composite pays exchange-repartition for both sides (the Q08 SF10
+// regression, 2026-07-09: +135% from shuffling what should replicate).
+// Gated on the flag: flag-off keeps semi/anti-leaf builds on their
+// SF100-validated shuffle plans.
 func (p *Planner) estimateSubtreeBytes(n *logical.Node) (int64, bool) {
 	scan := findScanNode(n)
 	if scan == nil {
+		if logical.BushyJoinReorder.Load() {
+			return p.estimateJoinSubtreeBytes(n)
+		}
 		return 0, false
 	}
 	// Estimate size from file count
@@ -3813,6 +3834,62 @@ func (p *Planner) estimateSubtreeBytes(n *logical.Node) (int64, bool) {
 		}
 	}
 	return totalBytes, true
+}
+
+// estimateJoinSubtreeBytes estimates the output size of a join-shaped
+// subtree: estimated output rows × the per-row width of the join's visible
+// inputs (probe + build for inner/outer, probe only for semi/anti). Width
+// derives from each input's own bytes/rows estimate (mutual recursion with
+// estimateSubtreeBytes), so filter selectivity scaling composes through
+// nesting; the plan tree is finite so the recursion terminates.
+func (p *Planner) estimateJoinSubtreeBytes(n *logical.Node) (int64, bool) {
+	if n == nil {
+		return 0, false
+	}
+	// Unwrap single-child pass-through nodes to the join.
+	for n != nil && n.Type != logical.NodeJoin {
+		switch n.Type {
+		case logical.NodeFilter, logical.NodeProject, logical.NodeLimit:
+			if len(n.Children) == 1 {
+				n = n.Children[0]
+				continue
+			}
+		}
+		return 0, false
+	}
+	if n == nil || len(n.Children) != 2 {
+		return 0, false
+	}
+
+	sideWidth := func(child *logical.Node) (float64, bool) {
+		bytes, ok := p.estimateSubtreeBytes(child)
+		if !ok {
+			return 0, false
+		}
+		rows := logical.RelStatsOf(child).Rows
+		if rows < 1 {
+			rows = 1
+		}
+		return float64(bytes) / rows, true
+	}
+
+	width, ok := sideWidth(n.Children[0])
+	if !ok {
+		return 0, false
+	}
+	jt := strings.ToLower(n.JoinType)
+	if jt != "semi" && jt != "anti" {
+		buildWidth, ok := sideWidth(n.Children[1])
+		if !ok {
+			return 0, false
+		}
+		width += buildWidth
+	}
+	rows := logical.RelStatsOf(n).Rows
+	if rows < 1 {
+		rows = 1
+	}
+	return int64(rows * width), true
 }
 
 // findScanNode walks through pass-through nodes (Filter, Project, Limit)


### PR DESCRIPTION
Two distributed-path fixes for bushy plans, both found by the SF10 A/B
pair (rows stayed identical; walls exposed them):

1. estimateSubtreeBytes returned unknown for join-shaped subtrees, so a
   25-row nation⋈region composite build could never broadcast and paid
   exchange-repartition for both sides — Q08 +135% at SF10. Composite
   subtrees now estimate as output rows × combined input row width,
   gated on BushyJoinReorder so flag-off semi/anti-leaf builds keep
   their SF100-validated shuffle plans.

2. fuseJoinStages absorbed a broadcast join into ANY consuming join —
   including one it fed on the BUILD side. Fusion replays the absorbed
   join as a broadcast-probe step on the consumer's probe STREAM, which
   is only valid for probe-side feeders; build-side absorption replayed
   against the wrong stream (Q02/Q03/Q05/Q07-Q11/Q21 → 0 rows in the
   3-worker harness; invisible to the 1-worker in-process suite where
   fusion is skipped). Absorption now requires LeftDepStage == candidate.
   Real-plan goldens are unchanged — only the synthetic byte-budget
   fixtures encoded the build-side shape and were corrected.

With both fixes the bushy plans broadcast AND fuse their composite
dimension builds (Q08: customer ⋈ fused(n1 ⋈ region); Q07: 22→19
stages) instead of shuffling them.

Gates: goldens byte-identical, TPC-H SF0.01 all variants, native-DAG
default + bushy-forced 22/22, harness --mode=local both arms
row-identical.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UgXRArvN16VitPkxV55g8S
