### PR TITLE
feat(worker): env-gated block/mutex profiling for benchmark runs

### DIFF
--- a/cmd/tpch-bench/main.go
+++ b/cmd/tpch-bench/main.go
@@ -149,6 +149,17 @@ func main() {
 		}()
 	}
 
+	// Env-gated contention profiling — same knobs as wadjet serve, because
+	// this binary hosts the in-process coordinator in distributed mode.
+	if rate, err := strconv.Atoi(os.Getenv("WADJET_BLOCK_PROFILE_RATE")); err == nil && rate > 0 {
+		runtime.SetBlockProfileRate(rate)
+		log.Printf("Block profiling enabled (rate=%dns)", rate)
+	}
+	if frac, err := strconv.Atoi(os.Getenv("WADJET_MUTEX_PROFILE_FRACTION")); err == nil && frac > 0 {
+		runtime.SetMutexProfileFraction(frac)
+		log.Printf("Mutex profiling enabled (fraction=%d)", frac)
+	}
+
 	// Set GOMEMLIMIT to prevent OOM on bare metal / EC2 instances.
 	// GOGC=off disables percentage-based GC triggering — GOMEMLIMIT alone
 	// acts as the safety net. This avoids GC assist overhead when the LRU
@@ -269,6 +280,23 @@ func main() {
 	// Collect worker profiles after benchmark
 	if nc != nil && *profDir != "" {
 		collectWorkerProfiles(nc, *workers, *profDir)
+	}
+
+	// Coordinator-side block/mutex profiles (records exist only when the
+	// env-gated samplers are on).
+	if *profDir != "" {
+		for _, name := range []string{"block", "mutex"} {
+			p := pprof.Lookup(name)
+			if p == nil || p.Count() == 0 {
+				continue
+			}
+			path := filepath.Join(*profDir, fmt.Sprintf("coord-%s.prof", name))
+			if f, err := os.Create(path); err == nil {
+				p.WriteTo(f, 0)
+				f.Close()
+				log.Printf("Saved coordinator %s profile: %s", name, path)
+			}
+		}
 	}
 
 	if *memProf != "" {
@@ -909,6 +937,16 @@ func collectWorkerProfiles(nc *nats.Conn, workerCount int, profDir string) {
 			path := filepath.Join(profDir, fmt.Sprintf("worker-%s-heap.prof", wp.WorkerID))
 			os.WriteFile(path, wp.Heap, 0644)
 			log.Printf("Saved worker heap profile: %s (%d bytes)", path, len(wp.Heap))
+		}
+		if len(wp.Block) > 0 {
+			path := filepath.Join(profDir, fmt.Sprintf("worker-%s-block.prof", wp.WorkerID))
+			os.WriteFile(path, wp.Block, 0644)
+			log.Printf("Saved worker block profile: %s (%d bytes)", path, len(wp.Block))
+		}
+		if len(wp.Mutex) > 0 {
+			path := filepath.Join(profDir, fmt.Sprintf("worker-%s-mutex.prof", wp.WorkerID))
+			os.WriteFile(path, wp.Mutex, 0644)
+			log.Printf("Saved worker mutex profile: %s (%d bytes)", path, len(wp.Mutex))
 		}
 		collected++
 	}

--- a/cmd/wadjet/main.go
+++ b/cmd/wadjet/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -208,6 +209,18 @@ func serveCmd() *cobra.Command {
 		defer cancel()
 
 		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: parseLogLevel(logLevel)}))
