### PR TITLE
feat(coordinator,worker): eager consumer dispatch — Phases C1 + C2 slice 1

### DIFF
--- a/cmd/tpch-bench/main.go
+++ b/cmd/tpch-bench/main.go
@@ -422,6 +422,12 @@ func setupDistributed(ctx context.Context, logger *slog.Logger, endpoint, region
 		// path (SF100 A/B 2026-07-12: 42m24s→30m38s, −27.7%, 22/22
 		// row-identical). Set 0/false as the kill switch.
 		StreamingExchange: envBoolDefaultOn("TPCH_STREAMING_EXCHANGE"),
+		// Eager consumer dispatch (docs/design/eager-consumer-dispatch.md,
+		// Phase C1): default OFF pending SF100 validation, so the parse is
+		// explicit opt-in ("1"/"true") — the OPPOSITE convention of the
+		// default-on kill switches above. Flip to envBoolDefaultOn only
+		// when the engine default flips.
+		EagerDispatch: os.Getenv("WADJET_EAGER_DISPATCH") == "1" || strings.EqualFold(os.Getenv("WADJET_EAGER_DISPATCH"), "true"),
 	}, cat, nc, js, logger)
 	coord.Workers().StartReaper(ctx)
 	coord.Workers().StartSubStatsLogger(ctx)

--- a/cmd/wadjet/main.go
+++ b/cmd/wadjet/main.go
@@ -104,6 +104,7 @@ var (
 	bushyJoinReorder      bool
 	broadcastBytes        int64
 	streamingExchange     bool
+	eagerDispatch         bool
 	peerExchangeAddr      string
 	peerExchangeAdvertise string
 )
@@ -171,6 +172,7 @@ func main() {
 	rootCmd.PersistentFlags().BoolVar(&bushyJoinReorder, "bushy-join-reorder", false, "Let the cost-based join reorder emit BUSHY plans (joins of two composite intermediates — e.g. pre-joining a snowflake dimension chain before it meets the fact stream) when strictly cheaper than every left-deep order. Cost ties keep the left-deep shape. Process-wide, default false. See docs/design/bushy-join-cbo.md.")
 	rootCmd.PersistentFlags().Int64Var(&localFastPathBytes, "local-fastpath-bytes", coordinator.DefaultLocalFastPathBytes, "Queries whose post-pruning catalog scan bytes stay under this threshold execute in-process on the coordinator (skipping the distributed stage DAG and its per-stage object-store round trips). 0 = disabled.")
 	rootCmd.PersistentFlags().BoolVar(&streamingExchange, "streaming-exchange", true, "Streaming exchange: consumers fetch stage outputs from the producing workers' local disk over gRPC with async S3 upload; every failure falls through to the durable S3 path. Default true (validated 2026-07-02: SF10 −10%, SF100 −23% suite wall, row-identical, zero fault-tolerance events); --streaming-exchange=false restores synchronous S3-only shuffle. See docs/design/streaming-exchange.md.")
+	rootCmd.PersistentFlags().BoolVar(&eagerDispatch, "eager-dispatch", false, "Eager consumer dispatch (Phase C1): eligible non-join consumer stages (aggregate/sort over a standalone repartition) start before their producer stage fully drains, consuming per-producer-task file manifests as tasks finish. Requires --streaming-exchange. Default false until SF100 validation (kill switch thereafter). See docs/design/eager-consumer-dispatch.md.")
 	rootCmd.PersistentFlags().StringVar(&peerExchangeAddr, "peer-exchange-addr", ":0", "Peer-exchange (FetchShuffle) listen address. Default :0 picks a free port (the address reaches peers via heartbeats, and a fixed default would collide when multiple workers share a host); pin it when firewalls need a known port.")
 	rootCmd.PersistentFlags().StringVar(&peerExchangeAdvertise, "peer-exchange-advertise", "", "Peer-exchange address advertised in heartbeats (default: derived from the bound listener)")
 	rootCmd.PersistentFlags().StringVar(&geoipCityDB, "geoip-city", "", "Path to MaxMind GeoIP City database (GeoLite2-City.mmdb)")
@@ -911,6 +913,7 @@ func runStandalone(ctx context.Context, store objstore.Store, logger *slog.Logge
 		LateMaterialization:    lateMaterialization,
 		SkewSplit:              skewSplit,
 		StreamingExchange:      streamingExchange,
+		EagerDispatch:          eagerDispatch,
 	}, cat, nc, js, logger)
 
 	// Phase A: same-process data-plane server + client when enabled.
@@ -1212,6 +1215,7 @@ func runCoordinator(ctx context.Context, store objstore.Store, logger *slog.Logg
 		LateMaterialization:    lateMaterialization,
 		SkewSplit:              skewSplit,
 		StreamingExchange:      streamingExchange,
+		EagerDispatch:          eagerDispatch,
 	}, cat, nc, js, logger)
 
 	// Phase A: start data-plane gRPC server alongside coord when enabled.

