### PR TITLE
fix(storage): don't count client-side cancellations as circuit-breaker failures

### DIFF
--- a/internal/storage/objstore/circuit.go
+++ b/internal/storage/objstore/circuit.go
@@ -139,6 +139,22 @@ func (cs *CircuitStore) onSuccess() {
 }
 
 func (cs *CircuitStore) onFailure(err error) {
+	// Client-side aborts are not S3 health signals. The worker cancels a
+	// terminal query's pending async uploads BY DESIGN (streaming
+	// exchange: uploadManager.CancelQuery fires on every query
+	// complete/cancel broadcast) — under mid-day S3 PUT latency a query
+	// boundary can cancel 5+ queued uploads back-to-back, which counted
+	// here as consecutive "failures", opened the breaker on every worker
+	// simultaneously, and made the NEXT query's healthy GETs fast-fail
+	// for the whole 30 s reset window (SF100 2026-07-12: Q21/Q22 —
+	// occasionally Q03 — failed terminally after their retries burned
+	// into the still-open breaker). context.Canceled can only come from
+	// our own callers; S3 slowness surfaces as DeadlineExceeded or
+	// transport errors, which still count.
+	if errors.Is(err, context.Canceled) {
+		return
+	}
+
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
 

--- a/internal/storage/objstore/circuit_test.go
+++ b/internal/storage/objstore/circuit_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -122,5 +123,64 @@ func TestCircuitStore_StateString(t *testing.T) {
 		if got := state.String(); got != want {
 			t.Errorf("State(%d).String() = %q, want %q", state, got, want)
 		}
+	}
+}
+
+// canceledPutStore fails Put with a (wrapped) context.Canceled — the shape
+// the worker's uploadManager.CancelQuery produces when it aborts a terminal
+// query's pending async uploads.
+type canceledPutStore struct {
+	*MemStore
+	realErrs int // Puts returning a genuine error after the canceled ones
+	calls    int
+}
+
+func (c *canceledPutStore) Put(ctx context.Context, bucket, key string, r io.Reader, size int64, contentType string) (string, error) {
+	c.calls++
+	if c.realErrs > 0 && c.calls > 8 {
+		c.realErrs--
+		return "", errors.New("simulated S3 500")
+	}
+	if c.calls <= 8 {
+		return "", fmt.Errorf("putting object: %w", context.Canceled)
+	}
+	return c.MemStore.Put(ctx, bucket, key, r, size, contentType)
+}
+
+// TestCircuitStore_CanceledDoesNotTrip is the regression for the SF100
+// 2026-07-12 incident: query-boundary upload cancellations (context.Canceled
+// from OUR OWN CancelQuery, not S3) counted as consecutive failures, opened
+// the breaker on every worker at once, and the next query's healthy reads
+// fast-failed for the 30 s reset window — Q21/Q22 (sometimes Q03) failed
+// terminally once their instant retries burned into the open breaker.
+// Client-side aborts must not move the breaker; real errors still must.
+func TestCircuitStore_CanceledDoesNotTrip(t *testing.T) {
+	ps := &canceledPutStore{MemStore: NewMemStore(), realErrs: 3}
+	ctx := context.Background()
+	ps.MakeBucket(ctx, "b")
+
+	cfg := DefaultCircuitConfig()
+	cfg.FailureThreshold = 3
+	cs := NewCircuitStore(ps, cfg, nil)
+
+	// 8 canceled Puts — far past the threshold — must leave the breaker
+	// closed: cancellation says nothing about S3 health.
+	for i := 0; i < 8; i++ {
+		if _, err := cs.Put(ctx, "b", "k", bytes.NewReader([]byte("x")), 1, ""); !errors.Is(err, context.Canceled) {
+			t.Fatalf("put %d: want context.Canceled, got %v", i, err)
+		}
+	}
+	if cs.State() != CircuitClosed {
+		t.Fatalf("breaker must stay closed through canceled puts, got %s", cs.State())
+	}
+
+	// Genuine errors still count and open the breaker at the threshold.
+	for i := 0; i < 3; i++ {
+		if _, err := cs.Put(ctx, "b", "k", bytes.NewReader([]byte("x")), 1, ""); err == nil {
+			t.Fatalf("real-error put %d: want error", i)
+		}
+	}
+	if cs.State() != CircuitOpen {
+		t.Fatalf("breaker must open on real consecutive failures, got %s", cs.State())
 	}
 }


### PR DESCRIPTION
## Incident (SF100, 2026-07-12 afternoon)

Three SF100 runs failed Q21/Q22 (once also Q03) terminally while a fourth ran clean. Worker logs captured mid-run show the trigger:

```
msg="circuit breaker opened" failures=5 threshold=5 reset_timeout=30s error="putting object: context canceled"
```

in clusters on **all three workers at the same instant — a query boundary**. The chain:

1. Streaming exchange uploads stage outputs asynchronously; on every query complete/cancel broadcast the worker aborts that query's still-pending uploads (`uploadManager.CancelQuery`) — **by design**, the scratch is about to be purged.
2. The circuit breaker counted each canceled PUT as an S3 failure. Under elevated mid-day S3 PUT latency the boundary backlog exceeds the 5-failure threshold → breaker opens on every worker for 30 s.
3. The next query's healthy GETs fast-fail against the open breaker, and task retries re-dispatch with **no backoff** (attempts observed 11 ms apart) — all 3 attempts burn inside the window → terminal task failure → query failure.

Overnight runs never showed this because fast PUTs keep boundary backlogs under the threshold; the same binaries pass or fail purely on S3 latency weather.

## Fix

`CircuitStore.onFailure` ignores `errors.Is(err, context.Canceled)`: cancellation can only originate from our own callers and carries no information about S3 health. `DeadlineExceeded` (the breaker's own `RequestTimeout` firing on slow S3) and transport errors still count.

Regression test: 8 canceled Puts leave the breaker closed; 3 genuine failures still open it.

## Not in this PR

Retry re-dispatch has no backoff, so a *legitimately* open breaker (real S3 outage) still converts in-flight queries' retries into terminal failures instead of a ~30 s stall. Worth a follow-up discussion — it changes retry semantics.

Gates: objstore suite under `-race`, full build, TPC-H SF0.01 22/22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcKKX1fvthE6zpyFsXcrYE