### PR TITLE
fix(coordinator): require a skew ratio, not just size, to split a group

### DIFF
--- a/docs/design/skew-aware-shuffle.md
+++ b/docs/design/skew-aware-shuffle.md
@@ -50,11 +50,18 @@ bucketing `runShuffleSide` already does for files at :288-300) into
 
     splitFactor[p] = ceil(bytes[p] / targetTaskBytes)   capped at workerCount
     hot iff splitFactor[p] > 1 AND bytes[p] > absolute floor (e.g. 256 MiB)
+    AND bytes[p] >= skewSplitMinRatio × mean group bytes (2.0)
     AND build[p] fits the replication bound (see safety below)
 
-Relative-only ratios (max/mean) are NOT the trigger — an absolute
-bytes-vs-budget threshold is what protects memory; ratio is logged for
-observability only.
+v1 shipped the absolute floor alone ("an absolute bytes-vs-budget threshold
+is what protects memory; ratio is observability only") — **falsified by the
+2026-07-11 SF10 no-harm A/B**: Q21's uniformly-heavy shuffle put every
+group (~374 MB, mean_ratio ≈ 1.0) over the floor, the blanket k=2 split of
+all groups bought zero skew relief, and Q21 regressed +21% wall. The 374 MB
+groups were nowhere near any memory budget, so the memory argument didn't
+apply; the trigger now requires an actual skew signal (ratio ≥ 2× the mean,
+which — since the mean includes the hot group — caps at the group count).
+Regression test: TestPlanSkewSplitTasks_UniformHeavyNoSplit.
 
 ### (d) Hot-partition-aware task layout
 In `dispatchComputeStage` (execute_stage_dag.go:1830) +

--- a/internal/coordinator/skew_split.go
+++ b/internal/coordinator/skew_split.go
@@ -25,11 +25,21 @@ var (
 
 	// skewSplitMinGroupBytes is the absolute floor below which a group is
 	// never considered hot, regardless of how uneven the layout looks.
-	// The trigger is deliberately absolute, not a max/mean ratio: what
-	// breaks under skew is one task's bytes vs its memory budget and the
-	// stage's wall clock, not the shape of the distribution. Ratio is
-	// logged for observability only.
 	skewSplitMinGroupBytes int64 = 256 << 20
+
+	// skewSplitMinRatio is the minimum group-probe-bytes / mean-group-bytes
+	// ratio for a group to count as hot. v1 shipped the absolute floor
+	// alone ("what breaks under skew is one task's bytes vs its budget,
+	// not the shape of the distribution") — the 2026-07-11 SF10 no-harm
+	// A/B falsified that: TPC-H Q21's uniformly-heavy shuffle (~374 MB per
+	// group, mean_ratio ≈ 1.0, nowhere near any memory budget) tripped the
+	// floor on EVERY group, doubled the stage's task count for zero skew
+	// relief, and regressed +21% wall. Requiring a real skew signal keeps
+	// the mechanism to its name; the hot-key fixture's groups sit at
+	// ratio 2.9 (local, 3 groups) to 21.7 (SF10) and still fire. Note the
+	// mean includes the hot group itself, so with N groups the ratio is
+	// bounded by N — at N=3 a group must carry 2/3 of all probe bytes.
+	skewSplitMinRatio = 2.0
 
 	// skewSplitMaxBuildBytes caps the build bytes a hot group may have and
 	// still split, when the cluster hasn't reported worker pool budgets
@@ -72,7 +82,10 @@ type skewTaskAssignment struct {
 //   - both primary deps are OutputPartitioned with the same partition count
 //     and reported PartitionBytes (nil vectors = legacy workers → off).
 //
-// A hot group splits into k = ceil(probeBytes/skewSplitTargetBytes)
+// A group is hot when it crosses the absolute floor (skewSplitMinGroupBytes)
+// AND carries at least skewSplitMinRatio× the mean group's probe bytes —
+// heavy-but-uniform stages (every group over the floor, ratio ≈ 1) keep the
+// standard layout. A hot group splits into k = ceil(probeBytes/skewSplitTargetBytes)
 // sub-tasks, capped by workerCount and by the group's probe file count
 // (v1 splits at file granularity; a hot partition written by T shuffle
 // tasks has up to T files). Each sub-task reads 1/k of the probe files and
@@ -126,7 +139,7 @@ func (c *Coordinator) planSkewSplitTasks(
 		}
 	}
 
-	// Mean group probe bytes, for the observability ratio only.
+	// Mean group probe bytes, denominator of the skew-ratio trigger.
 	var totalProbeBytes int64
 	for _, b := range probeOut.PartitionBytes {
 		totalProbeBytes += b
@@ -165,7 +178,11 @@ func (c *Coordinator) planSkewSplitTasks(
 		if k > len(probeFiles) {
 			k = len(probeFiles)
 		}
-		hot := k > 1 && probeBytes > skewSplitMinGroupBytes
+		ratio := float64(0)
+		if meanGroupBytes > 0 {
+			ratio = float64(probeBytes) / float64(meanGroupBytes)
+		}
+		hot := k > 1 && probeBytes > skewSplitMinGroupBytes && ratio >= skewSplitMinRatio
 
 		if hot && buildBytes > buildBound {
 			// Build-side-hot: do not split (see skewSplitMaxBuildBytes).
@@ -191,10 +208,6 @@ func (c *Coordinator) planSkewSplitTasks(
 
 		anySplit = true
 		SkewSplitsPlanned.Add(1)
-		ratio := float64(0)
-		if meanGroupBytes > 0 {
-			ratio = float64(probeBytes) / float64(meanGroupBytes)
-		}
 		c.logger.Info("skew split planned",
 			"stage_id", stage.ID, "group", w,
 			"partitions_start", start, "partitions_end", end,

--- a/internal/coordinator/skew_split_test.go
+++ b/internal/coordinator/skew_split_test.go
@@ -145,6 +145,23 @@ func TestPlanSkewSplitTasks_HotGroupSplits(t *testing.T) {
 	}
 }
 
+// TestPlanSkewSplitTasks_UniformHeavyNoSplit encodes the TPC-H Q21 SF10
+// profile from the 2026-07-11 no-harm A/B: every group's probe crosses the
+// absolute floor (~374 MB vs the 256 MiB default) but the layout is
+// perfectly uniform (mean_ratio ≈ 1.0). v1's floor-only trigger split every
+// group k=2 and regressed Q21 +21% wall for zero skew relief; the ratio
+// gate must keep the standard layout. Runs at REAL default thresholds.
+func TestPlanSkewSplitTasks_UniformHeavyNoSplit(t *testing.T) {
+	c := &Coordinator{logger: slog.Default()}
+	inputs := map[string]StageOutput{
+		"probe-stage": skewTestOutput("probe", []int64{374 << 20, 374 << 20, 374 << 20}, 6),
+		"build-stage": skewTestOutput("build", []int64{24 << 20, 24 << 20, 24 << 20}, 2),
+	}
+	if got := c.planSkewSplitTasks(skewTestStage(), inputs, 3, 3); got != nil {
+		t.Fatalf("uniform heavy layout planned a split: %+v", got)
+	}
+}
+
 func TestPlanSkewSplitTasks_BuildSideHotNoSplit(t *testing.T) {
 	lowerSkewThresholds(t, 100<<20, 100<<20)
 	c := &Coordinator{logger: slog.Default()}


### PR DESCRIPTION
## Summary

The SF10 TPC-H no-harm A/B (2026-07-11, run for the `--skew-split` default-flip decision) falsified v1's absolute-floor trigger: **Q21 regressed +21% wall (72.2s → 87.5s) with 24 "skew split planned" markers** — its uniformly-heavy shuffle put every group (~374 MB, `mean_ratio ≈ 1.0`) over the 256 MiB floor, so the planner blanket-split all groups k=2 for zero skew relief. The groups were nowhere near any memory budget, so the design memo's bytes-vs-budget argument for a floor-only trigger didn't apply. Q21 was the only marker-attributed delta in the pair; all 22 row counts matched.

A group is now hot only when it crosses the absolute floor **and** carries ≥ `skewSplitMinRatio` (2.0) × the mean group's probe bytes. The mean includes the hot group itself, so the ratio caps at the group count. The hot-key fixture (PR #212) still fires: ratio 2.9 locally (3 groups), 21.7 at SF10 — its −41% straggler-wall win is unaffected.

Design memo updated with the falsification note.

## Test plan

- New regression test `TestPlanSkewSplitTasks_UniformHeavyNoSplit` — the Q21 SF10 profile at real default thresholds (fails before this fix, passes after)
- Skew unit tests + `TestSkewSplitParity` green
- `tpch-harness --mode=local` 22/22 + micros PASS
- Fixture on-arm re-run: still marker-proven (2 splits planned), row checksums identical to pre-gate runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)