### PR TITLE
feat(coordinator): adaptive skew-aware shuffle (--skew-split, default off)

### DIFF
--- a/cmd/tpch-bench/main.go
+++ b/cmd/tpch-bench/main.go
@@ -355,6 +355,11 @@ func setupDistributed(ctx context.Context, logger *slog.Logger, endpoint, region
 		// first touch. Default ON (matches the wadjet CLI default;
 		// SF10/SF100 validated 2026-07-09); set 0/false as the kill switch.
 		LateMaterialization: os.Getenv("WADJET_LATE_MATERIALIZATION") != "0" && !strings.EqualFold(os.Getenv("WADJET_LATE_MATERIALIZATION"), "false"),
+		// Skew-aware shuffle layout (docs/design/skew-aware-shuffle.md):
+		// split hot partition groups at join dispatch. Default off; set 1
+		// as the A/B arm. Coordinator-side decision only — workers always
+		// report the per-partition accounting it consumes.
+		SkewSplit: os.Getenv("WADJET_SKEW_SPLIT") == "1" || strings.EqualFold(os.Getenv("WADJET_SKEW_SPLIT"), "true"),
 		// Broadcast threshold override: <0 = never broadcast. 0/unset =
 		// cluster-derived default.
 		BroadcastBytesOverride: envInt64("WADJET_BROADCAST_BYTES"),

--- a/cmd/wadjet/main.go
+++ b/cmd/wadjet/main.go
@@ -99,6 +99,7 @@ var (
 	localFastPathBytes    int64
 	sortMergeJoinBytes    int64
 	lateMaterialization   bool
+	skewSplit             bool
 	bushyJoinReorder      bool
 	broadcastBytes        int64
 	streamingExchange     bool
@@ -165,6 +166,7 @@ func main() {
 	rootCmd.PersistentFlags().Int64Var(&broadcastBytes, "broadcast-bytes", 0, "Override the broadcast-join threshold: joins whose estimated build side is under this many bytes replicate the build to every worker. 0 = derive from worker pool budget (default), <0 = never broadcast (every join takes the hash-shuffle/sort-merge path; benchmarking/debugging surface).")
 	rootCmd.PersistentFlags().Int64Var(&sortMergeJoinBytes, "sort-merge-join-bytes", 0, "Inner equi-joins whose sides BOTH exceed this estimated size run as sort-merge joins (both sides sort to spill-friendly runs and stream a merge) instead of hash joins, bounding join memory at merge-cursor state instead of a resident build table. Applies to both the local single-process paths and the distributed stage DAG (the join stage swaps operator; its exchange children are identical). 0 = disabled (default). See docs/design/sort-merge-join.md.")
 	rootCmd.PersistentFlags().BoolVar(&lateMaterialization, "late-materialization", true, "Emit inner/left hash-join output as view (dictionary) columns over the probe input and build batches, deferring the column gather to the first consumer that needs owned storage — join chains compose the indirection so a column is copied once, at its final consumer or the shuffle encode. Default true (validated 2026-07-09: SF10 −6.2%, SF100 −4.9% suite wall, Q08 −36%/−44%, row-identical both scales); --late-materialization=false restores eager join-output gather. See docs/design/late-materialization.md.")
+	rootCmd.PersistentFlags().BoolVar(&skewSplit, "skew-split", false, "Adaptive skew-aware shuffle layout: when a shuffled hash join's per-partition input bytes (reported by the shuffle stages) show a hot partition group, split it into k sub-tasks that divide the group's probe files and replicate its build files, bounding the straggler task's input and memory footprint. Default false (dormant; the per-partition accounting is always on). See docs/design/skew-aware-shuffle.md.")
 	rootCmd.PersistentFlags().BoolVar(&bushyJoinReorder, "bushy-join-reorder", false, "Let the cost-based join reorder emit BUSHY plans (joins of two composite intermediates — e.g. pre-joining a snowflake dimension chain before it meets the fact stream) when strictly cheaper than every left-deep order. Cost ties keep the left-deep shape. Process-wide, default false. See docs/design/bushy-join-cbo.md.")
 	rootCmd.PersistentFlags().Int64Var(&localFastPathBytes, "local-fastpath-bytes", coordinator.DefaultLocalFastPathBytes, "Queries whose post-pruning catalog scan bytes stay under this threshold execute in-process on the coordinator (skipping the distributed stage DAG and its per-stage object-store round trips). 0 = disabled.")
 	rootCmd.PersistentFlags().BoolVar(&streamingExchange, "streaming-exchange", true, "Streaming exchange: consumers fetch stage outputs from the producing workers' local disk over gRPC with async S3 upload; every failure falls through to the durable S3 path. Default true (validated 2026-07-02: SF10 −10%, SF100 −23% suite wall, row-identical, zero fault-tolerance events); --streaming-exchange=false restores synchronous S3-only shuffle. See docs/design/streaming-exchange.md.")
@@ -894,6 +896,7 @@ func runStandalone(ctx context.Context, store objstore.Store, logger *slog.Logge
 		BroadcastBytesOverride: broadcastBytes,
 		SortMergeJoinBytes:     sortMergeJoinBytes,
 		LateMaterialization:    lateMaterialization,
+		SkewSplit:              skewSplit,
 		StreamingExchange:      streamingExchange,
 	}, cat, nc, js, logger)
 
@@ -1194,6 +1197,7 @@ func runCoordinator(ctx context.Context, store objstore.Store, logger *slog.Logg
 		BroadcastBytesOverride: broadcastBytes,
 		SortMergeJoinBytes:     sortMergeJoinBytes,
 		LateMaterialization:    lateMaterialization,
+		SkewSplit:              skewSplit,
 		StreamingExchange:      streamingExchange,
 	}, cat, nc, js, logger)
 

--- a/deploy/benchmark/terraform/main.tf
+++ b/deploy/benchmark/terraform/main.tf
@@ -275,6 +275,7 @@ locals {
     echo "WADJET_SORT_MERGE_JOIN_BYTES=${var.sort_merge_join_bytes}" >> /etc/environment
     echo "WADJET_LATE_MATERIALIZATION=${var.late_materialization}" >> /etc/environment
     echo "WADJET_BUSHY_JOIN_REORDER=${var.bushy_join_reorder}" >> /etc/environment
+    echo "WADJET_SKEW_SPLIT=${var.skew_split}" >> /etc/environment
     echo "BUILD_COMPLETE=1" >> /etc/environment
   SCRIPT
 
@@ -311,6 +312,7 @@ locals {
     echo "WADJET_SORT_MERGE_JOIN_BYTES=${var.sort_merge_join_bytes}" >> /etc/environment
     echo "WADJET_LATE_MATERIALIZATION=${var.late_materialization}" >> /etc/environment
     echo "WADJET_BUSHY_JOIN_REORDER=${var.bushy_join_reorder}" >> /etc/environment
+    echo "WADJET_SKEW_SPLIT=${var.skew_split}" >> /etc/environment
     echo "BUILD_COMPLETE=1" >> /etc/environment
   SCRIPT
 
@@ -381,6 +383,7 @@ locals {
     export WADJET_SORT_MERGE_JOIN_BYTES="${var.sort_merge_join_bytes}"
     export WADJET_LATE_MATERIALIZATION="${var.late_materialization}"
     export WADJET_BUSHY_JOIN_REORDER="${var.bushy_join_reorder}"
+    export WADJET_SKEW_SPLIT="${var.skew_split}"
     export USE_NATIVE_DAG="${var.use_native_dag ? "1" : "0"}"
     # Phase C/D/E data-plane selection. Empty/"nats" = legacy NATS reply
     # subjects; "grpc" routes task dispatch + results + gather +
@@ -530,6 +533,7 @@ resource "aws_instance" "worker" {
     export WADJET_SORT_MERGE_JOIN_BYTES="${var.sort_merge_join_bytes}"
     export WADJET_LATE_MATERIALIZATION="${var.late_materialization}"
     export WADJET_BUSHY_JOIN_REORDER="${var.bushy_join_reorder}"
+    export WADJET_SKEW_SPLIT="${var.skew_split}"
 
     # Verify binary was downloaded successfully
     if [ ! -x /usr/local/bin/wadjet ]; then

--- a/deploy/benchmark/terraform/variables.tf
+++ b/deploy/benchmark/terraform/variables.tf
@@ -216,6 +216,12 @@ variable "late_materialization" {
   default     = ""
 }
 
+variable "skew_split" {
+  description = "Set to 1 to enable adaptive skew-aware shuffle layout on the coordinator (docs/design/skew-aware-shuffle.md): hot partition groups split into sub-tasks that divide probe files and replicate build files. Off by default."
+  type        = string
+  default     = ""
+}
+
 variable "dynamic_filters" {
   description = "Set to 1 to enable Trino-style semi-join dynamic-filter pushdown on the coordinator. Off by default for v1 rollout."
   type        = string

--- a/docs/design/skew-aware-shuffle.md
+++ b/docs/design/skew-aware-shuffle.md
@@ -1,7 +1,14 @@
 # Adaptive skew-aware shuffle
 
-Status: DRAFT design — 2026-07-10. Grounded against main c9e139a by explorer
-sweep; all anchors verified current at write time.
+Status: Phases 1–2 IMPLEMENTED 2026-07-10 (feat/skew-aware-shuffle) — flag
+`--skew-split`, default off; per-partition accounting always on. Decision
+logic: internal/coordinator/skew_split.go. Two deviations from the draft
+below, both deliberate: partition bytes come from the upload paths'
+existing per-partition os.Stat (actual on-disk size; no redundant sink
+byte counter), and the decision unit is the task's contiguous partition
+RANGE (a task binds NumPartitions/numTasks partitions; per-partition
+decisions would mis-align with task binding). Phase 3 (skewed-dataset A/B
+deploy) not started.
 
 ## 1. Problem
 

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -82,6 +82,14 @@ type Config struct {
 	// (docs/design/late-materialization.md), on the local fast path and in
 	// worker fragments alike (rides the join-probe OpSpec). Off by default.
 	LateMaterialization bool
+	// SkewSplit enables adaptive skew-aware task layout for shuffled hash
+	// joins (docs/design/skew-aware-shuffle.md): hot partition groups —
+	// detected from the worker-reported per-partition shuffle output bytes
+	// — split into k sub-tasks that divide the group's probe files and
+	// replicate its build files, bounding the straggler task's input and
+	// memory footprint. Decision logic in skew_split.go. Default false
+	// (dormant; the per-partition accounting is always on).
+	SkewSplit bool
 	// StreamingExchange annotates dispatched tasks with peer-location
 	// hints (Task.InputLocations) and per-query fetch tokens so consumers
 	// stream stage outputs from the producing workers' local disk instead

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -813,15 +813,17 @@ func (c *Coordinator) dispatchShuffleStage(
 	// Forward any dynamic-filter specs the upstream (probe-side) leaf scan
 	// resolved through pass-through. Each shuffle task gets a copy so its
 	// parquet scan applies the bloom at row-group level.
-	shards, shardBytes, err := c.runShuffleSide(ctx, queryID, "stage-"+stage.ID, synthetic, stage.Exchange.Keys, numParts, workerCount, upstream.DynamicFilters)
+	shards, shardStats, err := c.runShuffleSide(ctx, queryID, "stage-"+stage.ID, synthetic, stage.Exchange.Keys, numParts, workerCount, upstream.DynamicFilters)
 	if err != nil {
 		return StageOutput{}, err
 	}
 	return StageOutput{
-		Kind:          OutputPartitioned,
-		NumPartitions: numParts,
-		Files:         shards,
-		Bytes:         shardBytes,
+		Kind:           OutputPartitioned,
+		NumPartitions:  numParts,
+		Files:          shards,
+		Bytes:          shardStats.TotalBytes,
+		PartitionRows:  shardStats.PartitionRows,
+		PartitionBytes: shardStats.PartitionBytes,
 	}, nil
 }
 
@@ -1792,13 +1794,15 @@ func (c *Coordinator) dispatchScanFilterStage(
 				shardFiles[p] = append(shardFiles[p], f)
 			}
 		}
-		return StageOutput{
+		out := StageOutput{
 			Kind:          OutputPartitioned,
 			NumPartitions: numParts,
 			Files:         shardFiles,
 			BuildStats:    buildStats,
 			Bytes:         retrier.TotalBytes(),
-		}, nil
+		}
+		out.PartitionRows, out.PartitionBytes = retrier.PartitionAccounting(numParts)
+		return out, nil
 	}
 	return StageOutput{
 		Kind:          OutputPartitioned,
@@ -2272,12 +2276,14 @@ func (c *Coordinator) dispatchComputeStage(
 				shardFiles[p] = append(shardFiles[p], f)
 			}
 		}
-		return StageOutput{
+		out := StageOutput{
 			Kind:          OutputPartitioned,
 			NumPartitions: numParts,
 			Files:         shardFiles,
 			Bytes:         retrier.TotalBytes(),
-		}, nil
+		}
+		out.PartitionRows, out.PartitionBytes = retrier.PartitionAccounting(numParts)
+		return out, nil
 	}
 	// resultFiles is in dispatch order (taskRetrier keys results by task ID),
 	// which is deterministic — an improvement over the old arrival-order slice.

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -1890,6 +1890,21 @@ func (c *Coordinator) dispatchComputeStage(
 		numTasks = n
 		probeSplit = true
 	}
+	// Adaptive skew split (--skew-split, docs/design/skew-aware-shuffle.md):
+	// a shuffled hash join whose deps report per-partition bytes may split
+	// hot partition groups into k sub-tasks (probe files divided, build
+	// files replicated). skewGroups keeps the UNSPLIT slot count so the
+	// output below re-groups sub-task files by original partition range —
+	// downstream partition-aligned consumers see the same layout shape
+	// either way.
+	skewGroups := numTasks
+	var skewAssign []skewTaskAssignment
+	if c.config.SkewSplit && !probeSplit {
+		if a := c.planSkewSplitTasks(stage, inputs, numTasks, workerCount); a != nil {
+			skewAssign = a
+			numTasks = len(a)
+		}
+	}
 	resultPrefix := fmt.Sprintf("queries/%s/%s/", queryID, stage.ID)
 	dispatchAttrs := []any{
 		"stage_id", stage.ID, "stage_type", stage.Type,
@@ -1897,6 +1912,7 @@ func (c *Coordinator) dispatchComputeStage(
 		"distribution_kind", stage.Distribution.Kind,
 		"distribution_count", stage.Distribution.Count,
 		"probe_split", probeSplit,
+		"skew_split", skewAssign != nil,
 		"inputs_aliases", len(inputs),
 	}
 	// Plan-side engagement marker for late-materialization A/B arms: join
@@ -1941,6 +1957,8 @@ func (c *Coordinator) dispatchComputeStage(
 		var err error
 		if probeSplit {
 			taskInputs, err = buildTaskInputsForBroadcastJoinSplitProbe(stage, inputs, w, numTasks)
+		} else if skewAssign != nil {
+			taskInputs = skewAssign[w].inputs
 		} else {
 			taskInputs, err = buildTaskInputsForStage(stage, inputs, w, numTasks)
 		}
@@ -2181,11 +2199,17 @@ func (c *Coordinator) dispatchComputeStage(
 	// tasks; replicated and single-part inputs are read in full by EVERY
 	// task (partitionFilesForWorker hands non-partitioned deps to each task
 	// whole), so they charge their full bytes.
-	perTaskEst := estimateComputeTaskBytes(stage, inputs, numTasks, probeSplit)
+	// skewGroups (== numTasks when no skew split) keeps the divisor at the
+	// logical slot count: sub-tasks carry their own measured estimate below,
+	// and unsplit tasks shouldn't see estimates diluted by the extra tasks.
+	perTaskEst := estimateComputeTaskBytes(stage, inputs, skewGroups, probeSplit)
 	for i := range tasks {
 		tasks[i].QueryID = stageQueryID
 		tasks[i].Attempt = 1
 		tasks[i].EstimatedBytes = perTaskEst
+		if skewAssign != nil && skewAssign[i].estBytes > 0 {
+			tasks[i].EstimatedBytes = skewAssign[i].estBytes
+		}
 	}
 	done := make(chan struct{}, 1)
 	progress := make(chan struct{}, len(tasks))
@@ -2284,6 +2308,25 @@ func (c *Coordinator) dispatchComputeStage(
 		}
 		out.PartitionRows, out.PartitionBytes = retrier.PartitionAccounting(numParts)
 		return out, nil
+	}
+	// Skew-split output re-grouping: sub-task outputs collapse back into
+	// their group's slot so the stage's OutputPartitioned layout matches
+	// the unsplit shape (skewGroups slots; a hot group's slot just holds k
+	// files). All of a hot group's rows carry that group's key range, so
+	// downstream partition-aligned consumption stays correct. The Exchange
+	// branch above needs no equivalent — it buckets by partition path,
+	// which is task-count agnostic.
+	if skewAssign != nil {
+		grouped := make([][]string, skewGroups)
+		for i, a := range skewAssign {
+			grouped[a.group] = append(grouped[a.group], resultFiles[i]...)
+		}
+		return StageOutput{
+			Kind:          OutputPartitioned,
+			NumPartitions: skewGroups,
+			Files:         grouped,
+			Bytes:         retrier.TotalBytes(),
+		}, nil
 	}
 	// resultFiles is in dispatch order (taskRetrier keys results by task ID),
 	// which is deterministic — an improvement over the old arrival-order slice.

--- a/internal/coordinator/orchestrate_repartition.go
+++ b/internal/coordinator/orchestrate_repartition.go
@@ -62,6 +62,12 @@ type ShuffleLayout struct {
 	BuildShardFiles [][]string
 	// ProbeShardFiles[p] contains the S3 keys for probe partition p.
 	ProbeShardFiles [][]string
+	// Per-partition on-disk bytes for each side, reduced across the final
+	// surviving shuffle task set (worker-reported; nil when unreported).
+	// Recorded for observability — the legacy pipeline path built from this
+	// layout stays non-adaptive; skew splitting lives on the native-DAG path.
+	BuildPartitionBytes []int64
+	ProbePartitionBytes []int64
 }
 
 // orchestrateRepartition runs both shuffle stages (build side and probe side)
@@ -93,23 +99,24 @@ func (c *Coordinator) orchestrateRepartition(
 
 	// Run build and probe shuffles in parallel. Failure of either cancels both.
 	var buildShards, probeShards [][]string
+	var buildStats, probeStats shuffleSideStats
 	g, gctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		shards, _, err := c.runShuffleSide(gctx, queryID, "build", buildStage, cand.BuildKeys, numParts, workerCount, nil)
+		shards, stats, err := c.runShuffleSide(gctx, queryID, "build", buildStage, cand.BuildKeys, numParts, workerCount, nil)
 		if err != nil {
 			return fmt.Errorf("build-side shuffle for %s: %w", cand.BuildAlias, err)
 		}
-		buildShards = shards
+		buildShards, buildStats = shards, stats
 		return nil
 	})
 
 	g.Go(func() error {
-		shards, _, err := c.runShuffleSide(gctx, queryID, "probe", probeStage, cand.ProbeKeys, numParts, workerCount, nil)
+		shards, stats, err := c.runShuffleSide(gctx, queryID, "probe", probeStage, cand.ProbeKeys, numParts, workerCount, nil)
 		if err != nil {
 			return fmt.Errorf("probe-side shuffle for %s: %w", cand.ProbeAlias, err)
 		}
-		probeShards = shards
+		probeShards, probeStats = shards, stats
 		return nil
 	})
 
@@ -123,20 +130,30 @@ func (c *Coordinator) orchestrateRepartition(
 	)
 
 	return &ShuffleLayout{
-		BuildAlias:      cand.BuildAlias,
-		ProbeAlias:      cand.ProbeAlias,
-		NumPartitions:   numParts,
-		BuildShardFiles: buildShards,
-		ProbeShardFiles: probeShards,
+		BuildAlias:          cand.BuildAlias,
+		ProbeAlias:          cand.ProbeAlias,
+		NumPartitions:       numParts,
+		BuildShardFiles:     buildShards,
+		ProbeShardFiles:     probeShards,
+		BuildPartitionBytes: buildStats.PartitionBytes,
+		ProbePartitionBytes: probeStats.PartitionBytes,
 	}, nil
+}
+
+// shuffleSideStats carries worker-reported output accounting for one
+// shuffle side, reduced across the final surviving task set. TotalBytes is
+// 0 and the vectors are nil when workers didn't report (legacy builds).
+type shuffleSideStats struct {
+	TotalBytes     int64
+	PartitionRows  []int64 // indexed by partition id
+	PartitionBytes []int64 // indexed by partition id, on-disk uncompressed
 }
 
 // runShuffleSide dispatches workerCount TaskTypeShuffle tasks for one side
 // (build or probe), each reading its file slice and hash-partitioning into
 // numParts outputs. Waits for all tasks. Returns shardFiles[p] = slice of
 // S3 keys for partition p (concatenated from each task's per-partition
-// output) plus the worker-reported total bytes written across all tasks
-// (0 if workers didn't report).
+// output) plus the worker-reported output accounting.
 func (c *Coordinator) runShuffleSide(
 	ctx context.Context,
 	parentQueryID string,
@@ -146,7 +163,7 @@ func (c *Coordinator) runShuffleSide(
 	numParts int,
 	workerCount int,
 	dynamicFilters []distributed.DynamicFilterSpec, // resolved bloom/range pushdowns from upstream build stat
-) ([][]string, int64, error) {
+) ([][]string, shuffleSideStats, error) {
 	ctx, cancel := context.WithTimeout(ctx, shuffleStageTimeout)
 	defer cancel()
 
@@ -180,7 +197,7 @@ func (c *Coordinator) runShuffleSide(
 	actualTasks := len(fileSets)
 	if actualTasks == 0 {
 		// No files — nothing to shuffle. Return empty partition layout.
-		return make([][]string, numParts), 0, nil
+		return make([][]string, numParts), shuffleSideStats{}, nil
 	}
 
 	// Register an ephemeral tracker entry for this shuffle stage.
@@ -261,24 +278,24 @@ func (c *Coordinator) runShuffleSide(
 		}
 	})
 	if err != nil {
-		return nil, 0, fmt.Errorf("subscribing for shuffle-%s results: %w", sideName, err)
+		return nil, shuffleSideStats{}, fmt.Errorf("subscribing for shuffle-%s results: %w", sideName, err)
 	}
 	defer sub.Unsubscribe()
 
 	if err := c.scheduler.PublishTasks(ctx, tasks); err != nil {
-		return nil, 0, fmt.Errorf("publishing shuffle-%s tasks: %w", sideName, err)
+		return nil, shuffleSideStats{}, fmt.Errorf("publishing shuffle-%s tasks: %w", sideName, err)
 	}
 
 	// Wait for all tasks to complete.
 	select {
 	case <-done:
 	case <-ctx.Done():
-		return nil, 0, fmt.Errorf("shuffle-%s timed out after %s: %w", sideName, shuffleStageTimeout, ctx.Err())
+		return nil, shuffleSideStats{}, fmt.Errorf("shuffle-%s timed out after %s: %w", sideName, shuffleStageTimeout, ctx.Err())
 	}
 
 	// Check for any task failures (terminal: retries exhausted).
 	if taskID, errMsg, failed := retrier.FirstError(); failed {
-		return nil, 0, fmt.Errorf("shuffle-%s task %s failed after %d attempts: %s", sideName, taskID, maxTaskAttempts, errMsg)
+		return nil, shuffleSideStats{}, fmt.Errorf("shuffle-%s task %s failed after %d attempts: %s", sideName, taskID, maxTaskAttempts, errMsg)
 	}
 
 	// Bucket result files by partition. Each file has a path like:
@@ -290,10 +307,10 @@ func (c *Coordinator) runShuffleSide(
 		for _, f := range taskFiles {
 			p, parseErr := parsePartitionFromPath(f)
 			if parseErr != nil {
-				return nil, 0, fmt.Errorf("shuffle-%s: parsing partition from %q: %w", sideName, f, parseErr)
+				return nil, shuffleSideStats{}, fmt.Errorf("shuffle-%s: parsing partition from %q: %w", sideName, f, parseErr)
 			}
 			if p < 0 || p >= numParts {
-				return nil, 0, fmt.Errorf("shuffle-%s: partition %d out of range [0,%d) in path %q", sideName, p, numParts, f)
+				return nil, shuffleSideStats{}, fmt.Errorf("shuffle-%s: partition %d out of range [0,%d) in path %q", sideName, p, numParts, f)
 			}
 			shardFiles[p] = append(shardFiles[p], f)
 		}
@@ -314,7 +331,9 @@ func (c *Coordinator) runShuffleSide(
 		"num_partitions", numParts,
 	)
 
-	return shardFiles, retrier.TotalBytes(), nil
+	stats := shuffleSideStats{TotalBytes: retrier.TotalBytes()}
+	stats.PartitionRows, stats.PartitionBytes = retrier.PartitionAccounting(numParts)
+	return shardFiles, stats, nil
 }
 
 // parsePartitionFromPath extracts the partition index from an S3 key that

--- a/internal/coordinator/skew_split.go
+++ b/internal/coordinator/skew_split.go
@@ -1,0 +1,220 @@
+package coordinator
+
+import (
+	"sync/atomic"
+
+	"github.com/citc-tech/wadjet/internal/planner/physical"
+)
+
+// Adaptive skew-aware task layout for shuffled hash joins
+// (docs/design/skew-aware-shuffle.md). The shuffle stages report
+// per-partition output bytes (StageOutput.PartitionBytes); at join dispatch
+// the planner below detects task groups whose probe input exceeds an
+// absolute byte threshold and splits them into k sub-tasks that divide the
+// group's probe files and replicate its build files — the broadcast
+// probe-split pattern applied per hot partition group. Flag-gated by
+// Config.SkewSplit (--skew-split), default off.
+
+var (
+	// skewSplitTargetBytes is the per-sub-task probe input target: a hot
+	// group splits into ceil(probeBytes / target) sub-tasks. Bytes are
+	// on-disk uncompressed .wshf — the same unit per-task admission
+	// estimates use. Var so tests can lower it to force splits on small
+	// fixtures.
+	skewSplitTargetBytes int64 = 256 << 20
+
+	// skewSplitMinGroupBytes is the absolute floor below which a group is
+	// never considered hot, regardless of how uneven the layout looks.
+	// The trigger is deliberately absolute, not a max/mean ratio: what
+	// breaks under skew is one task's bytes vs its memory budget and the
+	// stage's wall clock, not the shape of the distribution. Ratio is
+	// logged for observability only.
+	skewSplitMinGroupBytes int64 = 256 << 20
+
+	// skewSplitMaxBuildBytes caps the build bytes a hot group may have and
+	// still split, when the cluster hasn't reported worker pool budgets
+	// (broadcastThresholdFromCluster returns 0). Replicating the build to
+	// k sub-tasks multiplies its footprint cluster-wide; a build-side-hot
+	// group must NOT split — the worker's grace partition-on-arrival
+	// already bounds an oversized build inside a single task, whereas k
+	// replicas of an over-budget build multiply the OOM.
+	skewSplitMaxBuildBytes int64 = 200 << 20
+)
+
+// SkewSplitsPlanned counts hot-group split decisions (one per group per
+// stage dispatch). The A/B mechanism marker: a wall-clock delta without
+// this counter moving (and its "skew split planned" Info log) is window
+// drift, not skew-split signal.
+var SkewSplitsPlanned atomic.Int64
+
+// skewTaskAssignment is one task of a skew-aware layout. group is the
+// logical output slot — the task index of the UNSPLIT layout — so the
+// dispatcher can re-group sub-task outputs by original partition range,
+// keeping the stage's OutputPartitioned shape byte-compatible with the
+// unsplit layout (downstream consumers already read multi-file slots).
+type skewTaskAssignment struct {
+	group    int
+	inputs   map[string][]string
+	estBytes int64 // per-task admission estimate; 0 = use the stage-wide default
+}
+
+// planSkewSplitTasks decides the skew-aware task layout for a shuffled
+// hash-join stage. Returns nil (dispatcher keeps the standard layout) when
+// the stage is ineligible or no group crosses the hot threshold; otherwise
+// one assignment per task, in group order.
+//
+// Eligibility:
+//   - hash_join with hash-partitioned distribution (broadcast_join has
+//     probe-split; sort-merge-join needs aligned sorted runs — excluded v1)
+//   - probe-side join semantics only (inner/left/semi/anti). right/full
+//     emit unmatched BUILD rows, which a replicated build would duplicate
+//     k times.
+//   - both primary deps are OutputPartitioned with the same partition count
+//     and reported PartitionBytes (nil vectors = legacy workers → off).
+//
+// A hot group splits into k = ceil(probeBytes/skewSplitTargetBytes)
+// sub-tasks, capped by workerCount and by the group's probe file count
+// (v1 splits at file granularity; a hot partition written by T shuffle
+// tasks has up to T files). Each sub-task reads 1/k of the probe files and
+// the group's FULL build files — a probe row for key k needs the complete
+// build side for k, which replication preserves. Fused builds are already
+// replicated to every task by the dispatcher (task.FusedJoins[i].BuildFiles)
+// and need no handling here.
+func (c *Coordinator) planSkewSplitTasks(
+	stage physical.Stage,
+	inputs map[string]StageOutput,
+	numTasks, workerCount int,
+) []skewTaskAssignment {
+	if stage.Type != physical.StageHashJoin ||
+		stage.Distribution.Kind != physical.DistHashPartitioned ||
+		numTasks <= 0 || workerCount <= 1 {
+		return nil
+	}
+	switch stage.JoinType {
+	case "inner", "left", "semi", "anti":
+	default:
+		return nil
+	}
+	if len(stage.Dependencies) != 2+len(stage.FusedJoins) {
+		return nil
+	}
+	probeDep := stage.LeftDepStage
+	buildDep := stage.RightDepStage
+	if probeDep == "" {
+		probeDep = stage.Dependencies[0]
+	}
+	if buildDep == "" {
+		buildDep = stage.Dependencies[1]
+	}
+	probeOut, probeOK := inputs[probeDep]
+	buildOut, buildOK := inputs[buildDep]
+	if !probeOK || !buildOK ||
+		probeOut.Kind != OutputPartitioned || buildOut.Kind != OutputPartitioned ||
+		probeOut.NumPartitions != buildOut.NumPartitions ||
+		len(probeOut.PartitionBytes) != probeOut.NumPartitions ||
+		len(buildOut.PartitionBytes) != buildOut.NumPartitions {
+		return nil
+	}
+
+	// Build replication bound: prefer the cluster-derived broadcast
+	// threshold (the same "does a duplicated build fit the smallest
+	// worker's pool" question broadcast planning answers).
+	buildBound := skewSplitMaxBuildBytes
+	if c.workers != nil {
+		if t := broadcastThresholdFromCluster(c.workers.MinWorkerPoolBudget()); t > 0 {
+			buildBound = t
+		}
+	}
+
+	// Mean group probe bytes, for the observability ratio only.
+	var totalProbeBytes int64
+	for _, b := range probeOut.PartitionBytes {
+		totalProbeBytes += b
+	}
+	meanGroupBytes := totalProbeBytes / int64(numTasks)
+
+	buildAlias := stage.BuildTableAlias
+	if buildAlias == "" {
+		buildAlias = "build"
+	}
+	probeAlias := "probe"
+	if probeAlias == buildAlias {
+		probeAlias = "probe_side"
+	}
+
+	assignments := make([]skewTaskAssignment, 0, numTasks)
+	anySplit := false
+	for w := 0; w < numTasks; w++ {
+		start, end := partitionRangeForWorker(probeOut.NumPartitions, w, numTasks)
+		var probeBytes, buildBytes int64
+		var probeFiles, buildFiles []string
+		for p := start; p < end; p++ {
+			probeBytes += probeOut.PartitionBytes[p]
+			buildBytes += buildOut.PartitionBytes[p]
+			probeFiles = append(probeFiles, probeOut.Files[p]...)
+			buildFiles = append(buildFiles, buildOut.Files[p]...)
+		}
+
+		k := 0
+		if probeBytes > 0 {
+			k = int((probeBytes + skewSplitTargetBytes - 1) / skewSplitTargetBytes)
+		}
+		if k > workerCount {
+			k = workerCount
+		}
+		if k > len(probeFiles) {
+			k = len(probeFiles)
+		}
+		hot := k > 1 && probeBytes > skewSplitMinGroupBytes
+
+		if hot && buildBytes > buildBound {
+			// Build-side-hot: do not split (see skewSplitMaxBuildBytes).
+			// Logged so the no-split decision is visible in benchmark logs.
+			c.logger.Info("skew split skipped: build side over replication bound",
+				"stage_id", stage.ID, "group", w,
+				"partitions_start", start, "partitions_end", end,
+				"probe_bytes", probeBytes, "build_bytes", buildBytes,
+				"build_bound", buildBound)
+			hot = false
+		}
+
+		if !hot {
+			assignments = append(assignments, skewTaskAssignment{
+				group: w,
+				inputs: map[string][]string{
+					buildAlias: buildFiles,
+					probeAlias: probeFiles,
+				},
+			})
+			continue
+		}
+
+		anySplit = true
+		SkewSplitsPlanned.Add(1)
+		ratio := float64(0)
+		if meanGroupBytes > 0 {
+			ratio = float64(probeBytes) / float64(meanGroupBytes)
+		}
+		c.logger.Info("skew split planned",
+			"stage_id", stage.ID, "group", w,
+			"partitions_start", start, "partitions_end", end,
+			"probe_bytes", probeBytes, "build_bytes", buildBytes,
+			"split_factor", k, "probe_files", len(probeFiles),
+			"mean_ratio", ratio)
+		perSubEst := buildBytes + probeBytes/int64(k)
+		for _, slice := range splitFilesEvenly(probeFiles, k) {
+			assignments = append(assignments, skewTaskAssignment{
+				group: w,
+				inputs: map[string][]string{
+					buildAlias: buildFiles,
+					probeAlias: slice,
+				},
+				estBytes: perSubEst,
+			})
+		}
+	}
+	if !anySplit {
+		return nil
+	}
+	return assignments
+}

--- a/internal/coordinator/skew_split_test.go
+++ b/internal/coordinator/skew_split_test.go
@@ -1,0 +1,436 @@
+package coordinator
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/planner/physical"
+	"github.com/citc-tech/wadjet/internal/storage/catalog"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+	"github.com/citc-tech/wadjet/internal/worker"
+)
+
+// lowerSkewThresholds drops the skew-split byte thresholds so small test
+// fixtures cross them, restoring the defaults on cleanup.
+func lowerSkewThresholds(t *testing.T, target, floor int64) {
+	t.Helper()
+	oldTarget, oldFloor := skewSplitTargetBytes, skewSplitMinGroupBytes
+	skewSplitTargetBytes, skewSplitMinGroupBytes = target, floor
+	t.Cleanup(func() {
+		skewSplitTargetBytes, skewSplitMinGroupBytes = oldTarget, oldFloor
+	})
+}
+
+func skewTestStage() physical.Stage {
+	return physical.Stage{
+		ID:              "join-1",
+		Type:            physical.StageHashJoin,
+		JoinType:        "inner",
+		Dependencies:    []string{"probe-stage", "build-stage"},
+		LeftDepStage:    "probe-stage",
+		RightDepStage:   "build-stage",
+		BuildTableAlias: "d",
+		Distribution:    physical.Distribution{Kind: physical.DistHashPartitioned, Keys: []string{"k"}, Count: 3},
+	}
+}
+
+// skewTestOutput builds an OutputPartitioned StageOutput with nFiles files
+// per partition and the given per-partition bytes.
+func skewTestOutput(prefix string, partBytes []int64, nFiles int) StageOutput {
+	files := make([][]string, len(partBytes))
+	for p := range partBytes {
+		for f := 0; f < nFiles; f++ {
+			files[p] = append(files[p], fmt.Sprintf("%s/partition=%04d/t%d.wshf", prefix, p, f))
+		}
+	}
+	rows := make([]int64, len(partBytes))
+	for p, b := range partBytes {
+		rows[p] = b / 100
+	}
+	return StageOutput{
+		Kind:           OutputPartitioned,
+		NumPartitions:  len(partBytes),
+		Files:          files,
+		PartitionRows:  rows,
+		PartitionBytes: partBytes,
+	}
+}
+
+func TestPlanSkewSplitTasks_UniformNoSplit(t *testing.T) {
+	lowerSkewThresholds(t, 100<<20, 100<<20)
+	c := &Coordinator{logger: slog.Default()}
+	inputs := map[string]StageOutput{
+		"probe-stage": skewTestOutput("probe", []int64{10 << 20, 12 << 20, 11 << 20}, 2),
+		"build-stage": skewTestOutput("build", []int64{1 << 20, 1 << 20, 1 << 20}, 2),
+	}
+	if got := c.planSkewSplitTasks(skewTestStage(), inputs, 3, 3); got != nil {
+		t.Fatalf("uniform layout planned a split: %+v", got)
+	}
+}
+
+func TestPlanSkewSplitTasks_HotGroupSplits(t *testing.T) {
+	lowerSkewThresholds(t, 100<<20, 100<<20)
+	c := &Coordinator{logger: slog.Default()}
+	probe := skewTestOutput("probe", []int64{10 << 20, 400 << 20, 10 << 20}, 4)
+	build := skewTestOutput("build", []int64{1 << 20, 2 << 20, 1 << 20}, 2)
+	inputs := map[string]StageOutput{"probe-stage": probe, "build-stage": build}
+
+	before := SkewSplitsPlanned.Load()
+	got := c.planSkewSplitTasks(skewTestStage(), inputs, 3, 3)
+	if got == nil {
+		t.Fatal("hot group not split")
+	}
+	if SkewSplitsPlanned.Load() != before+1 {
+		t.Errorf("SkewSplitsPlanned delta = %d, want 1", SkewSplitsPlanned.Load()-before)
+	}
+	// Group 1 is hot: k = ceil(400MB/100MB) = 4, capped at workerCount 3.
+	// Layout: group 0 (1 task), group 1 (3 sub-tasks), group 2 (1 task).
+	if len(got) != 5 {
+		t.Fatalf("len(assignments) = %d, want 5 (%+v)", len(got), got)
+	}
+	wantGroups := []int{0, 1, 1, 1, 2}
+	for i, a := range got {
+		if a.group != wantGroups[i] {
+			t.Errorf("assignment %d group = %d, want %d", i, a.group, wantGroups[i])
+		}
+	}
+	// Every group-1 sub-task replicates the FULL build files of partition 1
+	// and the probe slices are a disjoint cover of partition 1's files.
+	var probeSlices []string
+	for _, a := range got[1:4] {
+		if len(a.inputs["d"]) != len(build.Files[1]) {
+			t.Errorf("sub-task build files = %v, want full %v", a.inputs["d"], build.Files[1])
+		}
+		if a.estBytes != (2<<20)+(400<<20)/3 {
+			t.Errorf("sub-task estBytes = %d, want %d", a.estBytes, (2<<20)+(400<<20)/3)
+		}
+		probeSlices = append(probeSlices, a.inputs["probe"]...)
+	}
+	sort.Strings(probeSlices)
+	wantProbe := append([]string(nil), probe.Files[1]...)
+	sort.Strings(wantProbe)
+	if len(probeSlices) != len(wantProbe) {
+		t.Fatalf("probe slices cover %d files, want %d", len(probeSlices), len(wantProbe))
+	}
+	for i := range wantProbe {
+		if probeSlices[i] != wantProbe[i] {
+			t.Errorf("probe slice file %d = %s, want %s", i, probeSlices[i], wantProbe[i])
+		}
+	}
+	// Non-hot assignments must match the unsplit layout's binding exactly.
+	for _, a := range []skewTaskAssignment{got[0], got[4]} {
+		wantInputs, err := buildTaskInputsForStage(skewTestStage(), inputs, a.group, 3)
+		if err != nil {
+			t.Fatalf("buildTaskInputsForStage: %v", err)
+		}
+		for alias, want := range wantInputs {
+			gotFiles := a.inputs[alias]
+			if len(gotFiles) != len(want) {
+				t.Fatalf("group %d alias %s: %v, want %v", a.group, alias, gotFiles, want)
+			}
+			for i := range want {
+				if gotFiles[i] != want[i] {
+					t.Errorf("group %d alias %s file %d: %s, want %s", a.group, alias, i, gotFiles[i], want[i])
+				}
+			}
+		}
+	}
+}
+
+func TestPlanSkewSplitTasks_BuildSideHotNoSplit(t *testing.T) {
+	lowerSkewThresholds(t, 100<<20, 100<<20)
+	c := &Coordinator{logger: slog.Default()}
+	inputs := map[string]StageOutput{
+		"probe-stage": skewTestOutput("probe", []int64{10 << 20, 400 << 20, 10 << 20}, 4),
+		// Build partition 1 exceeds skewSplitMaxBuildBytes (200 MiB):
+		// replicating it would multiply the OOM, so the group must not split.
+		"build-stage": skewTestOutput("build", []int64{1 << 20, 300 << 20, 1 << 20}, 2),
+	}
+	if got := c.planSkewSplitTasks(skewTestStage(), inputs, 3, 3); got != nil {
+		t.Fatalf("build-side-hot group split anyway: %+v", got)
+	}
+}
+
+func TestPlanSkewSplitTasks_IneligibleShapes(t *testing.T) {
+	lowerSkewThresholds(t, 100<<20, 100<<20)
+	c := &Coordinator{logger: slog.Default()}
+	hotProbe := skewTestOutput("probe", []int64{10 << 20, 400 << 20, 10 << 20}, 4)
+	build := skewTestOutput("build", []int64{1 << 20, 2 << 20, 1 << 20}, 2)
+
+	// Right/full outer joins emit unmatched BUILD rows — replication would
+	// duplicate them.
+	for _, jt := range []string{"right", "full", "cross"} {
+		stage := skewTestStage()
+		stage.JoinType = jt
+		if got := c.planSkewSplitTasks(stage, map[string]StageOutput{"probe-stage": hotProbe, "build-stage": build}, 3, 3); got != nil {
+			t.Errorf("join type %q split: %+v", jt, got)
+		}
+	}
+	// Missing vectors (legacy workers) → off.
+	noVec := hotProbe
+	noVec.PartitionBytes = nil
+	if got := c.planSkewSplitTasks(skewTestStage(), map[string]StageOutput{"probe-stage": noVec, "build-stage": build}, 3, 3); got != nil {
+		t.Errorf("nil probe vectors split: %+v", got)
+	}
+	noBuildVec := build
+	noBuildVec.PartitionBytes = nil
+	if got := c.planSkewSplitTasks(skewTestStage(), map[string]StageOutput{"probe-stage": hotProbe, "build-stage": noBuildVec}, 3, 3); got != nil {
+		t.Errorf("nil build vectors split: %+v", got)
+	}
+	// Single worker → nothing to fan out to.
+	if got := c.planSkewSplitTasks(skewTestStage(), map[string]StageOutput{"probe-stage": hotProbe, "build-stage": build}, 3, 1); got != nil {
+		t.Errorf("single-worker split: %+v", got)
+	}
+	// SMJ excluded v1 (needs aligned sorted runs).
+	smj := skewTestStage()
+	smj.Type = physical.StageSortMergeJoin
+	if got := c.planSkewSplitTasks(smj, map[string]StageOutput{"probe-stage": hotProbe, "build-stage": build}, 3, 3); got != nil {
+		t.Errorf("SMJ split: %+v", got)
+	}
+}
+
+// TestPlanSkewSplitTasks_RangeGrouping: numTasks < NumPartitions — groups
+// bind contiguous partition ranges exactly as partitionFilesForWorker does,
+// and hotness is judged per group (range sum), not per partition.
+func TestPlanSkewSplitTasks_RangeGrouping(t *testing.T) {
+	lowerSkewThresholds(t, 100<<20, 100<<20)
+	c := &Coordinator{logger: slog.Default()}
+	// 6 partitions, 3 tasks → ranges [0,2) [2,4) [4,6). Partition 3 is hot.
+	probe := skewTestOutput("probe", []int64{5 << 20, 5 << 20, 10 << 20, 350 << 20, 5 << 20, 5 << 20}, 3)
+	build := skewTestOutput("build", []int64{1 << 20, 1 << 20, 1 << 20, 1 << 20, 1 << 20, 1 << 20}, 1)
+	inputs := map[string]StageOutput{"probe-stage": probe, "build-stage": build}
+	got := c.planSkewSplitTasks(skewTestStage(), inputs, 3, 3)
+	if got == nil {
+		t.Fatal("hot range not split")
+	}
+	// Group 1 (partitions 2+3, 360 MB) → k = ceil(360/100) = 4 → cap 3.
+	if len(got) != 5 {
+		t.Fatalf("len(assignments) = %d, want 5", len(got))
+	}
+	// The group's probe files must cover BOTH partitions of the range.
+	var hotFiles []string
+	for _, a := range got[1:4] {
+		hotFiles = append(hotFiles, a.inputs["probe"]...)
+	}
+	want := len(probe.Files[2]) + len(probe.Files[3])
+	if len(hotFiles) != want {
+		t.Fatalf("hot group covers %d probe files, want %d", len(hotFiles), want)
+	}
+}
+
+// TestSkewSplitParity is the end-to-end dispatch gate: a 3-worker cluster
+// over a manufactured hot-key dataset, the same join queries run with
+// --skew-split off and on, rows must be identical and the on-arm must have
+// actually planned splits (SkewSplitsPlanned counter — the mechanism
+// marker). 1-worker in-process suites cannot catch dispatch bugs; this is
+// the fixture the design memo requires before any deploy.
+func TestSkewSplitParity(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	t.Cleanup(cancel)
+
+	// Thresholds low enough that only the hot key's partition group
+	// crosses: hot group carries ~90% of ~5 MB, others share the rest.
+	lowerSkewThresholds(t, 512<<10, 512<<10)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	natsCfg := distributed.DefaultNATSConfig()
+	natsCfg.Port = -1
+	natsCfg.StoreDir = t.TempDir()
+	embeddedNATS, err := distributed.NewEmbeddedNATS(natsCfg, logger)
+	if err != nil {
+		t.Fatalf("starting NATS: %v", err)
+	}
+	t.Cleanup(embeddedNATS.Shutdown)
+
+	nc, err := distributed.ConnectInProcess(embeddedNATS.Server())
+	if err != nil {
+		t.Fatalf("connecting to NATS: %v", err)
+	}
+	t.Cleanup(func() { nc.Close() })
+
+	js, err := distributed.NewJetStream(nc)
+	if err != nil {
+		t.Fatalf("creating JetStream: %v", err)
+	}
+	if err := distributed.SetupStreams(ctx, js); err != nil {
+		t.Fatalf("setting up streams: %v", err)
+	}
+
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(ctx, "test"); err != nil {
+		t.Fatal(err)
+	}
+	kv, err := catalog.NewNATSKV(js)
+	if err != nil {
+		t.Fatalf("creating NATS KV: %v", err)
+	}
+	cat := catalog.New(kv, store, "test")
+	if err := cat.Init(ctx); err != nil {
+		t.Fatalf("catalog init: %v", err)
+	}
+
+	// Fixture: events (probe, skewed — 90% of rows on one key) joins dims
+	// (build, uniform). Some event keys are absent from dims so the LEFT
+	// JOIN query exercises unmatched-probe emission under a replicated
+	// build. events is written as 8 chunks so the shuffle fans out and the
+	// hot partition accumulates multiple files (v1 splits at file
+	// granularity).
+	eventsSchema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "k", Type: parquet.TypeInt64},
+		{Name: "v", Type: parquet.TypeString},
+	}}
+	dimsSchema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "k", Type: parquet.TypeInt64},
+		{Name: "name", Type: parquet.TypeString},
+	}}
+	if err := cat.CreateTable(ctx, "events", eventsSchema, nil); err != nil {
+		t.Fatalf("creating events: %v", err)
+	}
+	if err := cat.CreateTable(ctx, "dims", dimsSchema, nil); err != nil {
+		t.Fatalf("creating dims: %v", err)
+	}
+
+	const (
+		hotKey    = int64(7)
+		numDims   = 48 // dims hold keys [0, 48); event keys [0, 64) — keys ≥ 48 miss
+		numChunks = 8
+		rowsPer   = 8192
+	)
+	pad := make([]byte, 56)
+	for i := range pad {
+		pad[i] = 'x'
+	}
+	writeChunk := func(table string, schema parquet.Schema, rows []map[string]any, ci int) {
+		t.Helper()
+		var buf bytes.Buffer
+		pw, err := parquet.NewWriter(&buf, schema, parquet.DefaultWriterConfig())
+		if err != nil {
+			t.Fatalf("parquet writer %s/%d: %v", table, ci, err)
+		}
+		if err := pw.WriteRows(rows); err != nil {
+			t.Fatalf("writing %s/%d: %v", table, ci, err)
+		}
+		if err := pw.Close(); err != nil {
+			t.Fatalf("closing %s/%d: %v", table, ci, err)
+		}
+		filePath := fmt.Sprintf("tables/%s/chunk_%04d.parquet", table, ci)
+		pdata := buf.Bytes()
+		if _, err := store.Put(ctx, "test", filePath, bytes.NewReader(pdata), int64(len(pdata)), "application/octet-stream"); err != nil {
+			t.Fatalf("storing %s/%d: %v", table, ci, err)
+		}
+		if err := cat.AddFiles(ctx, table, map[string]string{}, "tables/"+table+"/", []catalog.FileEntry{{
+			Path:      filePath,
+			SizeBytes: int64(len(pdata)),
+			NumRows:   int64(len(rows)),
+			CreatedAt: time.Now(),
+		}}); err != nil {
+			t.Fatalf("manifest %s/%d: %v", table, ci, err)
+		}
+	}
+
+	for ci := 0; ci < numChunks; ci++ {
+		rows := make([]map[string]any, rowsPer)
+		for i := range rows {
+			k := hotKey
+			if i%10 == 9 { // 90% hot, 10% spread over [0, 64)
+				k = int64((ci*rowsPer + i) % 64)
+			}
+			rows[i] = map[string]any{"k": k, "v": string(pad)}
+		}
+		writeChunk("events", eventsSchema, rows, ci)
+	}
+	dimRows := make([]map[string]any, numDims)
+	for i := range dimRows {
+		dimRows[i] = map[string]any{"k": int64(i), "name": fmt.Sprintf("dim-%02d", i)}
+	}
+	writeChunk("dims", dimsSchema, dimRows, 0)
+
+	for i := 0; i < 3; i++ {
+		w := worker.New(worker.Config{
+			NATSUrl:       embeddedNATS.ClientURL(),
+			MaxConcurrent: 4,
+			CacheBytes:    64 * 1024 * 1024,
+		}, store, nc, js, logger)
+		workerCtx, workerCancel := context.WithCancel(context.Background())
+		t.Cleanup(workerCancel)
+		if err := w.Start(workerCtx); err != nil {
+			t.Fatalf("starting worker %d: %v", i, err)
+		}
+		t.Cleanup(w.Stop)
+	}
+
+	newCoord := func(skew bool) *Coordinator {
+		c := New(Config{
+			NATSUrl:      embeddedNATS.ClientURL(),
+			ResultBucket: "test",
+			// Never broadcast: forces the shuffled hash-join path the
+			// skew split targets (otherwise the tiny dims build would
+			// ride broadcast_join + probe-split and never repartition).
+			BroadcastBytesOverride: -1,
+			SkewSplit:              skew,
+		}, cat, nc, js, logger)
+		for i := 0; i < 3; i++ {
+			c.workers.record(distributed.WorkerHeartbeat{
+				WorkerID:  fmt.Sprintf("fake-worker-%d", i),
+				Timestamp: time.Now(),
+			})
+		}
+		return c
+	}
+
+	queries := []string{
+		// Inner join + aggregate over the hot key's dimension.
+		"SELECT d.name, count(*) AS cnt FROM events e JOIN dims d ON e.k = d.k GROUP BY d.name ORDER BY d.name",
+		// Left join: unmatched probe rows (keys >= 48) must survive the
+		// split exactly once each.
+		"SELECT count(*) AS total_rows, count(d.name) AS matched_rows FROM events e LEFT JOIN dims d ON e.k = d.k",
+	}
+
+	run := func(c *Coordinator, sql string) string {
+		t.Helper()
+		result, err := c.ExecuteSQL(ctx, sql)
+		if err != nil {
+			t.Fatalf("ExecuteSQL(%q): %v", sql, err)
+		}
+		if result.Error != "" {
+			t.Fatalf("query error (%q): %s", sql, result.Error)
+		}
+		rows := mustRows(t, result)
+		rendered := make([]string, len(rows))
+		for i, r := range rows {
+			rendered[i] = fmt.Sprintf("%v", r)
+		}
+		sort.Strings(rendered)
+		return fmt.Sprintf("%d rows\n%v", len(rows), rendered)
+	}
+
+	coordOff := newCoord(false)
+	coordOn := newCoord(true)
+
+	for qi, sql := range queries {
+		beforeOff := SkewSplitsPlanned.Load()
+		want := run(coordOff, sql)
+		if d := SkewSplitsPlanned.Load() - beforeOff; d != 0 {
+			t.Fatalf("q%d: flag-off arm planned %d splits", qi, d)
+		}
+		beforeOn := SkewSplitsPlanned.Load()
+		got := run(coordOn, sql)
+		if got != want {
+			t.Errorf("q%d row mismatch under skew split\nsql: %s\n--- off ---\n%s\n--- on ---\n%s", qi, sql, want, got)
+		}
+		if d := SkewSplitsPlanned.Load() - beforeOn; d == 0 {
+			t.Errorf("q%d: skew-split arm planned no splits — fixture did not engage the mechanism", qi)
+		} else {
+			t.Logf("q%d: %d skew splits planned, rows identical", qi, d)
+		}
+	}
+}

