### PR TITLE
docs(coordinator): eager-consumer-dispatch design memo (Phase C bridge)

### DIFF
--- a/docs/design/eager-consumer-dispatch.md
+++ b/docs/design/eager-consumer-dispatch.md
@@ -1,0 +1,304 @@
+# Eager consumer dispatch (streaming-exchange Phase C bridge)
+
+> **Status:** DESIGN FOR REVIEW — no code. **Date:** 2026-07-12.
+> **Verified against:** main @ `d076bda`. Anchors below were confirmed
+> against that commit; they drift.
+> **Prerequisite state:** morsel-driven execution DONE (PR #181, default
+> auto since PR #198) — the condition streaming-exchange.md §3C set for
+> starting this work. Peer fetch + async upload (Phases A/B) default-on
+> everywhere since PR #217.
+
+## 1. Goal and evidence
+
+Remove the per-edge stage barrier for shuffle consumers: a consumer stage
+starts while its producer stage is still running, consuming each producer
+*task's* output files as that task finishes (pull-based fetch retained,
+no operator changes — pipeline breakers are sinks and don't care about
+input arrival order).
+
+Why this is the top lever now (SF100 profiling run
+`results/20260712-034241`, SE-on, post zstd fix):
+
+- Workers run **2.5 of 16 cores** (was 1.4 before this week's fixes; the
+  remaining 84% idle is structural, not CPU).
+- Largest critical-path block class: fragment/stage barrier waits
+  (`runFragmentLinearParallel` ~5.5k goroutine-s/worker) — downstream
+  stages idle while the slowest producer task of the previous stage
+  drains.
+- CPU-side costs (memmove/SetFrom ~16%, s2 ~8%) are second-order while
+  utilization is this low.
+- Trino's remaining ~5.6× advantage is streaming execution between
+  stages; we materialize + barrier per edge.
+
+The win mechanism is overlap: producer stages run in waves
+(`tasks > cluster slots`), and today the consumer waits for the last
+straggler before reading the *first* wave's files. Eager dispatch lets
+consumer scan/decode/join-build work overlap the producer tail. It does
+NOT change when the consumer can *finish* (its last input still lands
+last) — this bounds the win honestly (§9).
+
+## 2. What the code does today (verified)
+
+- **The barrier:** `executeStageDAG` allocates one `done` channel per
+  stage (`execute_stage_dag.go:361`); each stage goroutine blocks on all
+  dependencies' channels (`:410-420`); `close(done[s.ID])` fires only
+  after the whole stage completes (`:487-490`). Release is all-or-nothing.
+- **Consumer inputs are built after the barrier:** task specs carry
+  explicit per-partition S3 key lists (`Task.Inputs map[string][]string`,
+  built by `buildTaskInputsForStage` → `partitionFilesForWorker` from the
+  completed producer's `StageOutput.Files`). The worker never Lists a
+  prefix (`newPartitionShardSource` has no non-test caller); the file set
+  is frozen at task build (`cachedFileStreamSource` iterates a fixed
+  slice, `stream_source.go:234`).
+- **Keys are deterministic:** producers write
+  `<ResultPrefix>partition=%04d/<TaskID>.wshf` (`executor.go:1021`).
+  Producer TaskIDs and ResultPrefix are coordinator-assigned at producer
+  dispatch — so the *candidate* key universe for a consumer is knowable
+  before any producer task runs. What is NOT knowable upfront: which
+  candidates exist (empty partitions write no file) and where they are
+  (peer location), both of which today arrive via `ResultNotification` →
+  `peerFileRegistry.Record` (`peer_locations.go:65-86`) only for
+  completed tasks.
+- **Skew-split needs full accounting:** `planSkewSplitTasks` returns nil
+  unless `len(PartitionBytes) == NumPartitions` for both deps
+  (`skew_split.go:124-130`); those vectors reduce over final surviving
+  attempts of *every* producer task (`task_retry.go:236-260`).
+- **Worker slots don't yield:** admission is a `MaxConcurrent` semaphore
+  (`worker.go:470`); a running task holds its slot until completion or
+  deadline. A consumer waiting on a missing input blocks in
+  `awaitDurableObject` for 15 s then fails the task
+  (`peer_exchange.go:172-219`). There is no requeue.
+- **Retry contract (Phase B, settled):** task retries are verbatim
+  re-sends against durable-by-key inputs; `MissingInputKey` with a dead,
+  non-durable producer → `ErrInputLost` → one-shot whole-query rerun
+  with streaming exchange disabled (`coordinator.go:787-792`). The
+  terminal gather already streams (no barrier) and is out of scope.
+
+## 3. Design overview: manifest-fed consumers
+
+Three pieces, all coordinator/worker plumbing — zero operator changes.
+
+### 3.1 Producer-task manifests
+
+The coordinator already observes every producer task completion
+(`taskRetrier.Observe` → `noteTaskResult`). New: for an eager edge it
+re-publishes a compact **manifest** per completed producer task on a
+root-query-scoped NATS subject (`wadjet.eager.<rootID>.<stageID>`):
+
+```
+ProducerTaskManifest {
+  StageID, TaskID, Attempt  // attempt fencing, §5
+  Files []string            // the keys that EXIST (empty partitions absent)
+  WorkerID                  // peer-fetch hint
+  Final bool                // true on the stage's last terminal task
+}
+```
+
+Metadata-only (~a few KB); no payload bytes flow through the
+coordinator. NATS pub/sub fits (control-plane scale: tens of messages
+per stage); the gRPC data-plane stays untouched in v1.
+
+### 3.2 Eager consumer tasks
+
+An eager consumer task spec replaces the frozen `Inputs` list for the
+eager edge with:
+
+```
+EagerInput {
+  StageID            // producer stage
+  ProducerTaskIDs [] // full candidate set, known at dispatch
+  ResultPrefix, NumPartitions
+  PartitionRange     // this task's contiguous range, as today
+}
+```
+
+Worker side: a new `manifestStreamSource` implementing the existing
+`Source` interface, wrapping today's `cachedFileStreamSource` machinery:
+it subscribes to the manifest subject **before** signalling readiness
+(subscribe-then-replay: the coordinator includes already-completed
+manifests in the task spec so no completion is missed), and feeds files
+for its partition range into the fetch tier (peer → S3) exactly as
+today, in producer-task-completion order. `Next()` blocks when no
+fetched batch is available AND not all producer tasks have reported;
+returns EOF after processing `Final` + all candidates resolved.
+Everything downstream of `Next()` is unchanged.
+
+Non-eager aliases in the same task (e.g. a broadcast build side) keep
+today's frozen lists.
+
+### 3.3 Dispatch policy (deadlock-safe by construction)
+
+The consumer stage goroutine no longer waits for `done[dep]`; it waits
+for **dispatch clearance**:
+
+- **Producer-lane reservation.** Eager consumer tasks assigned to a
+  worker are capped at `MaxConcurrent − 1` until the producer stage has
+  no undispatched/running tasks on that worker; the reserved lane
+  guarantees producer progress (worst case producers drain serially,
+  which is today's behavior). The coordinator enforces this from
+  heartbeat `ActiveTasks` + its own dispatch bookkeeping — no worker
+  changes.
+- **Join edges: after the early skew decision** (§6) — clearance is the
+  decision point, not full producer completion.
+- The stage-level `dispatchSem` (`execute_stage_dag.go:387-397`) is
+  acquired as today; eager stages hold their slot longer (they start
+  earlier), so the sem floor stays ≥ 2 to avoid self-starvation of
+  producers' stage goroutines. (`ClusterCapacity` sizing already
+  guarantees this.)
+
+A feature flag `--eager-dispatch` (default **off** until SF100 + skew
+fixture validation; kill switch thereafter) gates the whole path at the
+coordinator; workers treat `EagerInput` presence as the signal, so a
+mixed-version cluster degrades loudly (unknown field → task fails →
+retry → same failure → stage fails) rather than silently. Deploys are
+atomic in practice (bin_version), so this is a non-issue operationally.
+
+## 4. The §3C objections, revisited for eager dispatch
+
+The four grounds that rejected full pipelined co-scheduling, and where
+eager dispatch stands:
+
+1. **Admission-control deadlock.** Full pipelining gates one side on
+   resources the other releases. Eager dispatch keeps both sides
+   pull-based and makes deadlock structurally impossible via the
+   producer-lane reservation (§3.3): producers never wait on consumers
+   for anything; consumers only wait on producer *outputs*, and producer
+   progress is guaranteed by the reserved lane. No gang admission.
+2. **Retry granularity.** Unchanged from Phase B for producers (outputs
+   are whole files, overwrite-safe by key). Consumers gain one new
+   failure mode — consumed a file whose producer attempt was later
+   superseded — handled by fencing (§5) with the existing consumer-task
+   retry as the recovery, and the existing one-shot SE-disabled rerun as
+   the backstop. Task-level retry survives; the #109/#110 investment is
+   not forfeited.
+3. **Memory floor.** No new resident classes: consumers hold exactly the
+   operator state they hold today, just starting earlier; manifests are
+   metadata; fetched files land in the same NVMe temp + mmap path.
+   Wall-clock overlap does raise *cluster-wide* concurrent memory use
+   (two stages' working sets alive at once on a worker) — but that is
+   already true today whenever sibling DAG branches run concurrently,
+   and the per-task budget/admission estimate machinery (`waitForPoolHeadroom`,
+   estimates doubling on retry) governs it identically. No new ledger
+   surface.
+4. **Sequencing.** Morsel landed (PR #181/#198). The consumer-side
+   pipeline this feeds is the post-morsel executor. Prerequisite
+   satisfied; `docs/design/morsel-execution.md`'s stale "proposed"
+   status line is corrected alongside this memo.
+
+## 5. Attempt fencing and the consumed-file-set
+
+The one genuinely new correctness surface (named by §3C when it defined
+this bridge).
+
+Hazard: consumer reads producer task T attempt 1's file; T's worker dies
+pre-durability; T retries as attempt 2 and **overwrites the same key**
+with (deterministically identical, but not guaranteed byte-identical —
+batch order within the file may differ) content. The consumer's already-
+consumed rows came from attempt 1; mixing attempt 2's file for the same
+task on another partition of the same consumer task is fine (row sets
+are identical per §5 of streaming-exchange.md: same task spec, same
+inputs, deterministic partitioning) — **but a partially-read file being
+overwritten mid-GET is not**, and "identical rows" relies on producer
+determinism we should fence, not assume.
+
+Contract:
+
+- Manifests carry `Attempt`. The consumer records
+  `consumed[taskID] = attempt` at first byte read of any of that task's
+  files (files are streamed to local temp in one GET, then mmap'd — a
+  single-object read is atomic at S3/peer level, so per-file torn reads
+  cannot happen; the fence is about cross-file/cross-attempt mixing).
+- If a manifest arrives for `taskID` with `Attempt >` a consumed entry,
+  the consumer task **fails itself with a new `StaleInputAttempt`
+  marker** (poison-pill, loud). Files not yet consumed are simply
+  re-pointed at the newest attempt's manifest.
+- Coordinator classification: `StaleInputAttempt` → retry the consumer
+  task (attempts cap 3, as today). By the retry, the producer attempt
+  set is stable (the retrier republished the manifest only after the new
+  attempt completed). If instability persists (producer flapping), the
+  existing `ErrInputLost`/rerun-with-SE-disabled backstop terminates the
+  pathology.
+- Frequency argument: this fires only when a producer worker dies
+  mid-stage AND a consumer already consumed its output — the same rare
+  window Phase B's `ErrInputLost` handles today; the cost is one
+  consumer-task retry instead of a query rerun.
+
+## 6. Skew-split: early decision via ratio invariance
+
+Skew-split (default on) decides at join dispatch from complete
+`PartitionBytes` (§2). Eager dispatch must not wait for that — and does
+not need to:
+
+- Every producer task hash-partitions its input slice across **all**
+  partitions, so each completed task contributes a full cross-partition
+  byte profile. The split trigger `ratio = probeBytes(group) /
+  meanGroupBytes` is **scale-invariant**: numerator and denominator both
+  scale ~linearly with completed-task fraction. The ratio estimate from
+  the first completed wave converges fast and is unbiased for hash
+  partitioning.
+- The absolute floor (`skewSplitMinGroupBytes` 256 MiB) uses a linear
+  projection: `projected = observed × numTasks / completedTasks`.
+- **Decision point:** when `completedTasks ≥ max(workerCount,
+  ⌈numTasks/4⌉)` for both deps — one full wave, enough that every
+  producer's slice shape is represented. The decision is then **frozen**
+  (split layout = assignment of producer TaskIDs × hot-partition files to
+  sub-tasks, all nameable from the candidate set) and consumers dispatch.
+- Degrade rule unchanged in spirit from `stage_output.go:48-49`: any
+  doubt (accounting missing, projection below floor but near it,
+  probeSplit path) → **no split, never a wrong split**. A group that
+  full data would have split but the early decision missed = today's
+  behavior (no split), i.e. eager dispatch can cost at most the split
+  win on that edge, never correctness.
+- The skew A/B fixture (`benchmarks/skew`) gates this exactly: eager-on
+  must reproduce the −41% straggler win within noise, with split
+  markers present in the log (the observability counters from PR #213
+  era already exist).
+
+## 7. What v1 does NOT do
+
+- No mid-file streaming, no batch-level flow (files remain the unit;
+  producers finalize whole partition files exactly as today).
+- No operator changes; no change to pipeline breakers, morsel scheduling,
+  or the memory ledger.
+- No gather changes (already streaming), no broadcast-edge changes
+  (broadcast stays S3+KV per streaming-exchange.md §B), no scalar-
+  subquery edges (string-substitution dependencies keep the barrier).
+- No worker-side slot yield/requeue. If profiling shows reserved-lane
+  idle time matters, that is a v2 item.
+- No change to the small-query local fast path (no stages to overlap).
+
+## 8. Phases and gates
+
+Phase C1 — protocol + non-join edges (agg/sort/distinct/repartition
+consumers):
+1. Manifest publication + `manifestStreamSource` + dispatch clearance
+   with producer-lane reservation; flag default off.
+2. Gates: unit tests (manifest replay, fencing poison, empty-partition
+   candidates, Final ordering); `tpch-harness --mode=local` both flag
+   states; TPC-H SF0.01 22/22 both flag states; race-built harness arm.
+Phase C2 — join edges + early skew decision:
+3. Ratio-invariance decision + frozen split layout; skew fixture A/B
+   (eager×split matrix, all four arms row-identical, split markers
+   verified); harness local.
+Phase C3 — activation evidence:
+4. SF100 same-window pair (needs deploy approval), flag on vs off, on
+   current main. Success = 22/22 row-identical, suite improvement beyond
+   the ±15% single-pair envelope or a per-query mechanism-marked win
+   pattern (eager overlap counters — add `EagerEdgesPlanned` /
+   `ManifestsConsumedEarly` counters mirroring the SortMergeJoinsPlanned
+   observability precedent so the treatment is provable in the log).
+5. Default flip in a separate PR after soak, mirroring the
+   skew-split/morsel rollout pattern.
+
+## 9. Expected effect, honestly bounded
+
+Overlap saves `min(consumer head work, producer tail wall)` per eager
+edge. It cannot beat the last producer file's arrival; single-wave
+producer stages (tasks ≤ slots) yield little; multi-wave stages (the
+Q18/Q21 repartition shape: dozens of tasks over 12 effective slots)
+yield the most. The measurable prediction: fragment-barrier block time
+(~5.5k gs/worker in `results/20260712-034241`) shrinks in proportion to
+overlap achieved, and worker utilization rises above 2.5/16 cores on
+multi-stage queries. If the SF100 pair shows no movement in those two
+markers, the thesis is wrong and the flag stays off — no threshold
+tuning to force it.

--- a/docs/design/morsel-execution.md
+++ b/docs/design/morsel-execution.md
@@ -1,6 +1,8 @@
 # Morsel-Driven Execution — Design Memo
 
-> **Status:** proposed (v1 scoped, not started). **Date:** 2026-07-02.
+> **Status:** DONE — implemented in PR #181, default AUTO since PR #198
+> (SF100 −3.4%, Q08 −40%; `--morsel-workers 1` = kill switch). Kept as
+> design record. **Date:** 2026-07-02 (status updated 2026-07-12).
 > **Verified against:** main @ 0cc5419 (post-#177). `file:line` anchors
 > drift — confirm before relying on them.
 


### PR DESCRIPTION
## Summary

Design memo only — **no code**. This is the next-lever design following last night's arc (zstd fix #216, streaming-exchange harness alignment #217; SF100 48m35s → 30m38s, Trino gap 8.9× → 5.6×).

`docs/design/eager-consumer-dispatch.md`: remove the per-edge stage barrier by dispatching consumer stages while producers run, feeding them per-producer-task file manifests as tasks finish. This is the exact intermediate streaming-exchange.md §3C sanctioned ("worth doing after morsel, as the bridge toward C") — and morsel is done (PR #181/#198), which the rider fix to `morsel-execution.md`'s stale status line records.

Evidence base: post-SE SF100 profile (`results/20260712-034241`) — workers at 2.5/16 cores, top critical-path blocker = fragment/stage barrier waits (~5.5k goroutine-s/worker).

Key design points, each grounded in file:line facts from the current scheduler:
- **Manifests, not prefixes**: shuffle keys are deterministic (`prefix/partition=NNNN/taskID.wshf`), so the candidate set is nameable at dispatch; existence + peer location stream in via per-task manifests on a root-scoped NATS subject.
- **Zero operator changes**: a `manifestStreamSource` behind the existing `Source` interface; pipeline breakers are sinks and don't care about arrival order.
- **Deadlock-safe by construction**: producer-lane reservation (eager consumers capped at `MaxConcurrent−1` per worker) — producers never wait on consumers; no gang admission.
- **Attempt fencing**: consumed-file-set per producer attempt; `StaleInputAttempt` poison → consumer-task retry → existing `ErrInputLost`/SE-disabled rerun as backstop. Task-level retry survives.
- **Skew-split coexistence**: early split decision from the first completed wave using the ratio gate's scale-invariance + projected absolute floor; degrade-to-off, never wrong. Gated by the skew fixture A/B matrix.
- **Phased**: C1 non-join edges → C2 join edges + early skew → C3 SF100 pair with mechanism counters (`EagerEdgesPlanned`/`ManifestsConsumedEarly`); flag `--eager-dispatch` default off until validated.
- §9 states the honest bound: overlap = min(consumer head, producer tail); multi-wave stages (Q18/Q21 shape) benefit most; no-movement ⇒ flag stays off, no threshold tuning.

## Review asks

1. The attempt-fencing contract (§5) — is failing the consumer task on attempt supersession acceptable, or do you want consumed-row hashing paranoia in v1?
2. The early-skew decision point (§6: `max(workerCount, ⌈numTasks/4⌉)`) — principled via ratio invariance, but it is a new decision surface on the skew path that just shipped.
3. Phase C1 scope (non-join edges first) vs going straight at join edges where the Q18/Q21 wall lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcKKX1fvthE6zpyFsXcrYE