+
+		// Env-gated contention profiling for benchmark/profiling deploys.
+		// Rates are the raw runtime knobs (block rate in ns, mutex 1-in-N);
+		// unset or 0 keeps both samplers off — zero cost in production.
+		if rate, err := strconv.Atoi(os.Getenv("WADJET_BLOCK_PROFILE_RATE")); err == nil && rate > 0 {
+			runtime.SetBlockProfileRate(rate)
+			logger.Info("block profiling enabled", "rate_ns", rate)
+		}
+		if frac, err := strconv.Atoi(os.Getenv("WADJET_MUTEX_PROFILE_FRACTION")); err == nil && frac > 0 {
+			runtime.SetMutexProfileFraction(frac)
+			logger.Info("mutex profiling enabled", "fraction", frac)
+		}
 
 		if memLimit := memory.DetectMemoryLimit(); memLimit > 0 {
 			maxConc := int64(maxConcurrent)

--- a/deploy/benchmark/terraform/main.tf
+++ b/deploy/benchmark/terraform/main.tf
@@ -541,6 +541,8 @@ resource "aws_instance" "worker" {
     export WADJET_LATE_MATERIALIZATION="${var.late_materialization}"
     export WADJET_BUSHY_JOIN_REORDER="${var.bushy_join_reorder}"
     export WADJET_SKEW_SPLIT="${var.skew_split}"
+    export WADJET_BLOCK_PROFILE_RATE="${var.block_profile_rate}"
+    export WADJET_MUTEX_PROFILE_FRACTION="${var.mutex_profile_fraction}"
 
     # Verify binary was downloaded successfully
     if [ ! -x /usr/local/bin/wadjet ]; then

--- a/deploy/benchmark/terraform/main.tf
+++ b/deploy/benchmark/terraform/main.tf
@@ -276,6 +276,8 @@ locals {
     echo "WADJET_LATE_MATERIALIZATION=${var.late_materialization}" >> /etc/environment
     echo "WADJET_BUSHY_JOIN_REORDER=${var.bushy_join_reorder}" >> /etc/environment
     echo "WADJET_SKEW_SPLIT=${var.skew_split}" >> /etc/environment
+    echo "WADJET_BLOCK_PROFILE_RATE=${var.block_profile_rate}" >> /etc/environment
+    echo "WADJET_MUTEX_PROFILE_FRACTION=${var.mutex_profile_fraction}" >> /etc/environment
     echo "BUILD_COMPLETE=1" >> /etc/environment
   SCRIPT
 
@@ -313,6 +315,8 @@ locals {
     echo "WADJET_LATE_MATERIALIZATION=${var.late_materialization}" >> /etc/environment
     echo "WADJET_BUSHY_JOIN_REORDER=${var.bushy_join_reorder}" >> /etc/environment
     echo "WADJET_SKEW_SPLIT=${var.skew_split}" >> /etc/environment
+    echo "WADJET_BLOCK_PROFILE_RATE=${var.block_profile_rate}" >> /etc/environment
+    echo "WADJET_MUTEX_PROFILE_FRACTION=${var.mutex_profile_fraction}" >> /etc/environment
     echo "BUILD_COMPLETE=1" >> /etc/environment
   SCRIPT
 
@@ -385,6 +389,8 @@ locals {
     export WADJET_BUSHY_JOIN_REORDER="${var.bushy_join_reorder}"
     export WADJET_SKEW_SPLIT="${var.skew_split}"
     export WADJET_SKEW_SUITE="${var.skew_suite}"
+    export WADJET_BLOCK_PROFILE_RATE="${var.block_profile_rate}"
+    export WADJET_MUTEX_PROFILE_FRACTION="${var.mutex_profile_fraction}"
     export USE_NATIVE_DAG="${var.use_native_dag ? "1" : "0"}"
     # Phase C/D/E data-plane selection. Empty/"nats" = legacy NATS reply
     # subjects; "grpc" routes task dispatch + results + gather +

--- a/deploy/benchmark/terraform/variables.tf
+++ b/deploy/benchmark/terraform/variables.tf
@@ -228,6 +228,18 @@ variable "skew_suite" {
   default     = ""
 }
 
+variable "block_profile_rate" {
+  description = "runtime.SetBlockProfileRate value in ns for coordinator + workers (profiling runs only). Empty/0 = sampler off."
+  type        = string
+  default     = ""
+}
+
+variable "mutex_profile_fraction" {
+  description = "runtime.SetMutexProfileFraction 1-in-N value for coordinator + workers (profiling runs only). Empty/0 = sampler off."
+  type        = string
+  default     = ""
+}
+
 variable "dynamic_filters" {
   description = "Set to 1 to enable Trino-style semi-join dynamic-filter pushdown on the coordinator. Off by default for v1 rollout."
   type        = string

--- a/internal/worker/profile_envelope_test.go
+++ b/internal/worker/profile_envelope_test.go
@@ -1,0 +1,69 @@
+package worker
+
+import (
+	"io"
+	"log/slog"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestCollectProfileEnvelope_BlockMutexGated verifies the WorkerProfile
+// envelope carries block/mutex profiles only when the runtime samplers are
+// enabled (the WADJET_BLOCK_PROFILE_RATE / WADJET_MUTEX_PROFILE_FRACTION
+// path), and that heap is always present.
+func TestCollectProfileEnvelope_BlockMutexGated(t *testing.T) {
+	w := &Worker{
+		config: Config{WorkerID: "test-worker"},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	// Samplers off (default): no block/mutex payload. This half must run
+	// first — once records accumulate they persist for the process.
+	env := w.collectProfileEnvelope()
+	if env.WorkerID != "test-worker" {
+		t.Fatalf("WorkerID = %q, want test-worker", env.WorkerID)
+	}
+	if len(env.Heap) == 0 {
+		t.Fatal("heap profile missing from envelope")
+	}
+	if len(env.Block) != 0 || len(env.Mutex) != 0 {
+		t.Fatalf("block/mutex present with samplers off: block=%d mutex=%d",
+			len(env.Block), len(env.Mutex))
+	}
+
+	// Samplers on: generate one blocking event and one mutex contention
+	// event, then expect both profiles in the envelope.
+	runtime.SetBlockProfileRate(1)
+	defer runtime.SetBlockProfileRate(0)
+	runtime.SetMutexProfileFraction(1)
+	defer runtime.SetMutexProfileFraction(0)
+
+	ch := make(chan struct{})
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		close(ch)
+	}()
+	<-ch // channel-receive block event
+
+	var mu sync.Mutex
+	mu.Lock()
+	done := make(chan struct{})
+	go func() {
+		mu.Lock() // contends until parent unlocks
+		mu.Unlock()
+		close(done)
+	}()
+	time.Sleep(10 * time.Millisecond)
+	mu.Unlock()
+	<-done
+
+	env = w.collectProfileEnvelope()
+	if len(env.Block) == 0 {
+		t.Fatal("block profile missing with SetBlockProfileRate(1)")
+	}
+	if len(env.Mutex) == 0 {
+		t.Fatal("mutex profile missing with SetMutexProfileFraction(1)")
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -1642,8 +1642,10 @@ func (w *Worker) reapCancelled(maxAge time.Duration) {
 // WorkerProfile is the JSON envelope for profile data sent over NATS.
 type WorkerProfile struct {
 	WorkerID string `json:"worker_id"`
-	CPU      []byte `json:"cpu,omitempty"`  // pprof CPU profile (gzip-compressed)
-	Heap     []byte `json:"heap,omitempty"` // pprof heap profile (gzip-compressed)
+	CPU      []byte `json:"cpu,omitempty"`   // pprof CPU profile (gzip-compressed)
+	Heap     []byte `json:"heap,omitempty"`  // pprof heap profile (gzip-compressed)
+	Block    []byte `json:"block,omitempty"` // pprof block profile; empty unless WADJET_BLOCK_PROFILE_RATE set
+	Mutex    []byte `json:"mutex,omitempty"` // pprof mutex profile; empty unless WADJET_MUTEX_PROFILE_FRACTION set
 }
 
 // handleProfileStart begins CPU profiling to an in-memory buffer.
@@ -1670,6 +1672,18 @@ func (w *Worker) handleProfileStart(msg *nats.Msg) {
 // handleProfileCollect stops CPU profiling, collects a heap snapshot,
 // and responds with both profiles as JSON.
 func (w *Worker) handleProfileCollect(msg *nats.Msg) {
+	resp := w.collectProfileEnvelope()
+	data, err := json.Marshal(resp)
+	if err != nil {
+		msg.Respond([]byte("error: " + err.Error()))
+		return
+	}
+	msg.Respond(data)
+}
+
+// collectProfileEnvelope stops any in-flight CPU profile and snapshots
+// heap, block, and mutex profiles into a WorkerProfile envelope.
+func (w *Worker) collectProfileEnvelope() WorkerProfile {
 	w.profMu.Lock()
 	defer w.profMu.Unlock()
 
@@ -1686,15 +1700,22 @@ func (w *Worker) handleProfileCollect(msg *nats.Msg) {
 	var heapBuf bytes.Buffer
 	pprof.WriteHeapProfile(&heapBuf)
 
-	resp := WorkerProfile{
+	// Block/mutex profiles carry records only when the env-gated samplers
+	// (WADJET_BLOCK_PROFILE_RATE / WADJET_MUTEX_PROFILE_FRACTION) are on;
+	// the Count gate keeps the envelope free of empty profiles otherwise.
+	var blockBuf, mutexBuf bytes.Buffer
+	if p := pprof.Lookup("block"); p != nil && p.Count() > 0 {
+		p.WriteTo(&blockBuf, 0)
+	}
+	if p := pprof.Lookup("mutex"); p != nil && p.Count() > 0 {
+		p.WriteTo(&mutexBuf, 0)
+	}
+
+	return WorkerProfile{
 		WorkerID: w.config.WorkerID,
 		CPU:      cpuData,
 		Heap:     heapBuf.Bytes(),
+		Block:    blockBuf.Bytes(),
+		Mutex:    mutexBuf.Bytes(),
 	}
-	data, err := json.Marshal(resp)
-	if err != nil {
-		msg.Respond([]byte("error: " + err.Error()))
-		return
-	}
-	msg.Respond(data)
 }


### PR DESCRIPTION
## Summary

- `WADJET_BLOCK_PROFILE_RATE` (ns) / `WADJET_MUTEX_PROFILE_FRACTION` (1-in-N) feed `runtime.SetBlockProfileRate` / `SetMutexProfileFraction` in `wadjet serve` (all modes) and `tpch-bench` (which hosts the in-process coordinator in distributed mode). Both default off — zero sampling cost when unset.
- Worker NATS profile envelope (`WorkerProfile`) gains `block`/`mutex` fields, gated on `profile.Count()` so it stays free of empty profiles; `tpch-bench` saves `worker-<id>-block.prof` / `-mutex.prof` alongside the existing CPU/heap profiles, plus `coord-block.prof`/`coord-mutex.prof` for its own process.
- Terraform vars `block_profile_rate` / `mutex_profile_fraction` plumb the envs to workers (`/etc/environment`) and the coordinator bench run.

## Motivation

The only whole-suite block profile on record predates morsel scheduling, streaming exchange, and late materialization. Nothing in the tree ever called `SetBlockProfileRate`, so `/debug/pprof/block` and the NATS profile collection returned empty profiles — a fresh SF100 bottleneck re-ranking needs this.

## Validation

- New `TestCollectProfileEnvelope_BlockMutexGated`: samplers off → block/mutex absent from envelope; on → present after forced block + mutex contention events.
- Full `internal/worker` suite green; `go vet` clean; `tofu validate` clean.
- `cmd/tpch-harness --mode=local` green with both samplers enabled (all 22 + micros; q18 rows=0 confirmed pre-existing on unmodified main at the small slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcKKX1fvthE6zpyFsXcrYE