--- a/internal/coordinator/stage_output.go
+++ b/internal/coordinator/stage_output.go
@@ -41,6 +41,15 @@ type StageOutput struct {
 	// estimates use; in-memory footprint is larger by the codec ratio.
 	Bytes int64
 
+	// PartitionRows/PartitionBytes: per-partition output totals reduced
+	// across the producing stage's tasks (final surviving attempts only),
+	// indexed by partition id. Valid when Kind == OutputPartitioned; nil
+	// when the workers didn't report (legacy build) — downstream skew
+	// detection degrades to off, never to wrong. Bytes are on-disk
+	// uncompressed .wshf sizes, the unit per-task admission estimates use.
+	PartitionRows  []int64
+	PartitionBytes []int64
+
 	// BuildStats, populated when this stage's Stage.EmitDynamicFilters was
 	// non-empty. One entry per emit, keyed by FilterID. Downstream consumer
 	// stages reach in via the stat-dep edge to pull the materialized stats.

--- a/internal/coordinator/stage_output.go
+++ b/internal/coordinator/stage_output.go
@@ -111,29 +111,41 @@ func partitionFilesForWorker(out StageOutput, w, workerCount int) []string {
 		}
 		return out.Files[0]
 	}
-	if out.NumPartitions == 0 || workerCount <= 0 || w < 0 || w >= workerCount {
-		return nil
-	}
-	partsPerWorker := out.NumPartitions / workerCount
-	if partsPerWorker == 0 {
-		partsPerWorker = 1
-	}
-	start := w * partsPerWorker
-	end := start + partsPerWorker
-	if w == workerCount-1 {
-		end = out.NumPartitions // last worker absorbs remainder
-	}
-	if start >= out.NumPartitions {
-		return nil
-	}
-	if end > out.NumPartitions {
-		end = out.NumPartitions
-	}
+	start, end := partitionRangeForWorker(out.NumPartitions, w, workerCount)
 	var files []string
 	for p := start; p < end; p++ {
 		files = append(files, out.Files[p]...)
 	}
 	return files
