### PR TITLE
fix(tpch): align benchmark streaming-exchange default with engine default

### DIFF
--- a/cmd/tpch-bench/env_test.go
+++ b/cmd/tpch-bench/env_test.go
@@ -1,0 +1,28 @@
+package main
+
+import "testing"
+
+// TPCH_STREAMING_EXCHANGE must default ON (matching the wadjet serve
+// default): the prior default-off parse silently ran every benchmark
+// 2026-07-02..07-12 on the synchronous S3 shuffle path (−27.7% left on
+// the table at SF100).
+func TestEnvBoolDefaultOn(t *testing.T) {
+	cases := []struct {
+		val  string
+		want bool
+	}{
+		{"", true}, // unset = engine default = on
+		{"1", true},
+		{"true", true},
+		{"TRUE", true},
+		{"0", false},
+		{"false", false},
+		{"False", false},
+	}
+	for _, c := range cases {
+		t.Setenv("TPCH_TEST_BOOL", c.val)
+		if got := envBoolDefaultOn("TPCH_TEST_BOOL"); got != c.want {
+			t.Errorf("envBoolDefaultOn(%q) = %v, want %v", c.val, got, c.want)
+		}
+	}
+}

--- a/cmd/tpch-bench/main.go
+++ b/cmd/tpch-bench/main.go
@@ -415,8 +415,13 @@ func setupDistributed(ctx context.Context, logger *slog.Logger, endpoint, region
 		// Streaming exchange (docs/design/streaming-exchange.md): annotate
 		// tasks with peer-location hints + fetch tokens and run stage
 		// uploads async. Workers must run with --streaming-exchange too
-		// (terraform var streaming_exchange wires both sides).
-		StreamingExchange: os.Getenv("TPCH_STREAMING_EXCHANGE") == "1" || strings.EqualFold(os.Getenv("TPCH_STREAMING_EXCHANGE"), "true"),
+		// (terraform var streaming_exchange wires both sides). Default ON,
+		// matching the wadjet serve default (flipped 2026-07-02, SF100
+		// −23%); this env-gate previously defaulted OFF, which silently ran
+		// every benchmark 2026-07-02..07-12 on the synchronous S3 shuffle
+		// path (SF100 A/B 2026-07-12: 42m24s→30m38s, −27.7%, 22/22
+		// row-identical). Set 0/false as the kill switch.
+		StreamingExchange: envBoolDefaultOn("TPCH_STREAMING_EXCHANGE"),
 	}, cat, nc, js, logger)
 	coord.Workers().StartReaper(ctx)
 	coord.Workers().StartSubStatsLogger(ctx)
@@ -951,6 +956,17 @@ func collectWorkerProfiles(nc *nats.Conn, workerCount int, profDir string) {
 		collected++
 	}
 	log.Printf("Collected profiles from %d/%d workers", collected, workerCount)
+}
+
+// envBoolDefaultOn reports true unless the env var is explicitly "0" or
+// "false" — the parse for default-on engine flags whose benchmark env acts
+// as a kill switch. An unset var MUST mean on: TPCH_STREAMING_EXCHANGE
+// previously defaulted off here while the engine default was on, which
+// silently ran every 2026-07-02..07-12 benchmark on the synchronous S3
+// shuffle path.
+func envBoolDefaultOn(key string) bool {
+	v := os.Getenv(key)
+	return v != "0" && !strings.EqualFold(v, "false")
 }
 
 // envInt64 parses an int64 env var; empty or malformed values return 0 so an

--- a/deploy/benchmark/terraform/variables.tf
+++ b/deploy/benchmark/terraform/variables.tf
@@ -265,9 +265,9 @@ variable "data_plane" {
 }
 
 variable "streaming_exchange" {
-  description = "Streaming exchange (docs/design/streaming-exchange.md): consumers fetch stage outputs from producing workers' local disk over gRPC (peer-exchange port below) with async S3 upload; every failure falls through to the S3 path. Wires the coordinator (TPCH_STREAMING_EXCHANGE) and worker --streaming-exchange flags together. Default false = today's synchronous S3 shuffle."
+  description = "Streaming exchange (docs/design/streaming-exchange.md): consumers fetch stage outputs from producing workers' local disk over gRPC (peer-exchange port below) with async S3 upload; every failure falls through to the S3 path. Wires the coordinator (TPCH_STREAMING_EXCHANGE) and worker --streaming-exchange flags together. Default true, matching the engine default since 2026-07-02 (this var defaulted false until 2026-07-12, silently benchmarking the synchronous S3 shuffle path; SF100 A/B: −27.7%). Set false as the kill switch."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "peer_exchange_port" {


### PR DESCRIPTION
## Summary

The `wadjet serve --streaming-exchange` default flipped to **true** when the streaming-exchange arc closed (2026-07-02, SF100 −23%), but the benchmark harness never followed: `tpch-bench` gated its in-process coordinator on `TPCH_STREAMING_EXCHANGE` with a default-**off** parse, and terraform's `streaming_exchange` var defaulted `false` (its description still read "Default false = today's synchronous S3 shuffle"). `sf100-distributed.tfvars` never set it.

**Consequence: every benchmark run 2026-07-02 → 2026-07-12 — the 52.9m and 48.5m SF100 baselines, the 4-arm campaign, the morsel/late-mat/dyn-filter A/Bs — silently ran the synchronous S3 shuffle path with zero peer fetches.** A/B deltas remain valid (both arms equally misconfigured); the absolute walls carried a validated −23%-class lever switched off.

The chain, for the record: `task.AsyncUpload` + peer hints are set only by `annotateTaskPeerLocations`, installed only when the coordinator's `StreamingExchange` config is true (`coordinator.go:253`) → benchmark coordinator = tpch-bench → env default off.

## Fix

- `tpch-bench`: `TPCH_STREAMING_EXCHANGE` now parses default-ON (`envBoolDefaultOn`, `0`/`false` = kill switch), matching the engine default.
- terraform `streaming_exchange` default `true`; stale description corrected.

## Validation (SF100 same-window pair, main `0511bc1`, clean walls)

| | SE off (`results/20260712-011147`) | SE on (`results/20260712-025644`) |
|---|---|---|
| Suite | 42m24s | **30m38s (−27.7%)** |
| Correctness | 22/22 | 22/22, all rows identical |

Q07 −58%, Q13 −53%, Q02 −50%, Q19 −49%, Q03/Q09/Q10 −31…32%, Q18 −25%, Q21 −24%. Worst delta: Q06 +10.7% (scan-only, +1.8s absolute — window noise). The post-fix block profiles (`results/20260712-020833`) had independently ranked the synchronous upload path as the top remaining work-path blocker (~5.7k goroutine-s/worker in `CircuitStore.Put` + upload semaphore).

Combined with #216 (zstd decode parallelism), tonight's SF100 wall went 48m35s → 30m38s (−37%); gap vs the cold-S3 Trino SF100 reference: 8.9× → **5.6×**.

New `TestEnvBoolDefaultOn` regression test; `tofu validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcKKX1fvthE6zpyFsXcrYE