### PR TITLE
feat(planner): cell-based exchange pricing in the bushy DP

### DIFF
--- a/internal/planner/logical/optimizer.go
+++ b/internal/planner/logical/optimizer.go
@@ -2878,6 +2878,7 @@ const bushyMaxRels = 10
 type dpEntry struct {
 	cost       float64
 	rows       float64
+	width      float64 // output row width in columns (exchange cell pricing)
 	colNDV     map[string]float64
 	plan       *Node
 	bushyJoins int // count of bushy (composite ⋈ composite) joins in plan
@@ -2923,6 +2924,7 @@ func dpJoinReorder(rels []*Node, edges []joinEdge) (*Node, int) {
 		dp[mask] = dpEntry{
 			cost:      0,
 			rows:      baseStats[i].Rows,
+			width:     subtreeOutputWidth(rels[i]),
 			colNDV:    baseStats[i].ColNDV,
 			plan:      rels[i],
 			connected: true,
@@ -2983,11 +2985,12 @@ func dpJoinReorder(rels []*Node, edges []joinEdge) (*Node, int) {
 				outputRows := estimateJoinCard(dp[probe].rows, dp[build].rows, probeNDV, buildNDV, joinType)
 				totalCost := dp[probe].cost + dp[build].cost +
 					hashJoinCost(dp[probe].rows, dp[build].rows) +
-					distributedExchangeCost(dp[probe].rows, dp[build].rows)
+					distributedExchangeCost(dp[probe].rows, dp[probe].width, dp[build].rows, dp[build].width)
 				if totalCost < dp[mask].cost {
 					dp[mask] = dpEntry{
 						cost:       totalCost,
 						rows:       outputRows,
+						width:      dp[probe].width + dp[build].width,
 						colNDV:     mergeNDVs(dp[probe].colNDV, dp[build].colNDV, outputRows),
 						plan:       NewJoin(dp[probe].plan, dp[build].plan, joinType, joinCond),
 						bushyJoins: dp[probe].bushyJoins + dp[build].bushyJoins + 1,
@@ -3044,7 +3047,9 @@ func dpJoinReorder(rels []*Node, edges []joinEdge) (*Node, int) {
 					// non-broadcastable build forces (both transitions use
 					// the same model so left-deep and bushy candidates
 					// compare fairly). Flag-off keeps the pure-CPU model.
-					joinCost += distributedExchangeCost(dp[mask].rows, baseStats[j].Rows)
+					joinCost += distributedExchangeCost(
+						dp[mask].rows, dp[mask].width,
+						baseStats[j].Rows, subtreeOutputWidth(rels[j]))
 				}
 			} else {
 				// Cross join — heavy penalty to avoid unless necessary
@@ -3062,6 +3067,7 @@ func dpJoinReorder(rels []*Node, edges []joinEdge) (*Node, int) {
 				dp[newMask] = dpEntry{
 					cost:       totalCost,
 					rows:       outputRows,
+					width:      dp[mask].width + subtreeOutputWidth(rels[j]),
 					colNDV:     ndvs,
 					plan:       newPlan,
 					bushyJoins: dp[mask].bushyJoins,

--- a/internal/planner/logical/stats.go
+++ b/internal/planner/logical/stats.go
@@ -514,19 +514,63 @@ func hashJoinCost(probeRows, buildRows float64) float64 {
 // cheaper. Applied only in the BushyJoinReorder regime so flag-off plan
 // selection is untouched.
 //
-// broadcastableRows approximates the runtime bytes threshold
-// (isBroadcastCandidate, ~100 MB) at typical analytic row widths;
-// exchangeCostPerRow prices serialize+write+read+deserialize relative to
-// hashJoinCost's 1.0/row probe unit.
-func distributedExchangeCost(probeRows, buildRows float64) float64 {
+// Cost scales with CELLS (rows × row width), not rows: a composite's
+// output row is as wide as all its members combined, so shuffling it costs
+// proportionally more than shuffling the narrow scan outputs a left-deep
+// chain moves. Row-based pricing left Q08's bushy pick standing at +88%
+// (SF10 pair 3, 2026-07-10). broadcastableRows approximates the runtime
+// bytes threshold (isBroadcastCandidate, ~100 MB) at typical analytic row
+// widths; exchangeCostPerCell ≈ 2.0/row at a typical 8-column shuffle row,
+// relative to hashJoinCost's 1.0/row probe unit.
+func distributedExchangeCost(probeRows, probeWidth, buildRows, buildWidth float64) float64 {
 	const (
-		broadcastableRows  = 1_000_000
-		exchangeCostPerRow = 2.0
+		broadcastableRows   = 1_000_000
+		exchangeCostPerCell = 0.25
 	)
 	if buildRows <= broadcastableRows {
 		return 0
 	}
-	return (probeRows + buildRows) * exchangeCostPerRow
+	return (probeRows*probeWidth + buildRows*buildWidth) * exchangeCostPerCell
+}
+
+// subtreeOutputWidth approximates a relation subtree's output row width as
+// the number of columns visible in its output: scans expose their table
+// width, semi/anti joins expose the probe side only, inner/outer joins
+// expose both sides combined, aggregates and explicit projections collapse
+// to their output lists. Feeds distributedExchangeCost's cell pricing.
+func subtreeOutputWidth(n *Node) float64 {
+	const defaultWidth = 8
+	if n == nil {
+		return defaultWidth
+	}
+	switch n.Type {
+	case NodeScan:
+		if len(n.ScanColumns) > 0 {
+			return float64(len(n.ScanColumns))
+		}
+		return defaultWidth
+	case NodeAggregate:
+		if w := len(n.GroupBy) + len(n.AggExprs); w > 0 {
+			return float64(w)
+		}
+		return 1
+	case NodeProject:
+		if len(n.Projections) > 0 {
+			return float64(len(n.Projections))
+		}
+	case NodeJoin:
+		if len(n.Children) == 2 {
+			jt := strings.ToLower(n.JoinType)
+			if jt == "semi" || jt == "anti" {
+				return subtreeOutputWidth(n.Children[0])
+			}
+			return subtreeOutputWidth(n.Children[0]) + subtreeOutputWidth(n.Children[1])
+		}
+	}
+	if len(n.Children) >= 1 {
+		return subtreeOutputWidth(n.Children[0])
+	}
+	return defaultWidth
 }
 
 // mergeNDVs combines column NDV maps from two relations, capping at outputRows.


### PR DESCRIPTION
Row-based exchange pricing left Q08's bushy pick standing at +88%
(SF10 pair 3): a composite's output row is as wide as all its members
combined, so shuffling it costs proportionally more than the narrow
scan outputs a left-deep chain moves. dpEntry tracks output width
(column count; semi/anti expose probe only, aggregates collapse to
their output list) and distributedExchangeCost prices cells.

Gates: all parity suites green, harness bushy arm row-identical.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UgXRArvN16VitPkxV55g8S