+}
+
+// partitionRangeForWorker returns the half-open partition range [start, end)
+// worker w of workerCount binds under the contiguous-slice assignment.
+// Returns an empty range (start == end) when w gets nothing. Extracted from
+// partitionFilesForWorker so the skew-split planner (skew_split.go) groups
+// partitions by EXACTLY the ranges the unsplit layout would bind — any
+// divergence between the two would mis-align split decisions with task
+// inputs.
+func partitionRangeForWorker(numPartitions, w, workerCount int) (start, end int) {
+	if numPartitions == 0 || workerCount <= 0 || w < 0 || w >= workerCount {
+		return 0, 0
+	}
+	partsPerWorker := numPartitions / workerCount
+	if partsPerWorker == 0 {
+		partsPerWorker = 1
+	}
+	start = w * partsPerWorker
+	end = start + partsPerWorker
+	if w == workerCount-1 {
+		end = numPartitions // last worker absorbs remainder
+	}
+	if start >= numPartitions {
+		return 0, 0
+	}
+	if end > numPartitions {
+		end = numPartitions
+	}
+	return start, end
 }
 
 // flattenStageFiles returns all output files in a single flat list,

--- a/internal/coordinator/task_retry.go
+++ b/internal/coordinator/task_retry.go
@@ -68,9 +68,15 @@ type taskAttemptState struct {
 	files    []string
 	partials []distributed.DynamicFilterPartialRef
 	bytes    int64
-	errMsg   string
-	attempts int
-	terminal bool
+	// partRows/partBytes are the per-partition output vectors from the
+	// SUCCESSFUL attempt's ResultNotification (nil when the worker didn't
+	// report). Keying by the surviving attempt is what makes the stage-level
+	// reduction retry-safe: a failed attempt's partial writes never count.
+	partRows  []int64
+	partBytes []int64
+	errMsg    string
+	attempts  int
+	terminal  bool
 }
 
 // newTaskRetrier registers the dispatched tasks. republish re-dispatches a
