### PR TITLE
feat(storage,worker): base-table NVMe cache (S1+S2, flag default off)

### DIFF
--- a/cmd/wadjet/main.go
+++ b/cmd/wadjet/main.go
@@ -107,6 +107,8 @@ var (
 	eagerDispatch         bool
 	peerExchangeAddr      string
 	peerExchangeAdvertise string
+	baseTableCacheBytes   int64
+	baseTableCacheDir     string
 )
 
 func main() {
@@ -175,6 +177,8 @@ func main() {
 	rootCmd.PersistentFlags().BoolVar(&eagerDispatch, "eager-dispatch", false, "Eager consumer dispatch (Phase C1): eligible non-join consumer stages (aggregate/sort over a standalone repartition) start before their producer stage fully drains, consuming per-producer-task file manifests as tasks finish. Requires --streaming-exchange. Default false until SF100 validation (kill switch thereafter). See docs/design/eager-consumer-dispatch.md.")
 	rootCmd.PersistentFlags().StringVar(&peerExchangeAddr, "peer-exchange-addr", ":0", "Peer-exchange (FetchShuffle) listen address. Default :0 picks a free port (the address reaches peers via heartbeats, and a fixed default would collide when multiple workers share a host); pin it when firewalls need a known port.")
 	rootCmd.PersistentFlags().StringVar(&peerExchangeAdvertise, "peer-exchange-advertise", "", "Peer-exchange address advertised in heartbeats (default: derived from the bound listener)")
+	rootCmd.PersistentFlags().Int64Var(&baseTableCacheBytes, "base-table-cache-bytes", 0, "Cross-query disk cache for immutable base-table parquet objects: LRU byte budget on the cache volume. Hits are served from local disk without touching S3 (or the circuit breaker); misses tee the download into the cache. The cache survives restarts (index rebuilt from the directory). 0 = disabled (default until SF100 validation). See docs/design/base-table-nvme-cache.md.")
+	rootCmd.PersistentFlags().StringVar(&baseTableCacheDir, "base-table-cache-dir", "", "Directory for the base-table cache (default: <spill-dir>/base-cache, inheriting the spill volume's NVMe mount)")
 	rootCmd.PersistentFlags().StringVar(&geoipCityDB, "geoip-city", "", "Path to MaxMind GeoIP City database (GeoLite2-City.mmdb)")
 	rootCmd.PersistentFlags().StringVar(&geoipASNDB, "geoip-asn", "", "Path to MaxMind GeoIP ASN database (GeoLite2-ASN.mmdb)")
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Log level: debug, info, warn, error")
@@ -403,6 +407,36 @@ func serveCmd() *cobra.Command {
 
 		// Wrap store with circuit breaker for S3 resilience
 		store = objstore.NewCircuitStore(store, objstore.DefaultCircuitConfig(), logger)
+
+		// Base-table NVMe cache sits ABOVE the breaker: hits never consult
+		// it (a warm cache keeps serving through an S3 brownout), misses
+		// keep full breaker protection. One process-wide seam serves every
+		// scan path (docs/design/base-table-nvme-cache.md §3).
+		if baseTableCacheBytes > 0 {
+			cacheDir := baseTableCacheDir
+			if cacheDir == "" && spillDir != "" {
+				cacheDir = filepath.Join(spillDir, "base-cache")
+			}
+			if cacheDir == "" {
+				logger.Warn("base-table cache disabled: set --base-table-cache-dir or --spill-dir to place it")
+			} else {
+				btc, err := objstore.NewBaseTableCache(store, cacheDir, baseTableCacheBytes, logger)
+				if err != nil {
+					return fmt.Errorf("initializing base-table cache: %w", err)
+				}
+				store = btc
+				logger.Info("base-table cache enabled", "dir", cacheDir, "budget_bytes", baseTableCacheBytes)
+				go func() {
+					var last objstore.BaseTableCacheStats
+					for range time.Tick(60 * time.Second) {
+						if s := btc.Stats(); s != last {
+							last = s
+							btc.LogStats()
+						}
+					}
+				}()
+			}
+		}
 
 		if v := os.Getenv("WADJET_ENABLE_ALERTS"); v == "1" || strings.EqualFold(v, "true") {
 			enableAlerts = true
@@ -989,11 +1023,11 @@ func runStandalone(ctx context.Context, store objstore.Store, logger *slog.Logge
 
 	// Build config manager and auth provider for hot-reload
 	srvCfg := server.Config{
-		Addr:               httpAddr,
-		Catalog:            cat,
-		Coordinator:        coord,
-		Metrics:            m,
-		SortMergeJoinBytes: sortMergeJoinBytes,
+		Addr:                httpAddr,
+		Catalog:             cat,
+		Coordinator:         coord,
+		Metrics:             m,
+		SortMergeJoinBytes:  sortMergeJoinBytes,
 		LateMaterialization: lateMaterialization,
 	}
 
@@ -1280,12 +1314,12 @@ func runCoordinator(ctx context.Context, store objstore.Store, logger *slog.Logg
 	dlq := coordinator.NewDLQ(js)
 
 	srvCfg := server.Config{
-		Addr:               httpAddr,
-		Catalog:            cat,
-		Coordinator:        coord,
-		DLQ:                dlq,
-		Metrics:            m,
-		SortMergeJoinBytes: sortMergeJoinBytes,
+		Addr:                httpAddr,
+		Catalog:             cat,
+		Coordinator:         coord,
+		DLQ:                 dlq,
+		Metrics:             m,
+		SortMergeJoinBytes:  sortMergeJoinBytes,
 		LateMaterialization: lateMaterialization,
 	}
 

--- a/deploy/benchmark/terraform/main.tf
+++ b/deploy/benchmark/terraform/main.tf
@@ -678,6 +678,7 @@ resource "aws_instance" "worker" {
             --mmap-relief-threshold-mb=${var.mmap_relief_threshold_mb} \
             --bounded-dirty-writes=${var.bounded_dirty_writes} \
             --morsel-workers=${var.morsel_workers} \
+            --base-table-cache-bytes=${var.base_table_cache_bytes} \
             %{if var.spill_floating_budget~}
             --spill-floating-budget \
             %{endif~}

--- a/deploy/benchmark/terraform/variables.tf
+++ b/deploy/benchmark/terraform/variables.tf
@@ -276,6 +276,12 @@ variable "eager_dispatch" {
   default     = false
 }
 
+variable "base_table_cache_bytes" {
+  description = "Base-table NVMe cache LRU budget in bytes per worker process (docs/design/base-table-nvme-cache.md): cross-query disk cache for immutable base-table parquet under <spill-dir>/base-cache, so repeat scans skip the S3 GET. Worker-side flag only. 0 = disabled (default pending SF100 validation). SF100 shape proposal: 150 GB (161061273600) — working set ~100 GB, leaves ~85 GB of the 237 GB NVMe for spill."
+  type        = number
+  default     = 0
+}
+
 variable "peer_exchange_port" {
   description = "Worker↔worker peer-exchange (FetchShuffle) port; SG opens it intra-cluster whenever streaming_exchange is set."
   type        = number

--- a/docs/design/base-table-nvme-cache.md
+++ b/docs/design/base-table-nvme-cache.md
@@ -305,7 +305,33 @@ SF100 pair (same-window, control first, teardown discipline):
   latency events, and S3 GET cost reduction on long-lived clusters
   (the AtumForge deployment model — same tables queried all day).
 
-## 10. Open questions for review
+## 10. SF100 validation results (2026-07-13, added post-pair)
+
+Same-window pair on bin `c32fbc6` (PR #222), clusters destroyed+verified:
+
+- **Control** (cache off) `results/20260713-013357`: 22/22, **31m42s**.
+- **Treatment** (150 GB, `benchmark_runs=2`) `results/20260713-021126`:
+  run 1 (cold+warming) **29m54s = −5.7%**, run 2 (steady-state)
+  **28m50s = −9.0%**. 22/22 both runs, **row counts identical to control
+  on every query in all three suites**.
+- Steady-state scan-band deltas vs control: Q19 −32%, Q06 −29%, Q08
+  −29%, Q20 −29%, Q16 −24%, Q12 −23%, Q09 −21%, Q05 −17%, Q15 −15%,
+  Q21 −12%. Exchange-bound stayed flat exactly as §9 predicted: Q17
+  +1.5%, Q03 −1.7%, Q18 −3.3%. Positive movers (Q02 +15%, Q13 +13.5%)
+  are the known day-window-volatile pair, not cache-marked.
+- Engagement: worker base-cache reached **24 GB ≈ the entire SF100
+  parquet footprint** mid-run-1 (live `du` via SSM); run-1's own tail
+  already benefited (Q06 −31% cold — lineitem was resident by Q06 from
+  earlier queries' populations).
+- Not captured: per-worker hit-byte ratios (worker logs went down with
+  the prompt teardown; the stats ticker lines weren't pulled first).
+  The wall pattern + cache-size evidence is decisive enough that the
+  pair wasn't re-run for it; capture stats lines before teardown next
+  time.
+- New SF100 steady-state reference: **28m50s** (prior best 30m38s,
+  results/20260712-025644).
+
+## 11. Open questions for review
 
 1. **Benchmark reporting convention (PM):** a warm cache changes what the
    suite measures — cold-S3 has been the implicit contract for every

--- a/internal/storage/objstore/base_table_cache.go
+++ b/internal/storage/objstore/base_table_cache.go
@@ -1,0 +1,569 @@
+package objstore
+
+import (
+	"container/list"
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/citc-tech/wadjet/internal/engine/diskio"
+)
+
+// LocalPathStore is an optional interface for stores that hold whole
+// objects on local disk. Callers that would otherwise stream a copy to
+// their own scratch file (e.g. the worker's parquet mmap path) can open
+// the store's file in place. The path is best-effort: eviction may unlink
+// it between the call and the open — POSIX keeps the inode alive for
+// already-open descriptors, so callers open first, then treat an open
+// failure as a miss and fall back to Get.
+type LocalPathStore interface {
+	// CachedLocalPath returns the local file for a resident object. It
+	// counts as a cache hit — call it only to serve.
+	CachedLocalPath(bucket, key string) (string, bool)
+	// HasCachedPath is the counting-free membership probe, for callers
+	// deciding whether to skip work (e.g. a prefetcher electing not to
+	// download) without inflating hit statistics.
+	HasCachedPath(bucket, key string) bool
+}
+
+// BaseTableCacheStats is a point-in-time snapshot of cache counters.
+type BaseTableCacheStats struct {
+	Hits      int64
+	Misses    int64
+	Evictions int64
+	HitBytes  int64
+	MissBytes int64
+	Entries   int
+	Bytes     int64
+}
+
+// BaseTableCache is a read-through, disk-backed, whole-file cache for
+// immutable base-table parquet objects, decorating an inner Store
+// (docs/design/base-table-nvme-cache.md). Eligible keys (*.parquet
+// outside the queries/ scratch prefix) are served from the cache
+// directory on hit — never consulting the inner store or, when stacked
+// above CircuitStore, the breaker — and teed into the cache on miss.
+// Non-eligible keys pass through untouched.
+//
+// A (bucket, key) pair is content-stable for its lifetime: ingest writes
+// UUID-named chunks and compaction/GC swap in new keys via the manifest
+// rather than overwriting (see the design memo §2), so entries need no
+// ETag validation. Population is strictly best-effort — any tee failure,
+// short read, or size mismatch discards the temp file and the caller's
+// stream is unaffected.
+type BaseTableCache struct {
+	inner  Store
+	dir    string
+	tmpDir string
+	budget int64
+	logger *slog.Logger
+
+	mu       sync.Mutex
+	entries  map[string]*list.Element // cache key -> element holding *btcEntry
+	lru      *list.List               // front = most recently used
+	curBytes int64
+	inflight map[string]struct{} // keys with a tee in progress (dedupe, non-blocking)
+
+	hits      atomic.Int64
+	misses    atomic.Int64
+	evictions atomic.Int64
+	hitBytes  atomic.Int64
+	missBytes atomic.Int64
+}
+
+var (
+	_ Store          = (*BaseTableCache)(nil)
+	_ ReaderAtStore  = (*BaseTableCache)(nil)
+	_ LocalPathStore = (*BaseTableCache)(nil)
+)
+
+type btcEntry struct {
+	key  string // bucket + "/" + object key
+	path string
+	size int64
+}
+
+// NewBaseTableCache creates the cache rooted at dir with an LRU byte
+// budget. The directory layout mirrors <dir>/<bucket>/<key>; existing
+// entries are adopted at startup (recency seeded by mtime) so the cache
+// survives process restarts. budget must be > 0 — a zero budget means
+// the feature is off and the decorator should not be constructed.
+func NewBaseTableCache(inner Store, dir string, budget int64, logger *slog.Logger) (*BaseTableCache, error) {
+	if budget <= 0 {
+		return nil, fmt.Errorf("base-table cache: budget must be > 0, got %d", budget)
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	c := &BaseTableCache{
+		inner:    inner,
+		dir:      dir,
+		tmpDir:   filepath.Join(dir, "tmp"),
+		budget:   budget,
+		logger:   logger,
+		entries:  make(map[string]*list.Element),
+		lru:      list.New(),
+		inflight: make(map[string]struct{}),
+	}
+	if err := os.MkdirAll(c.dir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating base-table cache dir: %w", err)
+	}
+	// Partial populations from a previous run are never valid entries.
+	if err := os.RemoveAll(c.tmpDir); err != nil {
+		return nil, fmt.Errorf("sweeping base-table cache tmp dir: %w", err)
+	}
+	if err := os.MkdirAll(c.tmpDir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating base-table cache tmp dir: %w", err)
+	}
+	if err := c.rebuild(); err != nil {
+		return nil, fmt.Errorf("rebuilding base-table cache index: %w", err)
+	}
+	return c, nil
+}
+
+// rebuild adopts entries already on disk, oldest-mtime first so the most
+// recently written files end up at the LRU front, then evicts down to
+// budget (the budget may have shrunk across restarts).
+func (c *BaseTableCache) rebuild() error {
+	type found struct {
+		key   string
+		path  string
+		size  int64
+		mtime int64
+	}
+	var files []found
+	err := filepath.WalkDir(c.dir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if p == c.tmpDir {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(c.dir, p)
+		if err != nil {
+			return err
+		}
+		// rel is <bucket>/<key...>; anything shallower is not ours — leave it.
+		if !strings.Contains(filepath.ToSlash(rel), "/") {
+			return nil
+		}
+		files = append(files, found{
+			key:   filepath.ToSlash(rel),
+			path:  p,
+			size:  info.Size(),
+			mtime: info.ModTime().UnixNano(),
+		})
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].mtime < files[j].mtime })
+	var evicted int
+	for _, f := range files {
+		c.entries[f.key] = c.lru.PushFront(&btcEntry{key: f.key, path: f.path, size: f.size})
+		c.curBytes += f.size
+	}
+	for c.curBytes > c.budget && c.lru.Len() > 0 {
+		e := c.removeTailLocked()
+		_ = os.Remove(e.path)
+		evicted++
+	}
+	if len(files) > 0 {
+		c.logger.Info("base-table cache: adopted entries from previous run",
+			"entries", c.lru.Len(), "bytes", c.curBytes, "evicted", evicted)
+	}
+	return nil
+}
+
+// eligibleKey reports whether the object is a cacheable base-table file.
+// Query-scratch objects (stage outputs, aggregate/build caches under
+// queries/<id>/) have their own tiers and race async uploads — never
+// cache them. The path-shape checks keep the mirrored on-disk layout
+// inside c.dir.
+func (c *BaseTableCache) eligibleKey(bucket, key string) bool {
+	if !strings.HasSuffix(key, ".parquet") || strings.HasPrefix(key, "queries/") {
+		return false
+	}
+	if bucket == "" || strings.ContainsAny(bucket, "/\\") || bucket == ".." || bucket == "." {
+		return false
+	}
+	for _, seg := range strings.Split(key, "/") {
+		if seg == "" || seg == "." || seg == ".." {
+			return false
+		}
+	}
+	return true
+}
+
+func cacheKey(bucket, key string) string { return bucket + "/" + key }
+
+func (c *BaseTableCache) localPath(bucket, key string) string {
+	return filepath.Join(c.dir, bucket, filepath.FromSlash(key))
+}
+
+// Get implements Store. Hits stream from the cache file; misses stream
+// from the inner store while teeing into the cache.
+func (c *BaseTableCache) Get(ctx context.Context, bucket, key string) (io.ReadCloser, ObjectInfo, error) {
+	if !c.eligibleKey(bucket, key) {
+		return c.inner.Get(ctx, bucket, key)
+	}
+	ck := cacheKey(bucket, key)
+	if f, info, ok := c.openHit(ck, key); ok {
+		return f, info, nil
+	}
+	rc, info, err := c.inner.Get(ctx, bucket, key)
+	if err != nil {
+		return rc, info, err
+	}
+	c.misses.Add(1)
+	if info.Size > 0 {
+		c.missBytes.Add(info.Size)
+	}
+	tee := c.startTee(ck, bucket, key, info.Size)
+	if tee == nil {
+		return rc, info, nil
+	}
+	return &teeCacheReader{rc: rc, tee: tee}, info, nil
+}
+
+// openHit opens the cached file for ck, bumping recency. A failed open
+// (evicted concurrently, corrupt) drops the entry and reports a miss.
+func (c *BaseTableCache) openHit(ck, objKey string) (*os.File, ObjectInfo, bool) {
+	c.mu.Lock()
+	el, ok := c.entries[ck]
+	if ok {
+		c.lru.MoveToFront(el)
+	}
+	c.mu.Unlock()
+	if !ok {
+		return nil, ObjectInfo{}, false
+	}
+	e := el.Value.(*btcEntry)
+	f, err := os.Open(e.path)
+	if err != nil {
+		c.dropEntry(ck)
+		return nil, ObjectInfo{}, false
+	}
+	st, err := f.Stat()
+	if err != nil {
+		f.Close()
+		c.dropEntry(ck)
+		return nil, ObjectInfo{}, false
+	}
+	c.hits.Add(1)
+	c.hitBytes.Add(st.Size())
+	return f, ObjectInfo{Key: objKey, Size: st.Size(), LastModified: st.ModTime()}, true
+}
+
+// GetReaderAt implements ReaderAtStore. Hits serve column-chunk range
+// reads as local preads; misses pass through WITHOUT populating (ranged
+// misses are footer-sized — the whole-file Get on every scan path is the
+// populator).
+func (c *BaseTableCache) GetReaderAt(ctx context.Context, bucket, key string) (ReaderAtCloser, int64, error) {
+	if c.eligibleKey(bucket, key) {
+		if f, info, ok := c.openHit(cacheKey(bucket, key), key); ok {
+			return f, info.Size, nil
+		}
+	}
+	ras, ok := c.inner.(ReaderAtStore)
+	if !ok {
+		return nil, 0, fmt.Errorf("underlying store does not support ReaderAt")
+	}
+	return ras.GetReaderAt(ctx, bucket, key)
+}
+
+// CachedLocalPath implements LocalPathStore.
+func (c *BaseTableCache) CachedLocalPath(bucket, key string) (string, bool) {
+	e, ok := c.lookup(bucket, key)
+	if !ok {
+		return "", false
+	}
+	c.hits.Add(1)
+	c.hitBytes.Add(e.size)
+	return e.path, true
+}
+
+// HasCachedPath implements LocalPathStore.
+func (c *BaseTableCache) HasCachedPath(bucket, key string) bool {
+	_, ok := c.lookup(bucket, key)
+	return ok
+}
+
+// lookup finds a resident entry and bumps its recency.
+func (c *BaseTableCache) lookup(bucket, key string) (*btcEntry, bool) {
+	if !c.eligibleKey(bucket, key) {
+		return nil, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	el, ok := c.entries[cacheKey(bucket, key)]
+	if !ok {
+		return nil, false
+	}
+	c.lru.MoveToFront(el)
+	return el.Value.(*btcEntry), true
+}
+
+// startTee begins a population for ck unless one is already in flight,
+// the entry already exists, or the advertised size is unknown or over
+// budget. Returns nil when the caller should stream without teeing.
+func (c *BaseTableCache) startTee(ck, bucket, key string, size int64) *cacheTee {
+	if size <= 0 || size > c.budget {
+		return nil
+	}
+	c.mu.Lock()
+	_, busy := c.inflight[ck]
+	_, exists := c.entries[ck]
+	if busy || exists {
+		c.mu.Unlock()
+		return nil
+	}
+	c.inflight[ck] = struct{}{}
+	c.mu.Unlock()
+	f, err := os.CreateTemp(c.tmpDir, "populate-*.tmp")
+	if err != nil {
+		c.clearInflight(ck)
+		c.logger.Warn("base-table cache: creating populate temp failed", "error", err)
+		return nil
+	}
+	w, fl := diskio.NewWriter(f, diskio.Spill)
+	return &cacheTee{c: c, ck: ck, bucket: bucket, key: key, f: f, w: w, fl: fl, want: size}
+}
+
+func (c *BaseTableCache) clearInflight(ck string) {
+	c.mu.Lock()
+	delete(c.inflight, ck)
+	c.mu.Unlock()
+}
+
+// admit registers a renamed-into-place file. Evicts from the LRU tail
+// until the entry fits. If a concurrent populate raced us in, the rename
+// replaced the file with identical bytes — keep the existing accounting.
+func (c *BaseTableCache) admit(ck, path string, size int64) {
+	var evicted []*btcEntry
+	c.mu.Lock()
+	if el, ok := c.entries[ck]; ok {
+		c.lru.MoveToFront(el)
+		c.mu.Unlock()
+		return
+	}
+	for c.curBytes+size > c.budget && c.lru.Len() > 0 {
+		evicted = append(evicted, c.removeTailLocked())
+	}
+	c.entries[ck] = c.lru.PushFront(&btcEntry{key: ck, path: path, size: size})
+	c.curBytes += size
+	c.mu.Unlock()
+	for _, e := range evicted {
+		_ = os.Remove(e.path)
+		c.evictions.Add(1)
+	}
+}
+
+// removeTailLocked unlinks the least-recently-used entry from the index
+// (not the filesystem). Caller holds c.mu and removes the file.
+func (c *BaseTableCache) removeTailLocked() *btcEntry {
+	tail := c.lru.Back()
+	e := tail.Value.(*btcEntry)
+	c.lru.Remove(tail)
+	delete(c.entries, e.key)
+	c.curBytes -= e.size
+	return e
+}
+
+func (c *BaseTableCache) dropEntry(ck string) {
+	c.mu.Lock()
+	el, ok := c.entries[ck]
+	var e *btcEntry
+	if ok {
+		e = el.Value.(*btcEntry)
+		c.lru.Remove(el)
+		delete(c.entries, ck)
+		c.curBytes -= e.size
+	}
+	c.mu.Unlock()
+	if ok {
+		_ = os.Remove(e.path)
+	}
+}
+
+// Stats returns a snapshot of the cache counters.
+func (c *BaseTableCache) Stats() BaseTableCacheStats {
+	c.mu.Lock()
+	entries := c.lru.Len()
+	bytes := c.curBytes
+	c.mu.Unlock()
+	return BaseTableCacheStats{
+		Hits:      c.hits.Load(),
+		Misses:    c.misses.Load(),
+		Evictions: c.evictions.Load(),
+		HitBytes:  c.hitBytes.Load(),
+		MissBytes: c.missBytes.Load(),
+		Entries:   entries,
+		Bytes:     bytes,
+	}
+}
+
+// LogStats emits the greppable stats marker (design memo §8).
+func (c *BaseTableCache) LogStats() {
+	s := c.Stats()
+	c.logger.Info("base-table cache stats",
+		"hits", s.Hits, "misses", s.Misses,
+		"hit_bytes", s.HitBytes, "miss_bytes", s.MissBytes,
+		"evictions", s.Evictions, "entries", s.Entries, "bytes", s.Bytes)
+}
+
+// Put implements Store. Eligible keys invalidate defensively — ingest
+// never rewrites a live key (memo §2), but a stale entry after any
+// out-of-contract overwrite would silently serve old bytes.
+func (c *BaseTableCache) Put(ctx context.Context, bucket, key string, r io.Reader, size int64, contentType string) (string, error) {
+	etag, err := c.inner.Put(ctx, bucket, key, r, size, contentType)
+	if err == nil && c.eligibleKey(bucket, key) {
+		c.dropEntry(cacheKey(bucket, key))
+	}
+	return etag, err
+}
+
+// PutIfMatch implements Store.
+func (c *BaseTableCache) PutIfMatch(ctx context.Context, bucket, key string, r io.Reader, size int64, contentType string, expectedETag string) (string, error) {
+	etag, err := c.inner.PutIfMatch(ctx, bucket, key, r, size, contentType, expectedETag)
+	if err == nil && c.eligibleKey(bucket, key) {
+		c.dropEntry(cacheKey(bucket, key))
+	}
+	return etag, err
+}
+
+// Delete implements Store. Dropping the entry eagerly reclaims disk that
+// LRU pressure would otherwise take time to find (compaction/GC swaps).
+func (c *BaseTableCache) Delete(ctx context.Context, bucket, key string) error {
+	err := c.inner.Delete(ctx, bucket, key)
+	if err == nil && c.eligibleKey(bucket, key) {
+		c.dropEntry(cacheKey(bucket, key))
+	}
+	return err
+}
+
+// Head implements Store.
+func (c *BaseTableCache) Head(ctx context.Context, bucket, key string) (ObjectInfo, error) {
+	return c.inner.Head(ctx, bucket, key)
+}
+
+// List implements Store.
+func (c *BaseTableCache) List(ctx context.Context, bucket string, opts ListOptions) ([]ObjectInfo, error) {
+	return c.inner.List(ctx, bucket, opts)
+}
+
+// BucketExists implements Store.
+func (c *BaseTableCache) BucketExists(ctx context.Context, bucket string) (bool, error) {
+	return c.inner.BucketExists(ctx, bucket)
+}
+
+// MakeBucket implements Store.
+func (c *BaseTableCache) MakeBucket(ctx context.Context, bucket string) error {
+	return c.inner.MakeBucket(ctx, bucket)
+}
+
+// Unwrap returns the underlying store.
+func (c *BaseTableCache) Unwrap() Store { return c.inner }
+
+// cacheTee owns one in-flight population: the temp file the miss body is
+// copied into, finalized (fsync + rename + admit) only on clean EOF with
+// the byte count matching the advertised size.
+type cacheTee struct {
+	c         *BaseTableCache
+	ck        string
+	bucket    string
+	key       string
+	f         *os.File
+	w         io.Writer
+	fl        *diskio.Flusher
+	want, got int64
+	failed    bool
+}
+
+// write copies one chunk into the temp. Failures poison the tee but never
+// surface to the consumer's stream.
+func (t *cacheTee) write(p []byte) {
+	if t.failed {
+		return
+	}
+	n, err := t.w.Write(p)
+	t.got += int64(n)
+	if err != nil || t.got > t.want {
+		t.failed = true
+	}
+}
+
+func (t *cacheTee) finish(sawEOF bool) {
+	defer t.c.clearInflight(t.ck)
+	discard := func() {
+		t.f.Close()
+		_ = os.Remove(t.f.Name())
+	}
+	if t.failed || !sawEOF || t.got != t.want {
+		discard()
+		return
+	}
+	t.fl.Finish()
+	if err := t.f.Sync(); err != nil {
+		discard()
+		return
+	}
+	tmpPath := t.f.Name()
+	if err := t.f.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return
+	}
+	final := t.c.localPath(t.bucket, t.key)
+	if err := os.MkdirAll(filepath.Dir(final), 0o755); err != nil {
+		_ = os.Remove(tmpPath)
+		return
+	}
+	if err := os.Rename(tmpPath, final); err != nil {
+		_ = os.Remove(tmpPath)
+		return
+	}
+	t.c.admit(t.ck, final, t.want)
+}
+
+// teeCacheReader passes the inner body through while feeding the tee.
+type teeCacheReader struct {
+	rc     io.ReadCloser
+	tee    *cacheTee
+	sawEOF bool
+}
+
+func (r *teeCacheReader) Read(p []byte) (int, error) {
+	n, err := r.rc.Read(p)
+	if n > 0 {
+		r.tee.write(p[:n])
+	}
+	if err == io.EOF {
+		r.sawEOF = true
+	}
+	return n, err
+}
+
+func (r *teeCacheReader) Close() error {
+	err := r.rc.Close()
+	if r.tee != nil {
+		r.tee.finish(r.sawEOF)
+		r.tee = nil
+	}
+	return err
+}

--- a/internal/storage/objstore/base_table_cache_test.go
+++ b/internal/storage/objstore/base_table_cache_test.go
@@ -1,0 +1,451 @@
+package objstore
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// countingStore wraps a Store and counts Get / GetReaderAt calls so tests
+// can assert whether the cache consulted the inner store.
+type countingStore struct {
+	Store
+	gets      atomic.Int64
+	readerAts atomic.Int64
+	// sizeInflate, when non-zero, is added to the ObjectInfo.Size that Get
+	// advertises — simulating a store whose metadata disagrees with the
+	// body it streams.
+	sizeInflate int64
+}
+
+func (s *countingStore) Get(ctx context.Context, bucket, key string) (io.ReadCloser, ObjectInfo, error) {
+	s.gets.Add(1)
+	rc, info, err := s.Store.Get(ctx, bucket, key)
+	info.Size += s.sizeInflate
+	return rc, info, err
+}
+
+func (s *countingStore) GetReaderAt(ctx context.Context, bucket, key string) (ReaderAtCloser, int64, error) {
+	s.readerAts.Add(1)
+	return s.Store.(ReaderAtStore).GetReaderAt(ctx, bucket, key)
+}
+
+func newTestCache(tb testing.TB, budget int64) (*BaseTableCache, *countingStore, string) {
+	tb.Helper()
+	dir := tb.TempDir()
+	inner := &countingStore{Store: NewMemStore()}
+	c, err := NewBaseTableCache(inner, dir, budget, nil)
+	if err != nil {
+		tb.Fatalf("NewBaseTableCache: %v", err)
+	}
+	return c, inner, dir
+}
+
+func putObject(tb testing.TB, s Store, bucket, key string, data []byte) {
+	tb.Helper()
+	ctx := context.Background()
+	if err := s.MakeBucket(ctx, bucket); err != nil {
+		tb.Fatalf("MakeBucket: %v", err)
+	}
+	if _, err := s.Put(ctx, bucket, key, bytes.NewReader(data), int64(len(data)), "application/octet-stream"); err != nil {
+		tb.Fatalf("Put: %v", err)
+	}
+}
+
+// getAll reads an object through the cache to EOF and closes it, the way
+// every scan-path consumer does.
+func getAll(tb testing.TB, c *BaseTableCache, bucket, key string) []byte {
+	tb.Helper()
+	rc, info, err := c.Get(context.Background(), bucket, key)
+	if err != nil {
+		tb.Fatalf("Get(%s/%s): %v", bucket, key, err)
+	}
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		tb.Fatalf("ReadAll: %v", err)
+	}
+	if err := rc.Close(); err != nil {
+		tb.Fatalf("Close: %v", err)
+	}
+	if info.Size > 0 && int64(len(data)) != info.Size {
+		tb.Fatalf("body length %d != advertised size %d", len(data), info.Size)
+	}
+	return data
+}
+
+func TestBaseTableCacheRoundTrip(t *testing.T) {
+	c, inner, _ := newTestCache(t, 1<<20)
+	data := bytes.Repeat([]byte("wadjet"), 1000)
+	putObject(t, inner.Store, "data", "tables/lineitem/chunk_abc.parquet", data)
+
+	if got := getAll(t, c, "data", "tables/lineitem/chunk_abc.parquet"); !bytes.Equal(got, data) {
+		t.Fatal("miss body mismatch")
+	}
+	if got := getAll(t, c, "data", "tables/lineitem/chunk_abc.parquet"); !bytes.Equal(got, data) {
+		t.Fatal("hit body mismatch")
+	}
+	if inner.gets.Load() != 1 {
+		t.Fatalf("inner gets = %d, want 1 (second read must be a cache hit)", inner.gets.Load())
+	}
+	s := c.Stats()
+	if s.Hits != 1 || s.Misses != 1 || s.Entries != 1 {
+		t.Fatalf("stats = %+v, want 1 hit / 1 miss / 1 entry", s)
+	}
+	if s.HitBytes != int64(len(data)) || s.MissBytes != int64(len(data)) {
+		t.Fatalf("byte stats = %+v, want %d each", s, len(data))
+	}
+}
+
+func TestBaseTableCacheEligibility(t *testing.T) {
+	c, inner, dir := newTestCache(t, 1<<20)
+	cases := []struct {
+		name   string
+		bucket string
+		key    string
+	}{
+		{"non-parquet", "data", "tables/t/chunk.wshf"},
+		{"query scratch", "data", "queries/q1/stage-2/part.parquet"},
+		{"dot-dot segment", "data", "tables/../escape.parquet"},
+		{"empty segment", "data", "tables//x.parquet"},
+		{"bucket with slash", "da/ta", "tables/t/x.parquet"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			putObject(t, inner.Store, tc.bucket, tc.key, []byte("payload"))
+			before := inner.gets.Load()
+			if got := getAll(t, c, tc.bucket, tc.key); string(got) != "payload" {
+				t.Fatal("body mismatch")
+			}
+			if got := getAll(t, c, tc.bucket, tc.key); string(got) != "payload" {
+				t.Fatal("body mismatch on second read")
+			}
+			if inner.gets.Load() != before+2 {
+				t.Fatalf("ineligible key was cached: inner gets went %d -> %d", before, inner.gets.Load())
+			}
+		})
+	}
+	if s := c.Stats(); s.Entries != 0 {
+		t.Fatalf("ineligible keys created %d entries", s.Entries)
+	}
+	// Nothing may have escaped or landed under the cache dir.
+	var files []string
+	_ = filepath.WalkDir(dir, func(p string, d os.DirEntry, err error) error {
+		if err == nil && !d.IsDir() {
+			files = append(files, p)
+		}
+		return nil
+	})
+	if len(files) != 0 {
+		t.Fatalf("ineligible keys left files on disk: %v", files)
+	}
+}
+
+func TestBaseTableCacheEarlyCloseDiscards(t *testing.T) {
+	c, inner, _ := newTestCache(t, 1<<20)
+	data := bytes.Repeat([]byte("x"), 64<<10)
+	putObject(t, inner.Store, "data", "t/a.parquet", data)
+
+	rc, _, err := c.Get(context.Background(), "data", "t/a.parquet")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	buf := make([]byte, 1024)
+	if _, err := rc.Read(buf); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	rc.Close() // abandon before EOF
+
+	if got := getAll(t, c, "data", "t/a.parquet"); !bytes.Equal(got, data) {
+		t.Fatal("body mismatch after abandoned read")
+	}
+	if inner.gets.Load() != 2 {
+		t.Fatalf("inner gets = %d, want 2 (abandoned read must not populate)", inner.gets.Load())
+	}
+}
+
+func TestBaseTableCacheSizeMismatchDiscards(t *testing.T) {
+	c, inner, _ := newTestCache(t, 1<<20)
+	inner.sizeInflate = 17
+	data := []byte("short body")
+	putObject(t, inner.Store, "data", "t/a.parquet", data)
+
+	if got := getAll2(t, c, "data", "t/a.parquet"); !bytes.Equal(got, data) {
+		t.Fatal("body mismatch")
+	}
+	if s := c.Stats(); s.Entries != 0 {
+		t.Fatalf("size-mismatched body was admitted: %+v", s)
+	}
+	if got := getAll2(t, c, "data", "t/a.parquet"); !bytes.Equal(got, data) {
+		t.Fatal("body mismatch on re-read")
+	}
+	if inner.gets.Load() != 2 {
+		t.Fatalf("inner gets = %d, want 2", inner.gets.Load())
+	}
+}
+
+// getAll2 is getAll without the size cross-check (for tests that
+// deliberately advertise a wrong size).
+func getAll2(tb testing.TB, c *BaseTableCache, bucket, key string) []byte {
+	tb.Helper()
+	rc, _, err := c.Get(context.Background(), bucket, key)
+	if err != nil {
+		tb.Fatalf("Get: %v", err)
+	}
+	defer rc.Close()
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		tb.Fatalf("ReadAll: %v", err)
+	}
+	return data
+}
+
+func TestBaseTableCacheEvictionLRU(t *testing.T) {
+	obj := func(i int) (string, []byte) {
+		return fmt.Sprintf("t/chunk_%d.parquet", i), bytes.Repeat([]byte{byte('a' + i)}, 400)
+	}
+	c, inner, _ := newTestCache(t, 1000) // fits two 400-byte entries, not three
+	for i := 0; i < 2; i++ {
+		key, data := obj(i)
+		putObject(t, inner.Store, "data", key, data)
+		getAll(t, c, "data", key)
+	}
+	// Touch entry 0 so entry 1 is the LRU tail.
+	key0, _ := obj(0)
+	getAll(t, c, "data", key0)
+
+	key2, data2 := obj(2)
+	putObject(t, inner.Store, "data", key2, data2)
+	getAll(t, c, "data", key2)
+
+	s := c.Stats()
+	if s.Entries != 2 || s.Evictions != 1 {
+		t.Fatalf("stats = %+v, want 2 entries / 1 eviction", s)
+	}
+	// Entry 1 (the LRU tail at admit time) must be the one evicted; 0 and 2
+	// stay resident. Probe membership via CachedLocalPath — a Get would
+	// re-populate and evict again.
+	key1, _ := obj(1)
+	if _, ok := c.CachedLocalPath("data", key1); ok {
+		t.Fatal("LRU-tail entry survived eviction")
+	}
+	if _, ok := c.CachedLocalPath("data", key0); !ok {
+		t.Fatal("recently-touched entry was evicted")
+	}
+	if _, ok := c.CachedLocalPath("data", key2); !ok {
+		t.Fatal("newest entry was evicted")
+	}
+}
+
+func TestBaseTableCacheOverBudgetNeverAdmitted(t *testing.T) {
+	c, inner, _ := newTestCache(t, 100)
+	data := bytes.Repeat([]byte("y"), 500)
+	putObject(t, inner.Store, "data", "t/big.parquet", data)
+	getAll(t, c, "data", "t/big.parquet")
+	if s := c.Stats(); s.Entries != 0 {
+		t.Fatalf("over-budget object admitted: %+v", s)
+	}
+}
+
+func TestBaseTableCacheStartupRebuild(t *testing.T) {
+	dir := t.TempDir()
+	inner := &countingStore{Store: NewMemStore()}
+	c1, err := NewBaseTableCache(inner, dir, 1<<20, nil)
+	if err != nil {
+		t.Fatalf("NewBaseTableCache: %v", err)
+	}
+	data := bytes.Repeat([]byte("z"), 2048)
+	putObject(t, inner.Store, "data", "t/a.parquet", data)
+	getAll(t, c1, "data", "t/a.parquet")
+
+	// Leave a stray partial population behind; the next instance must sweep it.
+	stray := filepath.Join(dir, "tmp", "populate-stray.tmp")
+	if err := os.WriteFile(stray, []byte("partial"), 0o644); err != nil {
+		t.Fatalf("writing stray tmp: %v", err)
+	}
+
+	c2, err := NewBaseTableCache(inner, dir, 1<<20, nil)
+	if err != nil {
+		t.Fatalf("NewBaseTableCache (rebuild): %v", err)
+	}
+	before := inner.gets.Load()
+	if got := getAll(t, c2, "data", "t/a.parquet"); !bytes.Equal(got, data) {
+		t.Fatal("body mismatch after rebuild")
+	}
+	if inner.gets.Load() != before {
+		t.Fatal("rebuilt cache did not serve the adopted entry")
+	}
+	if _, err := os.Stat(stray); !os.IsNotExist(err) {
+		t.Fatal("stray tmp file survived the startup sweep")
+	}
+	if s := c2.Stats(); s.Entries != 1 || s.Bytes != int64(len(data)) {
+		t.Fatalf("rebuilt stats = %+v", s)
+	}
+}
+
+func TestBaseTableCacheRebuildEvictsToShrunkBudget(t *testing.T) {
+	dir := t.TempDir()
+	inner := &countingStore{Store: NewMemStore()}
+	c1, err := NewBaseTableCache(inner, dir, 1<<20, nil)
+	if err != nil {
+		t.Fatalf("NewBaseTableCache: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		key := fmt.Sprintf("t/c%d.parquet", i)
+		putObject(t, inner.Store, "data", key, bytes.Repeat([]byte{byte(i)}, 400))
+		getAll(t, c1, "data", key)
+	}
+
+	c2, err := NewBaseTableCache(inner, dir, 900, nil)
+	if err != nil {
+		t.Fatalf("NewBaseTableCache (shrunk): %v", err)
+	}
+	if s := c2.Stats(); s.Entries != 2 || s.Bytes > 900 {
+		t.Fatalf("shrunk-budget rebuild stats = %+v, want 2 entries <= 900 bytes", s)
+	}
+}
+
+func TestBaseTableCacheConcurrentSameKey(t *testing.T) {
+	c, inner, _ := newTestCache(t, 1<<20)
+	data := bytes.Repeat([]byte("c"), 128<<10)
+	putObject(t, inner.Store, "data", "t/hot.parquet", data)
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 16)
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			got := getAll(t, c, "data", "t/hot.parquet")
+			if !bytes.Equal(got, data) {
+				errs <- fmt.Errorf("body mismatch (%d bytes)", len(got))
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+	if s := c.Stats(); s.Entries != 1 {
+		t.Fatalf("stats = %+v, want exactly 1 entry", s)
+	}
+	// Steady state: everything is a hit.
+	before := inner.gets.Load()
+	getAll(t, c, "data", "t/hot.parquet")
+	if inner.gets.Load() != before {
+		t.Fatal("steady-state read consulted the inner store")
+	}
+}
+
+func TestBaseTableCacheGetReaderAt(t *testing.T) {
+	c, inner, _ := newTestCache(t, 1<<20)
+	data := []byte("0123456789abcdef")
+	putObject(t, inner.Store, "data", "t/a.parquet", data)
+
+	// Miss: passes through to the inner ReaderAtStore, does NOT populate.
+	ra, size, err := c.GetReaderAt(context.Background(), "data", "t/a.parquet")
+	if err != nil {
+		t.Fatalf("GetReaderAt (miss): %v", err)
+	}
+	if size != int64(len(data)) {
+		t.Fatalf("size = %d, want %d", size, len(data))
+	}
+	buf := make([]byte, 4)
+	if _, err := ra.ReadAt(buf, 10); err != nil {
+		t.Fatalf("ReadAt: %v", err)
+	}
+	if string(buf) != "abcd" {
+		t.Fatalf("ReadAt = %q, want abcd", buf)
+	}
+	ra.Close()
+	if inner.readerAts.Load() != 1 {
+		t.Fatalf("inner readerAts = %d, want 1", inner.readerAts.Load())
+	}
+	if s := c.Stats(); s.Entries != 0 {
+		t.Fatalf("ranged miss populated the cache: %+v", s)
+	}
+
+	// Populate via whole-file Get, then the ReaderAt must be a local hit.
+	getAll(t, c, "data", "t/a.parquet")
+	ra, size, err = c.GetReaderAt(context.Background(), "data", "t/a.parquet")
+	if err != nil {
+		t.Fatalf("GetReaderAt (hit): %v", err)
+	}
+	defer ra.Close()
+	if size != int64(len(data)) {
+		t.Fatalf("hit size = %d, want %d", size, len(data))
+	}
+	if _, err := ra.ReadAt(buf, 0); err != nil {
+		t.Fatalf("ReadAt (hit): %v", err)
+	}
+	if string(buf) != "0123" {
+		t.Fatalf("ReadAt (hit) = %q, want 0123", buf)
+	}
+	if inner.readerAts.Load() != 1 {
+		t.Fatalf("inner readerAts = %d, want 1 (hit must not pass through)", inner.readerAts.Load())
+	}
+}
+
+func TestBaseTableCacheDeleteAndPutInvalidate(t *testing.T) {
+	c, inner, _ := newTestCache(t, 1<<20)
+	ctx := context.Background()
+	data := []byte("version one!")
+	putObject(t, inner.Store, "data", "t/a.parquet", data)
+	getAll(t, c, "data", "t/a.parquet")
+	if s := c.Stats(); s.Entries != 1 {
+		t.Fatalf("setup failed: %+v", s)
+	}
+
+	if err := c.Delete(ctx, "data", "t/a.parquet"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if s := c.Stats(); s.Entries != 0 {
+		t.Fatalf("Delete did not invalidate: %+v", s)
+	}
+
+	// Out-of-contract overwrite through the cache must invalidate too.
+	putObject(t, inner.Store, "data", "t/b.parquet", data)
+	getAll(t, c, "data", "t/b.parquet")
+	newData := []byte("version two.")
+	if _, err := c.Put(ctx, "data", "t/b.parquet", bytes.NewReader(newData), int64(len(newData)), ""); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if got := getAll(t, c, "data", "t/b.parquet"); !bytes.Equal(got, newData) {
+		t.Fatalf("stale bytes after overwrite: %q", got)
+	}
+}
+
+func TestBaseTableCacheCachedLocalPath(t *testing.T) {
+	c, inner, _ := newTestCache(t, 1<<20)
+	if _, ok := c.CachedLocalPath("data", "t/a.parquet"); ok {
+		t.Fatal("CachedLocalPath reported a hit on an empty cache")
+	}
+	data := []byte("mmap me in place")
+	putObject(t, inner.Store, "data", "t/a.parquet", data)
+	getAll(t, c, "data", "t/a.parquet")
+
+	p, ok := c.CachedLocalPath("data", "t/a.parquet")
+	if !ok {
+		t.Fatal("CachedLocalPath missed a resident entry")
+	}
+	got, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("reading cache file: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatal("cache file content mismatch")
+	}
+	if !strings.HasSuffix(filepath.ToSlash(p), "data/t/a.parquet") {
+		t.Fatalf("unexpected cache layout: %s", p)
+	}
+	if _, ok := c.CachedLocalPath("data", "queries/q/x.parquet"); ok {
+		t.Fatal("CachedLocalPath answered for an ineligible key")
+	}
+}

--- a/internal/worker/base_table_cache_tier_test.go
+++ b/internal/worker/base_table_cache_tier_test.go
@@ -1,0 +1,137 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// getCountingStore counts Get calls so the test can prove the second scan
+// pass never reached S3.
+type getCountingStore struct {
+	objstore.Store
+	gets atomic.Int64
+}
+
+func (s *getCountingStore) Get(ctx context.Context, bucket, key string) (io.ReadCloser, objstore.ObjectInfo, error) {
+	s.gets.Add(1)
+	return s.Store.Get(ctx, bucket, key)
+}
+
+// TestBaseTableCacheTier_SecondPassServesWithoutGET: with the base-table
+// cache enabled, the first scan pass populates the cache (via the miss
+// tee) and the second pass must be served entirely from local disk — the
+// prefetcher skips resident files (HasCachedPath probe) and openNextFile
+// mmaps the cache files in place, which also means Close must NOT unlink
+// them (the cache owns its files; docs/design/base-table-nvme-cache.md §7).
+func TestBaseTableCacheTier_SecondPassServesWithoutGET(t *testing.T) {
+	schema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+	}}
+	inner := &getCountingStore{Store: objstore.NewMemStore()}
+	ctx := context.Background()
+	if err := inner.MakeBucket(ctx, "b"); err != nil {
+		t.Fatal(err)
+	}
+	var files []string
+	const rowsPerFile = 100
+	for f := 0; f < 3; f++ {
+		var buf bytes.Buffer
+		w, err := parquet.NewWriter(&buf, schema, parquet.DefaultWriterConfig())
+		if err != nil {
+			t.Fatal(err)
+		}
+		rows := make([]map[string]any, rowsPerFile)
+		for i := range rows {
+			rows[i] = map[string]any{"id": int64(f*rowsPerFile + i)}
+		}
+		if err := w.WriteRows(rows); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		path := fmt.Sprintf("tables/t/chunk_%d.parquet", f)
+		if _, err := inner.Put(ctx, "b", path, bytes.NewReader(buf.Bytes()), int64(buf.Len()), ""); err != nil {
+			t.Fatal(err)
+		}
+		files = append(files, path)
+	}
+
+	cacheDir := t.TempDir()
+	btc, err := objstore.NewBaseTableCache(inner, cacheDir, 1<<30, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ex := &Executor{store: btc, spillDir: t.TempDir()}
+
+	scanAll := func() int {
+		t.Helper()
+		src := newCachedFileStreamSource(ex, "", "b", files)
+		if err := src.Init(ctx); err != nil {
+			t.Fatal(err)
+		}
+		rows := 0
+		for {
+			b, err := src.Next(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if b == nil {
+				break
+			}
+			rows += b.Len
+		}
+		if err := src.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if src.mmapData != nil || src.localPath != "" {
+			t.Fatal("mmap/localPath still held after Close")
+		}
+		return rows
+	}
+
+	if rows := scanAll(); rows != 3*rowsPerFile {
+		t.Fatalf("cold pass rows = %d, want %d", rows, 3*rowsPerFile)
+	}
+	coldGets := inner.gets.Load()
+	if coldGets == 0 {
+		t.Fatal("cold pass issued no inner Gets")
+	}
+	if s := btc.Stats(); s.Entries != 3 {
+		t.Fatalf("cold pass cached %d entries, want 3 (stats %+v)", s.Entries, s)
+	}
+
+	if rows := scanAll(); rows != 3*rowsPerFile {
+		t.Fatalf("warm pass rows = %d, want %d", rows, 3*rowsPerFile)
+	}
+	if got := inner.gets.Load(); got != coldGets {
+		t.Fatalf("warm pass reached the inner store: gets %d -> %d", coldGets, got)
+	}
+	if s := btc.Stats(); s.Hits < 3 {
+		t.Fatalf("warm pass hits = %d, want >= 3 (stats %+v)", s.Hits, s)
+	}
+
+	// The warm pass mmap'd the cache's files in place — they must survive
+	// the source Close (only LRU eviction may unlink them).
+	survivors := 0
+	if err := filepath.Walk(filepath.Join(cacheDir, "b"), func(_ string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() {
+			survivors++
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if survivors != 3 {
+		t.Fatalf("%d cache files survive after warm pass, want 3", survivors)
+	}
+}

--- a/internal/worker/scan_prefetch.go
+++ b/internal/worker/scan_prefetch.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/citc-tech/wadjet/internal/engine/diskio"
 	"github.com/citc-tech/wadjet/internal/engine/exec"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
 )
 
 // Prefetch tuning. Vars (not consts) so tests can shrink them to exercise
@@ -147,6 +148,13 @@ func (p *filePrefetcher) fetch(ctx context.Context, s *cachedFileStreamSource, i
 		if addr, _ := peers.hintFor(filePath); addr != "" {
 			return &prefetchResult{skipped: true}
 		}
+	}
+	// Base-table cache resident: the consumer's cache tier mmaps the file
+	// in place — downloading it again here would waste the GET the cache
+	// exists to save. Counting-free probe: the serve (and the hit stat)
+	// happens in openNextFile.
+	if lps, ok := s.executor.store.(objstore.LocalPathStore); ok && lps.HasCachedPath(s.bucket, filePath) {
+		return &prefetchResult{skipped: true}
 	}
 
 	rc, info, err := s.executor.store.Get(ctx, s.bucket, filePath)

--- a/internal/worker/stream_source.go
+++ b/internal/worker/stream_source.go
@@ -331,6 +331,24 @@ func (s *cachedFileStreamSource) openNextFile(ctx context.Context) error {
 		// authoritative for both resolution and error reporting.
 	}
 
+	// Base-table cache tier: the process-wide NVMe cache already holds
+	// this parquet object — mmap its file in place, no GET and no disk
+	// copy (docs/design/base-table-nvme-cache.md §7 S2). The cache owns
+	// the file (LRU eviction unlinks it; POSIX keeps the inode alive
+	// under a live mmap), so s.localPath stays empty. Any failure —
+	// evicted between lookup and open, unreadable entry — falls through
+	// to the tiered path, whose durable copy is authoritative.
+	if lps, ok := s.executor.store.(objstore.LocalPathStore); ok {
+		if cached, ok := lps.CachedLocalPath(s.bucket, filePath); ok {
+			if err := s.openParquetFromBaseCache(cached, filePath); err == nil {
+				return nil
+			} else if s.executor.logger != nil {
+				s.executor.logger.Debug("base-table cache open fell through",
+					"key", filePath, "path", cached, "error", err)
+			}
+		}
+	}
+
 	// Tier-0 same-worker fast path: if a producer task on this worker
 	// already wrote this stage output to local disk and registered it in
 	// LocalStageCache, mmap it directly — no KV / S3 round-trip. The cache
@@ -502,6 +520,30 @@ func (s *cachedFileStreamSource) openPrefetchedParquet(localPath, filePath strin
 	// finishOpenParquet unwinds mmap+file itself if the payload isn't
 	// valid parquet (e.g. a legacy shuffle object under a .parquet key).
 	return s.finishOpenParquet(filePath, mmapData, mmapData, localPath)
+}
+
+// openParquetFromBaseCache opens a parquet file the process-wide
+// base-table cache holds on local disk: mmap it in place and hand the
+// region to the shared open tail. localPath stays empty throughout — the
+// cache owns the file, so neither releaseCurrentFile nor the open-failure
+// unwind may unlink it.
+func (s *cachedFileStreamSource) openParquetFromBaseCache(cachePath, filePath string) error {
+	f, err := os.Open(cachePath)
+	if err != nil {
+		return fmt.Errorf("opening base-cache file %s: %w", cachePath, err)
+	}
+	defer f.Close()
+	fi, err := f.Stat()
+	if err != nil || fi.Size() == 0 {
+		return fmt.Errorf("base-cache file %s unusable (err=%v)", cachePath, err)
+	}
+	mmapData, err := syscall.Mmap(int(f.Fd()), 0, int(fi.Size()), syscall.PROT_READ, syscall.MAP_SHARED)
+	if err != nil {
+		return fmt.Errorf("mmap base-cache file %s: %w", cachePath, err)
+	}
+	// finishOpenParquet unwinds the mmap itself on a bad payload; its
+	// os.Remove of the empty localPath is a no-op.
+	return s.finishOpenParquet(filePath, mmapData, mmapData, "")
 }
 
 // finishOpenParquet is the shared tail of the parquet open path: build the


### PR DESCRIPTION
Implements the design memo merged in #221 (docs/design/base-table-nvme-cache.md), slices S1+S2. Flag `--base-table-cache-bytes` **default 0 = off**; SF100 pair (S3) is the next step and gates any default change.

## What

- **S1 — `objstore.BaseTableCache`**: read-through whole-file disk cache decorator, stacked above `CircuitStore` (hits bypass the breaker entirely; misses keep full protection). Eligibility = `*.parquet` outside `queries/`. Miss bodies tee to a temp (`diskio` Spill class, bounded dirty pages) and atomically rename on clean size-verified EOF — strictly best-effort. LRU-by-bytes, `<dir>/<bucket>/<key>` layout, startup index rebuild (survives restarts), stale-tmp sweep, defensive invalidation on Put/Delete, no blocking single-flight (memo §3 — PR #220 lesson).
- **S2 — worker mmap-in-place hit tier**: `cachedFileStreamSource` mmaps resident cache files in place (cache owns the file; `localPath` stays empty so nothing unlinks it) and the prefetcher skips resident files via a counting-free probe. Warm scans: zero GETs, zero disk copies.
- Flags in `cmd/wadjet` (dir defaults to `<spill-dir>/base-cache`), terraform `base_table_cache_bytes` var wired to the worker start command, 60s stats log marker (`base-table cache stats`).

## Gates (all green)

- Full `./internal/...` unit; `-race` on objstore + worker.
- SF0.01 TPC-H 22/22.
- `tpch-harness --mode=local`, 4 arms (default/cache-on × fastpath/DAG-forced): 22 TPC-H queries + grace-join micro **row- and checksum-identical across all arms**. (`micro_hash_agg_high_card` / `micro_reverse_bloom` checksums differ between *any* two runs including off-vs-off controls — pre-existing run-nondeterminism, row counts identical.)
- Engagement verified live: cache dirs populated on coord + both workers (all 8 TPC-H tables), `base-table cache enabled` markers on every process; warm-pass zero-GET regression test (`TestBaseTableCacheTier_SecondPassServesWithoutGET`).
- Race-built binary through the DAG-forced cache-on harness arm: passed, zero races, rows identical to baseline arm.

## Next (not this PR)

S3 per memo §7-8: SF100 same-window pair (control off / treatment 150 GB), decisive markers = hit-byte ratio → prefetcher block collapse → utilization → wall last; treatment suite run twice for cold vs steady-state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcKKX1fvthE6zpyFsXcrYE