### PR TITLE
test(coordinator): hot-key skew benchmark fixture for the Phase 3 A/B

### DIFF
--- a/benchmarks/skew/skew.go
+++ b/benchmarks/skew/skew.go
@@ -1,0 +1,204 @@
+// Package skew generates the synthetic hot-key benchmark fixture for the
+// adaptive skew-aware shuffle A/B (docs/design/skew-aware-shuffle.md,
+// Phase 3). It is the TestSkewSplitParity fixture shape scaled to sizes that
+// engage the mechanism at PRODUCTION thresholds — no lowered knobs.
+//
+// Shape: skew_events (probe side, one hot join key carrying HotPct% of all
+// rows) joins skew_dims (build side, uniform keys). The sizes are dialed to
+// the mechanism's engagement envelope on a 3-worker cluster:
+//
+//   - skew_dims manifest bytes must exceed the cluster broadcast threshold
+//     (broadcastThresholdFromCluster, capped at 200 MiB) so the planner emits
+//     a hash-partitioned join instead of broadcast+probe-split. The wide
+//     `pad` column exists only for this: queries never project it, so the
+//     shuffled build stays a few tens of MB — far under the skew split's
+//     build-replication bound. Wide dimension table, narrow projection: the
+//     common shape in the security workloads this mechanism targets.
+//   - The hot group's probe bytes must exceed skewSplitMinGroupBytes
+//     (256 MiB) while the uniform groups stay below it, so exactly one group
+//     splits. Suite queries aggregate over events.v (count(DISTINCT e.v)),
+//     which forces the ~256-byte payload through the shuffle — projection
+//     pruning would otherwise reduce the probe to its 8-byte key and no
+//     realistic row count would cross the threshold.
+//
+// Generation is deterministic for a given Config (seeded rand, fixed chunk
+// boundaries), so two harness runs — the flag-off and flag-on A/B arms —
+// see byte-identical logical rows and row-level parity checks are valid.
+package skew
+
+import (
+	"fmt"
+	"math/rand"
+	"strconv"
+
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// Tables maps table name → schema, for catalog registration and S3 discovery.
+var Tables = map[string]parquet.Schema{
+	"skew_events": {Columns: []parquet.Column{
+		{Name: "k", Type: parquet.TypeInt64},
+		{Name: "v", Type: parquet.TypeString},
+	}},
+	"skew_dims": {Columns: []parquet.Column{
+		{Name: "k", Type: parquet.TypeInt64},
+		{Name: "name", Type: parquet.TypeString},
+		{Name: "pad", Type: parquet.TypeString},
+	}},
+}
+
+// Queries is the fixed suite, keyed by name. Both queries force events.v
+// through the shuffle (see package comment) and produce small deterministic
+// result sets so cross-arm parity can compare full row checksums.
+//
+// skew_join_agg: inner join + aggregate over the build side's low-cardinality
+// category. The hot key's category count and per-category distinct-payload
+// counts surface any row loss or duplication under the split. The
+// count(DISTINCT e.v) partial state also makes task memory proportional to
+// task probe bytes — the memory-relief signal.
+//
+// skew_left_join: unmatched probe rows (events keys outside dims' key range)
+// must survive a replicated-build split exactly once each; total_rows and
+// distinct_payloads equal the generated events row count.
+var Queries = map[string]string{
+	"skew_join_agg": `SELECT d.name, count(*) AS cnt, count(DISTINCT e.v) AS distinct_payloads
+FROM skew_events e JOIN skew_dims d ON e.k = d.k
+GROUP BY d.name ORDER BY d.name`,
+	"skew_left_join": `SELECT count(*) AS total_rows, count(d.name) AS matched_rows, count(DISTINCT e.v) AS distinct_payloads
+FROM skew_events e LEFT JOIN skew_dims d ON e.k = d.k`,
+}
+
+// QueryOrder is the canonical execution order of the suite.
+var QueryOrder = []string{"skew_join_agg", "skew_left_join"}
+
+// Config parameterizes the generator. All sizes are row counts; byte sizes
+// follow from PadBytes (~PadBytes+16 per events row).
+type Config struct {
+	EventsRows int   // total probe rows
+	DimsRows   int   // total build rows; dims keys are [0, DimsRows)
+	HotKey     int64 // the hot events key; must be < DimsRows so it matches
+	HotPct     int   // percent of events rows on HotKey (0-100)
+	KeySpace   int64 // non-hot events keys are uniform in [0, KeySpace); keys >= DimsRows miss
+	NameCard   int   // distinct dims.name values (result cardinality of skew_join_agg)
+	PadBytes   int   // random payload width for events.v and dims.pad
+	ChunkRows  int   // rows per emitted parquet chunk
+	Seed       int64
+}
+
+// DefaultLocalConfig engages the skew split at production thresholds on a
+// 3-worker local harness cluster: dims ≈ 330 MB parquet (over the 200 MiB
+// broadcast cap), events ≈ 1.7 GB with 90% on the hot key — hot group
+// ≈ 1.6 GB probe (splits at k=3), uniform groups ≈ 60 MB (stay unsplit).
+func DefaultLocalConfig() Config {
+	return Config{
+		EventsRows: 6_500_000,
+		DimsRows:   1_200_000,
+		HotKey:     7,
+		HotPct:     90,
+		KeySpace:   1_600_000,
+		NameCard:   48,
+		PadBytes:   248,
+		ChunkRows:  250_000,
+		Seed:       42,
+	}
+}
+
+// DefaultDeployConfig is the SF10-class fixture: events ≈ 8.5 GB with a
+// ≈ 7.6 GB hot partition, dims identical to the local config. Uniform groups
+// ≈ 220 MB stay under the 256 MiB floor; only the hot group splits.
+func DefaultDeployConfig() Config {
+	cfg := DefaultLocalConfig()
+	cfg.EventsRows = 32_000_000
+	cfg.ChunkRows = 500_000
+	return cfg
+}
+
+// Validate rejects configs the generator or the suite queries would
+// misbehave on.
+func (c Config) Validate() error {
+	switch {
+	case c.EventsRows <= 0 || c.DimsRows <= 0 || c.ChunkRows <= 0:
+		return fmt.Errorf("skew config: rows and chunk size must be positive: %+v", c)
+	case c.HotKey < 0 || c.HotKey >= int64(c.DimsRows):
+		return fmt.Errorf("skew config: HotKey %d must be in [0, DimsRows %d) so it matches a dim", c.HotKey, c.DimsRows)
+	case c.HotPct < 0 || c.HotPct > 100:
+		return fmt.Errorf("skew config: HotPct %d out of [0,100]", c.HotPct)
+	case c.KeySpace <= int64(c.DimsRows):
+		return fmt.Errorf("skew config: KeySpace %d must exceed DimsRows %d so LEFT JOIN has unmatched rows", c.KeySpace, c.DimsRows)
+	case c.NameCard <= 0 || c.PadBytes <= 0:
+		return fmt.Errorf("skew config: NameCard and PadBytes must be positive: %+v", c)
+	}
+	return nil
+}
+
+// GenerateChunked streams the fixture through emit in deterministic chunk
+// order: all skew_dims chunks, then all skew_events chunks. emit receives at
+// most ChunkRows rows per call, mirroring tpch.GenerateChunked's contract.
+func GenerateChunked(cfg Config, emit func(table string, rows []map[string]any) error) error {
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+	rng := rand.New(rand.NewSource(cfg.Seed))
+
+	for start := 0; start < cfg.DimsRows; start += cfg.ChunkRows {
+		n := cfg.ChunkRows
+		if start+n > cfg.DimsRows {
+			n = cfg.DimsRows - start
+		}
+		rows := make([]map[string]any, n)
+		for i := range rows {
+			k := int64(start + i)
+			rows[i] = map[string]any{
+				"k":    k,
+				"name": fmt.Sprintf("cat-%02d", k%int64(cfg.NameCard)),
+				"pad":  randPayload(rng, cfg.PadBytes),
+			}
+		}
+		if err := emit("skew_dims", rows); err != nil {
+			return fmt.Errorf("emitting skew_dims chunk at %d: %w", start, err)
+		}
+	}
+
+	row := 0
+	for start := 0; start < cfg.EventsRows; start += cfg.ChunkRows {
+		n := cfg.ChunkRows
+		if start+n > cfg.EventsRows {
+			n = cfg.EventsRows - start
+		}
+		rows := make([]map[string]any, n)
+		for i := range rows {
+			k := cfg.HotKey
+			if row%100 >= cfg.HotPct {
+				k = rng.Int63n(cfg.KeySpace)
+			}
+			// The "-<row>" suffix makes v unique, so count(DISTINCT e.v)
+			// equals the joined row count exactly — a parity invariant.
+			rows[i] = map[string]any{
+				"k": k,
+				"v": randPayload(rng, cfg.PadBytes) + "-" + strconv.Itoa(row),
+			}
+			row++
+		}
+		if err := emit("skew_events", rows); err != nil {
+			return fmt.Errorf("emitting skew_events chunk at %d: %w", start, err)
+		}
+	}
+	return nil
+}
+
+// payloadAlphabet has 64 symbols so each output byte carries 6 bits of
+// entropy: the payloads stay near-incompressible under parquet's snappy
+// pages AND the .wshf shuffle format, keeping manifest-byte estimates and
+// per-partition shuffle accounting within ~25% of each other. Compressible
+// pads would shrink the two measures differently and silently shift the
+// fixture out of the engagement envelope.
+const payloadAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+
+func randPayload(rng *rand.Rand, n int) string {
+	buf := make([]byte, n)
+	rng.Read(buf)
+	for i, b := range buf {
+		buf[i] = payloadAlphabet[b&63]
+	}
+	return string(buf)
+}

--- a/benchmarks/skew/skew_test.go
+++ b/benchmarks/skew/skew_test.go
@@ -1,0 +1,134 @@
+package skew
+
+import (
+	"fmt"
+	"testing"
+)
+
+func testConfig() Config {
+	return Config{
+		EventsRows: 10_000,
+		DimsRows:   1_000,
+		HotKey:     7,
+		HotPct:     90,
+		KeySpace:   1_400,
+		NameCard:   48,
+		PadBytes:   32,
+		ChunkRows:  3_000,
+		Seed:       42,
+	}
+}
+
+// collect runs GenerateChunked and returns rows per table plus chunk sizes.
+func collect(t *testing.T, cfg Config) (map[string][]map[string]any, map[string][]int) {
+	t.Helper()
+	rows := make(map[string][]map[string]any)
+	chunks := make(map[string][]int)
+	err := GenerateChunked(cfg, func(table string, r []map[string]any) error {
+		rows[table] = append(rows[table], r...)
+		chunks[table] = append(chunks[table], len(r))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("GenerateChunked: %v", err)
+	}
+	return rows, chunks
+}
+
+func TestGenerateChunked_ShapeAndDeterminism(t *testing.T) {
+	cfg := testConfig()
+	rows1, chunks1 := collect(t, cfg)
+	rows2, _ := collect(t, cfg)
+
+	if got := len(rows1["skew_events"]); got != cfg.EventsRows {
+		t.Errorf("events rows = %d, want %d", got, cfg.EventsRows)
+	}
+	if got := len(rows1["skew_dims"]); got != cfg.DimsRows {
+		t.Errorf("dims rows = %d, want %d", got, cfg.DimsRows)
+	}
+	for table, sizes := range chunks1 {
+		for i, n := range sizes {
+			if n > cfg.ChunkRows {
+				t.Errorf("%s chunk %d has %d rows > ChunkRows %d", table, i, n, cfg.ChunkRows)
+			}
+		}
+	}
+	// Same config → identical rows (the A/B arms regenerate independently).
+	for _, table := range []string{"skew_events", "skew_dims"} {
+		for i := range rows1[table] {
+			if fmt.Sprintf("%v", rows1[table][i]) != fmt.Sprintf("%v", rows2[table][i]) {
+				t.Fatalf("%s row %d differs between identical-config runs", table, i)
+			}
+		}
+	}
+}
+
+func TestGenerateChunked_HotFractionAndKeyRanges(t *testing.T) {
+	cfg := testConfig()
+	rows, _ := collect(t, cfg)
+
+	hot := 0
+	unique := make(map[string]bool, cfg.EventsRows)
+	for i, r := range rows["skew_events"] {
+		k := r["k"].(int64)
+		if k == cfg.HotKey {
+			hot++
+		}
+		if k < 0 || k >= cfg.KeySpace {
+			t.Fatalf("events row %d key %d outside [0, %d)", i, k, cfg.KeySpace)
+		}
+		unique[r["v"].(string)] = true
+	}
+	// row%100 < HotPct rows are pinned to HotKey; uniform draws can add a few.
+	minHot := cfg.EventsRows * cfg.HotPct / 100
+	if hot < minHot {
+		t.Errorf("hot rows = %d, want >= %d", hot, minHot)
+	}
+	if hot > minHot+cfg.EventsRows/50 {
+		t.Errorf("hot rows = %d, way over pinned %d — hot fraction wrong", hot, minHot)
+	}
+	if len(unique) != cfg.EventsRows {
+		t.Errorf("distinct v = %d, want %d (v must be unique for parity invariants)", len(unique), cfg.EventsRows)
+	}
+
+	names := make(map[string]bool)
+	for i, r := range rows["skew_dims"] {
+		if k := r["k"].(int64); k != int64(i) {
+			t.Fatalf("dims row %d has key %d, want sequential", i, k)
+		}
+		names[r["name"].(string)] = true
+	}
+	if len(names) != cfg.NameCard {
+		t.Errorf("distinct dims.name = %d, want %d", len(names), cfg.NameCard)
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	if err := DefaultLocalConfig().Validate(); err != nil {
+		t.Errorf("DefaultLocalConfig invalid: %v", err)
+	}
+	if err := DefaultDeployConfig().Validate(); err != nil {
+		t.Errorf("DefaultDeployConfig invalid: %v", err)
+	}
+	bad := testConfig()
+	bad.HotKey = int64(bad.DimsRows) // hot key would never match a dim
+	if err := bad.Validate(); err == nil {
+		t.Error("HotKey >= DimsRows not rejected")
+	}
+	bad = testConfig()
+	bad.KeySpace = int64(bad.DimsRows) // no unmatched rows for LEFT JOIN
+	if err := bad.Validate(); err == nil {
+		t.Error("KeySpace <= DimsRows not rejected")
+	}
+}
+
+func TestQueriesCoverOrder(t *testing.T) {
+	if len(QueryOrder) != len(Queries) {
+		t.Fatalf("QueryOrder has %d entries, Queries has %d", len(QueryOrder), len(Queries))
+	}
+	for _, name := range QueryOrder {
+		if _, ok := Queries[name]; !ok {
+			t.Errorf("QueryOrder entry %q missing from Queries", name)
+		}
+	}
+}

--- a/cmd/tpch-bench/main.go
+++ b/cmd/tpch-bench/main.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/citc-tech/wadjet/benchmarks/skew"
 	tpch "github.com/citc-tech/wadjet/benchmarks/tpch"
 	"github.com/citc-tech/wadjet/internal/coordinator"
 	"github.com/citc-tech/wadjet/internal/dataplane"
@@ -63,9 +64,14 @@ func main() {
 		memProf               = flag.String("memprofile", "", "Write memory profile to file")
 		profDir               = flag.String("profdir", "", "Directory for per-query profiles")
 		dataPrefix            = flag.String("data-prefix", "tables/", "S3 prefix for table data (e.g. 'tables/' or '' for root)")
+		skewSuite             = flag.Bool("skew-suite", false, "Run the hot-key skew fixture (benchmarks/skew) instead of TPC-H: without --skip-load, generate + upload the fixture under --data-prefix first. Also enabled by WADJET_SKEW_SUITE=1.")
 		catalogSnapshotPrefix = flag.String("catalog-snapshot-prefix", "", "S3 prefix for catalog snapshots (e.g. 'catalog/'). With --skip-load: restore the latest snapshot instead of running discovery+ANALYZE; after a fresh discovery, write one. Empty = disabled.")
 	)
 	flag.Parse()
+
+	if !*skewSuite && skewSuiteEnabled() {
+		*skewSuite = true
+	}
 
 	// Apply profile: values from YAML override flag defaults, but
 	// explicitly-set CLI flags take precedence over the profile.
@@ -175,6 +181,20 @@ func main() {
 	}
 
 	sf := tpch.ScaleFactor(float64(*scale))
+	if *skewSuite {
+		// Skew fixture (docs/design/skew-aware-shuffle.md Phase 3): its own
+		// load/discover path — the catalog-snapshot shortcut is TPC-H-only
+		// (skew discovery is 2 tables and takes seconds).
+		if *skipLoad {
+			discoverData(ctx, db, *s3Endpoint, *s3Region, *s3Bucket, *ssl, *dataPrefix, skew.Tables)
+		} else {
+			loadSkewData(ctx, db, *s3Endpoint, *s3Region, *s3Bucket, *ssl, *dataPrefix)
+		}
+		if !*dataOnly {
+			runSkewSuite(ctx, coord, *workers, *runs, *queryTimeout)
+		}
+		return
+	}
 	if *skipLoad {
 		// Pre-staged bucket data is immutable across deploys, so the
 		// post-discovery catalog (schemas, file manifests with row counts,
@@ -184,11 +204,11 @@ func main() {
 		if *catalogSnapshotPrefix != "" {
 			snapStore := newCatalogSnapshotStore(*s3Endpoint, *s3Region, *ssl)
 			if !restoreCatalogSnapshot(ctx, db.Catalog(), snapStore, *s3Bucket, *catalogSnapshotPrefix) {
-				discoverData(ctx, db, *s3Endpoint, *s3Region, *s3Bucket, *ssl, *dataPrefix)
+				discoverData(ctx, db, *s3Endpoint, *s3Region, *s3Bucket, *ssl, *dataPrefix, tpch.AllTables)
 				snapshotCatalog(ctx, db.Catalog(), snapStore, *s3Bucket, *catalogSnapshotPrefix)
 			}
 		} else {
-			discoverData(ctx, db, *s3Endpoint, *s3Region, *s3Bucket, *ssl, *dataPrefix)
+			discoverData(ctx, db, *s3Endpoint, *s3Region, *s3Bucket, *ssl, *dataPrefix, tpch.AllTables)
 		}
 	} else {
 		loadData(ctx, db, sf)
@@ -481,7 +501,7 @@ func snapshotCatalog(ctx context.Context, cat *catalog.Catalog, store objstore.S
 	log.Printf("Catalog snapshotted to s3://%s/%ssnapshots/%s (next boot restores it in seconds)", bucket, prefix, ts)
 }
 
-func discoverData(ctx context.Context, db *wadjet.DB, endpoint, region, bucket string, ssl bool, dataPrefix string) {
+func discoverData(ctx context.Context, db *wadjet.DB, endpoint, region, bucket string, ssl bool, dataPrefix string, tables map[string]parquet.Schema) {
 	store, err := objstore.NewMinIOStore(objstore.MinIOConfig{
 		Endpoint: endpoint,
 		UseSSL:   ssl,
@@ -504,7 +524,7 @@ func discoverData(ctx context.Context, db *wadjet.DB, endpoint, region, bucket s
 	// round-trip per table (range read of the parquet footer) and removes
 	// an entire class of correctness bugs.
 	totalFiles := 0
-	for name := range tpch.AllTables {
+	for name := range tables {
 		prefix := dataPrefix + name + "/"
 		objects, err := store.List(ctx, bucket, objstore.ListOptions{Prefix: prefix})
 		if err != nil {
@@ -531,7 +551,7 @@ func discoverData(ctx context.Context, db *wadjet.DB, endpoint, region, bucket s
 		}
 		if len(pqObjects) == 0 {
 			log.Printf("WARNING: no parquet files for table %s, using hardcoded schema", name)
-			if err := db.CreateTable(ctx, name, tpch.AllTables[name], nil); err != nil && !strings.Contains(err.Error(), "already exists") {
+			if err := db.CreateTable(ctx, name, tables[name], nil); err != nil && !strings.Contains(err.Error(), "already exists") {
 				log.Fatalf("create table %s: %v", name, err)
 			}
 			continue
@@ -540,7 +560,7 @@ func discoverData(ctx context.Context, db *wadjet.DB, endpoint, region, bucket s
 		schema, err := probeParquetSchema(ctx, store, bucket, pqObjects[0].Key)
 		if err != nil {
 			log.Printf("WARNING: probing %s/%s failed (%v); falling back to hardcoded schema", name, pqObjects[0].Key, err)
-			schema = tpch.AllTables[name]
+			schema = tables[name]
 		}
 		if err := db.CreateTable(ctx, name, schema, nil); err != nil && !strings.Contains(err.Error(), "already exists") {
 			log.Fatalf("create table %s: %v", name, err)
@@ -572,7 +592,7 @@ func discoverData(ctx context.Context, db *wadjet.DB, endpoint, region, bucket s
 		totalFiles += len(files)
 		log.Printf("Discovered %d files for table %s (%d cols, %d rows)", len(files), name, len(schema.Columns), totalRows)
 	}
-	log.Printf("Data discovery complete: %d total files across %d tables", totalFiles, len(tpch.AllTables))
+	log.Printf("Data discovery complete: %d total files across %d tables", totalFiles, len(tables))
 
 	// ANALYZE every table to populate per-column HLL sketches in the
 	// catalog. Without this, S3-staged data (every EC2 SF10/SF100 deploy
@@ -583,7 +603,7 @@ func discoverData(ctx context.Context, db *wadjet.DB, endpoint, region, bucket s
 	// Runs once at startup. Cost: ~1-2 minutes serial at SF10, dwarfed
 	// by the bench's per-query wall time. Output is cached in the
 	// catalog so subsequent queries reuse the sketches.
-	for name := range tpch.AllTables {
+	for name := range tables {
 		analyzed, err := db.Catalog().AnalyzeTable(ctx, name)
 		if err != nil {
 			log.Printf("WARNING: ANALYZE %s failed (%v); planner falls back to heuristic NDV", name, err)

--- a/cmd/tpch-bench/skew.go
+++ b/cmd/tpch-bench/skew.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"os"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/citc-tech/wadjet/benchmarks/skew"
+	"github.com/citc-tech/wadjet/internal/coordinator"
+	"github.com/citc-tech/wadjet/internal/storage/catalog"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+	"github.com/citc-tech/wadjet/wadjet"
+)
+
+// Skew-suite mode (docs/design/skew-aware-shuffle.md Phase 3): instead of
+// the 22 TPC-H queries, run the hot-key events⋈dims fixture from
+// benchmarks/skew. Enabled by --skew-suite or WADJET_SKEW_SUITE=1 (the
+// terraform deploy exports the env var, mirroring WADJET_SKEW_SPLIT).
+//
+// Data staging follows the TPC-H flags: without --skip-load the fixture is
+// generated and uploaded under --data-prefix (any stale objects there are
+// deleted first); with --skip-load the tables are discovered like TPC-H
+// ones. The A/B deploy stages once (GENERATE_DATA=1 on the first arm) and
+// discovers on later arms.
+
+// skewSuiteEnabled reports the env-var opt-in used by the terraform deploy.
+func skewSuiteEnabled() bool {
+	v := os.Getenv("WADJET_SKEW_SUITE")
+	return v == "1" || v == "true" || v == "TRUE"
+}
+
+// skewDeployConfig returns the deploy fixture config with the same env
+// overrides the harness honors, so undersized smoke deploys are possible.
+func skewDeployConfig() (skew.Config, error) {
+	cfg := skew.DefaultDeployConfig()
+	if v := os.Getenv("WADJET_SKEW_EVENTS_ROWS"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return cfg, fmt.Errorf("WADJET_SKEW_EVENTS_ROWS: %w", err)
+		}
+		cfg.EventsRows = n
+	}
+	if v := os.Getenv("WADJET_SKEW_DIMS_ROWS"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return cfg, fmt.Errorf("WADJET_SKEW_DIMS_ROWS: %w", err)
+		}
+		cfg.DimsRows = n
+		if ks := int64(n) * 4 / 3; cfg.KeySpace <= int64(n) || cfg.KeySpace > ks {
+			cfg.KeySpace = ks
+		}
+		if cfg.HotKey >= int64(n) {
+			cfg.HotKey = int64(n) / 2
+		}
+	}
+	return cfg, cfg.Validate()
+}
+
+// loadSkewData generates the skew fixture and uploads it under
+// bucket/dataPrefix, registering files + row counts in the catalog. Any
+// existing objects under the fixture tables' prefixes are deleted first so
+// a re-generation can never double the dataset (stale files would silently
+// double row counts AND change every parity invariant).
+func loadSkewData(ctx context.Context, db *wadjet.DB, endpoint, region, bucket string, ssl bool, dataPrefix string) {
+	cfg, err := skewDeployConfig()
+	if err != nil {
+		log.Fatalf("skew config: %v", err)
+	}
+	store, err := objstore.NewMinIOStore(objstore.MinIOConfig{
+		Endpoint: endpoint,
+		UseSSL:   ssl,
+		Region:   region,
+	})
+	if err != nil {
+		log.Fatalf("creating S3 store for skew load: %v", err)
+	}
+
+	for name := range skew.Tables {
+		prefix := dataPrefix + name + "/"
+		objects, err := store.List(ctx, bucket, objstore.ListOptions{Prefix: prefix})
+		if err != nil {
+			log.Fatalf("listing stale %s files: %v", name, err)
+		}
+		for _, obj := range objects {
+			if err := store.Delete(ctx, bucket, obj.Key); err != nil {
+				log.Fatalf("deleting stale %s: %v", obj.Key, err)
+			}
+		}
+		if len(objects) > 0 {
+			log.Printf("Deleted %d stale objects under %s", len(objects), prefix)
+		}
+	}
+
+	for name, schema := range skew.Tables {
+		if err := db.CreateTable(ctx, name, schema, nil); err != nil {
+			log.Fatalf("create table %s: %v", name, err)
+		}
+	}
+
+	log.Printf("Generating skew fixture: events=%d dims=%d hot_pct=%d pad=%dB",
+		cfg.EventsRows, cfg.DimsRows, cfg.HotPct, cfg.PadBytes)
+	start := time.Now()
+	chunkIdx := make(map[string]int)
+	entries := make(map[string][]catalog.FileEntry)
+	emit := func(table string, rows []map[string]any) error {
+		var buf bytes.Buffer
+		pw, err := parquet.NewWriter(&buf, skew.Tables[table], parquet.DefaultWriterConfig())
+		if err != nil {
+			return fmt.Errorf("parquet writer for %s: %w", table, err)
+		}
+		if err := pw.WriteRows(rows); err != nil {
+			return fmt.Errorf("writing %s: %w", table, err)
+		}
+		if err := pw.Close(); err != nil {
+			return fmt.Errorf("closing %s: %w", table, err)
+		}
+		idx := chunkIdx[table]
+		chunkIdx[table] = idx + 1
+		key := fmt.Sprintf("%s%s/chunk_%04d.parquet", dataPrefix, table, idx+1)
+		data := buf.Bytes()
+		if _, err := store.Put(ctx, bucket, key, bytes.NewReader(data), int64(len(data)), "application/octet-stream"); err != nil {
+			return fmt.Errorf("uploading %s: %w", key, err)
+		}
+		entries[table] = append(entries[table], catalog.FileEntry{
+			Path:      key,
+			SizeBytes: int64(len(data)),
+			NumRows:   int64(len(rows)),
+			CreatedAt: time.Now(),
+		})
+		return nil
+	}
+	if err := skew.GenerateChunked(cfg, emit); err != nil {
+		log.Fatalf("generating skew fixture: %v", err)
+	}
+	for table, files := range entries {
+		if err := db.Catalog().AddFiles(ctx, table, nil, "", files); err != nil {
+			log.Fatalf("registering %s files: %v", table, err)
+		}
+		var rows, bytesTotal int64
+		for _, f := range files {
+			rows += f.NumRows
+			bytesTotal += f.SizeBytes
+		}
+		log.Printf("Uploaded %s: %d files, %d rows, %.1f MB", table, len(files), rows, float64(bytesTotal)/(1024*1024))
+	}
+	log.Printf("Skew fixture staged in %s", time.Since(start).Round(time.Second))
+
+	for name := range skew.Tables {
+		analyzed, err := db.Catalog().AnalyzeTable(ctx, name)
+		if err != nil {
+			log.Printf("WARNING: ANALYZE %s failed (%v); planner falls back to heuristic NDV", name, err)
+			continue
+		}
+		if analyzed > 0 {
+			log.Printf("ANALYZE %s: HLL collected on %d files", name, analyzed)
+		}
+	}
+}
+
+// runSkewSuite executes the skew queries through the coordinator, printing
+// wall time, row count, a full-row checksum (the cross-arm parity signal),
+// and the SkewSplitsPlanned delta (the mechanism marker: wall deltas without
+// this counter moving are window drift, not skew-split signal).
+func runSkewSuite(ctx context.Context, coord *coordinator.Coordinator, expectedWorkers, runs int, timeout time.Duration) {
+	if coord == nil {
+		log.Fatal("--skew-suite requires distributed mode (the mechanism is coordinator task dispatch)")
+	}
+	for run := 1; run <= runs; run++ {
+		log.Printf("=== Skew suite run %d/%d ===", run, runs)
+		for _, name := range skew.QueryOrder {
+			for retries := 0; retries < 30 && coord.Workers().Count() < expectedWorkers; retries++ {
+				if retries == 0 {
+					log.Printf("  waiting for workers (%d/%d)...", coord.Workers().Count(), expectedWorkers)
+				}
+				time.Sleep(2 * time.Second)
+			}
+			qctx := ctx
+			var cancel context.CancelFunc
+			if timeout > 0 {
+				qctx, cancel = context.WithTimeout(ctx, timeout)
+			}
+			splitsBefore := coordinator.SkewSplitsPlanned.Load()
+			startQ := time.Now()
+			result, err := coord.ExecuteSQL(qctx, skew.Queries[name])
+			if err == nil && result.Error != "" {
+				err = fmt.Errorf("%s", result.Error)
+			}
+			var rows []map[string]any
+			if err == nil {
+				rows, err = result.Rows()
+			}
+			wall := time.Since(startQ)
+			splits := coordinator.SkewSplitsPlanned.Load() - splitsBefore
+			if cancel != nil {
+				cancel()
+			}
+			if err != nil {
+				log.Printf("SKEW RESULT run=%d query=%s wall_ms=%d skew_splits=%d ERROR: %v",
+					run, name, wall.Milliseconds(), splits, err)
+				continue
+			}
+			rendered := make([]string, len(rows))
+			for i, r := range rows {
+				rendered[i] = renderRow(r)
+			}
+			sort.Strings(rendered)
+			hash := sha256.New()
+			for _, r := range rendered {
+				fmt.Fprintln(hash, r)
+			}
+			log.Printf("SKEW RESULT run=%d query=%s wall_ms=%d rows=%d checksum=%s skew_splits=%d",
+				run, name, wall.Milliseconds(), len(rows), hex.EncodeToString(hash.Sum(nil))[:16], splits)
+			for _, r := range rendered {
+				log.Printf("  row: %s", r)
+			}
+		}
+	}
+}
+
+// renderRow renders a result row with sorted column names so checksums are
+// stable across map iteration order.
+func renderRow(r map[string]any) string {
+	cols := make([]string, 0, len(r))
+	for c := range r {
+		cols = append(cols, c)
+	}
+	sort.Strings(cols)
+	var b bytes.Buffer
+	for i, c := range cols {
+		if i > 0 {
+			b.WriteString(" ")
+		}
+		fmt.Fprintf(&b, "%s=%v", c, r[c])
+	}
+	return b.String()
+}

--- a/deploy/benchmark/terraform/main.tf
+++ b/deploy/benchmark/terraform/main.tf
@@ -384,6 +384,7 @@ locals {
     export WADJET_LATE_MATERIALIZATION="${var.late_materialization}"
     export WADJET_BUSHY_JOIN_REORDER="${var.bushy_join_reorder}"
     export WADJET_SKEW_SPLIT="${var.skew_split}"
+    export WADJET_SKEW_SUITE="${var.skew_suite}"
     export USE_NATIVE_DAG="${var.use_native_dag ? "1" : "0"}"
     # Phase C/D/E data-plane selection. Empty/"nats" = legacy NATS reply
     # subjects; "grpc" routes task dispatch + results + gather +

--- a/deploy/benchmark/terraform/sf10-skew-off.tfvars
+++ b/deploy/benchmark/terraform/sf10-skew-off.tfvars
@@ -1,0 +1,26 @@
+# Skew-split A/B — ARM A (control, --skew-split OFF) + fixture staging.
+# docs/design/skew-aware-shuffle.md Phase 3. Runs the benchmarks/skew hot-key
+# suite (tpch-bench --skew-suite via WADJET_SKEW_SUITE) instead of TPC-H.
+# generate_data=true stages the fixture under tables-skew/ on first boot
+# (loadSkewData deletes stale objects under the prefix before writing).
+# Cluster shape matches sf10-distributed.tfvars exactly — same-window arm B
+# (sf10-skew-on.tfvars) differs ONLY in skew_split and generate_data.
+
+scale_factor              = 10
+mode                      = "distributed"
+coordinator_instance_type = "c7g.2xlarge"
+worker_instance_type      = "c7gd.4xlarge" # NVMe: control arm's straggler task may spill
+worker_count              = 3
+workers_per_node          = 1
+max_concurrent            = 2
+data_bucket               = "wadjet-bench-sf10-use2"
+skip_queries              = ""
+query_timeout             = "30m"
+data_plane                = "grpc"
+catalog_snapshot_prefix   = "" # TPC-H-only shortcut; skew discovery is 2 tables, seconds
+
+skew_suite     = "1"
+data_prefix    = "tables-skew/"
+generate_data  = true
+benchmark_runs = 3
+skew_split     = ""

--- a/deploy/benchmark/terraform/sf10-skew-on.tfvars
+++ b/deploy/benchmark/terraform/sf10-skew-on.tfvars
@@ -1,0 +1,22 @@
+# Skew-split A/B — ARM B (treatment, --skew-split ON).
+# Discovers the fixture staged by the arm A run (sf10-skew-off.tfvars);
+# differs from arm A ONLY in skew_split and generate_data.
+
+scale_factor              = 10
+mode                      = "distributed"
+coordinator_instance_type = "c7g.2xlarge"
+worker_instance_type      = "c7gd.4xlarge"
+worker_count              = 3
+workers_per_node          = 1
+max_concurrent            = 2
+data_bucket               = "wadjet-bench-sf10-use2"
+skip_queries              = ""
+query_timeout             = "30m"
+data_plane                = "grpc"
+catalog_snapshot_prefix   = ""
+
+skew_suite     = "1"
+data_prefix    = "tables-skew/"
+generate_data  = false
+benchmark_runs = 3
+skew_split     = "1"

--- a/deploy/benchmark/terraform/sf10-tpch-skew-on.tfvars
+++ b/deploy/benchmark/terraform/sf10-tpch-skew-on.tfvars
@@ -1,0 +1,21 @@
+# TPC-H no-harm arm for the --skew-split default-flip decision:
+# standard SF10 TPC-H suite with the flag ON. TPC-H keys are uniform, so the
+# expectation is ~0 suite delta and zero "skew split planned" markers — this
+# arm exists to prove the flag doesn't harm uniform workloads. Pair with a
+# same-window sf10-distributed.tfvars control run (identical except
+# skew_split); never compare across time windows.
+
+scale_factor              = 10
+mode                      = "distributed"
+coordinator_instance_type = "c7g.2xlarge"
+worker_instance_type      = "c7gd.4xlarge"
+worker_count              = 3
+workers_per_node          = 1
+max_concurrent            = 2
+data_bucket               = "wadjet-bench-sf10-use2"
+skip_queries              = ""
+query_timeout             = "30m"
+data_plane                = "grpc"
+catalog_snapshot_prefix   = "catalog/"
+
+skew_split = "1"

--- a/deploy/benchmark/terraform/variables.tf
+++ b/deploy/benchmark/terraform/variables.tf
@@ -222,6 +222,12 @@ variable "skew_split" {
   default     = ""
 }
 
+variable "skew_suite" {
+  description = "Set to 1 to run the hot-key skew fixture (benchmarks/skew) instead of TPC-H — the Phase 3 skew-split A/B. Pair with data_prefix=tables-skew/ and generate_data=true on the first arm to stage the fixture."
+  type        = string
+  default     = ""
+}
+
 variable "dynamic_filters" {
   description = "Set to 1 to enable Trino-style semi-join dynamic-filter pushdown on the coordinator. Off by default for v1 rollout."
   type        = string

--- a/docs/design/skew-aware-shuffle.md
+++ b/docs/design/skew-aware-shuffle.md
@@ -101,6 +101,28 @@ fix it.
 3. **Validation**: skewed-dataset A/B on SF10-class deploy (marker-proven),
    then default-flip decision separately.
 
+   *Fixture (implemented 2026-07-10)*: `benchmarks/skew` — events⋈dims with
+   90% of probe rows on one hot key, sized to engage at PRODUCTION
+   thresholds (no lowered knobs). The envelope that drove the shape: the
+   build must exceed the cluster broadcast threshold (200 MiB cap) to take
+   the repartition path, while the hot group's build slice must stay under
+   the same bound to be replicable — so dims is a wide table (~300 MB
+   parquet) whose queries project only `k`+`name` (build shuffle ≈ 10 MB).
+   The suite queries aggregate `count(DISTINCT e.v)` to force the ~256-byte
+   probe payload through the shuffle (projection pruning would otherwise
+   reduce the probe to 8 B/row) and to make task memory proportional to
+   task probe bytes. Q18-shape TPC-H was rejected: SF10 orders (~1 GB
+   parquet) as build puts every group's build slice over the replication
+   bound — the safety gate refuses, correctly — and the hot orderkey would
+   also skew the GROUP BY l_orderkey aggregate, which the split does not
+   help, confounding the wall signal. Local 3-worker run at defaults:
+   splits planned (marker), rows checksum-identical both arms,
+   skew_left_join wall −46% and spill 423 MB → 0.
+   Runners: `tpch-harness --queries=skew_join_agg,skew_left_join`
+   (local; `--serve-args=--skew-split` = on-arm) and
+   `tpch-bench --skew-suite` (EC2; WADJET_SKEW_SUITE=1, data under
+   `tables-skew/`, staged via GENERATE_DATA=1 on the first arm).
+
 ## 5. Risks / notes
 
 - Retries: `retrier.Observe` replays failed tasks — per-partition vectors

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/citc-tech/wadjet/benchmarks/skew"
 	"github.com/citc-tech/wadjet/benchmarks/tpch"
 	"github.com/citc-tech/wadjet/internal/distributed"
 	"github.com/citc-tech/wadjet/internal/storage/catalog"
@@ -116,7 +117,8 @@ func Run(ctx context.Context, cfg Config, logger *slog.Logger) (RunResult, error
 			if scale <= 0 {
 				scale = tpch.SF001
 			}
-			if err := loadSampleData(ctx, cluster, cfg.DataDir, sliceCfg, scale, logger); err != nil {
+			seedSkew := anySkewQuery(SelectQueries(cfg.Queries))
+			if err := loadSampleData(ctx, cluster, cfg.DataDir, sliceCfg, scale, seedSkew, logger); err != nil {
 				return result, fmt.Errorf("loading sample data: %w", err)
 			}
 		}
@@ -322,6 +324,9 @@ func runOneQuery(
 		case "micro_hash_agg_high_card":
 			return RunMicroHashAggHighCard(ctx, coordURL, collector)
 		default:
+			if isSkewQuery(name) {
+				return RunSkewQuery(ctx, coordURL, name, collector)
+			}
 			return collector.EndWindow(name), err
 		}
 	}
@@ -390,7 +395,7 @@ func runOneQuery(
 // be called after cluster.StartNATS() and before cluster.StartProcesses()
 // so that when the coordinator and workers boot, the catalog already has
 // all tables and files registered.
-func loadSampleData(ctx context.Context, cluster *Cluster, dataDir string, _ SliceConfig, scale tpch.ScaleFactor, logger *slog.Logger) error {
+func loadSampleData(ctx context.Context, cluster *Cluster, dataDir string, _ SliceConfig, scale tpch.ScaleFactor, seedSkew bool, logger *slog.Logger) error {
 	// Connect to the coordinator's NATS for catalog access.
 	nc, err := cluster.ConnectNATS()
 	if err != nil {
@@ -442,7 +447,10 @@ func loadSampleData(ctx context.Context, cluster *Cluster, dataDir string, _ Sli
 		if len(rows) == 0 {
 			return nil
 		}
-		schema := tpch.AllTables[tableName]
+		schema, ok := tpch.AllTables[tableName]
+		if !ok {
+			schema = skew.Tables[tableName]
+		}
 		var buf bytes.Buffer
 		pw, err := parquet.NewWriter(&buf, schema, parquet.DefaultWriterConfig())
 		if err != nil {
@@ -472,6 +480,23 @@ func loadSampleData(ctx context.Context, cluster *Cluster, dataDir string, _ Sli
 	}
 	if err := tpch.GenerateChunked(scale, chunkSize, emit); err != nil {
 		return fmt.Errorf("generating SF%v data: %w", scale, err)
+	}
+	if seedSkew {
+		skewCfg, err := skewFixtureConfig()
+		if err != nil {
+			return fmt.Errorf("skew fixture config: %w", err)
+		}
+		for tableName, schema := range skew.Tables {
+			if err := cat.CreateTable(ctx, tableName, schema, nil); err != nil {
+				return fmt.Errorf("creating table %s: %w", tableName, err)
+			}
+		}
+		logger.Info("generating skew fixture",
+			"events_rows", skewCfg.EventsRows, "dims_rows", skewCfg.DimsRows,
+			"hot_pct", skewCfg.HotPct, "pad_bytes", skewCfg.PadBytes)
+		if err := skew.GenerateChunked(skewCfg, emit); err != nil {
+			return fmt.Errorf("generating skew fixture: %w", err)
+		}
 	}
 	for tableName, entries := range tableEntries {
 		if err := cat.AddFiles(ctx, tableName, map[string]string{}, "tables/"+tableName+"/", entries); err != nil {

--- a/internal/harness/load_data_test.go
+++ b/internal/harness/load_data_test.go
@@ -58,7 +58,7 @@ func TestLoadSampleDataPopulatesCatalog(t *testing.T) {
 	}
 
 	sliceCfg := SliceConfigs[SliceSmall]
-	if err := loadSampleData(ctx, cluster, dataDir, sliceCfg, tpch.SF001, logger); err != nil {
+	if err := loadSampleData(ctx, cluster, dataDir, sliceCfg, tpch.SF001, false, logger); err != nil {
 		t.Fatalf("loadSampleData: %v", err)
 	}
 

--- a/internal/harness/micros.go
+++ b/internal/harness/micros.go
@@ -123,13 +123,13 @@ func generateMicroData() map[string]microTable {
 	return data
 }
 
-// runMicroQuery is the shared execution logic for all micro-benchmarks.
-// It opens a pgx connection, runs the query, collects row count + checksum,
-// and returns the measurement from the collector window.
-func runMicroQuery(ctx context.Context, coordURL string, name string, sql string, collector *MeasurementCollector) (QueryMeasurement, error) {
+// runMicroQuery is the shared execution logic for all micro-benchmarks and
+// skew-suite queries. It opens a pgx connection, runs the query, collects
+// row count + checksum, and returns the measurement from the collector window.
+func runMicroQuery(ctx context.Context, coordURL string, name string, sql string, timeout time.Duration, collector *MeasurementCollector) (QueryMeasurement, error) {
 	collector.StartWindow(name)
 
-	queryCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	queryCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	conn, err := pgx.Connect(queryCtx, coordURL)
@@ -173,7 +173,7 @@ FROM micro_lineitem l
 JOIN micro_orders o ON l.l_orderkey = o.o_orderkey
 GROUP BY o.o_orderkey`
 
-	m, err := runMicroQuery(ctx, coordURL, "micro_reverse_bloom", sql, collector)
+	m, err := runMicroQuery(ctx, coordURL, "micro_reverse_bloom", sql, 2*time.Minute, collector)
 	if err != nil {
 		return m, err
 	}
@@ -191,7 +191,7 @@ func RunMicroGraceHashJoin(ctx context.Context, coordURL string, collector *Meas
 FROM micro_build b
 JOIN micro_probe p ON b.build_key = p.probe_key`
 
-	m, err := runMicroQuery(ctx, coordURL, "micro_grace_hash_join", sql, collector)
+	m, err := runMicroQuery(ctx, coordURL, "micro_grace_hash_join", sql, 2*time.Minute, collector)
 	if err != nil {
 		return m, err
 	}
@@ -208,7 +208,7 @@ func RunMicroHashAggHighCard(ctx context.Context, coordURL string, collector *Me
 FROM micro_agg
 GROUP BY group_key`
 
-	m, err := runMicroQuery(ctx, coordURL, "micro_hash_agg_high_card", sql, collector)
+	m, err := runMicroQuery(ctx, coordURL, "micro_hash_agg_high_card", sql, 2*time.Minute, collector)
 	if err != nil {
 		return m, err
 	}

--- a/internal/harness/skew.go
+++ b/internal/harness/skew.go
@@ -1,0 +1,102 @@
+package harness
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/citc-tech/wadjet/benchmarks/skew"
+)
+
+// Skew-suite integration (docs/design/skew-aware-shuffle.md Phase 3): the
+// hot-key A/B fixture runs through the harness local mode so the flag-off /
+// flag-on arms get the same cluster spawn, measurement, checksum, and hang
+// machinery as everything else. Opt-in only — the fixture is ~2 GB of
+// generated data, so it is seeded and run ONLY when --queries names a skew
+// query. Typical A/B:
+//
+//	tpch-harness --mode=local --workers=3 --no-compare \
+//	  --queries=skew_join_agg,skew_left_join                      # off arm
+//	tpch-harness --mode=local --workers=3 --no-compare \
+//	  --queries=skew_join_agg,skew_left_join \
+//	  --serve-args=--skew-split                                   # on arm
+//
+// Mechanism marker: grep the preserved coordinator log for "skew split
+// planned" (WADJET_HARNESS_KEEP=1 keeps the run dir on success).
+
+// skewQueryTimeout bounds one skew-suite query. The flag-off arm's straggler
+// task probes the entire ~1.6 GB hot group serially, so the micro suite's
+// 2-minute bound is too tight; WADJET_HARNESS_QUERY_TIMEOUT overrides.
+const skewQueryTimeout = 15 * time.Minute
+
+// isSkewQuery reports whether name belongs to the skew suite.
+func isSkewQuery(name string) bool {
+	_, ok := skew.Queries[name]
+	return ok
+}
+
+// anySkewQuery reports whether the resolved query list includes any
+// skew-suite query, i.e. whether loadSampleData must seed the fixture.
+func anySkewQuery(names []string) bool {
+	for _, n := range names {
+		if isSkewQuery(n) {
+			return true
+		}
+	}
+	return false
+}
+
+// skewFixtureConfig returns the local fixture config, honoring the
+// WADJET_SKEW_EVENTS_ROWS / WADJET_SKEW_DIMS_ROWS overrides used for quick
+// plumbing smoke runs (undersized fixtures don't engage the mechanism —
+// production thresholds need the defaults).
+func skewFixtureConfig() (skew.Config, error) {
+	cfg := skew.DefaultLocalConfig()
+	if v := os.Getenv("WADJET_SKEW_EVENTS_ROWS"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return cfg, fmt.Errorf("WADJET_SKEW_EVENTS_ROWS: %w", err)
+		}
+		cfg.EventsRows = n
+	}
+	if v := os.Getenv("WADJET_SKEW_DIMS_ROWS"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return cfg, fmt.Errorf("WADJET_SKEW_DIMS_ROWS: %w", err)
+		}
+		cfg.DimsRows = n
+		if ks := int64(n) * 4 / 3; cfg.KeySpace <= int64(n) || cfg.KeySpace > ks {
+			cfg.KeySpace = ks
+		}
+		if cfg.HotKey >= int64(n) {
+			cfg.HotKey = int64(n) / 2
+		}
+	}
+	return cfg, cfg.Validate()
+}
+
+// RunSkewQuery executes one skew-suite query by name and asserts its result
+// shape (both queries return at least one row; row values are checksummed by
+// the shared runner for cross-arm parity).
+func RunSkewQuery(ctx context.Context, coordURL string, name string, collector *MeasurementCollector) (QueryMeasurement, error) {
+	sql, ok := skew.Queries[name]
+	if !ok {
+		return collector.EndWindow(name), fmt.Errorf("unknown skew query %q", name)
+	}
+	timeout := skewQueryTimeout
+	if override := os.Getenv("WADJET_HARNESS_QUERY_TIMEOUT"); override != "" {
+		if d, err := time.ParseDuration(override); err == nil {
+			timeout = d
+		}
+	}
+	m, err := runMicroQuery(ctx, coordURL, name, sql, timeout, collector)
+	if err != nil {
+		return m, err
+	}
+	if m.RowCount == 0 {
+		return m, fmt.Errorf("%s: expected rows, got 0", name)
+	}
+	return m, nil
+}


### PR DESCRIPTION
## Summary

Phase 3 of the adaptive skew-aware shuffle (docs/design/skew-aware-shuffle.md): a hot-key benchmark fixture that engages `--skew-split` at **production thresholds** (no lowered knobs), plus the local and EC2 runners for the A/B. No engine behavior change — the flag stays default-off.

- **`benchmarks/skew`**: deterministic events(probe, 90% hot key) ⋈ dims(build, uniform) generator + 2-query suite. Sizing follows the engagement envelope: dims manifest (~300 MB) defeats the broadcast decision while queries project only `k`+`name`, so the shuffled build (~10 MB) stays under the replication bound; `count(DISTINCT e.v)` carries the 248 B payload through the shuffle (projection pruning would otherwise reduce the probe to its 8 B key) and makes task memory proportional to task probe bytes.
- **tpch-harness**: `--queries=skew_join_agg,skew_left_join` seeds and runs the fixture locally (opt-in; `--serve-args=--skew-split` = treatment arm).
- **tpch-bench**: `--skew-suite` / `WADJET_SKEW_SUITE=1` discovers or (without `--skip-load`) generates+uploads the fixture under `--data-prefix` (deleting stale prefix objects first), then prints per-query wall/rows/checksum and the `SkewSplitsPlanned` delta — marker and parity land directly in benchmark.log.
- **terraform**: `skew_suite` var + committed `sf10-skew-{off,on}.tfvars` A/B arm files.

Q18-shape TPC-H was rejected as the fixture: SF10 orders (~1 GB parquet) as build puts every group's build slice over the replication bound (the safety gate correctly refuses), and a hot orderkey would also skew the `GROUP BY l_orderkey` aggregate the split can't help — confounding the wall signal.

## Validation

Local 3-worker cluster at default thresholds: splits marker-proven on the treatment arm (0 on control), rows checksum-identical both arms, `skew_left_join` wall −46% with straggler spill 423 MB → 0.

SF10 A/B (2026-07-11, coord c7g.2xlarge + 3× c7gd.4xlarge, 3 runs/query/arm, results/20260711-121612 vs -133442):

| query | control mean | skew-split mean | delta |
|---|---|---|---|
| skew_join_agg | 210.0 s | 124.6 s | −40.6% |
| skew_left_join | 211.7 s | 125.1 s | −40.9% |

Exactly one split planned per treatment query (hot group only: probe 7.78 GB, build 13.5 MB, k=3, ratio 21.7×); uniform groups stayed unsplit; checksums identical across all 12 executions per query.

## Test plan

- `go test ./benchmarks/skew/ ./internal/harness/ ./cmd/tpch-bench/` (new generator unit tests: determinism, hot fraction, key ranges, config validation)
- `tpch-harness --mode=local` full suite: 22/22 + micros PASS
- TPC-H SF0.01 correctness + SF1 benchmark via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)