@@ -112,6 +118,8 @@ func (tr *taskRetrier) Observe(r distributed.ResultNotification) (allDone bool) 
 		st.files = r.ResultFiles
 		st.partials = r.DynamicFilterPartials
 		st.bytes = r.SizeBytes
+		st.partRows = r.PartitionRows
+		st.partBytes = r.PartitionBytes
 		st.errMsg = ""
 		st.terminal = true
 		tr.terminal++
@@ -216,6 +224,39 @@ func (tr *taskRetrier) TotalBytes() int64 {
 		total += st.bytes
 	}
 	return total
+}
+
+// PartitionAccounting reduces the per-task partition vectors element-wise
+// across the final surviving attempt of every task, producing stage-level
+// per-partition row and byte totals indexed by partition id. Returns
+// (nil, nil) when no task reported vectors (legacy workers, non-partitioned
+// output) — callers treat nil as "sizes unknown, skew detection off".
+// Vectors shorter than numParts (shouldn't happen; defensive) contribute
+// only their prefix; longer ones are truncated.
+func (tr *taskRetrier) PartitionAccounting(numParts int) (rows, bytes []int64) {
+	if numParts <= 0 {
+		return nil, nil
+	}
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	any := false
+	for _, st := range tr.states {
+		if len(st.partRows) == 0 && len(st.partBytes) == 0 {
+			continue
+		}
+		if !any {
+			rows = make([]int64, numParts)
+			bytes = make([]int64, numParts)
+			any = true
+		}
+		for p := 0; p < len(st.partRows) && p < numParts; p++ {
+			rows[p] += st.partRows[p]
+		}
+		for p := 0; p < len(st.partBytes) && p < numParts; p++ {
+			bytes[p] += st.partBytes[p]
+		}
+	}
+	return rows, bytes
 }
 
 // DynamicFilterPartials returns every successful task's dynamic-filter

