### PR TITLE
feat(planner): exchange-aware join costing in the bushy regime

### DIFF
--- a/internal/planner/logical/optimizer.go
+++ b/internal/planner/logical/optimizer.go
@@ -2981,7 +2981,9 @@ func dpJoinReorder(rels []*Node, edges []joinEdge) (*Node, int) {
 				buildStats := RelStats{Rows: dp[build].rows, ColNDV: dp[build].colNDV}
 				probeNDV, buildNDV := resolveJoinKeyNDVs(joinCond, probeStats, buildStats)
 				outputRows := estimateJoinCard(dp[probe].rows, dp[build].rows, probeNDV, buildNDV, joinType)
-				totalCost := dp[probe].cost + dp[build].cost + hashJoinCost(dp[probe].rows, dp[build].rows)
+				totalCost := dp[probe].cost + dp[build].cost +
+					hashJoinCost(dp[probe].rows, dp[build].rows) +
+					distributedExchangeCost(dp[probe].rows, dp[build].rows)
 				if totalCost < dp[mask].cost {
 					dp[mask] = dpEntry{
 						cost:       totalCost,
@@ -3037,6 +3039,13 @@ func dpJoinReorder(rels []*Node, edges []joinEdge) (*Node, int) {
 
 				// Hash join cost: build j (right side), probe current set (left side)
 				joinCost = hashJoinCost(dp[mask].rows, baseStats[j].Rows)
+				if bushy {
+					// Exchange-aware regime: price the repartition a
+					// non-broadcastable build forces (both transitions use
+					// the same model so left-deep and bushy candidates
+					// compare fairly). Flag-off keeps the pure-CPU model.
+					joinCost += distributedExchangeCost(dp[mask].rows, baseStats[j].Rows)
+				}
 			} else {
 				// Cross join — heavy penalty to avoid unless necessary
 				joinCond = ""

--- a/internal/planner/logical/stats.go
+++ b/internal/planner/logical/stats.go
@@ -504,6 +504,31 @@ func hashJoinCost(probeRows, buildRows float64) float64 {
 	return buildRows*buildCostPerRow + probeRows*probeCostPerRow
 }
 
+// distributedExchangeCost prices the exchange a distributed hash join adds
+// on top of its CPU cost. A broadcast-scale build replicates cheaply and the
+// probe side stays in place (cost ≈ 0 at plan-order granularity); a bigger
+// build forces hash-repartition of BOTH sides — serialize, materialize,
+// re-read. The SF10 A/B pairs of 2026-07-09 showed why the DP cannot ignore
+// this: a bushy composite that replaced broadcast-fused probes with a
+// repartition pair regressed Q08 +123% while pure-CPU cost called it
+// cheaper. Applied only in the BushyJoinReorder regime so flag-off plan
+// selection is untouched.
+//
+// broadcastableRows approximates the runtime bytes threshold
+// (isBroadcastCandidate, ~100 MB) at typical analytic row widths;
+// exchangeCostPerRow prices serialize+write+read+deserialize relative to
+// hashJoinCost's 1.0/row probe unit.
+func distributedExchangeCost(probeRows, buildRows float64) float64 {
+	const (
+		broadcastableRows  = 1_000_000
+		exchangeCostPerRow = 2.0
+	)
+	if buildRows <= broadcastableRows {
+		return 0
+	}
+	return (probeRows + buildRows) * exchangeCostPerRow
+}
+
 // mergeNDVs combines column NDV maps from two relations, capping at outputRows.
 func mergeNDVs(left, right map[string]float64, outputRows float64) map[string]float64 {
 	merged := make(map[string]float64, len(left)+len(right))


### PR DESCRIPTION
The DP priced CPU rows only; distributed reality prices exchanges. A
bushy composite that replaces broadcast-fused probes with a hash-
repartition pair regressed Q08 +123%/+135% across two SF10 A/B pairs
while pure-CPU cost called it cheaper. distributedExchangeCost adds a
repartition term for non-broadcast-scale builds (0 when the build can
replicate), applied to BOTH left-deep and bushy transitions under
BushyJoinReorder so candidates compare under one model. Flag-off
selection is untouched.

Gates: all parity suites green, harness bushy arm row-identical.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UgXRArvN16VitPkxV55g8S