--- a/deploy/benchmark/terraform/main.tf
+++ b/deploy/benchmark/terraform/main.tf
@@ -402,6 +402,10 @@ locals {
     # side of the flag; the worker cloud-init adds --streaming-exchange
     # from the same terraform var.
     export TPCH_STREAMING_EXCHANGE="${var.streaming_exchange ? "1" : "0"}"
+    # Eager consumer dispatch (Phase C1). Coordinator-side flag only;
+    # workers act on EagerInputs in the task spec. Default-off engine
+    # flag, so the env parse is explicit opt-in ("1"), not a kill switch.
+    export WADJET_EAGER_DISPATCH="${var.eager_dispatch ? "1" : "0"}"
     # Catalog snapshot/restore prefix (PR #115). Non-empty = restore the
     # post-discovery catalog from s3://<bucket>/<prefix> instead of paying
     # ~15 min of discovery+ANALYZE per deploy; first boot writes it.

--- a/deploy/benchmark/terraform/variables.tf
+++ b/deploy/benchmark/terraform/variables.tf
@@ -270,6 +270,12 @@ variable "streaming_exchange" {
   default     = true
 }
 
+variable "eager_dispatch" {
+  description = "Eager consumer dispatch (docs/design/eager-consumer-dispatch.md, Phase C1): eligible non-join consumer stages start before their producer stage fully drains, consuming per-producer-task manifests. Coordinator-side only (workers act on the task spec; no worker flag). Requires streaming_exchange. Default false pending SF100 validation — set true for the treatment arm of the C3 pair."
+  type        = bool
+  default     = false
+}
+
 variable "peer_exchange_port" {
   description = "Worker↔worker peer-exchange (FetchShuffle) port; SG opens it intra-cluster whenever streaming_exchange is set."
   type        = number

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -224,6 +224,20 @@ type Coordinator struct {
 	// a non-zero rate is the signal to revisit single-level producer
 	// re-run per the design memo).
 	streamingReruns atomic.Int64
+
+	// Eager consumer dispatch (docs/design/eager-consumer-dispatch.md,
+	// eager_feed.go). eagerFeeds maps eagerFeedKey → feed, created lazily
+	// by consumer goroutines and producer dispatchers, dropped per query.
+	// eagerStageSlot bounds in-flight eager consumer stages to ONE per
+	// coordinator (v1 producer-lane reservation, stricter than the memo's
+	// per-query bound): combined with numTasks ≤ workerCount eligibility
+	// and the scheduler's eager-spread placement, each worker holds at
+	// most one manifest-blocked task, so producers always keep
+	// MaxConcurrent−1 lanes. Relax to per-query after C2 if concurrent-
+	// query overlap matters.
+	eagerFeedsMu   sync.Mutex
+	eagerFeeds     map[string]*eagerFeed
+	eagerStageSlot chan struct{}
 }
 
 // New creates a new Coordinator.
@@ -248,6 +262,10 @@ func New(cfg Config, cat *catalog.Catalog, nc *nats.Conn, js jetstream.JetStream
 		queryMetas: make(map[string]*queryMeta),
 		querySem:   make(chan struct{}, maxInflight),
 		localSem:   make(chan struct{}, defaultLocalFastPathConcurrency),
+		eagerFeeds: make(map[string]*eagerFeed),
+		// v1 bound: one eager consumer stage in flight per coordinator
+		// (see the field comment).
+		eagerStageSlot: make(chan struct{}, 1),
 	}
 	// Memory-aware gRPC placement: the scheduler bin-packs estimated task
 	// footprints against heartbeat pool stats. No-op on the NATS path.

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -93,6 +93,13 @@ type Config struct {
 	// the ratio gate); this struct field's zero value stays false so
 	// embedded/test constructors opt in explicitly.
 	SkewSplit bool
+	// EagerDispatch enables eager consumer dispatch (docs/design/
+	// eager-consumer-dispatch.md): the coordinator republishes per-
+	// producer-task file manifests on EagerManifestSubject as shuffle
+	// tasks complete, and (Phase C1) dispatches eligible consumer stages
+	// before their producer stage fully drains. Zero value false —
+	// default off until SF100 validation; requires StreamingExchange.
+	EagerDispatch bool
 	// StreamingExchange annotates dispatched tasks with peer-location
 	// hints (Task.InputLocations) and per-query fetch tokens so consumers
 	// stream stage outputs from the producing workers' local disk instead

--- a/internal/coordinator/eager_dispatch.go
+++ b/internal/coordinator/eager_dispatch.go
@@ -39,6 +39,7 @@ func (c *Coordinator) eagerManifestPublisher(rootQueryID, stageID string) func(t
 			Attempt:  attempt,
 			Files:    files,
 			WorkerID: workerID,
+			PeerAddr: c.workers.PeerAddr(workerID),
 			Final:    final,
 		}
 		data, err := distributed.Marshal(m)

--- a/internal/coordinator/eager_dispatch.go
+++ b/internal/coordinator/eager_dispatch.go
@@ -39,12 +39,12 @@ var EagerEdgesPlanned atomic.Int64
 // late-built consumers: a consumer task built after the append sees the
 // manifest in its Replay; one built before has already subscribed (or will
 // catch the republisher's next re-send).
-func (c *Coordinator) eagerManifestPublisher(rootQueryID, stageID string, feed *eagerFeed) func(taskID string, attempt int, files []string, workerID string, final bool) {
+func (c *Coordinator) eagerManifestPublisher(rootQueryID, stageID string, feed *eagerFeed) func(taskID string, attempt int, files []string, workerID string, final bool, partBytes []int64) {
 	if !c.config.EagerDispatch || !c.config.StreamingExchange || rootQueryID == "" || c.nc == nil {
 		return nil
 	}
 	subject := distributed.EagerManifestSubject(rootQueryID, stageID)
-	return func(taskID string, attempt int, files []string, workerID string, final bool) {
+	return func(taskID string, attempt int, files []string, workerID string, final bool, partBytes []int64) {
 		m := distributed.ProducerTaskManifest{
 			StageID:  stageID,
 			TaskID:   taskID,
@@ -55,7 +55,11 @@ func (c *Coordinator) eagerManifestPublisher(rootQueryID, stageID string, feed *
 			Final:    final,
 		}
 		if feed != nil {
+			// Replay before accounting: a consumer released by the
+			// decision threshold must see every counted task's manifest
+			// in its Replay snapshot.
 			feed.appendReplay(m)
+			feed.noteCompletion(partBytes)
 		}
 		data, err := distributed.Marshal(m)
 		if err != nil {

--- a/internal/coordinator/eager_dispatch.go
+++ b/internal/coordinator/eager_dispatch.go
@@ -1,0 +1,60 @@
+package coordinator
+
+import (
+	"sync/atomic"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+)
+
+// Eager consumer dispatch, Phase C1 (docs/design/eager-consumer-dispatch.md).
+//
+// This file owns the coordinator side of the manifest feed: as each task
+// of an eager-edge producer stage reaches a successful terminal state,
+// the coordinator republishes a compact ProducerTaskManifest on
+// EagerManifestSubject(root, stage). Consumers' manifest sources
+// subscribe before dispatch and receive already-published manifests via
+// the task spec (subscribe-then-replay, memo §3.2), so publication here
+// is fire-and-forget Core NATS: a lost message is repaired by the replay
+// list on consumer retry, and the S3/peer fetch tiers are unaffected.
+
+// EagerManifestsPublished counts manifests published across all queries —
+// the mechanism marker proving the eager path engaged in a benchmark log
+// (the SortMergeJoinsPlanned/DynamicFiltersPlanned observability
+// precedent).
+var EagerManifestsPublished atomic.Int64
+
+// eagerManifestPublisher returns a taskRetrier onSuccess hook that
+// publishes one manifest per successful producer task, or nil when eager
+// dispatch is disabled or the root query ID is unavailable (legacy
+// pipeline tasks without scratch anchors never have eager consumers).
+func (c *Coordinator) eagerManifestPublisher(rootQueryID, stageID string) func(taskID string, attempt int, files []string, workerID string, final bool) {
+	if !c.config.EagerDispatch || !c.config.StreamingExchange || rootQueryID == "" || c.nc == nil {
+		return nil
+	}
+	subject := distributed.EagerManifestSubject(rootQueryID, stageID)
+	return func(taskID string, attempt int, files []string, workerID string, final bool) {
+		m := distributed.ProducerTaskManifest{
+			StageID:  stageID,
+			TaskID:   taskID,
+			Attempt:  attempt,
+			Files:    files,
+			WorkerID: workerID,
+			Final:    final,
+		}
+		data, err := distributed.Marshal(m)
+		if err != nil {
+			c.logger.Error("eager manifest marshal failed",
+				"stage_id", stageID, "task_id", taskID, "error", err)
+			return
+		}
+		if err := c.nc.Publish(subject, data); err != nil {
+			c.logger.Warn("eager manifest publish failed (replay list covers consumer retries)",
+				"stage_id", stageID, "task_id", taskID, "error", err)
+			return
+		}
+		EagerManifestsPublished.Add(1)
+		c.logger.Info("eager manifest published",
+			"stage_id", stageID, "task_id", taskID, "attempt", attempt,
+			"files", len(files), "worker", workerID, "final", final)
+	}
+}

--- a/internal/coordinator/eager_dispatch.go
+++ b/internal/coordinator/eager_dispatch.go
@@ -23,11 +23,23 @@ import (
 // precedent).
 var EagerManifestsPublished atomic.Int64
 
+// EagerEdgesPlanned counts consumer stages that cleared dispatch on an
+// eager feed instead of the done barrier — the memo §8 activation marker
+// for the SF100 pair (grep "eager dispatch: consumer cleared early" /
+// this counter's log line in benchmark.log).
+var EagerEdgesPlanned atomic.Int64
+
 // eagerManifestPublisher returns a taskRetrier onSuccess hook that
 // publishes one manifest per successful producer task, or nil when eager
 // dispatch is disabled or the root query ID is unavailable (legacy
 // pipeline tasks without scratch anchors never have eager consumers).
-func (c *Coordinator) eagerManifestPublisher(rootQueryID, stageID string) func(taskID string, attempt int, files []string, workerID string, final bool) {
+//
+// feed, when non-nil, receives every manifest into its replay list BEFORE
+// the NATS publish, making the feed the single source of truth for
+// late-built consumers: a consumer task built after the append sees the
+// manifest in its Replay; one built before has already subscribed (or will
+// catch the republisher's next re-send).
+func (c *Coordinator) eagerManifestPublisher(rootQueryID, stageID string, feed *eagerFeed) func(taskID string, attempt int, files []string, workerID string, final bool) {
 	if !c.config.EagerDispatch || !c.config.StreamingExchange || rootQueryID == "" || c.nc == nil {
 		return nil
 	}
@@ -41,6 +53,9 @@ func (c *Coordinator) eagerManifestPublisher(rootQueryID, stageID string) func(t
 			WorkerID: workerID,
 			PeerAddr: c.workers.PeerAddr(workerID),
 			Final:    final,
+		}
+		if feed != nil {
+			feed.appendReplay(m)
 		}
 		data, err := distributed.Marshal(m)
 		if err != nil {

--- a/internal/coordinator/eager_dispatch_e2e_test.go
+++ b/internal/coordinator/eager_dispatch_e2e_test.go
@@ -18,18 +18,17 @@ import (
 	"github.com/citc-tech/wadjet/internal/worker"
 )
 
-// TestEagerDispatchE2E runs the Phase C1 eager path end-to-end (real NATS,
-// 3 in-process workers): a GROUP BY over a shuffled join plans to the one
-// non-join repartition edge C1 targets (standalone exchange-repartition →
-// final_aggregate, the Q02 shape), so with the flag on the aggregate stage
-// clears dispatch on the shuffle's feed and consumes manifests while the
-// shuffle drains. Asserts flag-on results are identical to flag-off and
-// that the mechanism markers (EagerEdgesPlanned, EagerManifestsPublished)
-// engaged — the same markers the SF100 pair will be judged on (memo §8).
-func TestEagerDispatchE2E(t *testing.T) {
+// setupEagerE2E is the shared scaffolding for the eager-dispatch
+// end-to-end tests: embedded NATS, MemStore + NATS-KV catalog with the
+// requested TPC-H SF001 tables (each split into 3 files so shuffles fan
+// out to multiple producer tasks — multiple manifests, staggered arrival),
+// and 3 in-process workers. Returns a factory so each arm gets a fresh
+// coordinator against the shared cluster.
+func setupEagerE2E(t *testing.T, tables []string) (context.Context, func(eager bool) *Coordinator) {
+	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	t.Cleanup(cancel)
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 
 	natsCfg := distributed.DefaultNATSConfig()
 	natsCfg.Port = -1
@@ -64,11 +63,8 @@ func TestEagerDispatchE2E(t *testing.T) {
 		t.Fatalf("cat init: %v", err)
 	}
 
-	// Q02's tables, each split into 3 files so shuffles fan out to
-	// multiple producer tasks (multiple manifests, staggered arrival —
-	// the condition the manifest feed exists for).
 	data := tpch.Generate(tpch.SF001)
-	for _, table := range []string{"part", "supplier", "partsupp", "nation", "region"} {
+	for _, table := range tables {
 		schema := tpch.AllTables[table]
 		rows := data[table]
 		if err := cat.CreateTable(ctx, table, schema, nil); err != nil {
@@ -109,67 +105,59 @@ func TestEagerDispatchE2E(t *testing.T) {
 		t.Cleanup(w.Stop)
 	}
 
-	// TPC-H Q02 is the one query whose plan carries the C1 edge: the
-	// decorrelated MIN(ps_supplycost) subquery's final_aggregate consumes
-	// a standalone exchange-repartition AND feeds a join (not the gather,
-	// so it isn't gather-fused — fusion disables task retry, which fencing
-	// needs, so eligibility excludes fused stages). Simple GROUP BY
-	// queries don't exercise C1: their final aggregate either fuses into
-	// the gather or (with ORDER BY folded in) loses the exchange.
-	sql := tpch.TPCHQueries[2].SQL
-
-	run := func(eager bool) map[string]int {
+	newCoord := func(eager bool) *Coordinator {
 		coord := New(Config{
 			NATSUrl:           embeddedNATS.ClientURL(),
 			ResultBucket:      "test",
 			StreamingExchange: true,
 			EagerDispatch:     eager,
+			SkewSplit:         true, // exercise the early-skew decision path
 			// SF001 build sides are tiny — without this the planner
-			// broadcasts every join and no exchange-repartition (the C1
-			// producer) ever exists. 1 byte forces the shuffle path.
+			// broadcasts every join and no exchange-repartition (the
+			// eager producer) ever exists. 1 byte forces the shuffle path.
 			BroadcastBytesOverride: 1,
 		}, cat, nc, js, logger)
 		// The planner needs workerCount > 1 to insert exchanges at all
-		// (everything collapses to Singleton otherwise) — same fake-
-		// heartbeat bootstrap the other distributed e2e tests use.
+		// (everything collapses to Singleton otherwise).
 		for i := 0; i < 3; i++ {
 			coord.workers.record(distributed.WorkerHeartbeat{WorkerID: fmt.Sprintf("fake-%d", i), Timestamp: time.Now()})
 		}
-		res, err := coord.ExecuteSQL(ctx, sql)
-		if err != nil {
-			t.Fatalf("eager=%v: %v", eager, err)
-		}
-		if res.Error != "" {
-			t.Fatalf("eager=%v: %s", eager, res.Error)
-		}
-		rows := mustRows(t, res)
-		// Full-row multiset: Q02 has no single-column key, and eager vs
-		// barrier must agree on exact row content including duplicates.
-		out := make(map[string]int, len(rows))
-		for _, r := range rows {
-			cols := make([]string, 0, len(r))
-			for k := range r {
-				cols = append(cols, k)
-			}
-			sort.Strings(cols)
-			var row string
-			for _, k := range cols {
-				row += fmt.Sprintf("%s=%v|", k, r[k])
-			}
-			out[row]++
-		}
-		return out
+		return coord
 	}
+	return ctx, newCoord
+}
 
-	control := run(false)
-	if len(control) == 0 {
-		t.Fatal("control returned no rows")
+// runEagerE2EQuery executes sql and returns a full-row multiset (row
+// content → count): eager and barrier arms must agree on exact row content
+// including duplicates.
+func runEagerE2EQuery(ctx context.Context, t *testing.T, coord *Coordinator, sql string, label string) map[string]int {
+	t.Helper()
+	res, err := coord.ExecuteSQL(ctx, sql)
+	if err != nil {
+		t.Fatalf("%s: %v", label, err)
 	}
+	if res.Error != "" {
+		t.Fatalf("%s: %s", label, res.Error)
+	}
+	rows := mustRows(t, res)
+	out := make(map[string]int, len(rows))
+	for _, r := range rows {
+		cols := make([]string, 0, len(r))
+		for k := range r {
+			cols = append(cols, k)
+		}
+		sort.Strings(cols)
+		var row string
+		for _, k := range cols {
+			row += fmt.Sprintf("%s=%v|", k, r[k])
+		}
+		out[row]++
+	}
+	return out
+}
 
-	edgesBefore := EagerEdgesPlanned.Load()
-	manifestsBefore := EagerManifestsPublished.Load()
-	treatment := run(true)
-
+func assertEagerArmsIdentical(t *testing.T, control, treatment map[string]int) {
+	t.Helper()
 	if len(treatment) != len(control) {
 		t.Fatalf("distinct rows: eager=%d control=%d", len(treatment), len(control))
 	}
@@ -178,12 +166,62 @@ func TestEagerDispatchE2E(t *testing.T) {
 			t.Fatalf("row %q: eager ×%d != control ×%d", k, treatment[k], n)
 		}
 	}
+}
+
+// TestEagerDispatchE2E runs the Phase C1 eager path end-to-end (real NATS,
+// 3 in-process workers): TPC-H Q02 is the one TPC-H plan carrying the C1
+// edge — the decorrelated MIN(ps_supplycost) subquery's final_aggregate
+// consumes a standalone exchange-repartition AND feeds a join (not the
+// gather, so it isn't gather-fused; fusion disables the task retry that
+// fencing needs). Asserts flag-on results are identical to flag-off and
+// that the mechanism markers engaged (memo §8).
+func TestEagerDispatchE2E(t *testing.T) {
+	ctx, newCoord := setupEagerE2E(t, []string{"part", "supplier", "partsupp", "nation", "region"})
+	sql := tpch.TPCHQueries[2].SQL
+
+	control := runEagerE2EQuery(ctx, t, newCoord(false), sql, "control")
+	if len(control) == 0 {
+		t.Fatal("control returned no rows")
+	}
+	edgesBefore := EagerEdgesPlanned.Load()
+	manifestsBefore := EagerManifestsPublished.Load()
+	treatment := runEagerE2EQuery(ctx, t, newCoord(true), sql, "eager")
+
+	assertEagerArmsIdentical(t, control, treatment)
 	if got := EagerManifestsPublished.Load() - manifestsBefore; got == 0 {
 		t.Error("eager run published no manifests — producer wiring did not engage")
 	}
 	if got := EagerEdgesPlanned.Load() - edgesBefore; got == 0 {
 		t.Error("eager run cleared no consumer early — clearance did not engage")
 	}
-	t.Logf("eager engaged: edges=%d manifests=%d, %d groups row-identical",
+	t.Logf("C1 eager engaged: edges=%d manifests=%d, %d distinct rows identical",
 		EagerEdgesPlanned.Load()-edgesBefore, EagerManifestsPublished.Load()-manifestsBefore, len(control))
+}
+
+// TestEagerJoinDispatchE2E runs the Phase C2 slice-1 join path: a shuffled
+// hash join (both sides standalone exchange-repartitions) whose consumer
+// clears at the early-skew decision point and feeds BOTH the probe stream
+// and the hash-table build from producer-task manifests, published in
+// governed waves (join numTasks = partition count ≫ cluster capacity).
+// SF001 data is uniform, so the projected decision is no-split and eager
+// clearance proceeds; results must be row-identical to the barrier arm.
+func TestEagerJoinDispatchE2E(t *testing.T) {
+	ctx, newCoord := setupEagerE2E(t, []string{"lineitem", "orders"})
+	const sql = `SELECT l_orderkey, COUNT(*) AS cnt, SUM(l_quantity) AS qty
+		FROM lineitem JOIN orders ON l_orderkey = o_orderkey
+		GROUP BY l_orderkey`
+
+	control := runEagerE2EQuery(ctx, t, newCoord(false), sql, "control")
+	if len(control) == 0 {
+		t.Fatal("control returned no rows")
+	}
+	edgesBefore := EagerEdgesPlanned.Load()
+	treatment := runEagerE2EQuery(ctx, t, newCoord(true), sql, "eager")
+
+	assertEagerArmsIdentical(t, control, treatment)
+	if got := EagerEdgesPlanned.Load() - edgesBefore; got == 0 {
+		t.Error("eager join run cleared no consumer early — C2 clearance did not engage")
+	}
+	t.Logf("C2 join eager engaged: edges=%d, %d groups identical",
+		EagerEdgesPlanned.Load()-edgesBefore, len(control))
 }

--- a/internal/coordinator/eager_dispatch_e2e_test.go
+++ b/internal/coordinator/eager_dispatch_e2e_test.go
@@ -1,0 +1,189 @@
+package coordinator
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/benchmarks/tpch"
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/storage/catalog"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+	"github.com/citc-tech/wadjet/internal/worker"
+)
+
+// TestEagerDispatchE2E runs the Phase C1 eager path end-to-end (real NATS,
+// 3 in-process workers): a GROUP BY over a shuffled join plans to the one
+// non-join repartition edge C1 targets (standalone exchange-repartition →
+// final_aggregate, the Q02 shape), so with the flag on the aggregate stage
+// clears dispatch on the shuffle's feed and consumes manifests while the
+// shuffle drains. Asserts flag-on results are identical to flag-off and
+// that the mechanism markers (EagerEdgesPlanned, EagerManifestsPublished)
+// engaged — the same markers the SF100 pair will be judged on (memo §8).
+func TestEagerDispatchE2E(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	t.Cleanup(cancel)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	natsCfg := distributed.DefaultNATSConfig()
+	natsCfg.Port = -1
+	natsCfg.StoreDir = t.TempDir()
+	embeddedNATS, err := distributed.NewEmbeddedNATS(natsCfg, logger)
+	if err != nil {
+		t.Fatalf("nats: %v", err)
+	}
+	t.Cleanup(embeddedNATS.Shutdown)
+	nc, err := distributed.ConnectInProcess(embeddedNATS.Server())
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { nc.Close() })
+	js, err := distributed.NewJetStream(nc)
+	if err != nil {
+		t.Fatalf("js: %v", err)
+	}
+	if err := distributed.SetupStreams(ctx, js); err != nil {
+		t.Fatalf("streams: %v", err)
+	}
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(ctx, "test"); err != nil {
+		t.Fatal(err)
+	}
+	kv, err := catalog.NewNATSKV(js)
+	if err != nil {
+		t.Fatalf("kv: %v", err)
+	}
+	cat := catalog.New(kv, store, "test")
+	if err := cat.Init(ctx); err != nil {
+		t.Fatalf("cat init: %v", err)
+	}
+
+	// Q02's tables, each split into 3 files so shuffles fan out to
+	// multiple producer tasks (multiple manifests, staggered arrival —
+	// the condition the manifest feed exists for).
+	data := tpch.Generate(tpch.SF001)
+	for _, table := range []string{"part", "supplier", "partsupp", "nation", "region"} {
+		schema := tpch.AllTables[table]
+		rows := data[table]
+		if err := cat.CreateTable(ctx, table, schema, nil); err != nil {
+			t.Fatal(err)
+		}
+		const chunks = 3
+		per := (len(rows) + chunks - 1) / chunks
+		for c := 0; c < chunks; c++ {
+			lo, hi := c*per, c*per+per
+			if hi > len(rows) {
+				hi = len(rows)
+			}
+			if lo >= hi {
+				break
+			}
+			var buf bytes.Buffer
+			pw, _ := parquet.NewWriter(&buf, schema, parquet.DefaultWriterConfig())
+			if err := pw.WriteRows(rows[lo:hi]); err != nil {
+				t.Fatal(err)
+			}
+			pw.Close()
+			fp := fmt.Sprintf("tables/%s/chunk_%04d.parquet", table, c)
+			pd := buf.Bytes()
+			store.Put(ctx, "test", fp, bytes.NewReader(pd), int64(len(pd)), "application/octet-stream")
+			cat.AddFiles(ctx, table, map[string]string{}, "tables/"+table+"/", []catalog.FileEntry{{
+				Path: fp, SizeBytes: int64(len(pd)), NumRows: int64(hi - lo), CreatedAt: time.Now(),
+			}})
+		}
+	}
+
+	for i := 0; i < 3; i++ {
+		w := worker.New(worker.Config{NATSUrl: embeddedNATS.ClientURL(), MaxConcurrent: 4, CacheBytes: 64 << 20}, store, nc, js, logger)
+		wctx, wcancel := context.WithCancel(context.Background())
+		t.Cleanup(wcancel)
+		if err := w.Start(wctx); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(w.Stop)
+	}
+
+	// TPC-H Q02 is the one query whose plan carries the C1 edge: the
+	// decorrelated MIN(ps_supplycost) subquery's final_aggregate consumes
+	// a standalone exchange-repartition AND feeds a join (not the gather,
+	// so it isn't gather-fused — fusion disables task retry, which fencing
+	// needs, so eligibility excludes fused stages). Simple GROUP BY
+	// queries don't exercise C1: their final aggregate either fuses into
+	// the gather or (with ORDER BY folded in) loses the exchange.
+	sql := tpch.TPCHQueries[2].SQL
+
+	run := func(eager bool) map[string]int {
+		coord := New(Config{
+			NATSUrl:           embeddedNATS.ClientURL(),
+			ResultBucket:      "test",
+			StreamingExchange: true,
+			EagerDispatch:     eager,
+			// SF001 build sides are tiny — without this the planner
+			// broadcasts every join and no exchange-repartition (the C1
+			// producer) ever exists. 1 byte forces the shuffle path.
+			BroadcastBytesOverride: 1,
+		}, cat, nc, js, logger)
+		// The planner needs workerCount > 1 to insert exchanges at all
+		// (everything collapses to Singleton otherwise) — same fake-
+		// heartbeat bootstrap the other distributed e2e tests use.
+		for i := 0; i < 3; i++ {
+			coord.workers.record(distributed.WorkerHeartbeat{WorkerID: fmt.Sprintf("fake-%d", i), Timestamp: time.Now()})
+		}
+		res, err := coord.ExecuteSQL(ctx, sql)
+		if err != nil {
+			t.Fatalf("eager=%v: %v", eager, err)
+		}
+		if res.Error != "" {
+			t.Fatalf("eager=%v: %s", eager, res.Error)
+		}
+		rows := mustRows(t, res)
+		// Full-row multiset: Q02 has no single-column key, and eager vs
+		// barrier must agree on exact row content including duplicates.
+		out := make(map[string]int, len(rows))
+		for _, r := range rows {
+			cols := make([]string, 0, len(r))
+			for k := range r {
+				cols = append(cols, k)
+			}
+			sort.Strings(cols)
+			var row string
+			for _, k := range cols {
+				row += fmt.Sprintf("%s=%v|", k, r[k])
+			}
+			out[row]++
+		}
+		return out
+	}
+
+	control := run(false)
+	if len(control) == 0 {
+		t.Fatal("control returned no rows")
+	}
+
+	edgesBefore := EagerEdgesPlanned.Load()
+	manifestsBefore := EagerManifestsPublished.Load()
+	treatment := run(true)
+
+	if len(treatment) != len(control) {
+		t.Fatalf("distinct rows: eager=%d control=%d", len(treatment), len(control))
+	}
+	for k, n := range control {
+		if treatment[k] != n {
+			t.Fatalf("row %q: eager ×%d != control ×%d", k, treatment[k], n)
+		}
+	}
+	if got := EagerManifestsPublished.Load() - manifestsBefore; got == 0 {
+		t.Error("eager run published no manifests — producer wiring did not engage")
+	}
+	if got := EagerEdgesPlanned.Load() - edgesBefore; got == 0 {
+		t.Error("eager run cleared no consumer early — clearance did not engage")
+	}
+	t.Logf("eager engaged: edges=%d manifests=%d, %d groups row-identical",
+		EagerEdgesPlanned.Load()-edgesBefore, EagerManifestsPublished.Load()-manifestsBefore, len(control))
+}

--- a/internal/coordinator/eager_feed.go
+++ b/internal/coordinator/eager_feed.go
@@ -43,28 +43,62 @@ var eagerManifestRepublishEvery = 3 * time.Second
 type eagerFeed struct {
 	dispatched chan struct{} // closed by dispatch(); dispatch info valid after
 
-	// Set by dispatch(), immutable afterwards.
-	manifestStageID string   // stage ID used in EagerManifestSubject and manifests
-	rootQueryID     string   // root query ID scoping the manifest subject
-	producerTaskIDs []string // full candidate set (task IDs are stable across retries)
-	numPartitions   int
+	// decisionReady closes once decisionThreshold producer tasks have
+	// reached successful terminal state — the memo §6 early-skew decision
+	// point. Join consumers block on it before clearing; non-join (C1)
+	// consumers ignore it. Always closes at or before stage completion
+	// (threshold ≤ total tasks).
+	decisionReady chan struct{}
 
-	mu     sync.Mutex
-	replay []distributed.ProducerTaskManifest // manifests published so far
-	closed bool                               // query finished; republisher must stop
+	// Set by dispatch(), immutable afterwards.
+	manifestStageID   string   // stage ID used in EagerManifestSubject and manifests
+	rootQueryID       string   // root query ID scoping the manifest subject
+	producerTaskIDs   []string // full candidate set (task IDs are stable across retries)
+	numPartitions     int
+	decisionThreshold int // completions needed before decisionReady closes
+
+	mu        sync.Mutex
+	replay    []distributed.ProducerTaskManifest // manifests published so far
+	closed    bool                               // query finished; republisher must stop
+	completed int                                // producer tasks at successful terminal
+	// observedPartBytes accumulates worker-reported per-partition output
+	// bytes element-wise over completed tasks. nil until the first task
+	// reports a vector; stays nil for legacy workers (skew decision
+	// degrades to "would not split", matching planSkewSplitTasks on nil).
+	observedPartBytes []int64
+	decisionClosed    bool
 }
 
 func newEagerFeed() *eagerFeed {
-	return &eagerFeed{dispatched: make(chan struct{})}
+	return &eagerFeed{
+		dispatched:    make(chan struct{}),
+		decisionReady: make(chan struct{}),
+	}
 }
 
 // dispatch records the producer's task layout and releases consumers
 // blocked on the feed. Call exactly once, before publishing producer tasks.
-func (f *eagerFeed) dispatch(rootQueryID, manifestStageID string, producerTaskIDs []string, numPartitions int) {
+func (f *eagerFeed) dispatch(rootQueryID, manifestStageID string, producerTaskIDs []string, numPartitions, workerCount int) {
 	f.rootQueryID = rootQueryID
 	f.manifestStageID = manifestStageID
 	f.producerTaskIDs = producerTaskIDs
 	f.numPartitions = numPartitions
+	// Memo §6 decision point: one full wave AND at least a quarter of the
+	// producer tasks, so every producer's input-slice shape is represented
+	// in the byte profile; capped at the task count so single-task or
+	// tiny producers still reach a decision.
+	total := len(producerTaskIDs)
+	threshold := workerCount
+	if q := (total + 3) / 4; q > threshold {
+		threshold = q
+	}
+	if threshold > total {
+		threshold = total
+	}
+	if threshold < 1 {
+		threshold = 1
+	}
+	f.decisionThreshold = threshold
 	close(f.dispatched)
 }
 
@@ -74,6 +108,51 @@ func (f *eagerFeed) appendReplay(m distributed.ProducerTaskManifest) {
 	f.mu.Lock()
 	f.replay = append(f.replay, m)
 	f.mu.Unlock()
+}
+
+// noteCompletion records one producer task's successful terminal state and
+// its per-partition output vector (nil when the worker didn't report).
+// Closes decisionReady once the threshold is crossed. Called exactly once
+// per producer task, from the manifest publisher hook.
+func (f *eagerFeed) noteCompletion(partBytes []int64) {
+	f.mu.Lock()
+	f.completed++
+	if len(partBytes) > 0 {
+		if f.observedPartBytes == nil {
+			f.observedPartBytes = make([]int64, f.numPartitions)
+		}
+		for p := 0; p < len(partBytes) && p < len(f.observedPartBytes); p++ {
+			f.observedPartBytes[p] += partBytes[p]
+		}
+	}
+	fire := !f.decisionClosed && f.completed >= f.decisionThreshold
+	if fire {
+		f.decisionClosed = true
+	}
+	f.mu.Unlock()
+	if fire {
+		close(f.decisionReady)
+	}
+}
+
+// projectedPartitionBytes linearly extrapolates the observed per-partition
+// bytes to the full producer task set (memo §6: hash partitioning makes
+// each completed task an unbiased sample, so observed × total/completed
+// converges fast). Returns nil when no task reported accounting — the
+// caller treats that exactly like planSkewSplitTasks treats nil vectors:
+// no split would fire on full data either.
+func (f *eagerFeed) projectedPartitionBytes() []int64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.observedPartBytes == nil || f.completed == 0 {
+		return nil
+	}
+	total := int64(len(f.producerTaskIDs))
+	out := make([]int64, len(f.observedPartBytes))
+	for p, b := range f.observedPartBytes {
+		out[p] = b * total / int64(f.completed)
+	}
+	return out
 }
 
 // replaySnapshot returns a copy of the manifests published so far.
@@ -222,6 +301,210 @@ func (c *Coordinator) startEagerRepublisher(f *eagerFeed) {
 			}
 		}
 	}()
+}
+
+// joinPrimaryDeps returns a join stage's (probe, build) dependency stage
+// IDs, mirroring buildTaskInputsForStage / planSkewSplitTasks resolution.
+func joinPrimaryDeps(s physical.Stage) (probeDep, buildDep string) {
+	probeDep = s.LeftDepStage
+	buildDep = s.RightDepStage
+	if probeDep == "" && len(s.Dependencies) > 0 {
+		probeDep = s.Dependencies[0]
+	}
+	if buildDep == "" && len(s.Dependencies) > 1 {
+		buildDep = s.Dependencies[1]
+	}
+	return probeDep, buildDep
+}
+
+// eagerAliasForDep returns the Task.Inputs alias under which
+// buildTaskInputsForStage files dependency depID for this stage.
+// Task.EagerInputs must key identically, or the worker's fragment source /
+// join-build routing won't find the feed spec.
+func eagerAliasForDep(stage physical.Stage, depID string) string {
+	switch stage.Type {
+	case physical.StageHashJoin, physical.StageBroadcastJoin, physical.StageSortMergeJoin:
+		_, buildDep := joinPrimaryDeps(stage)
+		buildAlias := stage.BuildTableAlias
+		if buildAlias == "" {
+			buildAlias = "build"
+		}
+		if depID == buildDep {
+			return buildAlias
+		}
+		probeAlias := "probe"
+		if probeAlias == buildAlias {
+			probeAlias = "probe_side"
+		}
+		return probeAlias
+	default:
+		return depID
+	}
+}
+
+// eagerEligibleJoinConsumer reports whether join stage s may clear
+// dispatch on its two producers' eager feeds (memo §3.3/§6, Phase C2
+// scope). Requires:
+//   - a hash_join on the fragment path (no GroupByCols — those take the
+//     legacy task path, which reads frozen Task.Inputs). broadcast_join is
+//     out of scope (broadcast edges stay S3+KV per memo §7);
+//     sort_merge_join is dormant (gate off) and excluded from slice 1.
+//   - both primary deps are standalone exchange-repartitions (the feeds'
+//     producers); fused-build deps keep the barrier (their real outputs
+//     ride task.FusedJoins[i].BuildFiles).
+//   - not the gather-fused stage, no scalar deps (joins never carry
+//     dynamic-filter emits/consumes; checked defensively).
+//
+// The skew decision itself happens later, at the feed threshold
+// (eagerJoinWouldSplit) — this gate is structural only.
+func eagerEligibleJoinConsumer(s physical.Stage, stageByID map[string]physical.Stage, fuseStageID string) bool {
+	if s.Type != physical.StageHashJoin {
+		return false
+	}
+	if len(s.GroupByCols) > 0 || s.ID == fuseStageID || len(s.ScalarDependencies) > 0 {
+		return false
+	}
+	if len(s.EmitDynamicFilters) > 0 || len(s.ConsumeDynamicFilters) > 0 {
+		return false
+	}
+	if len(s.Dependencies) != 2+len(s.FusedJoins) {
+		return false
+	}
+	probeDep, buildDep := joinPrimaryDeps(s)
+	for _, dep := range []string{probeDep, buildDep} {
+		d, ok := stageByID[dep]
+		if !ok || d.Type != physical.StageExchangeRepartition || d.Exchange == nil || d.Exchange.Count <= 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// eagerJoinWouldSplit is the memo §6 early skew decision: projects both
+// feeds' observed per-partition bytes to the full producer set and asks
+// whether ANY task group would split under the exact planSkewSplitTasks
+// thresholds (absolute floor, ratio gate, build replication bound). A
+// "yes" sends the consumer back to the barrier, where the full-data
+// decision governs — eager dispatch may only ever cost a split win, never
+// produce a wrong split (slice 1; frozen eager split layouts are slice 2).
+//
+// Differences from planSkewSplitTasks, both conservative toward "would
+// split" (i.e. toward the barrier): no probe-file-count cap on the split
+// factor (file counts are unknowable before completion), and missing
+// accounting on either side returns false — nil vectors would disable the
+// full-data split too, so no win is lost by clearing eagerly.
+func (c *Coordinator) eagerJoinWouldSplit(stage physical.Stage, probeFeed, buildFeed *eagerFeed, numTasks, workerCount int) bool {
+	if !c.config.SkewSplit {
+		return false
+	}
+	if stage.Type != physical.StageHashJoin ||
+		stage.Distribution.Kind != physical.DistHashPartitioned ||
+		numTasks <= 0 || workerCount <= 1 {
+		return false
+	}
+	switch stage.JoinType {
+	case "inner", "left", "semi", "anti":
+	default:
+		return false
+	}
+	probeBytes := probeFeed.projectedPartitionBytes()
+	buildBytes := buildFeed.projectedPartitionBytes()
+	if probeFeed.numPartitions != buildFeed.numPartitions ||
+		len(probeBytes) != probeFeed.numPartitions ||
+		len(buildBytes) != buildFeed.numPartitions {
+		return false
+	}
+	buildBound := skewSplitMaxBuildBytes
+	if c.workers != nil {
+		if t := broadcastThresholdFromCluster(c.workers.MinWorkerPoolBudget()); t > 0 {
+			buildBound = t
+		}
+	}
+	var totalProbeBytes int64
+	for _, b := range probeBytes {
+		totalProbeBytes += b
+	}
+	meanGroupBytes := totalProbeBytes / int64(numTasks)
+	for w := 0; w < numTasks; w++ {
+		start, end := partitionRangeForWorker(probeFeed.numPartitions, w, numTasks)
+		var pb, bb int64
+		for p := start; p < end; p++ {
+			pb += probeBytes[p]
+			bb += buildBytes[p]
+		}
+		k := 0
+		if pb > 0 {
+			k = int((pb + skewSplitTargetBytes - 1) / skewSplitTargetBytes)
+		}
+		if k > workerCount {
+			k = workerCount
+		}
+		ratio := float64(0)
+		if meanGroupBytes > 0 {
+			ratio = float64(pb) / float64(meanGroupBytes)
+		}
+		if k > 1 && pb > skewSplitMinGroupBytes && ratio >= skewSplitMinRatio && bb <= buildBound {
+			return true
+		}
+	}
+	return false
+}
+
+// eagerPublishGovernor caps in-flight eager consumer tasks so producers
+// always keep worker task slots. Eager tasks block on producer manifests
+// while HOLDING their slot, and neither transport can reorder around them
+// (gRPC dispatch is targeted with no work stealing; NATS pulls are FIFO) —
+// so publishing a full join fan-out (numTasks = partition count, typically
+// several × cluster capacity) at once could wedge every slot behind tasks
+// waiting on producers that can no longer run. The governor publishes the
+// first `cap` tasks and tops up one-for-one as published tasks reach a
+// TERMINAL state (a failure that will retry keeps its slot — the retry
+// re-occupies it).
+//
+// The residual hazard is a producer-task retry published after eager
+// consumers (it queues behind them on one worker); the task deadline
+// bounds that stall, same as any other slot contention. Documented in the
+// memo §3.3 v1 notes.
+type eagerPublishGovernor struct {
+	mu      sync.Mutex
+	pending []distributed.Task
+	freed   map[string]bool // task IDs whose terminal state already topped up
+	publish func(distributed.Task)
+}
+
+// newEagerPublishGovernor splits tasks into a first wave (returned for the
+// caller's initial PublishTasks) and a governed remainder. inFlightCap is
+// clamped to ≥ 1.
+func newEagerPublishGovernor(tasks []distributed.Task, inFlightCap int, publish func(distributed.Task)) (firstWave []distributed.Task, g *eagerPublishGovernor) {
+	if inFlightCap < 1 {
+		inFlightCap = 1
+	}
+	if len(tasks) <= inFlightCap {
+		return tasks, nil
+	}
+	return tasks[:inFlightCap], &eagerPublishGovernor{
+		pending: append([]distributed.Task(nil), tasks[inFlightCap:]...),
+		freed:   make(map[string]bool),
+		publish: publish,
+	}
+}
+
+// noteTerminal releases one slot for task taskID (idempotent per task) and
+// publishes the next pending task, if any. Called from the stage's result
+// subscription after retrier.Observe confirms the task is terminal; the
+// publish runs on this goroutine — callers already tolerate the same NATS
+// round-trip in the retry republish path.
+func (g *eagerPublishGovernor) noteTerminal(taskID string) {
+	g.mu.Lock()
+	if g.freed[taskID] || len(g.pending) == 0 {
+		g.mu.Unlock()
+		return
+	}
+	g.freed[taskID] = true
+	next := g.pending[0]
+	g.pending = g.pending[1:]
+	g.mu.Unlock()
+	g.publish(next)
 }
 
 // eagerEligibleConsumer reports whether stage s may clear dispatch on its

--- a/internal/coordinator/eager_feed.go
+++ b/internal/coordinator/eager_feed.go
@@ -1,0 +1,283 @@
+package coordinator
+
+import (
+	"sync"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/planner/physical"
+)
+
+// Eager consumer dispatch, Phase C1 slice 3 (docs/design/
+// eager-consumer-dispatch.md §3.2-3.3): the coordinator-side feed that lets
+// a consumer stage clear dispatch when its producer stage has *dispatched*
+// (task IDs assigned, manifests flowing) instead of waiting for the
+// producer's done channel.
+//
+// Lifecycle: the consumer stage goroutine and the producer's shuffle
+// dispatcher race to create the feed (eagerFeedHandle is get-or-create);
+// the producer fills in the dispatch info and closes `dispatched` right
+// before publishing its tasks; executeStageDAG drops every feed of the
+// query on exit. A feed whose producer never dispatches (empty upstream,
+// flag raced off, legacy path) is inert — the consumer's select falls
+// through on the producer's done channel as before.
+
+// eagerManifestRepublishEvery is the cadence at which a live feed re-sends
+// its accumulated manifests on the manifest subject. Republishing makes
+// three loss windows self-heal within one tick, all with the same
+// idempotent mechanism (manifestStreamSource.observe drops duplicates):
+//   - a manifest published between the consumer task's Replay snapshot
+//     (coordinator task build) and the worker's subscribe (task Init);
+//   - a fire-and-forget Core NATS publish that never arrived;
+//   - a consumer-task retry, which re-sends the task spec verbatim with
+//     its original (now stale) Replay list.
+//
+// Without it, each of those degrades to a consumer-task deadline timeout
+// followed by a retry — correct but painfully slow. Var for tests.
+var eagerManifestRepublishEvery = 3 * time.Second
+
+// eagerFeed is the coordinator-side record of one eager-capable producer
+// stage. Created lazily by whichever side (consumer goroutine, producer
+// dispatcher) asks first; immutable dispatch info is set exactly once by
+// the producer before `dispatched` closes.
+type eagerFeed struct {
+	dispatched chan struct{} // closed by dispatch(); dispatch info valid after
+
+	// Set by dispatch(), immutable afterwards.
+	manifestStageID string   // stage ID used in EagerManifestSubject and manifests
+	rootQueryID     string   // root query ID scoping the manifest subject
+	producerTaskIDs []string // full candidate set (task IDs are stable across retries)
+	numPartitions   int
+
+	mu     sync.Mutex
+	replay []distributed.ProducerTaskManifest // manifests published so far
+	closed bool                               // query finished; republisher must stop
+}
+
+func newEagerFeed() *eagerFeed {
+	return &eagerFeed{dispatched: make(chan struct{})}
+}
+
+// dispatch records the producer's task layout and releases consumers
+// blocked on the feed. Call exactly once, before publishing producer tasks.
+func (f *eagerFeed) dispatch(rootQueryID, manifestStageID string, producerTaskIDs []string, numPartitions int) {
+	f.rootQueryID = rootQueryID
+	f.manifestStageID = manifestStageID
+	f.producerTaskIDs = producerTaskIDs
+	f.numPartitions = numPartitions
+	close(f.dispatched)
+}
+
+// appendReplay folds one published manifest into the replay list handed to
+// consumers built after this point (and re-sent by the republisher).
+func (f *eagerFeed) appendReplay(m distributed.ProducerTaskManifest) {
+	f.mu.Lock()
+	f.replay = append(f.replay, m)
+	f.mu.Unlock()
+}
+
+// replaySnapshot returns a copy of the manifests published so far.
+func (f *eagerFeed) replaySnapshot() []distributed.ProducerTaskManifest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]distributed.ProducerTaskManifest(nil), f.replay...)
+}
+
+// markClosed stops the republisher. Idempotent.
+func (f *eagerFeed) markClosed() {
+	f.mu.Lock()
+	f.closed = true
+	f.mu.Unlock()
+}
+
+func (f *eagerFeed) isClosed() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.closed
+}
+
+// provisionalOutput synthesizes the StageOutput a consumer uses when it
+// clears dispatch before the producer finishes. Everything unknown degrades
+// to unknown, never to wrong: Bytes=0 (admission falls back to the pressure
+// gate, estimateComputeTaskBytes skips it), PartitionRows/Bytes nil (skew
+// detection off; C1 consumers are non-join anyway), no BuildStats or
+// DynamicFilters (eligibility excludes stat-dep consumers). Files are the
+// empty per-partition layout — partitionFilesForWorker yields empty task
+// file lists and the eager alias feeds from manifests instead.
+func (f *eagerFeed) provisionalOutput() StageOutput {
+	return StageOutput{
+		Kind:          OutputPartitioned,
+		NumPartitions: f.numPartitions,
+		Files:         make([][]string, f.numPartitions),
+		eager:         f,
+	}
+}
+
+// eagerInputForTask builds the EagerInput spec for consumer task w of
+// numTasks, binding the same contiguous partition range the frozen path
+// binds (partitionRangeForWorker) so eager and barrier dispatch read
+// identical row sets. The Replay snapshot is taken at call time; anything
+// published later reaches the worker via its subscription or the
+// republisher.
+func (f *eagerFeed) eagerInputForTask(w, numTasks int) distributed.EagerInput {
+	start, end := partitionRangeForWorker(f.numPartitions, w, numTasks)
+	return distributed.EagerInput{
+		RootQueryID:     f.rootQueryID,
+		StageID:         f.manifestStageID,
+		ProducerTaskIDs: append([]string(nil), f.producerTaskIDs...),
+		PartitionStart:  start,
+		PartitionEnd:    end - 1, // half-open → inclusive; empty range = (0,-1), matches "no files"
+		Replay:          f.replaySnapshot(),
+	}
+}
+
+// refreshEagerReplay swaps each eager alias's Replay list for the feed's
+// current snapshot before a retry re-dispatch. Builds a fresh map (never
+// mutates the retrier's stored copy — Observe and RetryStuck may republish
+// concurrently). No-op for tasks without eager inputs.
+func refreshEagerReplay(t *distributed.Task, inputs map[string]StageOutput) {
+	if len(t.EagerInputs) == 0 {
+		return
+	}
+	fresh := make(map[string]distributed.EagerInput, len(t.EagerInputs))
+	for alias, ei := range t.EagerInputs {
+		if in, ok := inputs[alias]; ok && in.eager != nil {
+			ei.Replay = in.eager.replaySnapshot()
+		}
+		fresh[alias] = ei
+	}
+	t.EagerInputs = fresh
+}
+
+// eagerFeedKey scopes feeds by query so concurrent queries with colliding
+// plan-stage IDs (every plan numbers stages from 0) can't cross wires.
+func eagerFeedKey(rootQueryID, planStageID string) string {
+	return rootQueryID + "\x00" + planStageID
+}
+
+// eagerFeedHandle returns the feed for one producer stage of one query,
+// creating it if absent. Returns nil when eager dispatch is off — callers
+// treat nil as "barrier path only".
+func (c *Coordinator) eagerFeedHandle(rootQueryID, planStageID string) *eagerFeed {
+	if !c.config.EagerDispatch || !c.config.StreamingExchange || rootQueryID == "" {
+		return nil
+	}
+	key := eagerFeedKey(rootQueryID, planStageID)
+	c.eagerFeedsMu.Lock()
+	defer c.eagerFeedsMu.Unlock()
+	if c.eagerFeeds == nil {
+		c.eagerFeeds = make(map[string]*eagerFeed)
+	}
+	if f, ok := c.eagerFeeds[key]; ok {
+		return f
+	}
+	f := newEagerFeed()
+	c.eagerFeeds[key] = f
+	return f
+}
+
+// dropEagerFeeds removes and closes every feed of one query. Deferred by
+// executeStageDAG so republishers never outlive their query.
+func (c *Coordinator) dropEagerFeeds(rootQueryID string) {
+	prefix := rootQueryID + "\x00"
+	c.eagerFeedsMu.Lock()
+	for key, f := range c.eagerFeeds {
+		if len(key) >= len(prefix) && key[:len(prefix)] == prefix {
+			f.markClosed()
+			delete(c.eagerFeeds, key)
+		}
+	}
+	c.eagerFeedsMu.Unlock()
+}
+
+// startEagerRepublisher re-sends the feed's replay list on the manifest
+// subject every eagerManifestRepublishEvery. Called by the shuffle
+// dispatcher after feed.dispatch; runs until the QUERY ends (markClosed via
+// dropEagerFeeds), not just until the producer stage drains — a consumer
+// retry dispatched after the last producer finished still heals its stale
+// Replay list from these re-sends. Metadata-only traffic on a root-scoped
+// subject; a query's worth of manifests is tens of small messages.
+func (c *Coordinator) startEagerRepublisher(f *eagerFeed) {
+	if c.nc == nil {
+		return
+	}
+	subject := distributed.EagerManifestSubject(f.rootQueryID, f.manifestStageID)
+	go func() {
+		ticker := time.NewTicker(eagerManifestRepublishEvery)
+		defer ticker.Stop()
+		for range ticker.C {
+			if f.isClosed() {
+				return
+			}
+			for _, m := range f.replaySnapshot() {
+				data, err := distributed.Marshal(m)
+				if err != nil {
+					continue
+				}
+				// Fire-and-forget like the primary publish; a failed send
+				// is retried by the next tick.
+				if err := c.nc.Publish(subject, data); err != nil {
+					break
+				}
+			}
+		}
+	}()
+}
+
+// eagerEligibleConsumer reports whether stage s may clear dispatch on its
+// dependency's eager feed instead of the done barrier (memo §3.3, Phase C1
+// scope: non-join consumers only).
+//
+// The gate requires:
+//   - exactly one dependency and no scalar-substitution deps (those keep
+//     the barrier: their values are extracted from completed outputs);
+//   - a fragment-migrated single-input stage type: aggregate variants, or
+//     sort variants with SortKeys (a keyless "sort" would fall to the
+//     legacy task path, which reads Task.Inputs and cannot feed eagerly);
+//   - the dependency is a standalone exchange-repartition — the only
+//     producer the shuffle dispatcher registers feeds for in C1;
+//   - not the gather-fused stage (fusion disables task retry, and retry is
+//     the fencing recovery path — memo §5);
+//   - no dynamic-filter participation (provisional outputs carry no
+//     BuildStats);
+//   - a task count no larger than workerCount, so with the scheduler's
+//     eager-spread placement each worker holds at most one manifest-blocked
+//     task and keeps ≥ MaxConcurrent−1 lanes for producer progress (the
+//     §3.3 producer-lane reservation, v1 form).
+//
+// Join edges (56 of the 57 repartition edges in TPC-H plans) are Phase C2:
+// they need the early skew decision before clearance.
+func eagerEligibleConsumer(s physical.Stage, stageByID map[string]physical.Stage, fuseStageID string, workerCount int) bool {
+	if len(s.Dependencies) != 1 || len(s.ScalarDependencies) > 0 {
+		return false
+	}
+	if s.ID == fuseStageID {
+		return false
+	}
+	if len(s.EmitDynamicFilters) > 0 || len(s.ConsumeDynamicFilters) > 0 {
+		return false
+	}
+	switch s.Type {
+	case "aggregate", "final_aggregate", "merge_aggregate":
+	case "sort", "merge_sort":
+		if len(s.SortKeys) == 0 {
+			return false
+		}
+	default:
+		return false
+	}
+	dep, ok := stageByID[s.Dependencies[0]]
+	if !ok || dep.Type != physical.StageExchangeRepartition {
+		return false
+	}
+	// Consumer task count (mirrors dispatchComputeStage's derivation for
+	// the eligible types): Singleton → 1, HashPartitioned → Count.
+	numTasks := 1
+	if s.Distribution.Kind == physical.DistHashPartitioned {
+		numTasks = s.Distribution.Count
+		if numTasks <= 0 {
+			numTasks = workerCount
+		}
+	}
+	return numTasks <= workerCount
+}

--- a/internal/coordinator/eager_feed_test.go
+++ b/internal/coordinator/eager_feed_test.go
@@ -1,6 +1,7 @@
 package coordinator
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/citc-tech/wadjet/internal/distributed"
@@ -59,7 +60,7 @@ func TestEagerFeedDispatchUnblocksAndSnapshot(t *testing.T) {
 		t.Fatal("dispatched must block before dispatch()")
 	default:
 	}
-	f.dispatch("root-1", "shuffle-stage-x", []string{"t1", "t2"}, 6)
+	f.dispatch("root-1", "shuffle-stage-x", []string{"t1", "t2"}, 6, 3)
 	select {
 	case <-f.dispatched:
 	default:
@@ -92,7 +93,7 @@ func TestEagerInputRangesMatchFrozenBinding(t *testing.T) {
 		{6, 3}, {3, 3}, {24, 3}, {5, 3}, {3, 5}, {1, 1},
 	} {
 		f := newEagerFeed()
-		f.dispatch("root", "st", []string{"t1"}, tc.numParts)
+		f.dispatch("root", "st", []string{"t1"}, tc.numParts, tc.numTasks)
 		for w := 0; w < tc.numTasks; w++ {
 			ei := f.eagerInputForTask(w, tc.numTasks)
 			start, end := partitionRangeForWorker(tc.numParts, w, tc.numTasks)
@@ -106,7 +107,7 @@ func TestEagerInputRangesMatchFrozenBinding(t *testing.T) {
 
 func TestRefreshEagerReplay(t *testing.T) {
 	f := newEagerFeed()
-	f.dispatch("root", "st", []string{"t1", "t2"}, 3)
+	f.dispatch("root", "st", []string{"t1", "t2"}, 3, 1)
 	inputs := map[string]StageOutput{"dep-1": f.provisionalOutput()}
 
 	task := distributed.Task{
@@ -240,5 +241,240 @@ func TestEagerFeedKeyScoping(t *testing.T) {
 	}
 	if eagerFeedKey("q", "1s") == eagerFeedKey("q1", "s") {
 		t.Fatal("separator must prevent prefix collisions")
+	}
+}
+
+func TestEagerFeedDecisionThreshold(t *testing.T) {
+	// threshold = min(total, max(workerCount, ceil(total/4))), floor 1.
+	cases := []struct{ total, workers, want int }{
+		{12, 3, 3},  // one wave dominates
+		{24, 3, 6},  // quarter dominates
+		{2, 3, 2},   // capped at total
+		{1, 3, 1},   // single-task producer
+		{100, 4, 25},
+	}
+	for _, tc := range cases {
+		f := newEagerFeed()
+		ids := make([]string, tc.total)
+		for i := range ids {
+			ids[i] = string(rune('a' + i%26))
+		}
+		f.dispatch("r", "s", ids, 6, tc.workers)
+		if f.decisionThreshold != tc.want {
+			t.Errorf("total=%d workers=%d: threshold=%d, want %d",
+				tc.total, tc.workers, f.decisionThreshold, tc.want)
+		}
+	}
+
+	// decisionReady closes exactly when the threshold is crossed, and the
+	// projection scales observed bytes by total/completed.
+	f := newEagerFeed()
+	f.dispatch("r", "s", []string{"t1", "t2", "t3", "t4"}, 3, 2)
+	if f.decisionThreshold != 2 {
+		t.Fatalf("threshold = %d, want 2", f.decisionThreshold)
+	}
+	f.noteCompletion([]int64{10, 0, 0})
+	select {
+	case <-f.decisionReady:
+		t.Fatal("decisionReady must not close below threshold")
+	default:
+	}
+	f.noteCompletion([]int64{10, 20, 0})
+	select {
+	case <-f.decisionReady:
+	default:
+		t.Fatal("decisionReady must close at threshold")
+	}
+	// observed = {20,20,0} over 2 of 4 tasks → projected ×2.
+	got := f.projectedPartitionBytes()
+	want := []int64{40, 40, 0}
+	for p := range want {
+		if got[p] != want[p] {
+			t.Fatalf("projected = %v, want %v", got, want)
+		}
+	}
+	// Later completions keep accumulating without double-closing.
+	f.noteCompletion(nil)
+	f.noteCompletion([]int64{0, 0, 4})
+
+	// No accounting reported → nil projection (decision degrades to
+	// "would not split", matching planSkewSplitTasks on nil vectors).
+	blind := newEagerFeed()
+	blind.dispatch("r", "s", []string{"t1"}, 3, 1)
+	blind.noteCompletion(nil)
+	if blind.projectedPartitionBytes() != nil {
+		t.Fatal("projection must be nil without reported accounting")
+	}
+}
+
+func TestEagerJoinWouldSplit(t *testing.T) {
+	origTarget, origFloor := skewSplitTargetBytes, skewSplitMinGroupBytes
+	skewSplitTargetBytes, skewSplitMinGroupBytes = 100, 100
+	t.Cleanup(func() { skewSplitTargetBytes, skewSplitMinGroupBytes = origTarget, origFloor })
+
+	mkFeed := func(parts []int64, tasks int) *eagerFeed {
+		f := newEagerFeed()
+		ids := make([]string, tasks)
+		for i := range ids {
+			ids[i] = string(rune('a' + i))
+		}
+		f.dispatch("r", "s", ids, len(parts), 1)
+		f.noteCompletion(parts) // completed=1 of tasks → projection ×tasks
+		return f
+	}
+	join := physical.Stage{
+		ID: "join-1", Type: physical.StageHashJoin, JoinType: "inner",
+		Distribution: physical.Distribution{Kind: physical.DistHashPartitioned, Count: 3},
+	}
+	c := newEagerTestCoordinator(true)
+	c.config.SkewSplit = true
+
+	// Hot: partition 0 projects to 3000, others 30 — over floor, ratio ≫ 2.
+	hotProbe := mkFeed([]int64{1000, 10, 10}, 3)
+	coldBuild := mkFeed([]int64{1, 1, 1}, 3)
+	if !c.eagerJoinWouldSplit(join, hotProbe, coldBuild, 3, 3) {
+		t.Error("skewed projection must report would-split")
+	}
+	// Uniform: every group equal → ratio 1 < 2 → no split (the Q21 lesson).
+	uniform := mkFeed([]int64{1000, 1000, 1000}, 3)
+	if c.eagerJoinWouldSplit(join, uniform, coldBuild, 3, 3) {
+		t.Error("uniform-heavy projection must not split (ratio gate)")
+	}
+	// Build side over the replication bound → no split.
+	hotBuild := mkFeed([]int64{1 << 40, 0, 0}, 3)
+	if c.eagerJoinWouldSplit(join, hotProbe, hotBuild, 3, 3) {
+		t.Error("build-side-hot group must not split")
+	}
+	// Missing accounting on either side → false (full data would also
+	// decline to split on nil vectors).
+	blind := newEagerFeed()
+	blind.dispatch("r", "s", []string{"a"}, 3, 1)
+	blind.noteCompletion(nil)
+	if c.eagerJoinWouldSplit(join, blind, coldBuild, 3, 3) {
+		t.Error("missing probe accounting must not split")
+	}
+	// Flag off → false regardless.
+	c.config.SkewSplit = false
+	if c.eagerJoinWouldSplit(join, hotProbe, coldBuild, 3, 3) {
+		t.Error("skew-split disabled must never report would-split")
+	}
+	c.config.SkewSplit = true
+	// Right joins can't split (replicated build would duplicate unmatched
+	// build rows).
+	right := join
+	right.JoinType = "right"
+	if c.eagerJoinWouldSplit(right, hotProbe, coldBuild, 3, 3) {
+		t.Error("right join must not split")
+	}
+}
+
+func TestEagerEligibleJoinConsumer(t *testing.T) {
+	repartA := physical.Stage{ID: "ex-a", Type: physical.StageExchangeRepartition,
+		Exchange: &physical.ExchangeStage{Keys: []string{"k"}, Count: 24}}
+	repartB := physical.Stage{ID: "ex-b", Type: physical.StageExchangeRepartition,
+		Exchange: &physical.ExchangeStage{Keys: []string{"k"}, Count: 24}}
+	scan := physical.Stage{ID: "scan-1", Type: physical.StageScan}
+	byID := map[string]physical.Stage{"ex-a": repartA, "ex-b": repartB, "scan-1": scan}
+
+	base := physical.Stage{
+		ID: "join-1", Type: physical.StageHashJoin, JoinType: "inner",
+		Dependencies: []string{"ex-a", "ex-b"},
+		LeftDepStage: "ex-a", RightDepStage: "ex-b",
+		Distribution: physical.Distribution{Kind: physical.DistHashPartitioned, Count: 24},
+	}
+	if !eagerEligibleJoinConsumer(base, byID, "") {
+		t.Fatal("shuffled hash join over two repartitions must be eligible")
+	}
+	mutate := func(fn func(*physical.Stage)) physical.Stage {
+		s := base
+		fn(&s)
+		return s
+	}
+	cases := []struct {
+		name   string
+		s      physical.Stage
+		fuseID string
+		want   bool
+	}{
+		{"broadcast join out of scope", mutate(func(s *physical.Stage) { s.Type = physical.StageBroadcastJoin }), "", false},
+		{"sort-merge join out of slice-1 scope", mutate(func(s *physical.Stage) { s.Type = physical.StageSortMergeJoin }), "", false},
+		{"group-by join takes legacy path", mutate(func(s *physical.Stage) { s.GroupByCols = []string{"g"} }), "", false},
+		{"gather-fused excluded", base, "join-1", false},
+		{"scalar deps keep barrier", mutate(func(s *physical.Stage) {
+			s.ScalarDependencies = map[string]string{":s": "p"}
+		}), "", false},
+		{"probe dep not a repartition", mutate(func(s *physical.Stage) {
+			s.Dependencies = []string{"scan-1", "ex-b"}
+			s.LeftDepStage = "scan-1"
+		}), "", false},
+		{"fused-join dep count mismatch", mutate(func(s *physical.Stage) {
+			s.FusedJoins = []physical.FusedJoinSpec{{}}
+		}), "", false},
+	}
+	for _, tc := range cases {
+		if got := eagerEligibleJoinConsumer(tc.s, byID, tc.fuseID); got != tc.want {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestEagerAliasForDep(t *testing.T) {
+	join := physical.Stage{
+		Type:            physical.StageHashJoin,
+		Dependencies:    []string{"ex-probe", "ex-build"},
+		LeftDepStage:    "ex-probe",
+		RightDepStage:   "ex-build",
+		BuildTableAlias: "orders",
+	}
+	if got := eagerAliasForDep(join, "ex-build"); got != "orders" {
+		t.Errorf("build alias = %q, want orders", got)
+	}
+	if got := eagerAliasForDep(join, "ex-probe"); got != "probe" {
+		t.Errorf("probe alias = %q, want probe", got)
+	}
+	// Alias collision: build named "probe" pushes probe to "probe_side"
+	// (mirrors buildTaskInputsForStage).
+	join.BuildTableAlias = "probe"
+	if got := eagerAliasForDep(join, "ex-probe"); got != "probe_side" {
+		t.Errorf("collision probe alias = %q, want probe_side", got)
+	}
+	agg := physical.Stage{Type: "final_aggregate", Dependencies: []string{"ex-1"}}
+	if got := eagerAliasForDep(agg, "ex-1"); got != "ex-1" {
+		t.Errorf("single-input alias = %q, want dep ID", got)
+	}
+}
+
+func TestEagerPublishGovernor(t *testing.T) {
+	mk := func(n int) []distributed.Task {
+		ts := make([]distributed.Task, n)
+		for i := range ts {
+			ts[i] = distributed.Task{ID: fmt.Sprintf("t%02d", i)}
+		}
+		return ts
+	}
+	// Under the cap: everything in the first wave, no governor.
+	first, g := newEagerPublishGovernor(mk(3), 6, nil)
+	if len(first) != 3 || g != nil {
+		t.Fatalf("under cap: first=%d governor=%v", len(first), g != nil)
+	}
+	// Over the cap: first wave = cap, remainder governed one-for-one on
+	// terminal results; duplicate terminals for one task free one slot.
+	var published []string
+	first, g = newEagerPublishGovernor(mk(5), 2, func(t distributed.Task) {
+		published = append(published, t.ID)
+	})
+	if len(first) != 2 || g == nil {
+		t.Fatalf("over cap: first=%d governor=%v", len(first), g != nil)
+	}
+	g.noteTerminal("t00")
+	g.noteTerminal("t00") // duplicate delivery: no extra slot
+	g.noteTerminal("t01")
+	g.noteTerminal("t02")
+	if want := []string{"t02", "t03", "t04"}; fmt.Sprint(published) != fmt.Sprint(want) {
+		t.Fatalf("published = %v, want %v", published, want)
+	}
+	g.noteTerminal("t03") // pending exhausted: no-op
+	if len(published) != 3 {
+		t.Fatalf("exhausted governor must not publish more, got %v", published)
 	}
 }

--- a/internal/coordinator/eager_feed_test.go
+++ b/internal/coordinator/eager_feed_test.go
@@ -1,0 +1,244 @@
+package coordinator
+
+import (
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/planner/physical"
+)
+
+func newEagerTestCoordinator(eager bool) *Coordinator {
+	return New(Config{
+		ResultBucket:      "test",
+		EagerDispatch:     eager,
+		StreamingExchange: eager,
+	}, nil, nil, nil, nil)
+}
+
+func TestEagerFeedHandleGating(t *testing.T) {
+	off := newEagerTestCoordinator(false)
+	if f := off.eagerFeedHandle("q1", "stage-1"); f != nil {
+		t.Fatal("flag off: want nil feed")
+	}
+	on := newEagerTestCoordinator(true)
+	if f := on.eagerFeedHandle("", "stage-1"); f != nil {
+		t.Fatal("empty root: want nil feed")
+	}
+	f1 := on.eagerFeedHandle("q1", "stage-1")
+	if f1 == nil {
+		t.Fatal("flag on: want feed")
+	}
+	if f2 := on.eagerFeedHandle("q1", "stage-1"); f2 != f1 {
+		t.Fatal("get-or-create must return the same instance")
+	}
+	if f3 := on.eagerFeedHandle("q2", "stage-1"); f3 == f1 {
+		t.Fatal("different query must get a different feed")
+	}
+}
+
+func TestDropEagerFeedsClosesAndScopes(t *testing.T) {
+	c := newEagerTestCoordinator(true)
+	f1 := c.eagerFeedHandle("q1", "s1")
+	f2 := c.eagerFeedHandle("q2", "s1")
+	c.dropEagerFeeds("q1")
+	if !f1.isClosed() {
+		t.Error("q1 feed should be closed")
+	}
+	if f2.isClosed() {
+		t.Error("q2 feed must be untouched")
+	}
+	if f := c.eagerFeedHandle("q1", "s1"); f == f1 {
+		t.Error("dropped feed must not be returned again")
+	}
+}
+
+func TestEagerFeedDispatchUnblocksAndSnapshot(t *testing.T) {
+	f := newEagerFeed()
+	select {
+	case <-f.dispatched:
+		t.Fatal("dispatched must block before dispatch()")
+	default:
+	}
+	f.dispatch("root-1", "shuffle-stage-x", []string{"t1", "t2"}, 6)
+	select {
+	case <-f.dispatched:
+	default:
+		t.Fatal("dispatched must be closed after dispatch()")
+	}
+	f.appendReplay(distributed.ProducerTaskManifest{TaskID: "t1", Attempt: 1})
+	snap := f.replaySnapshot()
+	f.appendReplay(distributed.ProducerTaskManifest{TaskID: "t2", Attempt: 1})
+	if len(snap) != 1 {
+		t.Fatalf("snapshot must be isolated from later appends: got %d", len(snap))
+	}
+
+	out := f.provisionalOutput()
+	if out.Kind != OutputPartitioned || out.NumPartitions != 6 || len(out.Files) != 6 {
+		t.Fatalf("provisional layout: %+v", out)
+	}
+	if out.Bytes != 0 || out.PartitionBytes != nil || out.BuildStats != nil {
+		t.Fatalf("provisional must degrade to unknown: %+v", out)
+	}
+	if out.eager != f {
+		t.Fatal("provisional must carry the feed")
+	}
+}
+
+// TestEagerInputRangesMatchFrozenBinding pins the eager partition ranges to
+// partitionRangeForWorker — the contract that makes eager and barrier
+// dispatch read identical row sets per task.
+func TestEagerInputRangesMatchFrozenBinding(t *testing.T) {
+	for _, tc := range []struct{ numParts, numTasks int }{
+		{6, 3}, {3, 3}, {24, 3}, {5, 3}, {3, 5}, {1, 1},
+	} {
+		f := newEagerFeed()
+		f.dispatch("root", "st", []string{"t1"}, tc.numParts)
+		for w := 0; w < tc.numTasks; w++ {
+			ei := f.eagerInputForTask(w, tc.numTasks)
+			start, end := partitionRangeForWorker(tc.numParts, w, tc.numTasks)
+			if ei.PartitionStart != start || ei.PartitionEnd != end-1 {
+				t.Errorf("parts=%d tasks=%d w=%d: eager [%d,%d], frozen [%d,%d)",
+					tc.numParts, tc.numTasks, w, ei.PartitionStart, ei.PartitionEnd, start, end)
+			}
+		}
+	}
+}
+
+func TestRefreshEagerReplay(t *testing.T) {
+	f := newEagerFeed()
+	f.dispatch("root", "st", []string{"t1", "t2"}, 3)
+	inputs := map[string]StageOutput{"dep-1": f.provisionalOutput()}
+
+	task := distributed.Task{
+		EagerInputs: map[string]distributed.EagerInput{
+			"dep-1": f.eagerInputForTask(0, 1),
+		},
+	}
+	orig := task.EagerInputs
+	f.appendReplay(distributed.ProducerTaskManifest{TaskID: "t1", Attempt: 1})
+
+	refreshed := task
+	refreshEagerReplay(&refreshed, inputs)
+	if got := len(refreshed.EagerInputs["dep-1"].Replay); got != 1 {
+		t.Fatalf("refreshed replay: got %d manifests, want 1", got)
+	}
+	// The retrier's stored copy shares the original map; refresh must not
+	// mutate it (Observe and RetryStuck can republish concurrently).
+	if got := len(orig["dep-1"].Replay); got != 0 {
+		t.Fatalf("original task's replay mutated: %d", got)
+	}
+	// Aliases without a feed pass through unchanged.
+	noFeed := distributed.Task{EagerInputs: map[string]distributed.EagerInput{
+		"other": {StageID: "x"},
+	}}
+	refreshEagerReplay(&noFeed, inputs)
+	if noFeed.EagerInputs["other"].StageID != "x" {
+		t.Fatal("non-feed alias must pass through")
+	}
+}
+
+func TestEagerEligibleConsumer(t *testing.T) {
+	repart := physical.Stage{ID: "ex-1", Type: physical.StageExchangeRepartition,
+		Exchange: &physical.ExchangeStage{Keys: []string{"k"}, Count: 3}}
+	scan := physical.Stage{ID: "scan-1", Type: physical.StageScan}
+	byID := map[string]physical.Stage{"ex-1": repart, "scan-1": scan}
+
+	base := physical.Stage{
+		ID:           "agg-1",
+		Type:         "final_aggregate",
+		Dependencies: []string{"ex-1"},
+		Distribution: physical.Distribution{Kind: physical.DistHashPartitioned, Count: 3},
+	}
+	if !eagerEligibleConsumer(base, byID, "", 3) {
+		t.Fatal("base final_aggregate over repartition must be eligible")
+	}
+
+	mutate := func(fn func(*physical.Stage)) physical.Stage {
+		s := base
+		fn(&s)
+		return s
+	}
+	cases := []struct {
+		name    string
+		s       physical.Stage
+		fuseID  string
+		workers int
+		want    bool
+	}{
+		{"aggregate type", mutate(func(s *physical.Stage) { s.Type = "aggregate" }), "", 3, true},
+		{"merge_aggregate type", mutate(func(s *physical.Stage) { s.Type = "merge_aggregate" }), "", 3, true},
+		{"sort with keys", mutate(func(s *physical.Stage) {
+			s.Type = "sort"
+			s.SortKeys = []physical.SortKeySpec{{Column: "a"}}
+		}), "", 3, true},
+		{"sort without keys (legacy path)", mutate(func(s *physical.Stage) { s.Type = "sort" }), "", 3, false},
+		{"join is C2", mutate(func(s *physical.Stage) {
+			s.Type = physical.StageHashJoin
+			s.Dependencies = []string{"ex-1"}
+		}), "", 3, false},
+		{"window not migrated", mutate(func(s *physical.Stage) { s.Type = physical.StageWindow }), "", 3, false},
+		{"scalar deps keep barrier", mutate(func(s *physical.Stage) {
+			s.ScalarDependencies = map[string]string{":scalar_1": "prod-1"}
+		}), "", 3, false},
+		{"gather-fused excluded (retry unsafe)", base, "agg-1", 3, false},
+		{"dep not a repartition", mutate(func(s *physical.Stage) { s.Dependencies = []string{"scan-1"} }), "", 3, false},
+		{"dep unknown", mutate(func(s *physical.Stage) { s.Dependencies = []string{"ghost"} }), "", 3, false},
+		{"two deps", mutate(func(s *physical.Stage) { s.Dependencies = []string{"ex-1", "scan-1"} }), "", 3, false},
+		{"dynamic-filter consumer", mutate(func(s *physical.Stage) {
+			s.ConsumeDynamicFilters = []physical.DynamicFilterConsume{{FilterID: "f"}}
+		}), "", 3, false},
+		{"task count above workers (lane reservation)", mutate(func(s *physical.Stage) {
+			s.Distribution.Count = 24
+		}), "", 3, false},
+		{"singleton always one task", mutate(func(s *physical.Stage) {
+			s.Distribution = physical.Distribution{Kind: physical.DistSingleton}
+		}), "", 3, true},
+	}
+	for _, tc := range cases {
+		if got := eagerEligibleConsumer(tc.s, byID, tc.fuseID, tc.workers); got != tc.want {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestPickEagerWorkerFrom(t *testing.T) {
+	cases := []struct {
+		name      string
+		connected []string
+		maxConc   map[string]int
+		counts    map[string]int
+		want      string
+		wantOK    bool
+	}{
+		{"none connected", nil, nil, nil, "", false},
+		{"spreads to zero-count worker",
+			[]string{"w1", "w2"}, map[string]int{"w1": 3, "w2": 3},
+			map[string]int{"w1": 1}, "w2", true},
+		{"reservation skips full worker",
+			[]string{"w1", "w2"}, map[string]int{"w1": 2, "w2": 3},
+			map[string]int{"w1": 1, "w2": 1}, "w2", true},
+		{"all reserved: min count anyway",
+			[]string{"w1", "w2"}, map[string]int{"w1": 2, "w2": 2},
+			map[string]int{"w1": 2, "w2": 1}, "w2", true},
+		{"no stats: min count fallback",
+			[]string{"w1", "w2"}, nil,
+			map[string]int{"w1": 1}, "w2", true},
+	}
+	for _, tc := range cases {
+		got, ok := pickEagerWorkerFrom(tc.connected, tc.maxConc, tc.counts)
+		if got != tc.want || ok != tc.wantOK {
+			t.Errorf("%s: got (%q,%v), want (%q,%v)", tc.name, got, ok, tc.want, tc.wantOK)
+		}
+	}
+}
+
+// TestEagerFeedKeyScoping pins the key format so two queries whose plans
+// both contain "exchange-repartition-3" cannot collide.
+func TestEagerFeedKeyScoping(t *testing.T) {
+	if eagerFeedKey("q1", "s") == eagerFeedKey("q2", "s") {
+		t.Fatal("keys must be query-scoped")
+	}
+	if eagerFeedKey("q", "1s") == eagerFeedKey("q1", "s") {
+		t.Fatal("separator must prevent prefix collisions")
+	}
+}

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -407,53 +407,58 @@ func (c *Coordinator) executeStageDAG(
 		s := s
 		g.Go(func() error {
 			// Eager consumer dispatch (docs/design/eager-consumer-dispatch.md
-			// §3.3): an eligible consumer may clear on its producer's feed
+			// §3.3): an eligible consumer may clear on its producers' feeds
 			// (task layout fixed, manifests flowing) instead of the done
-			// barrier. The feed handle is get-or-create so it exists before
-			// the producer's dispatcher fills it in; a producer that never
-			// dispatches (empty upstream, non-shuffle path) leaves the feed
+			// barrier. Feed handles are get-or-create so they exist before
+			// the producers' dispatchers fill them in; a producer that never
+			// dispatches (empty upstream, non-shuffle path) leaves its feed
 			// inert and the done case fires as before.
-			var eagerConsumerFeed *eagerFeed
-			if c.config.EagerDispatch && eagerEligibleConsumer(s, stageByID, fuseStageID, workerCount) {
-				eagerConsumerFeed = c.eagerFeedHandle(queryID, s.Dependencies[0])
+			//
+			// Two shapes: C1 non-join consumers clear on their single dep's
+			// dispatch; C2 hash-join consumers clear on BOTH primary deps at
+			// the memo-§6 early-skew decision point (feed threshold + a
+			// projected planSkewSplitTasks decision — a would-split edge
+			// keeps the barrier so the full-data split governs; slice 2 adds
+			// frozen eager split layouts). Fused-build deps always keep the
+			// barrier: their real outputs ride task.FusedJoins[i].BuildFiles.
+			eagerFeeds := map[string]*eagerFeed{}
+			eagerJoin := false
+			if c.config.EagerDispatch {
+				if eagerEligibleConsumer(s, stageByID, fuseStageID, workerCount) {
+					eagerFeeds[s.Dependencies[0]] = c.eagerFeedHandle(queryID, s.Dependencies[0])
+				} else if eagerEligibleJoinConsumer(s, stageByID, fuseStageID) {
+					probeDep, buildDep := joinPrimaryDeps(s)
+					eagerFeeds[probeDep] = c.eagerFeedHandle(queryID, probeDep)
+					eagerFeeds[buildDep] = c.eagerFeedHandle(queryID, buildDep)
+					eagerJoin = true
+				}
+				for dep, f := range eagerFeeds {
+					if f == nil { // flag raced off / no root ID
+						delete(eagerFeeds, dep)
+					}
+				}
+				if eagerJoin && len(eagerFeeds) != 2 {
+					eagerFeeds = map[string]*eagerFeed{}
+				}
 			}
-			eagerActive := false
 			// Wait on each dependency's done signal. Deps not in the
 			// `done` map are leaf stages / pre-computed outputs (e.g.,
 			// the coordinator's initial inputs) and are treated as
-			// immediately ready.
+			// immediately ready. Eager-capable deps race their feed's
+			// dispatch against the barrier; if ANY of them completes
+			// first, the whole stage takes the barrier path (it has real
+			// outputs; mixing real and provisional gains nothing).
+			eagerBroken := len(eagerFeeds) == 0
 			for _, depID := range s.Dependencies {
 				ch, tracked := done[depID]
 				if !tracked {
 					continue
 				}
-				if eagerConsumerFeed != nil {
-					// Race the barrier against eager clearance. If the
-					// producer finishes first (or wins the select while
-					// both are ready), take the barrier path — it has the
-					// real output. Eager clearance additionally requires
-					// the coordinator-wide eager slot (v1 producer-lane
-					// reservation); a busy slot degrades to the barrier.
+				if f, ok := eagerFeeds[depID]; ok && !eagerBroken {
 					select {
 					case <-ch:
-						eagerConsumerFeed = nil
-					case <-eagerConsumerFeed.dispatched:
-						select {
-						case <-ch:
-							eagerConsumerFeed = nil
-						case c.eagerStageSlot <- struct{}{}:
-							eagerActive = true
-						case <-gctx.Done():
-							return gctx.Err()
-						default:
-							// Slot busy: wait out the barrier as today.
-							select {
-							case <-ch:
-								eagerConsumerFeed = nil
-							case <-gctx.Done():
-								return gctx.Err()
-							}
-						}
+						eagerBroken = true
+					case <-f.dispatched:
 					case <-gctx.Done():
 						return gctx.Err()
 					}
@@ -465,14 +470,69 @@ func (c *Coordinator) executeStageDAG(
 					return gctx.Err()
 				}
 			}
+			// C2 join clearance: hold until both feeds cross the decision
+			// threshold (decisionReady always closes at or before producer
+			// completion, so this cannot outwait a healthy producer; a
+			// failed producer cancels gctx), then apply the projected skew
+			// decision. Would-split → barrier.
+			if !eagerBroken && eagerJoin {
+				numTasks := 1
+				if s.Distribution.Kind == physical.DistHashPartitioned {
+					numTasks = s.Distribution.Count
+					if numTasks <= 0 {
+						numTasks = workerCount
+					}
+				}
+				for _, f := range eagerFeeds {
+					select {
+					case <-f.decisionReady:
+					case <-gctx.Done():
+						return gctx.Err()
+					}
+				}
+				probeDep, buildDep := joinPrimaryDeps(s)
+				if c.eagerJoinWouldSplit(s, eagerFeeds[probeDep], eagerFeeds[buildDep], numTasks, workerCount) {
+					c.logger.Info("eager dispatch: projected skew split — keeping barrier",
+						"query", queryID, "stage_id", s.ID)
+					eagerBroken = true
+				}
+			}
+			// v1 producer-lane reservation: at most one eager stage in
+			// flight per coordinator. A busy slot degrades to the barrier.
+			eagerActive := false
+			if !eagerBroken {
+				select {
+				case c.eagerStageSlot <- struct{}{}:
+					eagerActive = true
+				default:
+				}
+			}
 			if eagerActive {
 				defer func() { <-c.eagerStageSlot }()
 				EagerEdgesPlanned.Add(1)
+				producerTasks := 0
+				for _, f := range eagerFeeds {
+					producerTasks += len(f.producerTaskIDs)
+				}
 				c.logger.Info("eager dispatch: consumer cleared early",
 					"query", queryID, "stage_id", s.ID, "stage_type", s.Type,
-					"producer_stage", s.Dependencies[0],
-					"producer_tasks", len(eagerConsumerFeed.producerTaskIDs),
-					"num_partitions", eagerConsumerFeed.numPartitions)
+					"eager_deps", len(eagerFeeds), "join", eagerJoin,
+					"producer_tasks", producerTasks)
+			} else if len(eagerFeeds) > 0 {
+				// Barrier fallback: wait out every eager dep's done signal
+				// (non-eager deps were already awaited above).
+				for depID := range eagerFeeds {
+					ch, tracked := done[depID]
+					if !tracked {
+						continue
+					}
+					select {
+					case <-ch:
+					case <-gctx.Done():
+						return gctx.Err()
+					}
+				}
+				eagerFeeds = map[string]*eagerFeed{}
 			}
 			// Late-bind any scalar subqueries: await each producer stage
 			// separately (producer IDs are NOT in Dependencies because
@@ -510,14 +570,26 @@ func (c *Coordinator) executeStageDAG(
 			var inputs map[string]StageOutput
 			var err error
 			if eagerActive {
-				// The producer is still running; its slot in `outputs` is
-				// empty. Synthesize the provisional output (empty layout,
-				// unknown bytes, feed attached) — dispatchComputeStage
-				// routes the alias through Task.EagerInputs. Eligibility
-				// guarantees this is the stage's only dependency.
-				inputs = map[string]StageOutput{
-					s.Dependencies[0]: eagerConsumerFeed.provisionalOutput(),
+				// Eager deps' producers are still running; their slots in
+				// `outputs` are empty. Synthesize provisional outputs (empty
+				// layout, unknown bytes, feed attached) — dispatchComputeStage
+				// routes those aliases through Task.EagerInputs. Non-eager
+				// deps (fused builds) completed above and use real outputs.
+				inputs = make(map[string]StageOutput, len(s.Dependencies))
+				outputsMu.Lock()
+				for _, depID := range s.Dependencies {
+					if f, ok := eagerFeeds[depID]; ok {
+						inputs[depID] = f.provisionalOutput()
+						continue
+					}
+					out, ok := outputs[depID]
+					if !ok {
+						outputsMu.Unlock()
+						return fmt.Errorf("stage %s: non-eager dependency %s has no recorded output", s.ID, depID)
+					}
+					inputs[depID] = out
 				}
+				outputsMu.Unlock()
 			} else {
 				outputsMu.Lock()
 				inputs, err = collectInputs(s, outputs)
@@ -2124,19 +2196,21 @@ func (c *Coordinator) dispatchComputeStage(
 		// Eager consumer dispatch: a provisional upstream (producer still
 		// running) feeds this task's alias from producer-task manifests
 		// (Task.EagerInputs) rather than the frozen — here empty — file
-		// list in taskInputs. C1 eligibility restricts eager clearance to
-		// single-dep non-join stages, so the alias is the dep's stage ID
-		// (buildTaskInputsForStage's default branch) and skew/probe-split
-		// slicing never applies. The partition range matches what the
-		// frozen path would bind for task w.
+		// list in taskInputs. Aliases must match buildTaskInputsForStage's
+		// convention (dep ID for single-input stages; build/probe aliases
+		// for joins — eagerAliasForDep). Skew/probe-split slicing never
+		// applies to eager stages (provisional accounting is nil and the
+		// eager clearance already ruled out a projected split), so the
+		// partition range matches what the frozen path would bind for
+		// task w.
 		for depID, in := range inputs {
 			if in.eager == nil {
 				continue
 			}
 			if t.EagerInputs == nil {
-				t.EagerInputs = make(map[string]distributed.EagerInput, 1)
+				t.EagerInputs = make(map[string]distributed.EagerInput, 2)
 			}
-			t.EagerInputs[depID] = in.eager.eagerInputForTask(w, numTasks)
+			t.EagerInputs[eagerAliasForDep(stage, depID)] = in.eager.eagerInputForTask(w, numTasks)
 		}
 		// Fused join + downstream exchange-sender: emit a fragment task
 		// pipeline that runs the entire chain in one worker call without
@@ -2328,6 +2402,40 @@ func (c *Coordinator) dispatchComputeStage(
 		}
 	}, c.logger, stage.ID, c.classifyFatalResult)
 	defer c.watchStuckTasks(ctx, retrier)()
+	// Eager stages with more tasks than the cluster can hold at once
+	// publish in governed waves: eager tasks block on producer manifests
+	// while HOLDING a worker slot, so a full join fan-out (numTasks =
+	// partition count) dispatched at once could occupy every slot ahead
+	// of the very producer tasks it waits on. Cap in-flight eager tasks
+	// at capacity − workerCount (≥ one producer lane per worker on
+	// average); top up as tasks reach terminal state. Never coexists
+	// with fusion (eligibility excludes the gather-fused stage).
+	publishNow := tasks
+	var governor *eagerPublishGovernor
+	if len(tasks) > 0 && len(tasks[0].EagerInputs) > 0 {
+		capacity := c.workers.ClusterCapacity()
+		eagerCap := workerCount // capacity unreported: assume ≥ 2 slots/worker
+		if capacity > 0 {
+			eagerCap = capacity - workerCount
+		}
+		publishNow, governor = newEagerPublishGovernor(tasks, eagerCap, func(t distributed.Task) {
+			if ctx.Err() != nil {
+				return
+			}
+			// Late-wave tasks get a current Replay snapshot — their
+			// original one was taken at task build, before earlier waves'
+			// producers reported.
+			refreshEagerReplay(&t, inputs)
+			if pubErr := c.scheduler.PublishTasks(ctx, []distributed.Task{t}); pubErr != nil {
+				c.logger.Error("eager wave publish failed",
+					"stage_id", stage.ID, "task_id", t.ID, "error", pubErr)
+			}
+		})
+		if governor != nil {
+			c.logger.Info("eager dispatch: governed waves",
+				"stage_id", stage.ID, "tasks", len(tasks), "in_flight_cap", eagerCap)
+		}
+	}
 	sub, err := c.subscribeTaskResults(subject, func(msg *nats.Msg) {
 		var r distributed.ResultNotification
 		if err := distributed.Unmarshal(msg.Data, &r); err != nil {
@@ -2335,6 +2443,11 @@ func (c *Coordinator) dispatchComputeStage(
 		}
 		c.noteTaskResult(r)
 		allDone := retrier.Observe(r)
+		if governor != nil && retrier.IsTerminal(r.TaskID) {
+			// Off the subscription goroutine: the top-up publish flushes
+			// NATS, same as the retry republish path.
+			go governor.noteTerminal(r.TaskID)
+		}
 		select {
 		case progress <- struct{}{}:
 		default:
@@ -2363,7 +2476,7 @@ func (c *Coordinator) dispatchComputeStage(
 	if fusion != nil {
 		fusion.recv.SetExpectedTerminals(len(tasks))
 	}
-	if err := c.scheduler.PublishTasks(ctx, tasks); err != nil {
+	if err := c.scheduler.PublishTasks(ctx, publishNow); err != nil {
 		return StageOutput{}, fmt.Errorf("stage %s: publish: %w", stage.ID, err)
 	}
 

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -259,6 +259,9 @@ func (c *Coordinator) executeStageDAG(
 		c.tracker.Complete(queryID)
 		c.cleanupQuery(queryID)
 	}()
+	// Drop this query's eager feeds (stops manifest republishers). No-op
+	// when eager dispatch is off or the plan registered none.
+	defer c.dropEagerFeeds(queryID)
 
 	// Separate the terminal Gather from the DAG body: Gather is always run
 	// last, on the coordinator's NATS reply subscription, and returns the
@@ -403,6 +406,18 @@ func (c *Coordinator) executeStageDAG(
 	for _, s := range pending {
 		s := s
 		g.Go(func() error {
+			// Eager consumer dispatch (docs/design/eager-consumer-dispatch.md
+			// §3.3): an eligible consumer may clear on its producer's feed
+			// (task layout fixed, manifests flowing) instead of the done
+			// barrier. The feed handle is get-or-create so it exists before
+			// the producer's dispatcher fills it in; a producer that never
+			// dispatches (empty upstream, non-shuffle path) leaves the feed
+			// inert and the done case fires as before.
+			var eagerConsumerFeed *eagerFeed
+			if c.config.EagerDispatch && eagerEligibleConsumer(s, stageByID, fuseStageID, workerCount) {
+				eagerConsumerFeed = c.eagerFeedHandle(queryID, s.Dependencies[0])
+			}
+			eagerActive := false
 			// Wait on each dependency's done signal. Deps not in the
 			// `done` map are leaf stages / pre-computed outputs (e.g.,
 			// the coordinator's initial inputs) and are treated as
@@ -412,11 +427,52 @@ func (c *Coordinator) executeStageDAG(
 				if !tracked {
 					continue
 				}
+				if eagerConsumerFeed != nil {
+					// Race the barrier against eager clearance. If the
+					// producer finishes first (or wins the select while
+					// both are ready), take the barrier path — it has the
+					// real output. Eager clearance additionally requires
+					// the coordinator-wide eager slot (v1 producer-lane
+					// reservation); a busy slot degrades to the barrier.
+					select {
+					case <-ch:
+						eagerConsumerFeed = nil
+					case <-eagerConsumerFeed.dispatched:
+						select {
+						case <-ch:
+							eagerConsumerFeed = nil
+						case c.eagerStageSlot <- struct{}{}:
+							eagerActive = true
+						case <-gctx.Done():
+							return gctx.Err()
+						default:
+							// Slot busy: wait out the barrier as today.
+							select {
+							case <-ch:
+								eagerConsumerFeed = nil
+							case <-gctx.Done():
+								return gctx.Err()
+							}
+						}
+					case <-gctx.Done():
+						return gctx.Err()
+					}
+					continue
+				}
 				select {
 				case <-ch:
 				case <-gctx.Done():
 					return gctx.Err()
 				}
+			}
+			if eagerActive {
+				defer func() { <-c.eagerStageSlot }()
+				EagerEdgesPlanned.Add(1)
+				c.logger.Info("eager dispatch: consumer cleared early",
+					"query", queryID, "stage_id", s.ID, "stage_type", s.Type,
+					"producer_stage", s.Dependencies[0],
+					"producer_tasks", len(eagerConsumerFeed.producerTaskIDs),
+					"num_partitions", eagerConsumerFeed.numPartitions)
 			}
 			// Late-bind any scalar subqueries: await each producer stage
 			// separately (producer IDs are NOT in Dependencies because
@@ -451,11 +507,24 @@ func (c *Coordinator) executeStageDAG(
 					return fmt.Errorf("stage %s scalar substitution: %w", s.ID, subErr)
 				}
 			}
-			outputsMu.Lock()
-			inputs, err := collectInputs(s, outputs)
-			outputsMu.Unlock()
-			if err != nil {
-				return fmt.Errorf("stage %s collect inputs: %w", s.ID, err)
+			var inputs map[string]StageOutput
+			var err error
+			if eagerActive {
+				// The producer is still running; its slot in `outputs` is
+				// empty. Synthesize the provisional output (empty layout,
+				// unknown bytes, feed attached) — dispatchComputeStage
+				// routes the alias through Task.EagerInputs. Eligibility
+				// guarantees this is the stage's only dependency.
+				inputs = map[string]StageOutput{
+					s.Dependencies[0]: eagerConsumerFeed.provisionalOutput(),
+				}
+			} else {
+				outputsMu.Lock()
+				inputs, err = collectInputs(s, outputs)
+				outputsMu.Unlock()
+				if err != nil {
+					return fmt.Errorf("stage %s collect inputs: %w", s.ID, err)
+				}
 			}
 			// Acquire a dispatch slot now that we have inputs and are
 			// about to publish tasks. Held until the stage completes so
@@ -813,7 +882,12 @@ func (c *Coordinator) dispatchShuffleStage(
 	// Forward any dynamic-filter specs the upstream (probe-side) leaf scan
 	// resolved through pass-through. Each shuffle task gets a copy so its
 	// parquet scan applies the bloom at row-group level.
-	shards, shardStats, err := c.runShuffleSide(ctx, queryID, "stage-"+stage.ID, synthetic, stage.Exchange.Keys, numParts, workerCount, upstream.DynamicFilters)
+	//
+	// Eager dispatch: hand runShuffleSide this stage's feed so eligible
+	// consumers can clear their barrier once the shuffle tasks are built.
+	// nil when the flag is off. The empty-source early return above never
+	// dispatches the feed — consumers just fall through on done[dep].
+	shards, shardStats, err := c.runShuffleSide(ctx, queryID, "stage-"+stage.ID, synthetic, stage.Exchange.Keys, numParts, workerCount, upstream.DynamicFilters, c.eagerFeedHandle(queryID, stage.ID))
 	if err != nil {
 		return StageOutput{}, err
 	}
@@ -2047,6 +2121,23 @@ func (c *Coordinator) dispatchComputeStage(
 			// Q18 ignoring `HAVING SUM(l_quantity) > 300`.
 			PostFilterExprs: append([]string(nil), stage.FilterExprs...),
 		}
+		// Eager consumer dispatch: a provisional upstream (producer still
+		// running) feeds this task's alias from producer-task manifests
+		// (Task.EagerInputs) rather than the frozen — here empty — file
+		// list in taskInputs. C1 eligibility restricts eager clearance to
+		// single-dep non-join stages, so the alias is the dep's stage ID
+		// (buildTaskInputsForStage's default branch) and skew/probe-split
+		// slicing never applies. The partition range matches what the
+		// frozen path would bind for task w.
+		for depID, in := range inputs {
+			if in.eager == nil {
+				continue
+			}
+			if t.EagerInputs == nil {
+				t.EagerInputs = make(map[string]distributed.EagerInput, 1)
+			}
+			t.EagerInputs[depID] = in.eager.eagerInputForTask(w, numTasks)
+		}
 		// Fused join + downstream exchange-sender: emit a fragment task
 		// pipeline that runs the entire chain in one worker call without
 		// writing the join output to S3 only to immediately re-read+hash
@@ -2225,6 +2316,12 @@ func (c *Coordinator) dispatchComputeStage(
 		if ctx.Err() != nil {
 			return
 		}
+		// Eager consumers: retries are otherwise verbatim, but a stale
+		// Replay list would make the retried task wait on the republisher
+		// for manifests published since the original build (fencing
+		// recovery depends on the retry seeing the stable attempt set
+		// promptly). Refresh from the feed at re-dispatch.
+		refreshEagerReplay(&t, inputs)
 		if pubErr := c.scheduler.PublishTasks(ctx, []distributed.Task{t}); pubErr != nil {
 			c.logger.Error("task retry publish failed",
 				"stage_id", stage.ID, "task_id", t.ID, "error", pubErr)

--- a/internal/coordinator/orchestrate_repartition.go
+++ b/internal/coordinator/orchestrate_repartition.go
@@ -262,6 +262,10 @@ func (c *Coordinator) runShuffleSide(
 				"side", sideName, "task_id", t.ID, "error", pubErr)
 		}
 	}, c.logger, stageID, c.classifyFatalResult)
+	if len(tasks) > 0 {
+		t0 := tasks[0]
+		retrier.onSuccess = c.eagerManifestPublisher(distributed.TaskRootQueryID(&t0), stageID)
+	}
 	defer c.watchStuckTasks(ctx, retrier)()
 
 	sub, err := c.subscribeTaskResults(subject, func(msg *nats.Msg) {

--- a/internal/coordinator/orchestrate_repartition.go
+++ b/internal/coordinator/orchestrate_repartition.go
@@ -283,7 +283,7 @@ func (c *Coordinator) runShuffleSide(
 			ids[i] = tasks[i].ID
 		}
 		t0 := tasks[0]
-		eagerFeed.dispatch(distributed.TaskRootQueryID(&t0), stageID, ids, numParts)
+		eagerFeed.dispatch(distributed.TaskRootQueryID(&t0), stageID, ids, numParts, workerCount)
 		c.startEagerRepublisher(eagerFeed)
 	}
 	defer c.watchStuckTasks(ctx, retrier)()

--- a/internal/coordinator/orchestrate_repartition.go
+++ b/internal/coordinator/orchestrate_repartition.go
@@ -103,7 +103,7 @@ func (c *Coordinator) orchestrateRepartition(
 	g, gctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		shards, stats, err := c.runShuffleSide(gctx, queryID, "build", buildStage, cand.BuildKeys, numParts, workerCount, nil)
+		shards, stats, err := c.runShuffleSide(gctx, queryID, "build", buildStage, cand.BuildKeys, numParts, workerCount, nil, nil)
 		if err != nil {
 			return fmt.Errorf("build-side shuffle for %s: %w", cand.BuildAlias, err)
 		}
@@ -112,7 +112,7 @@ func (c *Coordinator) orchestrateRepartition(
 	})
 
 	g.Go(func() error {
-		shards, stats, err := c.runShuffleSide(gctx, queryID, "probe", probeStage, cand.ProbeKeys, numParts, workerCount, nil)
+		shards, stats, err := c.runShuffleSide(gctx, queryID, "probe", probeStage, cand.ProbeKeys, numParts, workerCount, nil, nil)
 		if err != nil {
 			return fmt.Errorf("probe-side shuffle for %s: %w", cand.ProbeAlias, err)
 		}
@@ -154,6 +154,12 @@ type shuffleSideStats struct {
 // numParts outputs. Waits for all tasks. Returns shardFiles[p] = slice of
 // S3 keys for partition p (concatenated from each task's per-partition
 // output) plus the worker-reported output accounting.
+//
+// eagerFeed, when non-nil (native-DAG dispatchShuffleStage under
+// --eager-dispatch), is dispatched with the task layout right before
+// publish so eligible consumer stages can clear their barrier and start
+// consuming per-task manifests. The legacy orchestrateRepartition path
+// passes nil — its consumers are built from the completed ShuffleLayout.
 func (c *Coordinator) runShuffleSide(
 	ctx context.Context,
 	parentQueryID string,
@@ -163,6 +169,7 @@ func (c *Coordinator) runShuffleSide(
 	numParts int,
 	workerCount int,
 	dynamicFilters []distributed.DynamicFilterSpec, // resolved bloom/range pushdowns from upstream build stat
+	eagerFeed *eagerFeed,
 ) ([][]string, shuffleSideStats, error) {
 	ctx, cancel := context.WithTimeout(ctx, shuffleStageTimeout)
 	defer cancel()
@@ -264,7 +271,20 @@ func (c *Coordinator) runShuffleSide(
 	}, c.logger, stageID, c.classifyFatalResult)
 	if len(tasks) > 0 {
 		t0 := tasks[0]
-		retrier.onSuccess = c.eagerManifestPublisher(distributed.TaskRootQueryID(&t0), stageID)
+		retrier.onSuccess = c.eagerManifestPublisher(distributed.TaskRootQueryID(&t0), stageID, eagerFeed)
+	}
+	// Release eligible consumers: with the task layout fixed (IDs stable
+	// across retries, partition count final), consumers can bind their
+	// partition ranges and start draining manifests. Dispatch before
+	// publish so no completion can beat the feed.
+	if eagerFeed != nil && retrier.onSuccess != nil {
+		ids := make([]string, len(tasks))
+		for i := range tasks {
+			ids[i] = tasks[i].ID
+		}
+		t0 := tasks[0]
+		eagerFeed.dispatch(distributed.TaskRootQueryID(&t0), stageID, ids, numParts)
+		c.startEagerRepublisher(eagerFeed)
 	}
 	defer c.watchStuckTasks(ctx, retrier)()
 

--- a/internal/coordinator/scheduler.go
+++ b/internal/coordinator/scheduler.go
@@ -51,6 +51,16 @@ type Scheduler struct {
 	inflightMu sync.Mutex
 	inflight   map[string]inflightTask // task ID → estimate charged to a worker
 
+	// eagerInflight tracks dispatched-not-yet-done eager consumer tasks
+	// (Task.EagerInputs non-empty) per worker, for the §3.3 producer-lane
+	// reservation: pickEagerWorker spreads these so no worker's task slots
+	// fill up with manifest-blocked consumers while its producer tasks
+	// queue behind them (dispatch is targeted gRPC — a saturated worker's
+	// queue cannot be stolen). Long TTL: eager tasks legitimately run for
+	// the whole producer stage, so the 60s estimate TTL would drop the
+	// charge mid-flight.
+	eagerInflight map[string]inflightTask // task ID → worker holding an eager task
+
 	// annotate, when set, mutates each task immediately before it is
 	// serialized for dispatch — the single egress every task (initial and
 	// retried) passes through. Used by streaming exchange to attach
@@ -63,8 +73,19 @@ func NewScheduler(nc *nats.Conn, logger *slog.Logger) *Scheduler {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Scheduler{nc: nc, logger: logger, inflight: make(map[string]inflightTask)}
+	return &Scheduler{
+		nc:            nc,
+		logger:        logger,
+		inflight:      make(map[string]inflightTask),
+		eagerInflight: make(map[string]inflightTask),
+	}
 }
+
+// eagerInflightTTL bounds how long an eager consumer task counts against
+// its worker in pickEagerWorker. Sized to the stage idle timeout — an
+// eager task can legitimately wait most of its producer stage's lifetime.
+// Result arrival clears the entry early via TaskDone.
+const eagerInflightTTL = 30 * time.Minute
 
 // SetDataPlaneServer enables gRPC task dispatch. When set, PublishTasks
 // pushes through the data-plane server instead of NATS publish.
@@ -92,6 +113,7 @@ func (s *Scheduler) SetTaskAnnotator(fn func(*distributed.Task)) {
 func (s *Scheduler) TaskDone(taskID string) {
 	s.inflightMu.Lock()
 	delete(s.inflight, taskID)
+	delete(s.eagerInflight, taskID)
 	s.inflightMu.Unlock()
 }
 
@@ -203,13 +225,90 @@ func (s *Scheduler) publishViaDataPlane(batch []preparedTask, deadlineNano int64
 // of 0 deliberately round-robin: with no per-task charge, "most free"
 // would be static between heartbeats and pile every task of a fan-out
 // onto one worker.
+//
+// Eager consumer tasks take their own placement path first: they can
+// block on producer manifests for the whole producer stage, so stacking
+// them on one worker starves that worker's producer lanes (targeted gRPC
+// dispatch has no work stealing).
 func (s *Scheduler) pickWorkerFor(t distributed.Task) (string, bool) {
+	if len(t.EagerInputs) > 0 {
+		if id, ok := s.pickEagerWorker(); ok {
+			return id, true
+		}
+	}
 	if t.EstimatedBytes > 0 && s.registry != nil {
 		if id, ok := s.pickLeastLoaded(); ok {
 			return id, true
 		}
 	}
 	return s.dpSrv.PickWorker()
+}
+
+// pickEagerWorker places one eager consumer task: the connected worker
+// with the fewest in-flight eager tasks, preferring workers that keep at
+// least one non-eager lane free (in-flight eager + this one ≤
+// MaxConcurrent − 1 — the memo §3.3 producer-lane reservation). When no
+// worker satisfies the reservation (tiny MaxConcurrent, missing stats),
+// min-count placement still bounds the stacking; the coordinator-wide
+// one-eager-stage slot plus numTasks ≤ workerCount eligibility keep the
+// total at one per worker in practice. ok=false when no worker is
+// connected (caller falls through to round-robin's error handling).
+func (s *Scheduler) pickEagerWorker() (string, bool) {
+	connected := s.dpSrv.ConnectedWorkers()
+	if len(connected) == 0 {
+		return "", false
+	}
+	maxConc := make(map[string]int)
+	if s.registry != nil {
+		for _, w := range s.registry.ActiveWorkers() {
+			maxConc[w.WorkerID] = w.MaxConcurrent
+		}
+	}
+	return pickEagerWorkerFrom(connected, maxConc, s.eagerInflightByWorker())
+}
+
+// pickEagerWorkerFrom is pickEagerWorker's pure scoring core: min in-flight
+// eager count over connected workers, first pass restricted to workers with
+// a spare non-eager lane (count+1 ≤ MaxConcurrent−1), second pass
+// unrestricted so dispatch never fails on reservation grounds alone.
+func pickEagerWorkerFrom(connected []string, maxConc, counts map[string]int) (string, bool) {
+	pick := func(requireLane bool) (string, bool) {
+		bestID, bestCount, found := "", 0, false
+		for _, id := range connected {
+			n := counts[id]
+			if requireLane {
+				mc := maxConc[id]
+				if mc <= 0 || n+1 > mc-1 {
+					continue
+				}
+			}
+			if !found || n < bestCount {
+				bestID, bestCount, found = id, n, true
+			}
+		}
+		return bestID, found
+	}
+	if id, ok := pick(true); ok {
+		return id, true
+	}
+	return pick(false)
+}
+
+// eagerInflightByWorker counts live eager tasks per worker, lazily
+// expiring stale entries.
+func (s *Scheduler) eagerInflightByWorker() map[string]int {
+	s.inflightMu.Lock()
+	defer s.inflightMu.Unlock()
+	now := time.Now()
+	perWorker := make(map[string]int)
+	for id, e := range s.eagerInflight {
+		if now.After(e.expires) {
+			delete(s.eagerInflight, id)
+			continue
+		}
+		perWorker[e.workerID]++
+	}
+	return perWorker
 }
 
 // pickLeastLoaded returns the connected worker with the most free shared
@@ -266,8 +365,17 @@ func (s *Scheduler) inflightByWorker() map[string]int64 {
 
 // noteInflight charges a dispatched task's estimate to its worker until
 // the result arrives (TaskDone) or the TTL hands accounting off to the
-// worker's heartbeat PoolUsed.
+// worker's heartbeat PoolUsed. Eager consumer tasks are additionally
+// tracked (regardless of estimate) for pickEagerWorker's lane accounting.
 func (s *Scheduler) noteInflight(t distributed.Task, workerID string) {
+	if len(t.EagerInputs) > 0 {
+		s.inflightMu.Lock()
+		s.eagerInflight[t.ID] = inflightTask{
+			workerID: workerID,
+			expires:  time.Now().Add(eagerInflightTTL),
+		}
+		s.inflightMu.Unlock()
+	}
 	if t.EstimatedBytes <= 0 {
 		return
 	}

--- a/internal/coordinator/stage_output.go
+++ b/internal/coordinator/stage_output.go
@@ -61,6 +61,14 @@ type StageOutput struct {
 	// descriptors so workers apply the bloom at scan time. Carries forward
 	// across pass-through leaf scans that don't dispatch tasks themselves.
 	DynamicFilters []distributed.DynamicFilterSpec
+
+	// eager marks a PROVISIONAL output synthesized by an eagerly-cleared
+	// consumer (eagerFeed.provisionalOutput): the producer stage is still
+	// running, Files is the empty layout, and dispatchComputeStage must
+	// feed the corresponding input alias from Task.EagerInputs manifests
+	// instead of a frozen file list. nil on every real (completed-stage)
+	// output. In-memory only — never serialized.
+	eager *eagerFeed
 }
 
 // BuildStats is the coordinator-merged dynamic-filter artifact for one

--- a/internal/coordinator/task_retry.go
+++ b/internal/coordinator/task_retry.go
@@ -53,9 +53,11 @@ type taskRetrier struct {
 	// onSuccess, when non-nil, fires once per task as it reaches a
 	// successful terminal state (eager consumer dispatch publishes the
 	// producer-task manifest from it). Invoked OUTSIDE the retrier lock;
-	// final is true for the stage's last terminal task. Must be assigned
-	// before the retrier starts observing results.
-	onSuccess func(taskID string, attempt int, files []string, workerID string, final bool)
+	// final is true for the stage's last terminal task; partBytes is the
+	// worker-reported per-partition output vector (nil when unreported) —
+	// the eager feed accumulates it for the early skew decision (memo §6).
+	// Must be assigned before the retrier starts observing results.
+	onSuccess func(taskID string, attempt int, files []string, workerID string, final bool, partBytes []int64)
 }
 
 // inputLostMarker tags terminal failures caused by an unresolvable
@@ -135,7 +137,7 @@ func (tr *taskRetrier) Observe(r distributed.ResultNotification) (allDone bool) 
 		onSuccess := tr.onSuccess
 		tr.mu.Unlock()
 		if onSuccess != nil {
-			onSuccess(r.TaskID, attempt, r.ResultFiles, r.WorkerID, done)
+			onSuccess(r.TaskID, attempt, r.ResultFiles, r.WorkerID, done, r.PartitionBytes)
 		}
 		return done
 	}
@@ -198,6 +200,17 @@ func (tr *taskRetrier) Terminal() int {
 	tr.mu.Lock()
 	defer tr.mu.Unlock()
 	return tr.terminal
+}
+
+// IsTerminal reports whether one task has reached a terminal state
+// (success, or failure with retries exhausted). The eager publish governor
+// uses it to distinguish a freed worker slot (terminal) from a
+// failure-then-retry, which re-occupies the slot.
+func (tr *taskRetrier) IsTerminal(taskID string) bool {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	st, ok := tr.states[taskID]
+	return ok && st.terminal
 }
 
 // FirstError returns the first terminal failure in dispatch order, if any.

--- a/internal/coordinator/task_retry.go
+++ b/internal/coordinator/task_retry.go
@@ -49,6 +49,13 @@ type taskRetrier struct {
 	// missing-input failures whose producer is dead with no durable copy
 	// (ErrInputLost) — a state no re-dispatch can fix.
 	fatal func(distributed.ResultNotification) bool
+
+	// onSuccess, when non-nil, fires once per task as it reaches a
+	// successful terminal state (eager consumer dispatch publishes the
+	// producer-task manifest from it). Invoked OUTSIDE the retrier lock;
+	// final is true for the stage's last terminal task. Must be assigned
+	// before the retrier starts observing results.
+	onSuccess func(taskID string, attempt int, files []string, workerID string, final bool)
 }
 
 // inputLostMarker tags terminal failures caused by an unresolvable
@@ -124,7 +131,12 @@ func (tr *taskRetrier) Observe(r distributed.ResultNotification) (allDone bool) 
 		st.terminal = true
 		tr.terminal++
 		done := tr.terminal >= len(tr.order)
+		attempt := st.attempts
+		onSuccess := tr.onSuccess
 		tr.mu.Unlock()
+		if onSuccess != nil {
+			onSuccess(r.TaskID, attempt, r.ResultFiles, r.WorkerID, done)
+		}
 		return done
 	}
 	// Failure: retry if attempts remain, else terminal failure. A

--- a/internal/coordinator/task_retry_test.go
+++ b/internal/coordinator/task_retry_test.go
@@ -1,12 +1,14 @@
 package coordinator
 
 import (
+	"errors"
 	"log/slog"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/worker"
 )
 
 func retryTestTasks(n int) []distributed.Task {
@@ -386,5 +388,43 @@ func TestTaskRetrier_PartitionAccountingUnreported(t *testing.T) {
 	rows, bytes := tr.PartitionAccounting(4)
 	if rows != nil || bytes != nil {
 		t.Fatalf("want nil vectors for unreported tasks, got rows=%v bytes=%v", rows, bytes)
+	}
+}
+
+// TestTaskRetrier_StaleInputAttemptRetries pins the Phase C1 slice-4
+// classification contract (docs/design/eager-consumer-dispatch.md §5): a
+// consumer task that poisons itself on a superseded producer attempt
+// (worker.StaleInputAttemptMarker in the failure text, NO MissingInputKey)
+// is RETRIABLE — it takes the standard re-dispatch path, unlike the
+// inputLostMarker family, which is terminal via the fatal classifier. By
+// the retry the producer attempt set is stable, so attempt 2 succeeds.
+func TestTaskRetrier_StaleInputAttemptRetries(t *testing.T) {
+	// The coordinator's real fatal classifier: peerFiles set (streaming
+	// exchange on) but the stale-attempt failure carries no
+	// MissingInputKey, so it must never classify fatal.
+	c := newEagerTestCoordinator(true)
+	staleErr := worker.StaleInputAttemptMarker + ": producer task p1 attempt 2 superseded consumed attempt 1"
+	stale := distributed.ResultNotification{TaskID: "a", Success: false, Error: staleErr}
+	if c.classifyFatalResult(stale) {
+		t.Fatal("stale-attempt failure must not classify fatal")
+	}
+	if IsInputLostErr(errors.New(staleErr)) {
+		t.Fatal("stale-attempt marker must not match the input-lost family (that path disables streaming exchange for a full rerun)")
+	}
+
+	rep := &collectingRepublisher{}
+	tr := newTaskRetrier(retryTestTasks(1), true, rep.republish, slog.Default(), "s", c.classifyFatalResult)
+	if tr.Observe(stale) {
+		t.Fatal("stale-attempt failure with retries left must not be terminal")
+	}
+	got := waitRepublished(t, rep, 1)
+	if got[0].Attempt != 2 {
+		t.Fatalf("republished attempt = %d, want 2", got[0].Attempt)
+	}
+	if !tr.Observe(okResult("a", "f-a2")) {
+		t.Fatal("not done after retry success")
+	}
+	if _, _, failed := tr.FirstError(); failed {
+		t.Fatal("stale-attempt retry must recover cleanly")
 	}
 }

--- a/internal/distributed/messages.go
+++ b/internal/distributed/messages.go
@@ -510,6 +510,23 @@ type UploadComplete struct {
 	Failed bool `json:"failed,omitempty"`
 }
 
+// ProducerTaskManifest announces one completed producer task's shuffle
+// output files to eagerly-dispatched consumers (docs/design/
+// eager-consumer-dispatch.md §3.1). Published by the coordinator on
+// EagerManifestSubject(root, stage) as each producer task reaches a
+// successful terminal state; metadata only.
+type ProducerTaskManifest struct {
+	StageID  string   `json:"stage_id"`
+	TaskID   string   `json:"task_id"`
+	Attempt  int      `json:"attempt"` // attempt fencing (memo §5)
+	Files    []string `json:"files"`   // keys that EXIST (empty partitions absent)
+	WorkerID string   `json:"worker_id"`
+	// Final marks the manifest of the producer stage's last terminal
+	// task; a consumer that has resolved every candidate and seen Final
+	// may EOF its manifest feed.
+	Final bool `json:"final,omitempty"`
+}
+
 // TaskStats captures per-task execution metrics for debugging.
 type TaskStats struct {
 	MemUsed       int64          `json:"mem_used"`                 // memory tracker usage at completion

--- a/internal/distributed/messages.go
+++ b/internal/distributed/messages.go
@@ -188,6 +188,13 @@ type Task struct {
 	// hints. Only populated when the coordinator runs --streaming-exchange.
 	InputLocations map[string]string `json:"input_locations,omitempty"`
 
+	// EagerInputs maps an input alias to its eager manifest-feed
+	// descriptor (docs/design/eager-consumer-dispatch.md). When an alias
+	// appears here, the worker builds a manifest-fed source for it
+	// instead of consuming a frozen file list; other aliases of the same
+	// task keep their explicit Inputs entries.
+	EagerInputs map[string]EagerInput `json:"eager_inputs,omitempty"`
+
 	// FetchToken authorizes peer-exchange fetches for this task's query.
 	// Producers record it (to validate incoming FetchShuffle requests
 	// against); consumers present it. Minted per QueryID by the
@@ -521,10 +528,29 @@ type ProducerTaskManifest struct {
 	Attempt  int      `json:"attempt"` // attempt fencing (memo §5)
 	Files    []string `json:"files"`   // keys that EXIST (empty partitions absent)
 	WorkerID string   `json:"worker_id"`
+	// PeerAddr is the producing worker's peer-exchange address, resolved
+	// by the coordinator at publish time. Empty when the worker is not
+	// serving peer fetches — consumers fall through to S3 as always.
+	PeerAddr string `json:"peer_addr,omitempty"`
 	// Final marks the manifest of the producer stage's last terminal
 	// task; a consumer that has resolved every candidate and seen Final
 	// may EOF its manifest feed.
 	Final bool `json:"final,omitempty"`
+}
+
+// EagerInput describes one eagerly-fed input alias of a consumer task
+// (docs/design/eager-consumer-dispatch.md §3.2): the full candidate set
+// is nameable at dispatch (deterministic shuffle keys); existence and
+// location stream in as ProducerTaskManifests. Replay carries manifests
+// already published before this task was built, so the subscribe-then-
+// replay contract never loses a completion.
+type EagerInput struct {
+	RootQueryID     string                `json:"root_query_id"`
+	StageID         string                `json:"stage_id"` // producer stage
+	ProducerTaskIDs []string              `json:"producer_task_ids"`
+	PartitionStart  int                   `json:"partition_start"` // inclusive
+	PartitionEnd    int                   `json:"partition_end"`   // inclusive
+	Replay          []ProducerTaskManifest `json:"replay,omitempty"`
 }
 
 // TaskStats captures per-task execution metrics for debugging.

--- a/internal/distributed/subjects.go
+++ b/internal/distributed/subjects.go
@@ -35,6 +35,13 @@ const (
 	// coordinator stays conservative about them.
 	SubjectUploadComplete = "wadjet.uploads.complete"
 
+	// Eager consumer dispatch (docs/design/eager-consumer-dispatch.md) —
+	// Core NATS. Coordinator republishes a compact per-producer-task file
+	// manifest as each task of an eager edge completes; consumer tasks'
+	// manifest sources subscribe per (root query, producer stage).
+	// Metadata-only; payload bytes never flow through these subjects.
+	SubjectEagerManifest = "wadjet.eager"
+
 	// Query cancellation — Core NATS
 	SubjectCancel = "wadjet.cancel"
 
@@ -128,4 +135,13 @@ func CompleteSubjectAll() string {
 // via wildcard by the coordinator.
 func TaskProgressSubject(queryID, taskID string) string {
 	return SubjectTaskProgress + "." + queryID + "." + taskID
+}
+
+// EagerManifestSubject returns the NATS subject on which the coordinator
+// publishes ProducerTaskManifest messages for one producer stage of one
+// root query. Consumer tasks subscribe with the exact subject (no
+// wildcard); root and stage IDs are sanitized to NATS token characters
+// by construction (UUIDs / stage-N names).
+func EagerManifestSubject(rootQueryID, stageID string) string {
+	return SubjectEagerManifest + "." + rootQueryID + "." + stageID
 }

--- a/internal/storage/objstore/circuit.go
+++ b/internal/storage/objstore/circuit.go
@@ -139,6 +139,22 @@ func (cs *CircuitStore) onSuccess() {
 }
 
 func (cs *CircuitStore) onFailure(err error) {
+	// Client-side aborts are not S3 health signals. The worker cancels a
+	// terminal query's pending async uploads BY DESIGN (streaming
+	// exchange: uploadManager.CancelQuery fires on every query
+	// complete/cancel broadcast) — under mid-day S3 PUT latency a query
+	// boundary can cancel 5+ queued uploads back-to-back, which counted
+	// here as consecutive "failures", opened the breaker on every worker
+	// simultaneously, and made the NEXT query's healthy GETs fast-fail
+	// for the whole 30 s reset window (SF100 2026-07-12: Q21/Q22 —
+	// occasionally Q03 — failed terminally after their retries burned
+	// into the still-open breaker). context.Canceled can only come from
+	// our own callers; S3 slowness surfaces as DeadlineExceeded or
+	// transport errors, which still count.
+	if errors.Is(err, context.Canceled) {
+		return
+	}
+
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
 

--- a/internal/storage/objstore/circuit_test.go
+++ b/internal/storage/objstore/circuit_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -122,5 +123,64 @@ func TestCircuitStore_StateString(t *testing.T) {
 		if got := state.String(); got != want {
 			t.Errorf("State(%d).String() = %q, want %q", state, got, want)
 		}
+	}
+}
+
+// canceledPutStore fails Put with a (wrapped) context.Canceled — the shape
+// the worker's uploadManager.CancelQuery produces when it aborts a terminal
+// query's pending async uploads.
+type canceledPutStore struct {
+	*MemStore
+	realErrs int // Puts returning a genuine error after the canceled ones
+	calls    int
+}
+
+func (c *canceledPutStore) Put(ctx context.Context, bucket, key string, r io.Reader, size int64, contentType string) (string, error) {
+	c.calls++
+	if c.realErrs > 0 && c.calls > 8 {
+		c.realErrs--
+		return "", errors.New("simulated S3 500")
+	}
+	if c.calls <= 8 {
+		return "", fmt.Errorf("putting object: %w", context.Canceled)
+	}
+	return c.MemStore.Put(ctx, bucket, key, r, size, contentType)
+}
+
+// TestCircuitStore_CanceledDoesNotTrip is the regression for the SF100
+// 2026-07-12 incident: query-boundary upload cancellations (context.Canceled
+// from OUR OWN CancelQuery, not S3) counted as consecutive failures, opened
+// the breaker on every worker at once, and the next query's healthy reads
+// fast-failed for the 30 s reset window — Q21/Q22 (sometimes Q03) failed
+// terminally once their instant retries burned into the open breaker.
+// Client-side aborts must not move the breaker; real errors still must.
+func TestCircuitStore_CanceledDoesNotTrip(t *testing.T) {
+	ps := &canceledPutStore{MemStore: NewMemStore(), realErrs: 3}
+	ctx := context.Background()
+	ps.MakeBucket(ctx, "b")
+
+	cfg := DefaultCircuitConfig()
+	cfg.FailureThreshold = 3
+	cs := NewCircuitStore(ps, cfg, nil)
+
+	// 8 canceled Puts — far past the threshold — must leave the breaker
+	// closed: cancellation says nothing about S3 health.
+	for i := 0; i < 8; i++ {
+		if _, err := cs.Put(ctx, "b", "k", bytes.NewReader([]byte("x")), 1, ""); !errors.Is(err, context.Canceled) {
+			t.Fatalf("put %d: want context.Canceled, got %v", i, err)
+		}
+	}
+	if cs.State() != CircuitClosed {
+		t.Fatalf("breaker must stay closed through canceled puts, got %s", cs.State())
+	}
+
+	// Genuine errors still count and open the breaker at the threshold.
+	for i := 0; i < 3; i++ {
+		if _, err := cs.Put(ctx, "b", "k", bytes.NewReader([]byte("x")), 1, ""); err == nil {
+			t.Fatalf("real-error put %d: want error", i)
+		}
+	}
+	if cs.State() != CircuitOpen {
+		t.Fatalf("breaker must open on real consecutive failures, got %s", cs.State())
 	}
 }

--- a/internal/worker/executor_fragment.go
+++ b/internal/worker/executor_fragment.go
@@ -1694,7 +1694,13 @@ func (e *Executor) buildFragmentJoinProbe(ctx context.Context, task distributed.
 	if len(spec.LeftKeys) == 0 || len(spec.RightKeys) == 0 {
 		return nil, nil, fmt.Errorf("hash_join_probe: LeftKeys and RightKeys required")
 	}
-	if len(spec.BuildFiles) == 0 {
+	// Eager consumer dispatch: a build alias registered in task.EagerInputs
+	// is fed by producer-task manifests — its BuildFiles is empty BY
+	// CONSTRUCTION, so the empty-build short-circuit below must not fire
+	// (it silently emitted zero join rows, the build-side twin of the
+	// executeFragment empty-InputFiles bug the C1 e2e caught).
+	eagerBuild, buildIsEager := task.EagerInputs[spec.BuildAlias]
+	if len(spec.BuildFiles) == 0 && !buildIsEager {
 		// Empty build → inner/semi joins emit no rows; upstream planner may
 		// have decided this fragment should not run, but we treat empty
 		// build as "no output". Returning an op chain that drops every row
@@ -1719,9 +1725,19 @@ func (e *Executor) buildFragmentJoinProbe(ctx context.Context, task distributed.
 	// Hash-shuffle probes don't share a build (each task probes its own
 	// partition) so they take the direct path.
 	buildHJ := func() (*exec.HashJoin, error) {
-		src, err := e.sourceForAlias(task.QueryID, bucket, spec.BuildAlias, spec.BuildFiles)
-		if err != nil {
-			return nil, fmt.Errorf("build source: %w", err)
+		var src exec.Source
+		if buildIsEager {
+			// Manifest-fed build: HashJoin.Build drains the source, which
+			// blocks between manifests until every producer candidate
+			// resolves — the build completes exactly when the producer
+			// side's files for this task's partition range all arrived.
+			src = newManifestStreamSource(e, task.QueryID, bucket, eagerBuild)
+		} else {
+			var err error
+			src, err = e.sourceForAlias(task.QueryID, bucket, spec.BuildAlias, spec.BuildFiles)
+			if err != nil {
+				return nil, fmt.Errorf("build source: %w", err)
+			}
 		}
 		if err := src.Init(ctx); err != nil {
 			src.Close()

--- a/internal/worker/executor_fragment.go
+++ b/internal/worker/executor_fragment.go
@@ -1619,6 +1619,13 @@ func (e *Executor) buildFragmentSource(task distributed.Task, spec distributed.O
 	if bucket == "" {
 		bucket = task.ResultBucket
 	}
+	// Eager consumer dispatch: an alias registered in task.EagerInputs is
+	// fed by producer-task manifests instead of a frozen file list
+	// (docs/design/eager-consumer-dispatch.md §3.2). InputFiles is empty
+	// by construction for these aliases.
+	if eager, ok := task.EagerInputs[spec.InputAlias]; ok {
+		return newManifestStreamSource(e, task.QueryID, bucket, eager), nil
+	}
 	if len(spec.InputFiles) == 0 {
 		return nil, fmt.Errorf("source %q: empty InputFiles", spec.Type)
 	}

--- a/internal/worker/executor_fragment.go
+++ b/internal/worker/executor_fragment.go
@@ -218,7 +218,14 @@ func (e *Executor) executeFragment(ctx context.Context, task distributed.Task, r
 	// hanging until the 10-minute gather timeout. Open + finalize the sink
 	// (its Finalize publishes a terminal even with no batches consumed) so
 	// the receiver unblocks immediately on empty fragments.
-	if len(sourceSpec.InputFiles) == 0 {
+	//
+	// Exception: eager-fed aliases (Task.EagerInputs). Their InputFiles is
+	// empty BY CONSTRUCTION — the file set streams in as producer-task
+	// manifests — so "no frozen files" carries no emptiness signal at all.
+	// Short-circuiting here silently dropped the entire input (0 rows,
+	// task success) when eager dispatch first went end-to-end.
+	_, eagerSource := task.EagerInputs[sourceSpec.InputAlias]
+	if len(sourceSpec.InputFiles) == 0 && !eagerSource {
 		if sinkSpec.Type == distributed.OpGatherSink {
 			sink, err := e.openFragmentSink(task, sinkSpec)
 			if err != nil {

--- a/internal/worker/manifest_stream_source.go
+++ b/internal/worker/manifest_stream_source.go
@@ -1,0 +1,255 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/engine/exec"
+)
+
+// manifestStreamSource is the eager-consumer input source
+// (docs/design/eager-consumer-dispatch.md §3.2): it consumes one producer
+// stage's shuffle files as each producer TASK completes, instead of a
+// frozen file list built after the whole stage drained.
+//
+// Contract:
+//   - The candidate set (spec.ProducerTaskIDs) is fixed at task build;
+//     which files exist, and where, streams in as ProducerTaskManifests
+//     (Replay for tasks completed before dispatch, NATS for the rest —
+//     subscribe happens in Init, before any wait, so nothing is missed;
+//     duplicates are idempotent).
+//   - Files outside [PartitionStart, PartitionEnd] are ignored.
+//   - Reads go through the standard tiered fetch (LocalStageCache → peer
+//     → S3) by delegating each resolved manifest's in-range files to an
+//     inner cachedFileStreamSource; manifest PeerAddr hints are
+//     registered so the peer tier works for files the task spec could
+//     not have hinted.
+//   - Attempt fencing (§5): consuming any file of producer task T pins
+//     T's attempt. A later manifest for T with a higher attempt poisons
+//     the source; Next returns errStaleInputAttempt and the task fails
+//     loudly (coordinator retries it against the stable attempt set).
+//
+// StaleInputAttemptMarker tags the poison error so the coordinator's
+// result classification can retry the consumer task without burning the
+// generic failure path's diagnostics.
+const StaleInputAttemptMarker = "eager-dispatch stale input attempt"
+
+type manifestFileSet struct {
+	taskID  string
+	attempt int
+	files   []string // in-range files only; may be empty (still resolves the task)
+}
+
+type manifestStreamSource struct {
+	executor *Executor
+	queryID  string
+	bucket   string
+	spec     distributed.EagerInput
+	nc       *nats.Conn
+	sub      *nats.Subscription
+
+	mu        sync.Mutex
+	arrived   chan struct{}            // closed+recreated on every state change
+	queue     []manifestFileSet        // resolved, not yet consumed
+	resolved  map[string]int           // producer taskID → attempt of resolved manifest
+	consumed  map[string]int           // producer taskID → attempt pinned at first read
+	poisoned  error                    // sticky fencing violation
+	candidate map[string]struct{}      // full producer task ID set
+
+	inner   *cachedFileStreamSource // current file-set reader
+	current manifestFileSet
+	initCtx context.Context
+}
+
+func newManifestStreamSource(e *Executor, queryID, bucket string, spec distributed.EagerInput) *manifestStreamSource {
+	cand := make(map[string]struct{}, len(spec.ProducerTaskIDs))
+	for _, id := range spec.ProducerTaskIDs {
+		cand[id] = struct{}{}
+	}
+	return &manifestStreamSource{
+		executor:  e,
+		queryID:   queryID,
+		bucket:    bucket,
+		spec:      spec,
+		nc:        e.nc,
+		arrived:   make(chan struct{}),
+		resolved:  make(map[string]int, len(cand)),
+		consumed:  make(map[string]int, len(cand)),
+		candidate: cand,
+	}
+}
+
+func (s *manifestStreamSource) Init(ctx context.Context) error {
+	s.initCtx = ctx
+	if s.nc != nil {
+		subject := distributed.EagerManifestSubject(s.spec.RootQueryID, s.spec.StageID)
+		sub, err := s.nc.Subscribe(subject, func(msg *nats.Msg) {
+			var m distributed.ProducerTaskManifest
+			if err := distributed.Unmarshal(msg.Data, &m); err != nil {
+				return
+			}
+			s.observe(m)
+		})
+		if err != nil {
+			return fmt.Errorf("eager source: subscribing %s: %w", subject, err)
+		}
+		s.sub = sub
+	}
+	// Replay after subscribe: observe() is idempotent per (task, attempt),
+	// so the overlap window between replay-list capture and subscription
+	// start cannot double-consume or drop a manifest.
+	for _, m := range s.spec.Replay {
+		s.observe(m)
+	}
+	return nil
+}
+
+// observe folds one manifest into the feed state. Idempotent for
+// duplicate (task, attempt) pairs; higher attempts supersede unconsumed
+// entries and poison consumed ones (fencing).
+func (s *manifestStreamSource) observe(m distributed.ProducerTaskManifest) {
+	if _, ok := s.candidate[m.TaskID]; !ok {
+		return // different edge of a shared producer stage, or garbage
+	}
+	inRange := filesInPartitionRange(m.Files, s.spec.PartitionStart, s.spec.PartitionEnd)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.poisoned != nil {
+		return
+	}
+	if pinned, ok := s.consumed[m.TaskID]; ok && m.Attempt > pinned {
+		s.poisoned = fmt.Errorf("%s: producer task %s attempt %d superseded consumed attempt %d",
+			StaleInputAttemptMarker, m.TaskID, m.Attempt, pinned)
+		s.signalLocked()
+		return
+	}
+	if prev, ok := s.resolved[m.TaskID]; ok {
+		if m.Attempt <= prev {
+			return // duplicate or stale
+		}
+		// Supersede an unconsumed resolution: drop the queued entry.
+		for i := range s.queue {
+			if s.queue[i].taskID == m.TaskID {
+				s.queue = append(s.queue[:i], s.queue[i+1:]...)
+				break
+			}
+		}
+	}
+	s.resolved[m.TaskID] = m.Attempt
+	if len(inRange) > 0 {
+		// Register peer hints before the files become fetchable.
+		if m.PeerAddr != "" {
+			for _, f := range inRange {
+				s.executor.peers.addHint(f, m.PeerAddr)
+			}
+		}
+		s.queue = append(s.queue, manifestFileSet{taskID: m.TaskID, attempt: m.Attempt, files: inRange})
+	}
+	s.signalLocked()
+}
+
+func (s *manifestStreamSource) signalLocked() {
+	close(s.arrived)
+	s.arrived = make(chan struct{})
+}
+
+func (s *manifestStreamSource) Next(ctx context.Context) (*batch.RecordBatch, error) {
+	for {
+		if s.inner != nil {
+			b, err := s.inner.Next(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if b != nil {
+				return b, nil
+			}
+			s.inner.Close()
+			s.inner = nil
+		}
+
+		s.mu.Lock()
+		if s.poisoned != nil {
+			err := s.poisoned
+			s.mu.Unlock()
+			return nil, err
+		}
+		if len(s.queue) > 0 {
+			s.current = s.queue[0]
+			s.queue = s.queue[1:]
+			// Pin the attempt at first read (fencing).
+			s.consumed[s.current.taskID] = s.current.attempt
+			s.mu.Unlock()
+			inner := newCachedFileStreamSource(s.executor, s.queryID, s.bucket, s.current.files)
+			if err := inner.Init(ctx); err != nil {
+				return nil, fmt.Errorf("eager source: inner init (%s): %w", s.current.taskID, err)
+			}
+			s.inner = inner
+			continue
+		}
+		if len(s.resolved) >= len(s.candidate) {
+			s.mu.Unlock()
+			return nil, nil // every producer task resolved and drained: EOF
+		}
+		wait := s.arrived
+		s.mu.Unlock()
+
+		select {
+		case <-wait:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+func (s *manifestStreamSource) Close() error {
+	if s.sub != nil {
+		s.sub.Unsubscribe()
+		s.sub = nil
+	}
+	if s.inner != nil {
+		s.inner.Close()
+		s.inner = nil
+	}
+	return nil
+}
+
+var _ exec.Source = (*manifestStreamSource)(nil)
+
+// filesInPartitionRange filters shuffle keys whose "partition=NNNN" path
+// segment falls inside [start, end] (inclusive). Keys without the segment
+// are excluded — eager feeds only ever carry partitioned shuffle output.
+func filesInPartitionRange(files []string, start, end int) []string {
+	var out []string
+	for _, f := range files {
+		p, ok := partitionOfKey(f)
+		if ok && p >= start && p <= end {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+func partitionOfKey(key string) (int, bool) {
+	const tag = "partition="
+	i := strings.Index(key, tag)
+	if i < 0 {
+		return 0, false
+	}
+	rest := key[i+len(tag):]
+	if j := strings.IndexByte(rest, '/'); j >= 0 {
+		rest = rest[:j]
+	}
+	n, err := strconv.Atoi(rest)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}

--- a/internal/worker/manifest_stream_source_test.go
+++ b/internal/worker/manifest_stream_source_test.go
@@ -1,0 +1,179 @@
+package worker
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+)
+
+func testEagerSpec(taskIDs []string, pStart, pEnd int) distributed.EagerInput {
+	return distributed.EagerInput{
+		RootQueryID:     "rootq",
+		StageID:         "stage-3",
+		ProducerTaskIDs: taskIDs,
+		PartitionStart:  pStart,
+		PartitionEnd:    pEnd,
+	}
+}
+
+func key(task string, part int) string {
+	return "queries/rootq/stage-3/partition=" + pad4(part) + "/" + task + ".wshf"
+}
+
+func pad4(n int) string {
+	s := "000" + itoa(n)
+	return s[len(s)-4:]
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+func TestPartitionOfKey(t *testing.T) {
+	cases := []struct {
+		key  string
+		want int
+		ok   bool
+	}{
+		{"queries/q/s/partition=0007/t1.wshf", 7, true},
+		{"queries/q/s/partition=0000/t1.wshf", 0, true},
+		{"queries/q/s/partition=1234/t1.wshf", 1234, true},
+		{"queries/q/s/t1.wshf", 0, false},
+		{"queries/q/s/partition=xx/t1.wshf", 0, false},
+	}
+	for _, c := range cases {
+		got, ok := partitionOfKey(c.key)
+		if got != c.want || ok != c.ok {
+			t.Errorf("partitionOfKey(%q) = (%d,%v), want (%d,%v)", c.key, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+// EOF requires every candidate resolved AND all in-range files drained;
+// manifests with no in-range files still resolve their task.
+func TestManifestSource_EOFAfterAllResolved(t *testing.T) {
+	e := &Executor{peers: newPeerExchange()}
+	s := newManifestStreamSource(e, "q", "b", testEagerSpec([]string{"t1", "t2"}, 0, 3))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// t1 resolves with files only OUTSIDE our range; t2 with none at all.
+	s.observe(distributed.ProducerTaskManifest{StageID: "stage-3", TaskID: "t1", Attempt: 1,
+		Files: []string{key("t1", 9)}})
+	s.observe(distributed.ProducerTaskManifest{StageID: "stage-3", TaskID: "t2", Attempt: 1})
+
+	b, err := s.Next(ctx)
+	if err != nil || b != nil {
+		t.Fatalf("Next = (%v, %v), want EOF (nil, nil)", b, err)
+	}
+}
+
+// Next blocks until a manifest arrives, then EOFs once all resolve.
+func TestManifestSource_BlocksThenResolves(t *testing.T) {
+	e := &Executor{peers: newPeerExchange()}
+	s := newManifestStreamSource(e, "q", "b", testEagerSpec([]string{"t1"}, 0, 3))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		b, err := s.Next(ctx)
+		if b != nil {
+			done <- context.DeadlineExceeded // unexpected batch
+			return
+		}
+		done <- err
+	}()
+
+	time.Sleep(50 * time.Millisecond) // let Next park on the arrival channel
+	s.observe(distributed.ProducerTaskManifest{StageID: "stage-3", TaskID: "t1", Attempt: 1})
+
+	if err := <-done; err != nil {
+		t.Fatalf("Next after resolve: %v", err)
+	}
+}
+
+// A higher attempt for a CONSUMED task poisons the source with the
+// StaleInputAttempt marker (memo §5); a higher attempt for an UNCONSUMED
+// task silently supersedes.
+func TestManifestSource_AttemptFencing(t *testing.T) {
+	e := &Executor{peers: newPeerExchange()}
+	s := newManifestStreamSource(e, "q", "b", testEagerSpec([]string{"t1", "t2"}, 0, 3))
+
+	// t1 resolves and is consumed (simulate the pin the read path takes).
+	s.observe(distributed.ProducerTaskManifest{StageID: "stage-3", TaskID: "t1", Attempt: 1,
+		Files: []string{key("t1", 1)}})
+	s.mu.Lock()
+	s.consumed["t1"] = 1
+	s.queue = nil // pretend the file was drained
+	s.mu.Unlock()
+
+	// t2 supersedes an unconsumed attempt — allowed, no poison.
+	s.observe(distributed.ProducerTaskManifest{StageID: "stage-3", TaskID: "t2", Attempt: 1,
+		Files: []string{key("t2", 2)}})
+	s.observe(distributed.ProducerTaskManifest{StageID: "stage-3", TaskID: "t2", Attempt: 2,
+		Files: []string{key("t2", 2)}})
+	s.mu.Lock()
+	if s.poisoned != nil {
+		s.mu.Unlock()
+		t.Fatal("unconsumed supersession must not poison")
+	}
+	if len(s.queue) != 1 || s.queue[0].attempt != 2 {
+		s.mu.Unlock()
+		t.Fatalf("queue = %+v, want single t2 attempt-2 entry", s.queue)
+	}
+	s.mu.Unlock()
+
+	// t1 attempt 2 arrives after t1 was consumed → poison.
+	s.observe(distributed.ProducerTaskManifest{StageID: "stage-3", TaskID: "t1", Attempt: 2,
+		Files: []string{key("t1", 1)}})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := s.Next(ctx)
+	if err == nil || !strings.Contains(err.Error(), StaleInputAttemptMarker) {
+		t.Fatalf("Next = %v, want StaleInputAttempt poison", err)
+	}
+}
+
+// Duplicate manifests are idempotent; unknown task IDs are ignored;
+// peer hints are registered for in-range files.
+func TestManifestSource_DuplicatesUnknownsHints(t *testing.T) {
+	e := &Executor{peers: newPeerExchange()}
+	s := newManifestStreamSource(e, "q", "b", testEagerSpec([]string{"t1"}, 0, 3))
+
+	m := distributed.ProducerTaskManifest{StageID: "stage-3", TaskID: "t1", Attempt: 1,
+		Files: []string{key("t1", 2), key("t1", 8)}, PeerAddr: "10.0.0.5:9445"}
+	s.observe(m)
+	s.observe(m) // duplicate
+	s.observe(distributed.ProducerTaskManifest{StageID: "stage-3", TaskID: "zz", Attempt: 1,
+		Files: []string{key("zz", 2)}})
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.queue) != 1 {
+		t.Fatalf("queue len = %d, want 1 (duplicate must not re-queue)", len(s.queue))
+	}
+	if got := len(s.queue[0].files); got != 1 {
+		t.Fatalf("in-range files = %d, want 1 (partition 8 outside range)", got)
+	}
+	if addr, _ := e.peers.hintFor(key("t1", 2)); addr != "10.0.0.5:9445" {
+		t.Fatalf("peer hint not registered: %q", addr)
+	}
+	if addr, _ := e.peers.hintFor(key("t1", 8)); addr != "" {
+		t.Fatal("out-of-range file must not be hinted")
+	}
+}

--- a/internal/worker/peer_exchange.go
+++ b/internal/worker/peer_exchange.go
@@ -71,6 +71,25 @@ func (p *peerExchange) registerTask(task *distributed.Task) {
 	p.mu.Unlock()
 }
 
+// addHint records one runtime-discovered file→peer-address hint (eager
+// consumer dispatch: manifests carry the producer's PeerAddr). Same
+// bookkeeping as registerTask so CleanupQuery drops it with the query.
+func (p *peerExchange) addHint(key, addr string) {
+	if p == nil || key == "" || addr == "" {
+		return
+	}
+	keyRoot := distributed.ScratchQueryID(key)
+	if keyRoot == "" {
+		return
+	}
+	p.mu.Lock()
+	if _, seen := p.hints[key]; !seen {
+		p.rootKeys[keyRoot] = append(p.rootKeys[keyRoot], key)
+	}
+	p.hints[key] = addr
+	p.mu.Unlock()
+}
+
 // hintFor returns the peer address hint and fetch token for one input file,
 // or empty strings when no hint exists.
 func (p *peerExchange) hintFor(key string) (addr, token string) {


### PR DESCRIPTION
## Status: C1 complete + C2 slice 1 (join edges, no-split), flag default OFF, all local gates green

Implements `docs/design/eager-consumer-dispatch.md` (merged as #218) through Phase C2 slice 1: eligible consumer stages clear dispatch when their producer shuffles *dispatch* (not drain), consuming per-producer-task file manifests as tasks finish — non-join consumers at producer dispatch (C1), **hash-join consumers at the memo-§6 early-skew decision point (C2)**.

### C1 (slices 1–4, previously reviewed content)
- Manifest publication from shuffle-stage retriers (`ProducerTaskManifest` on a root-scoped subject) + worker `manifestStreamSource` (subscribe-then-replay, partition-range filtering, §5 attempt fencing) + `eagerFeed` registry with a 3s replay republisher (heals build-snapshot→subscribe gap, Core NATS loss, verbatim-retry stale Replay) + provisional `StageOutput` (everything unknowable degrades to unknown) + flag plumbing (`--eager-dispatch`, `WADJET_EAGER_DISPATCH`, terraform `eager_dispatch`) + retriable `StaleInputAttempt` classification.

### C2 slice 1 (new)
- **Feed accounting**: `onSuccess` carries `PartitionBytes`; feeds accumulate completed count + per-partition bytes; `decisionReady` closes at `min(total, max(workerCount, ⌈total/4⌉))`.
- **Early skew decision**: linear projection through the exact `planSkewSplitTasks` thresholds (floor, ratio gate, build bound), minus the unknowable file-count cap — conservative toward the barrier. **Would-split ⇒ barrier**: slice 1 never emits eager split layouts, so the skew-split −41% straggler win cannot be lost and a wrong split cannot happen. Frozen eager split layouts (per-sub-task `ProducerTaskID` subsets) are slice 2.
- **Join clearance**: both primary deps race feed-dispatch vs barrier; fused-build deps always keep the barrier; `EagerInputs` keyed by the `buildTaskInputsForStage` alias convention.
- **Governed eager publish**: join fan-outs (numTasks = partition count) exceed cluster capacity, and manifest-blocked tasks hold their slots with no transport reordering around them — first wave capped at `capacity − workerCount`, topped up one-for-one on terminal results (`retrier.IsTerminal`; a failure that retries keeps its slot). Deadlock-free on both transports without worker scheduling changes; the residual producer-retry-behind-consumers stall is deadline-bounded and documented.
- **Worker**: eager build alias routes to `manifestStreamSource` in `buildFragmentJoinProbe`, exempted from the empty-`BuildFiles` drop-all-rows short-circuit (the build-side twin of the C1 empty-`InputFiles` bug found by the e2e).
- Scope: `hash_join` only (broadcast edges stay S3+KV per memo §7; SMJ dormant), fragment path only, never the gather-fused stage.

### Bugs found by the e2e gates (both fixed here)
1. `executeFragment`'s empty-`InputFiles` short-circuit ran before `EagerInputs` routing — eager tasks returned 0 rows *successfully*.
2. Same pattern on the join build side: empty `BuildFiles` returned a drop-every-row operator.

### Engagement surface (empirical, all 22 TPC-H plans)
C1 non-join: **1 edge** (Q02's subquery `final_aggregate`). C2 joins: the other **56 edges**. Harness DAG-forced run: 8 eager clearances per suite pass (C1 alone: 1), 8 governed-wave stages, 0 projected splits on uniform SF0.01 data.

### Gates (all green)
- Full `./internal/...` suites; eager + retrier tests under `-race`.
- E2E: TPC-H Q02 (C1 edge) and a 24-task shuffled join with probe AND build manifest-fed under governed waves (C2) — both row-identical to barrier arms with markers engaged.
- TPC-H SF0.01 (`TestTPCHQueries`) 22/22.
- `tpch-harness --mode=local`, eager on vs off, default AND DAG-forced (`--local-fastpath-bytes=0`) configs: 25/25 rows+checksums identical.
- Race-built wadjet harness arm (eager on, DAG forced): zero data races, rows identical, engaged.

### Remaining before default-flip consideration
- **C2 slice 2 (optional pre-SF100)**: frozen eager split layouts for skewed edges — today they just keep the barrier (correct; only costs overlap on those edges, and TPC-H is uniform).
- **EC2 validation (needs deploy approval)**: skew fixture 4-arm A/B (eager × split, `benchmarks/skew`) and the SF100 same-window pair per memo §8 (`EagerEdgesPlanned` + fragment-barrier-block movement are the judged markers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcKKX1fvthE6zpyFsXcrYE