--- a/internal/coordinator/task_retry_test.go
+++ b/internal/coordinator/task_retry_test.go
@@ -340,3 +340,51 @@ func TestReapStuckOnce(t *testing.T) {
 		t.Fatalf("fresh task redispatched %d times, want 0", n)
 	}
 }
+
+// TestTaskRetrier_PartitionAccounting: element-wise reduction across the
+// final surviving attempts, retry-safe (a failed attempt's vectors never
+// count — only the surviving attempt's do).
+func TestTaskRetrier_PartitionAccounting(t *testing.T) {
+	rep := &collectingRepublisher{}
+	tr := newTaskRetrier(retryTestTasks(2), true, rep.republish, slog.Default(), "s", nil)
+
+	ra := okResult("a", "f-a")
+	ra.PartitionRows = []int64{10, 0, 5}
+	ra.PartitionBytes = []int64{100, 0, 50}
+	tr.Observe(ra)
+
+	// Task b fails once (no vectors recorded), then its retry succeeds with
+	// vectors — the reduction must reflect only the surviving attempt.
+	tr.Observe(failResult("b", "worker died"))
+	waitRepublished(t, rep, 1)
+	rb := okResult("b", "f-b2")
+	rb.PartitionRows = []int64{1, 2, 3}
+	rb.PartitionBytes = []int64{10, 20, 30}
+	if !tr.Observe(rb) {
+		t.Fatal("not done after retry success")
+	}
+
+	rows, bytes := tr.PartitionAccounting(3)
+	wantRows := []int64{11, 2, 8}
+	wantBytes := []int64{110, 20, 80}
+	for p := range wantRows {
+		if rows[p] != wantRows[p] {
+			t.Errorf("rows[%d] = %d, want %d", p, rows[p], wantRows[p])
+		}
+		if bytes[p] != wantBytes[p] {
+			t.Errorf("bytes[%d] = %d, want %d", p, bytes[p], wantBytes[p])
+		}
+	}
+}
+
+// TestTaskRetrier_PartitionAccountingUnreported: nil vectors when no task
+// reported (legacy workers) — callers treat nil as skew-detection-off.
+func TestTaskRetrier_PartitionAccountingUnreported(t *testing.T) {
+	tr := newTaskRetrier(retryTestTasks(2), false, nil, slog.Default(), "s", nil)
+	tr.Observe(okResult("a", "f-a"))
+	tr.Observe(okResult("b", "f-b"))
+	rows, bytes := tr.PartitionAccounting(4)
+	if rows != nil || bytes != nil {
+		t.Fatalf("want nil vectors for unreported tasks, got rows=%v bytes=%v", rows, bytes)
+	}
+}

--- a/internal/distributed/messages.go
+++ b/internal/distributed/messages.go
@@ -456,6 +456,17 @@ type ResultNotification struct {
 	NumRows     int64    `json:"num_rows"`
 	SizeBytes   int64    `json:"size_bytes"`
 
+	// Per-partition output accounting for partition-writing tasks (shuffle
+	// tasks and fragment tasks with an exchange-sender sink), indexed by
+	// partition id with len == NumPartitions. Rows come from the partitioned
+	// sink's per-partition counters; bytes are the on-disk uncompressed
+	// .wshf sizes (same unit as SizeBytes). The coordinator reduces these
+	// element-wise across a stage's tasks to detect hot partitions at the
+	// repartition→join seam. Empty partitions hold zeros; nil = worker
+	// didn't report (legacy build or non-partitioned output).
+	PartitionRows  []int64 `json:"partition_rows,omitempty"`
+	PartitionBytes []int64 `json:"partition_bytes,omitempty"`
+
 	// Small result fast path (< 256 KB): inline result data
 	InlineData []byte `json:"inline_data,omitempty"`
 

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -1000,6 +1000,12 @@ func (e *Executor) executeShuffle(ctx context.Context, task distributed.Task, re
 	}
 	tFinalizeEnd = time.Now()
 
+	// Per-partition accounting for coordinator-side skew detection. Rows
+	// come from the sink's counters; bytes are filled from the per-partition
+	// stat calls the upload paths below already make.
+	result.PartitionRows = sink.PartitionRowCounts()
+	result.PartitionBytes = make([]int64, task.NumPartitions)
+
 	// Phase-B async upload: report completion now — every partition file is
 	// finalized on local disk — adopt each into the LocalStageCache (peers
 	// and the background upload read the adopted copy), and hand the S3
@@ -1017,6 +1023,7 @@ func (e *Executor) executeShuffle(ctx context.Context, task distributed.Task, re
 			if statErr != nil {
 				return fmt.Errorf("shuffle task %s: stat partition %d: %w", task.ID, p, statErr)
 			}
+			result.PartitionBytes[p] = fi.Size()
 			if job, ok := e.finishStageOutputAsync(ctx, &task, key, localPath, fi.Size(), true, result); ok {
 				jobs = append(jobs, job)
 				continue
@@ -1172,6 +1179,7 @@ func (e *Executor) executeShuffle(ctx context.Context, task distributed.Task, re
 		}
 		result.ResultFiles = append(result.ResultFiles, partResults[p].key)
 		result.SizeBytes += partResults[p].size
+		result.PartitionBytes[p] = partResults[p].size
 	}
 
 	result.NumRows = totalRows

--- a/internal/worker/executor_shuffle_test.go
+++ b/internal/worker/executor_shuffle_test.go
@@ -69,6 +69,29 @@ func TestExecuteShuffle_HappyPath(t *testing.T) {
 	t.Logf("shuffle: %d rows → %d partition files, %d bytes",
 		result.NumRows, len(result.ResultFiles), result.SizeBytes)
 
+	// Per-partition accounting: vectors sized to NumPartitions, rows sum to
+	// the task total, bytes sum to SizeBytes, and a partition has bytes iff
+	// it has rows.
+	if len(result.PartitionRows) != numParts || len(result.PartitionBytes) != numParts {
+		t.Fatalf("partition vectors len = %d/%d, want %d",
+			len(result.PartitionRows), len(result.PartitionBytes), numParts)
+	}
+	var vecRows, vecBytes int64
+	for p := 0; p < numParts; p++ {
+		vecRows += result.PartitionRows[p]
+		vecBytes += result.PartitionBytes[p]
+		if (result.PartitionRows[p] == 0) != (result.PartitionBytes[p] == 0) {
+			t.Errorf("partition %d: rows=%d bytes=%d — must be zero/nonzero together",
+				p, result.PartitionRows[p], result.PartitionBytes[p])
+		}
+	}
+	if vecRows != numRows {
+		t.Errorf("sum(PartitionRows) = %d, want %d", vecRows, numRows)
+	}
+	if vecBytes != result.SizeBytes {
+		t.Errorf("sum(PartitionBytes) = %d, want SizeBytes %d", vecBytes, result.SizeBytes)
+	}
+
 	// Verify each ResultFile key follows the expected naming convention and exists.
 	for _, key := range result.ResultFiles {
 		if !strings.Contains(key, "partition=") {

--- a/internal/worker/executor_stage.go
+++ b/internal/worker/executor_stage.go
@@ -318,6 +318,12 @@ func (e *Executor) writePartitionedShuffle(ctx context.Context, task distributed
 // between the legacy collect-then-partition path (writePartitionedShuffle) and
 // the streaming-partition path (runStageScanPartitionedStreaming).
 func (e *Executor) uploadPartitionedShuffleFiles(ctx context.Context, task distributed.Task, sink *partitionedShuffleSink, result *distributed.ResultNotification) error {
+	// Per-partition accounting for coordinator-side skew detection. Rows
+	// from the sink counters; bytes filled from the per-partition stats
+	// below.
+	result.PartitionRows = sink.PartitionRowCounts()
+	result.PartitionBytes = make([]int64, len(result.PartitionRows))
+
 	root, asyncOK := e.asyncUploadEligible(&task)
 	var jobs []uploadJob
 	defer func() {
@@ -336,6 +342,7 @@ func (e *Executor) uploadPartitionedShuffleFiles(ctx context.Context, task distr
 			if statErr != nil {
 				return fmt.Errorf("stage task %s: stat partition %d: %w", task.ID, p, statErr)
 			}
+			result.PartitionBytes[p] = fi.Size()
 			key := fmt.Sprintf("%spartition=%04d/%s.wshf", task.ResultPrefix, p, task.ID)
 			if job, ok := e.finishStageOutputAsync(ctx, &task, key, localPath, fi.Size(), false, result); ok {
 				jobs = append(jobs, job)
@@ -363,6 +370,7 @@ func (e *Executor) uploadPartitionedShuffleFiles(ctx context.Context, task distr
 		}
 		result.ResultFiles = append(result.ResultFiles, key)
 		result.SizeBytes += fi.Size()
+		result.PartitionBytes[p] = fi.Size()
 
 		// Best-effort KV cache for small partitions. Read the local file we
 		// already wrote to disk — cheaper than re-buffering. Failure is

--- a/internal/worker/partitioned_shuffle_sink.go
+++ b/internal/worker/partitioned_shuffle_sink.go
@@ -739,6 +739,20 @@ func (s *partitionedShuffleSink) PartitionFiles() []string {
 	return out
 }
 
+// PartitionRowCounts returns the number of rows written to each partition
+// file, indexed by partition id. Like PartitionFiles, must be called AFTER
+// Finalize — earlier calls miss rows still sitting in the accumulators.
+func (s *partitionedShuffleSink) PartitionRowCounts() []int64 {
+	out := make([]int64, s.numParts)
+	for p, pw := range s.parts {
+		if pw == nil {
+			continue
+		}
+		out[p] = pw.numRows
+	}
+	return out
+}
+
 // FNV-1a 64-bit constants.
 const (
 	fnvOffset64 uint64 = 14695981039346656037

--- a/internal/worker/partitioned_shuffle_sink_test.go
+++ b/internal/worker/partitioned_shuffle_sink_test.go
@@ -334,3 +334,54 @@ func TestPartitionedShuffleSink_LargeConsumeBurstParity(t *testing.T) {
 		t.Fatalf("rows across partitions = %d, want %d", rows, total)
 	}
 }
+
+// TestPartitionedShuffleSink_PartitionRowCounts verifies the post-Finalize
+// per-partition row counters match what a full read-back of each partition
+// file observes, and that empty partitions report zero.
+func TestPartitionedShuffleSink_PartitionRowCounts(t *testing.T) {
+	dir := t.TempDir()
+	const numParts = 4
+
+	schema := []parquet.Column{{Name: "k", Type: parquet.TypeInt64}}
+	sink := newPartitionedShuffleSink(dir, []string{"k"}, numParts, schema)
+	if err := sink.Init(context.Background()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	const n = 1000
+	b := batch.NewRecordBatch(schema, n)
+	for i := 0; i < n; i++ {
+		b.Columns[0].Int64Data[i] = int64(i)
+		b.Columns[0].Nulls.SetValid(i)
+	}
+	if err := sink.Consume(context.Background(), b); err != nil {
+		t.Fatalf("consume: %v", err)
+	}
+	if err := sink.Finalize(context.Background()); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	defer sink.Close()
+
+	counts := sink.PartitionRowCounts()
+	if len(counts) != numParts {
+		t.Fatalf("len(counts) = %d, want %d", len(counts), numParts)
+	}
+	paths := sink.PartitionFiles()
+	var total int64
+	for p, path := range paths {
+		var observed int64
+		if path != "" {
+			observed = int64(len(readWSHFInts(t, path, "k")))
+		}
+		if counts[p] != observed {
+			t.Errorf("counts[%d] = %d, read-back = %d", p, counts[p], observed)
+		}
+		if path == "" && counts[p] != 0 {
+			t.Errorf("empty partition %d reports %d rows", p, counts[p])
+		}
+		total += counts[p]
+	}
+	if total != n {
+		t.Errorf("sum of counts = %d, want %d", total, n)
+	}
+}


### PR DESCRIPTION
Implements Phases 1–2 of [docs/design/skew-aware-shuffle.md](docs/design/skew-aware-shuffle.md) (merged in #210). Last unstarted Tier-2 item on the Trino-gap roadmap; the payoff target is skewed security workloads and memory robustness, not TPC-H wall (uniform keys — expect ~0 there).

## Phase 1 — per-partition accounting (always on)

- Workers report `PartitionRows`/`PartitionBytes` on `ResultNotification` for every partitioned output: plain shuffle tasks (`executeShuffle`, both sync and async-upload paths) and fragment tasks with exchange-sender sinks (`uploadPartitionedShuffleFiles`). Rows come from the partitioned sink's existing per-partition counters; bytes from the upload paths' existing per-partition `os.Stat` — zero extra passes.
- The coordinator reduces the vectors element-wise across the **final surviving task set** (`taskRetrier.PartitionAccounting` — retry-safe by construction, since the retrier keys state by surviving attempt) onto `StageOutput` at all three partitioned-collection sites (repartition stages, fused scan+shuffle, fused join+exchange) and onto the legacy `ShuffleLayout`.

## Phase 2 — skew decision + layout (`--skew-split`, default off)

At shuffled-hash-join dispatch, `planSkewSplitTasks` (new `internal/coordinator/skew_split.go`) judges each task's contiguous partition range against an **absolute** byte threshold (what breaks under skew is one task's bytes vs its budget, not the distribution's shape; max/mean ratio is logged only). A hot group becomes k = ceil(probeBytes/256MiB) sub-tasks (capped at workerCount and the group's probe file count) that split the group's probe files and replicate its build files — the broadcast probe-split pattern applied per hot group. Sub-task outputs re-group into their original partition slot, so the stage's `OutputPartitioned` shape is byte-compatible with the unsplit layout for downstream partition-aligned consumers (multi-file slots are already the norm).

Safety bounds:
- **Join semantics**: only probe-side-emitting joins split (inner/left/semi/anti). Right/full would emit unmatched build rows once per replica.
- **Build-side-hot never splits**: the worker's grace partition-on-arrival already bounds an oversized build inside one task; k replicas would multiply the OOM. Bound = cluster broadcast threshold (same question broadcast planning answers), 200 MiB fallback.
- Legacy pipeline path stays non-adaptive; SMJ excluded v1.

Observability: `SkewSplitsPlanned` counter + `skew split planned` Info log (the same-window A/B mechanism marker) + a `skew split skipped` log for the build-side-hot case.

Flag plumbing: `--skew-split` on the CLI, `WADJET_SKEW_SPLIT` in tpch-bench, terraform var `skew_split`.

## Deviations from the memo (deliberate)

- No `bytesWritten` sink counter — the upload paths already stat every partition file; the stat is the actual on-disk size.
- Decision unit is the task's partition **range**, not a single partition: `Distribution.Count` defaults to workerCount, so a task binds `NumPartitions/numTasks` (typically 4) partitions; per-partition decisions would mis-align with task binding. `partitionRangeForWorker` is extracted from `partitionFilesForWorker` so both use identical arithmetic.

## Gates

- `TestSkewSplitParity`: 3-worker in-process cluster over a manufactured hot-key dataset (90% of ~5 MB probe on one key, broadcast disabled to force the repartition path), inner+aggregate and left-join queries **row-identical both arms**, with counter-proven engagement (1 split planned per query) and a flag-off no-engagement assertion.
- `planSkewSplitTasks` unit tests: uniform/hot/build-side-hot/right-full-cross/nil-vectors/single-worker/SMJ/range-grouping; non-hot assignments asserted byte-identical to `buildTaskInputsForStage`.
- Full `go test ./internal/...` green; TPC-H SF0.01 22/22.
- `tpch-harness --mode=local` both arms: **all 22 queries checksum-identical**. (Two micros differ in checksum only — verified unstable across two identical flag-off runs; no ORDER BY, arrival-order nondeterminism.)

## Not in this PR

Phase 3 — skewed-dataset A/B deploy (needs a hot-key benchmark fixture; TPC-H is uniform and is deliberately not the validation target) and any default-flip decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)