### PR TITLE
feat(scan): parallel row-group decode-ahead — scan decode pipelining S1-S3 (flag default off)

### DIFF
--- a/cmd/wadjet/main.go
+++ b/cmd/wadjet/main.go
@@ -110,6 +110,8 @@ var (
 	baseTableCacheBytes   int64
 	baseTableCacheDir     string
 	streamingShuffleRead  bool
+	scanDecodeAhead       bool
+	scanDecodeAheadBytes  int64
 )
 
 func main() {
@@ -179,6 +181,8 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&peerExchangeAddr, "peer-exchange-addr", ":0", "Peer-exchange (FetchShuffle) listen address. Default :0 picks a free port (the address reaches peers via heartbeats, and a fixed default would collide when multiple workers share a host); pin it when firewalls need a known port.")
 	rootCmd.PersistentFlags().StringVar(&peerExchangeAdvertise, "peer-exchange-advertise", "", "Peer-exchange address advertised in heartbeats (default: derived from the bound listener)")
 	rootCmd.PersistentFlags().BoolVar(&streamingShuffleRead, "streaming-shuffle-read", true, "Decode WSHF/WSHC exchange inputs directly from the peer/S3 byte stream instead of staging the whole file to NVMe + mmap first — the first chunk decodes as soon as its frames arrive. Any mid-stream failure falls back to a staged read of the durable copy, skipping already-delivered batches. Default true (SF100-validated); =false is the kill switch restoring the staged read path. See docs/design/exchange-streaming-consumption.md.")
+	rootCmd.PersistentFlags().BoolVar(&scanDecodeAhead, "scan-decode-ahead", false, "Decode parquet row groups ahead of scan consumption: k decode workers per scan source with in-order delivery and a bounded decoded-bytes window, instead of one row group per pull on the consumer's goroutine. Worker scan path only. Default false pending SF100 validation (kill switch thereafter). See docs/design/scan-decode-pipelining.md.")
+	rootCmd.PersistentFlags().Int64Var(&scanDecodeAheadBytes, "scan-decode-ahead-bytes", 0, "Decoded-but-unconsumed byte window per scan source for --scan-decode-ahead. 0 = engine default (256 MiB).")
 	rootCmd.PersistentFlags().Int64Var(&baseTableCacheBytes, "base-table-cache-bytes", 0, "Cross-query disk cache for immutable base-table parquet objects: LRU byte budget on the cache volume. Hits are served from local disk without touching S3 (or the circuit breaker); misses tee the download into the cache. The cache survives restarts (index rebuilt from the directory). 0 = disabled (default until SF100 validation). See docs/design/base-table-nvme-cache.md.")
 	rootCmd.PersistentFlags().StringVar(&baseTableCacheDir, "base-table-cache-dir", "", "Directory for the base-table cache (default: <spill-dir>/base-cache, inheriting the spill volume's NVMe mount)")
 	rootCmd.PersistentFlags().StringVar(&geoipCityDB, "geoip-city", "", "Path to MaxMind GeoIP City database (GeoLite2-City.mmdb)")
@@ -932,6 +936,8 @@ func runStandalone(ctx context.Context, store objstore.Store, logger *slog.Logge
 		PeerListenAddr:        peerListenAddr(),
 		PeerAdvertiseAddr:     peerExchangeAdvertise,
 		StreamingShuffleRead:  streamingShuffleRead,
+		ScanDecodeAhead:       scanDecodeAhead,
+		ScanDecodeAheadBytes:  scanDecodeAheadBytes,
 	}, store, nc, js, logger)
 
 	// Initialize Prometheus metrics (before worker.Start so spill metrics are wired)
@@ -1501,6 +1507,8 @@ func runWorker(ctx context.Context, store objstore.Store, logger *slog.Logger) e
 		PeerListenAddr:        peerListenAddr(),
 		PeerAdvertiseAddr:     peerExchangeAdvertise,
 		StreamingShuffleRead:  streamingShuffleRead,
+		ScanDecodeAhead:       scanDecodeAhead,
+		ScanDecodeAheadBytes:  scanDecodeAheadBytes,
 	}, store, nc, js, logger)
 	w.SetControlConn(controlNC)
 

--- a/internal/engine/scan/decode_ahead.go
+++ b/internal/engine/scan/decode_ahead.go
@@ -46,21 +46,23 @@ type DecodeAheadIter struct {
 	// for window estimation, resolved once at Open.
 	estLeaves []int
 
-	workers     int
-	windowBytes int64
+	workers int
 
 	dynamicRanges []exec.DynamicRange
 	bloomFilters  []*exec.BloomScanFilter
 
-	mu       sync.Mutex
-	cond     *sync.Cond
-	started  bool
-	closed   bool
-	nextIdx  int                 // next row-group index to assign to a worker
-	deliver  int                 // next row-group index to hand to the consumer
-	inflight int64               // window bytes reserved for assigned-but-undelivered groups
-	slots    map[int]*decodeSlot // decoded (or pruned/failed), awaiting delivery
-	wg       sync.WaitGroup
+	// win serializes ALL iterator state below and carries the byte
+	// window. Chained iterators (cross-file continuation) share one
+	// DecodeWindow, so one file's deliveries wake the next file's
+	// admission waiters — and share one mutex, which keeps the two
+	// iterators' state transitions trivially race-free.
+	win     *DecodeWindow
+	started bool
+	closed  bool
+	nextIdx int                 // next row-group index to assign to a worker
+	deliver int                 // next row-group index to hand to the consumer
+	slots   map[int]*decodeSlot // decoded (or pruned/failed), awaiting delivery
+	wg      sync.WaitGroup
 
 	// Empty-shard sentinel (mirrors RowGroupIter).
 	empty bool
@@ -87,8 +89,33 @@ type DecodeAheadOpts struct {
 	// DefaultDecodeAheadWorkers capped at GOMAXPROCS.
 	Workers int
 	// WindowBytes bounds decoded-but-undelivered batch bytes. <= 0
-	// selects DefaultDecodeAheadWindowBytes.
+	// selects DefaultDecodeAheadWindowBytes. Ignored when Window is set.
 	WindowBytes int64
+	// Window shares an existing byte window (and its lock) with another
+	// iterator — the cross-file continuation shape: the tail of file F
+	// and the head of file F+1 draw from one budget.
+	Window *DecodeWindow
+}
+
+// DecodeWindow is a byte budget shared by one or more DecodeAheadIters.
+// Its mutex doubles as the owning iterators' state lock.
+type DecodeWindow struct {
+	mu       sync.Mutex
+	cond     *sync.Cond
+	inflight int64
+	limit    int64
+}
+
+// NewDecodeWindow returns a window bounding decoded-but-undelivered
+// bytes across every iterator opened with it. bytes <= 0 selects
+// DefaultDecodeAheadWindowBytes.
+func NewDecodeWindow(bytes int64) *DecodeWindow {
+	if bytes <= 0 {
+		bytes = DefaultDecodeAheadWindowBytes
+	}
+	w := &DecodeWindow{limit: bytes}
+	w.cond = sync.NewCond(&w.mu)
+	return w
 }
 
 const (
@@ -130,18 +157,17 @@ func OpenDecodeAheadIter(reader *pqt.Reader, schema []pqt.Column, selectedCols [
 	}
 
 	it := &DecodeAheadIter{
-		workers:     opts.Workers,
-		windowBytes: opts.WindowBytes,
+		workers: opts.Workers,
+		win:     opts.Window,
 	}
-	it.cond = sync.NewCond(&it.mu)
+	if it.win == nil {
+		it.win = NewDecodeWindow(opts.WindowBytes)
+	}
 	if it.workers <= 0 {
 		it.workers = DefaultDecodeAheadWorkers
 	}
 	if gp := runtime.GOMAXPROCS(0); it.workers > gp {
 		it.workers = gp
-	}
-	if it.windowBytes <= 0 {
-		it.windowBytes = DefaultDecodeAheadWindowBytes
 	}
 
 	if shardIdx < 0 || shardIdx >= shardCount {
@@ -181,10 +207,47 @@ func (it *DecodeAheadIter) SetDynamicFilters(ranges []exec.DynamicRange, blooms 
 	if it == nil {
 		return
 	}
-	it.mu.Lock()
-	defer it.mu.Unlock()
+	it.win.mu.Lock()
+	defer it.win.mu.Unlock()
 	it.dynamicRanges = ranges
 	it.bloomFilters = blooms
+}
+
+// Start spawns the decode workers immediately instead of on the first
+// Next — the cross-file continuation pre-opens the next file's iterator
+// and wants its head decoding while the current file's tail delivers.
+// Filters must already be attached. Idempotent.
+func (it *DecodeAheadIter) Start() {
+	if it == nil || it.empty {
+		return
+	}
+	it.win.mu.Lock()
+	it.startLocked()
+	it.win.mu.Unlock()
+}
+
+func (it *DecodeAheadIter) startLocked() {
+	if it.started || it.closed {
+		return
+	}
+	it.started = true
+	for w := 0; w < it.workers; w++ {
+		it.wg.Add(1)
+		go it.decodeLoop()
+	}
+}
+
+// AssignmentDrained reports whether every row group has been assigned to
+// a decode worker (not necessarily delivered) — the cross-file
+// continuation's pre-open trigger: once true, idle workers exist or soon
+// will, and the next file's head is the only work left to feed them.
+func (it *DecodeAheadIter) AssignmentDrained() bool {
+	if it == nil || it.empty {
+		return true
+	}
+	it.win.mu.Lock()
+	defer it.win.mu.Unlock()
+	return !it.closed && it.started && it.nextIdx >= it.end
 }
 
 // PruneStats mirrors RowGroupIter.PruneStats.
@@ -210,15 +273,9 @@ func (it *DecodeAheadIter) Next() (*batch.RecordBatch, error) {
 	if it == nil || it.empty {
 		return nil, nil
 	}
-	it.mu.Lock()
-	defer it.mu.Unlock()
-	if !it.started && !it.closed {
-		it.started = true
-		for w := 0; w < it.workers; w++ {
-			it.wg.Add(1)
-			go it.decodeLoop()
-		}
-	}
+	it.win.mu.Lock()
+	defer it.win.mu.Unlock()
+	it.startLocked()
 	for {
 		if it.closed {
 			return nil, nil
@@ -226,13 +283,13 @@ func (it *DecodeAheadIter) Next() (*batch.RecordBatch, error) {
 		if slot, ok := it.slots[it.deliver]; ok {
 			delete(it.slots, it.deliver)
 			it.deliver++
-			it.inflight -= slot.est
-			it.cond.Broadcast()
+			it.win.inflight -= slot.est
+			it.win.cond.Broadcast()
 			if slot.err != nil {
 				// Mirror serial semantics: the error surfaces exactly at
 				// this group's position and the iterator is dead after.
 				it.closed = true
-				it.cond.Broadcast()
+				it.win.cond.Broadcast()
 				return nil, slot.err
 			}
 			if slot.batch == nil {
@@ -243,7 +300,7 @@ func (it *DecodeAheadIter) Next() (*batch.RecordBatch, error) {
 		if it.deliver >= it.end {
 			return nil, nil // all groups delivered
 		}
-		it.cond.Wait()
+		it.win.cond.Wait()
 	}
 }
 
@@ -251,10 +308,10 @@ func (it *DecodeAheadIter) Next() (*batch.RecordBatch, error) {
 // window, decode it outside the lock, park the result in its slot.
 func (it *DecodeAheadIter) decodeLoop() {
 	defer it.wg.Done()
-	it.mu.Lock()
+	it.win.mu.Lock()
 	for {
 		if it.closed || it.nextIdx >= it.end {
-			it.mu.Unlock()
+			it.win.mu.Unlock()
 			return
 		}
 		idx := it.nextIdx
@@ -262,16 +319,18 @@ func (it *DecodeAheadIter) decodeLoop() {
 		// The delivery-cursor group is always admitted: the consumer is
 		// (or will be) waiting on precisely this index, so reserving past
 		// the window here cannot grow it further, and refusing would
-		// deadlock on any single group larger than the window.
-		if it.inflight+est > it.windowBytes && idx != it.deliver {
+		// deadlock on any single group larger than the window. (Under a
+		// shared window this bounds transient overshoot to one group per
+		// chained iterator.)
+		if it.win.inflight+est > it.win.limit && idx != it.deliver {
 			it.windowFullStalls.Add(1)
-			it.cond.Wait()
+			it.win.cond.Wait()
 			continue
 		}
 		it.nextIdx++
-		it.inflight += est
+		it.win.inflight += est
 		ranges, blooms := it.dynamicRanges, it.bloomFilters
-		it.mu.Unlock()
+		it.win.mu.Unlock()
 
 		slot := &decodeSlot{est: est}
 		if pruned := it.pruneGroup(idx, ranges, blooms); !pruned {
@@ -286,9 +345,9 @@ func (it *DecodeAheadIter) decodeLoop() {
 			}
 		}
 
-		it.mu.Lock()
+		it.win.mu.Lock()
 		it.slots[idx] = slot
-		it.cond.Broadcast()
+		it.win.cond.Broadcast()
 	}
 }
 
@@ -348,13 +407,28 @@ func (it *DecodeAheadIter) Close() error {
 	if it == nil || it.empty {
 		return nil
 	}
-	it.mu.Lock()
+	it.win.mu.Lock()
 	it.closed = true
-	it.cond.Broadcast()
+	// Release this iterator's undelivered reservations so a chained
+	// iterator sharing the window doesn't inherit dead inflight bytes.
+	for idx, slot := range it.slots {
+		it.win.inflight -= slot.est
+		delete(it.slots, idx)
+	}
+	it.win.cond.Broadcast()
 	started := it.started
-	it.mu.Unlock()
+	it.win.mu.Unlock()
 	if started {
 		it.wg.Wait()
 	}
+	// Workers parked slots between the drain above and their exit; drop
+	// those reservations too. No new slots can appear once closed.
+	it.win.mu.Lock()
+	for idx, slot := range it.slots {
+		it.win.inflight -= slot.est
+		delete(it.slots, idx)
+	}
+	it.win.cond.Broadcast()
+	it.win.mu.Unlock()
 	return nil
 }

--- a/internal/engine/scan/decode_ahead.go
+++ b/internal/engine/scan/decode_ahead.go
@@ -1,0 +1,360 @@
+package scan
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"sync/atomic"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/engine/exec"
+	pqt "github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// DecodeAheadIter is the parallel sibling of RowGroupIter
+// (docs/design/scan-decode-pipelining.md): k decode workers pull
+// row-group indices in file order, each runs ReadRowGroupNative for its
+// group, and results deliver to the consumer strictly in source order.
+// The consumer-facing contract is identical to RowGroupIter — same
+// batches in the same order, same error surfaced at the same position,
+// same prune behavior — only the decode of group N+1..N+w overlaps the
+// consumption of group N instead of waiting for it.
+//
+// Memory is bounded by WindowBytes of decoded-but-undelivered batches,
+// estimated per group from the projected columns' TotalUncompressedSize
+// metadata (estimation error is bounded by one group per worker). The
+// group at the delivery cursor is always admitted regardless of the
+// window so a single oversized row group cannot deadlock the pipeline.
+//
+// Concurrency safety rests on ReadRowGroupNative's documented contract:
+// FileReader is read-only after construction and every ColumnPages call
+// allocates a fresh ColumnPageReader, so concurrent decodes of distinct
+// row groups never share mutable state (columnar_native.go:124-126).
+//
+// Lifecycle: workers start on the FIRST Next() call, not at Open — this
+// preserves RowGroupIter's "SetDynamicFilters before first Next"
+// contract (filters attach after Open on the worker scan path). Close()
+// stops assignment and JOINS in-flight decodes before returning: the
+// caller munmaps the file bytes right after Close, so no decode may
+// touch the underlying slice once Close returns.
+type DecodeAheadIter struct {
+	fr         *pqt.FileReader
+	readSchema []pqt.Column
+	start, end int
+	// estLeaves[i] is the leaf column index for readSchema[i], -1 when
+	// unresolved (ROW children, aliased or missing columns) — used only
+	// for window estimation, resolved once at Open.
+	estLeaves []int
+
+	workers     int
+	windowBytes int64
+
+	dynamicRanges []exec.DynamicRange
+	bloomFilters  []*exec.BloomScanFilter
+
+	mu       sync.Mutex
+	cond     *sync.Cond
+	started  bool
+	closed   bool
+	nextIdx  int                 // next row-group index to assign to a worker
+	deliver  int                 // next row-group index to hand to the consumer
+	inflight int64               // window bytes reserved for assigned-but-undelivered groups
+	slots    map[int]*decodeSlot // decoded (or pruned/failed), awaiting delivery
+	wg       sync.WaitGroup
+
+	// Empty-shard sentinel (mirrors RowGroupIter).
+	empty bool
+
+	// Counters. Prune counters mirror RowGroupIter's for diagnostic
+	// parity; the rest are the memo §5 markers, read via Stats.
+	rgPrunedBloom    atomic.Int64
+	rgPrunedRange    atomic.Int64
+	rgRead           atomic.Int64
+	windowFullStalls atomic.Int64
+}
+
+// decodeSlot is one row group's outcome, parked until the delivery
+// cursor reaches its index.
+type decodeSlot struct {
+	batch  *batch.RecordBatch // nil when pruned or empty
+	err    error
+	est    int64 // window bytes reserved for this group
+}
+
+// DecodeAheadOpts sizes a DecodeAheadIter.
+type DecodeAheadOpts struct {
+	// Workers is the decode worker count. <= 0 selects
+	// DefaultDecodeAheadWorkers capped at GOMAXPROCS.
+	Workers int
+	// WindowBytes bounds decoded-but-undelivered batch bytes. <= 0
+	// selects DefaultDecodeAheadWindowBytes.
+	WindowBytes int64
+}
+
+const (
+	// DefaultDecodeAheadWorkers is deliberately modest: decode workers
+	// multiply with the per-column errgroup inside ReadRowGroupNative
+	// (min(#cols, GOMAXPROCS) each), and with concurrent fragments per
+	// worker process. cpuToken integration (memo S3) replaces this with
+	// budget-aware width.
+	DefaultDecodeAheadWorkers = 4
+
+	// DefaultDecodeAheadWindowBytes matches the scanPrefetch byte-window
+	// order of magnitude; the morsel dispenser's budget bounds the next
+	// stage downstream.
+	DefaultDecodeAheadWindowBytes int64 = 256 << 20
+
+	// minGroupEstimateBytes floors the per-group window reservation so
+	// files with absent/zero size metadata cannot admit unboundedly.
+	minGroupEstimateBytes int64 = 1 << 20
+)
+
+// OpenDecodeAheadIter constructs a decode-ahead iterator over the
+// row-group range assigned to (shardIdx, shardCount), mirroring
+// OpenRowGroupIter's contract (empty-shard sentinel, Array/Map
+// rejection, projection via selectedCols).
+func OpenDecodeAheadIter(reader *pqt.Reader, schema []pqt.Column, selectedCols []string, shardIdx, shardCount int, opts DecodeAheadOpts) (*DecodeAheadIter, error) {
+	if reader == nil {
+		return nil, fmt.Errorf("OpenDecodeAheadIter: nil reader")
+	}
+	if shardCount < 1 {
+		shardCount = 1
+	}
+
+	readSchema := schema
+	if len(selectedCols) > 0 {
+		readSchema = projectSchema(schema, selectedCols)
+	}
+	if HasUnsupportedColumnarTypes(readSchema) {
+		return nil, fmt.Errorf("DecodeAheadIter does not support Array/Map types; caller must fall back to ReadFileBatchesShard")
+	}
+
+	it := &DecodeAheadIter{
+		workers:     opts.Workers,
+		windowBytes: opts.WindowBytes,
+	}
+	it.cond = sync.NewCond(&it.mu)
+	if it.workers <= 0 {
+		it.workers = DefaultDecodeAheadWorkers
+	}
+	if gp := runtime.GOMAXPROCS(0); it.workers > gp {
+		it.workers = gp
+	}
+	if it.windowBytes <= 0 {
+		it.windowBytes = DefaultDecodeAheadWindowBytes
+	}
+
+	if shardIdx < 0 || shardIdx >= shardCount {
+		it.empty = true
+		return it, nil
+	}
+	fr := reader.FileReader()
+	if fr == nil {
+		return nil, fmt.Errorf("OpenDecodeAheadIter: reader has no FileReader")
+	}
+	it.fr = fr
+	it.readSchema = readSchema
+	it.start, it.end = rowGroupRangeForShard(fr.NumRowGroups(), shardIdx, shardCount)
+	it.nextIdx, it.deliver = it.start, it.start
+	it.slots = make(map[int]*decodeSlot, it.workers)
+
+	leaves := fr.Leaves()
+	leafByName := make(map[string]int, len(leaves))
+	for i, leaf := range leaves {
+		leafByName[leaf.Name] = i
+	}
+	it.estLeaves = make([]int, len(readSchema))
+	for i, col := range readSchema {
+		if li, ok := leafByName[col.Name]; ok {
+			it.estLeaves[i] = li
+		} else {
+			it.estLeaves[i] = -1
+		}
+	}
+	return it, nil
+}
+
+// SetDynamicFilters attaches dynamic-filter pushdowns. Must be called
+// before the first Next() — workers snapshot the filters when they
+// start. Mirrors RowGroupIter.SetDynamicFilters.
+func (it *DecodeAheadIter) SetDynamicFilters(ranges []exec.DynamicRange, blooms []*exec.BloomScanFilter) {
+	if it == nil {
+		return
+	}
+	it.mu.Lock()
+	defer it.mu.Unlock()
+	it.dynamicRanges = ranges
+	it.bloomFilters = blooms
+}
+
+// PruneStats mirrors RowGroupIter.PruneStats.
+func (it *DecodeAheadIter) PruneStats() (bloom, rangeP, read int) {
+	if it == nil {
+		return 0, 0, 0
+	}
+	return int(it.rgPrunedBloom.Load()), int(it.rgPrunedRange.Load()), int(it.rgRead.Load())
+}
+
+// Stats returns the decode-ahead engagement counters (memo §5 markers):
+// row groups decoded and times a worker stalled on a full window.
+func (it *DecodeAheadIter) Stats() (groupsRead, windowFullStalls int64) {
+	if it == nil {
+		return 0, 0
+	}
+	return it.rgRead.Load(), it.windowFullStalls.Load()
+}
+
+// Next returns the next decoded row group in source order, or (nil, nil)
+// when exhausted. Contract identical to RowGroupIter.Next.
+func (it *DecodeAheadIter) Next() (*batch.RecordBatch, error) {
+	if it == nil || it.empty {
+		return nil, nil
+	}
+	it.mu.Lock()
+	defer it.mu.Unlock()
+	if !it.started && !it.closed {
+		it.started = true
+		for w := 0; w < it.workers; w++ {
+			it.wg.Add(1)
+			go it.decodeLoop()
+		}
+	}
+	for {
+		if it.closed {
+			return nil, nil
+		}
+		if slot, ok := it.slots[it.deliver]; ok {
+			delete(it.slots, it.deliver)
+			it.deliver++
+			it.inflight -= slot.est
+			it.cond.Broadcast()
+			if slot.err != nil {
+				// Mirror serial semantics: the error surfaces exactly at
+				// this group's position and the iterator is dead after.
+				it.closed = true
+				it.cond.Broadcast()
+				return nil, slot.err
+			}
+			if slot.batch == nil {
+				continue // pruned or empty group — same silent skip as serial
+			}
+			return slot.batch, nil
+		}
+		if it.deliver >= it.end {
+			return nil, nil // all groups delivered
+		}
+		it.cond.Wait()
+	}
+}
+
+// decodeLoop is one worker: admit the next index against the byte
+// window, decode it outside the lock, park the result in its slot.
+func (it *DecodeAheadIter) decodeLoop() {
+	defer it.wg.Done()
+	it.mu.Lock()
+	for {
+		if it.closed || it.nextIdx >= it.end {
+			it.mu.Unlock()
+			return
+		}
+		idx := it.nextIdx
+		est := it.estimateGroupBytes(idx)
+		// The delivery-cursor group is always admitted: the consumer is
+		// (or will be) waiting on precisely this index, so reserving past
+		// the window here cannot grow it further, and refusing would
+		// deadlock on any single group larger than the window.
+		if it.inflight+est > it.windowBytes && idx != it.deliver {
+			it.windowFullStalls.Add(1)
+			it.cond.Wait()
+			continue
+		}
+		it.nextIdx++
+		it.inflight += est
+		ranges, blooms := it.dynamicRanges, it.bloomFilters
+		it.mu.Unlock()
+
+		slot := &decodeSlot{est: est}
+		if pruned := it.pruneGroup(idx, ranges, blooms); !pruned {
+			b, err := ReadRowGroupNative(it.fr, idx, it.readSchema, nil)
+			if err != nil {
+				slot.err = fmt.Errorf("reading row group %d: %w", idx, err)
+			} else {
+				slot.batch = b // nil for empty (zero-row) groups
+				if b != nil {
+					it.rgRead.Add(1)
+				}
+			}
+		}
+
+		it.mu.Lock()
+		it.slots[idx] = slot
+		it.cond.Broadcast()
+	}
+}
+
+// pruneGroup applies the dynamic-filter row-group pruning, mirroring the
+// serial path in RowGroupIter.Next.
+func (it *DecodeAheadIter) pruneGroup(rgIdx int, ranges []exec.DynamicRange, blooms []*exec.BloomScanFilter) bool {
+	if len(ranges) == 0 && len(blooms) == 0 {
+		return false
+	}
+	stats := it.fr.RowGroupStats(rgIdx)
+	if len(ranges) > 0 && CanRangePruneRowGroup(ranges, stats) {
+		it.rgPrunedRange.Add(1)
+		return true
+	}
+	for _, bf := range blooms {
+		if CanBloomPruneRowGroup(bf, stats) {
+			it.rgPrunedBloom.Add(1)
+			return true
+		}
+	}
+	return false
+}
+
+// estimateGroupBytes estimates the decoded size of a row group as the
+// sum of the projected leaf columns' TotalUncompressedSize — under a
+// narrow projection the whole-group TotalByteSize would over-reserve by
+// the inverse of the projected fraction and starve the window. Callers
+// hold it.mu (reads immutable metadata only; the lock is incidental).
+func (it *DecodeAheadIter) estimateGroupBytes(rgIdx int) int64 {
+	rg := it.fr.RowGroupMeta(rgIdx)
+	if rg == nil {
+		return minGroupEstimateBytes
+	}
+	var est int64
+	for _, li := range it.estLeaves {
+		if li < 0 || li >= len(rg.Columns) {
+			continue
+		}
+		if md := rg.Columns[li].MetaData; md != nil {
+			est += md.TotalUncompressedSize
+		}
+	}
+	if est <= 0 {
+		est = rg.TotalByteSize
+	}
+	if est < minGroupEstimateBytes {
+		est = minGroupEstimateBytes
+	}
+	return est
+}
+
+// Close stops assignment, wakes everything, and joins in-flight decodes.
+// The caller may munmap the file bytes as soon as Close returns —
+// workers never touch the FileReader after the join. Undelivered decoded
+// batches are dropped (GC-eligible). Idempotent.
+func (it *DecodeAheadIter) Close() error {
+	if it == nil || it.empty {
+		return nil
+	}
+	it.mu.Lock()
+	it.closed = true
+	it.cond.Broadcast()
+	started := it.started
+	it.mu.Unlock()
+	if started {
+		it.wg.Wait()
+	}
+	return nil
+}

--- a/internal/engine/scan/decode_ahead.go
+++ b/internal/engine/scan/decode_ahead.go
@@ -46,7 +46,8 @@ type DecodeAheadIter struct {
 	// for window estimation, resolved once at Open.
 	estLeaves []int
 
-	workers int
+	workers  int
+	pressure func() bool
 
 	dynamicRanges []exec.DynamicRange
 	bloomFilters  []*exec.BloomScanFilter
@@ -73,6 +74,7 @@ type DecodeAheadIter struct {
 	rgPrunedRange    atomic.Int64
 	rgRead           atomic.Int64
 	windowFullStalls atomic.Int64
+	pressureStalls   atomic.Int64
 }
 
 // decodeSlot is one row group's outcome, parked until the delivery
@@ -95,6 +97,12 @@ type DecodeAheadOpts struct {
 	// iterator — the cross-file continuation shape: the tail of file F
 	// and the head of file F+1 draw from one budget.
 	Window *DecodeWindow
+	// Pressure, when set, is consulted before admitting any group beyond
+	// the delivery cursor. While it reports true the iterator degrades to
+	// effectively serial (one group in flight) and the window drains as
+	// the consumer takes — the memory-pressure collapse hook. Must be
+	// safe to call from multiple goroutines.
+	Pressure func() bool
 }
 
 // DecodeWindow is a byte budget shared by one or more DecodeAheadIters.
@@ -157,8 +165,9 @@ func OpenDecodeAheadIter(reader *pqt.Reader, schema []pqt.Column, selectedCols [
 	}
 
 	it := &DecodeAheadIter{
-		workers: opts.Workers,
-		win:     opts.Window,
+		workers:  opts.Workers,
+		win:      opts.Window,
+		pressure: opts.Pressure,
 	}
 	if it.win == nil {
 		it.win = NewDecodeWindow(opts.WindowBytes)
@@ -259,12 +268,13 @@ func (it *DecodeAheadIter) PruneStats() (bloom, rangeP, read int) {
 }
 
 // Stats returns the decode-ahead engagement counters (memo §5 markers):
-// row groups decoded and times a worker stalled on a full window.
-func (it *DecodeAheadIter) Stats() (groupsRead, windowFullStalls int64) {
+// row groups decoded, worker stalls on a full window, and admissions
+// refused under memory pressure.
+func (it *DecodeAheadIter) Stats() (groupsRead, windowFullStalls, pressureStalls int64) {
 	if it == nil {
-		return 0, 0
+		return 0, 0, 0
 	}
-	return it.rgRead.Load(), it.windowFullStalls.Load()
+	return it.rgRead.Load(), it.windowFullStalls.Load(), it.pressureStalls.Load()
 }
 
 // Next returns the next decoded row group in source order, or (nil, nil)
@@ -321,11 +331,22 @@ func (it *DecodeAheadIter) decodeLoop() {
 		// the window here cannot grow it further, and refusing would
 		// deadlock on any single group larger than the window. (Under a
 		// shared window this bounds transient overshoot to one group per
-		// chained iterator.)
-		if it.win.inflight+est > it.win.limit && idx != it.deliver {
-			it.windowFullStalls.Add(1)
-			it.win.cond.Wait()
-			continue
+		// chained iterator.) Memory pressure gates admission the same way
+		// — cursor-only progress until it clears, undelivered bytes drain
+		// as the consumer takes. Wakeups: every delivery broadcasts, and
+		// the cursor group is always decodable, so a stalled worker is
+		// re-checked at least once per delivered group.
+		if idx != it.deliver {
+			if it.win.inflight+est > it.win.limit {
+				it.windowFullStalls.Add(1)
+				it.win.cond.Wait()
+				continue
+			}
+			if it.pressure != nil && it.pressure() {
+				it.pressureStalls.Add(1)
+				it.win.cond.Wait()
+				continue
+			}
 		}
 		it.nextIdx++
 		it.win.inflight += est

--- a/internal/engine/scan/decode_ahead_test.go
+++ b/internal/engine/scan/decode_ahead_test.go
@@ -119,7 +119,7 @@ func TestDecodeAheadIter_MatchesSerial(t *testing.T) {
 			t.Fatalf("workers=%d drain: %v", workers, err)
 		}
 		requireSameBatches(t, want, got)
-		if groups, _ := it.Stats(); groups != 16 {
+		if groups, _, _ := it.Stats(); groups != 16 {
 			t.Errorf("workers=%d: groups read = %d, want 16", workers, groups)
 		}
 		// Post-exhaustion Next returns (nil, nil), like serial.
@@ -156,8 +156,39 @@ func TestDecodeAheadIter_TinyWindowStallsButDelivers(t *testing.T) {
 		t.Fatalf("drain: %v", err)
 	}
 	requireSameBatches(t, want, got)
-	if _, stalls := it.Stats(); stalls == 0 {
+	if _, stalls, _ := it.Stats(); stalls == 0 {
 		t.Error("WindowBytes=1 with 4 workers never stalled — window is not gating admission")
+	}
+}
+
+// TestDecodeAheadIter_PressureDegradesToSerial: with the pressure hook
+// permanently asserted, only the delivery-cursor group may be in flight
+// — output stays identical (no deadlock, no loss) and the stall counter
+// proves the hook gated admission.
+func TestDecodeAheadIter_PressureDegradesToSerial(t *testing.T) {
+	data := manyRowGroupFile(t, 8, 50)
+	schema := []pqt.Column{{Name: "id", Type: pqt.TypeInt64}}
+
+	serial, err := OpenRowGroupIter(openFileReader(t, data), schema, nil, 0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serial.Close()
+	want, _ := drainGroupIter(t, serial)
+
+	it, err := OpenDecodeAheadIter(openFileReader(t, data), schema, nil, 0, 1,
+		DecodeAheadOpts{Workers: 4, Pressure: func() bool { return true }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer it.Close()
+	got, err := drainGroupIter(t, it)
+	if err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	requireSameBatches(t, want, got)
+	if _, _, stalls := it.Stats(); stalls == 0 {
+		t.Error("permanent pressure with 4 workers never stalled — hook is not gating admission")
 	}
 }
 

--- a/internal/engine/scan/decode_ahead_test.go
+++ b/internal/engine/scan/decode_ahead_test.go
@@ -1,0 +1,343 @@
+package scan
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/engine/exec"
+	pqt "github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// manyRowGroupFile builds an in-memory parquet file with numGroups row
+// groups of rowsPerGroup rows each, ids tagged g*1000+i (fourRowGroupFile
+// shape, parameterized so decode-ahead tests can outnumber the workers).
+func manyRowGroupFile(t *testing.T, numGroups, rowsPerGroup int) []byte {
+	t.Helper()
+	schema := []pqt.Column{{Name: "id", Type: pqt.TypeInt64}}
+	cfg := pqt.DefaultWriterConfig()
+	cfg.RowGroupSize = rowsPerGroup
+
+	var buf bytes.Buffer
+	w, err := pqt.NewWriter(&buf, pqt.Schema{Columns: schema}, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for g := 0; g < numGroups; g++ {
+		rows := make([]map[string]any, rowsPerGroup)
+		for i := range rows {
+			rows[i] = map[string]any{"id": int64(g*1000 + i)}
+		}
+		if err := w.WriteRows(rows); err != nil {
+			t.Fatalf("write group %d: %v", g, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func openFileReader(t *testing.T, data []byte) *pqt.Reader {
+	t.Helper()
+	reader, err := pqt.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return reader
+}
+
+// drainGroupIter collects every batch an iterator yields, stopping on
+// error. Returns batches and the terminal error (nil on clean exhaust).
+type groupIter interface {
+	Next() (*batch.RecordBatch, error)
+}
+
+func drainGroupIter(t *testing.T, it groupIter) ([]*batch.RecordBatch, error) {
+	t.Helper()
+	var out []*batch.RecordBatch
+	for {
+		b, err := it.Next()
+		if err != nil {
+			return out, err
+		}
+		if b == nil {
+			return out, nil
+		}
+		out = append(out, b)
+	}
+}
+
+// requireSameBatches asserts batch-by-batch identity (count, length, and
+// every id value in order) between serial and decode-ahead output.
+func requireSameBatches(t *testing.T, want, got []*batch.RecordBatch) {
+	t.Helper()
+	if len(want) != len(got) {
+		t.Fatalf("batch count: got %d, want %d", len(got), len(want))
+	}
+	for bi := range want {
+		if want[bi].Len != got[bi].Len {
+			t.Fatalf("batch %d: len %d, want %d", bi, got[bi].Len, want[bi].Len)
+		}
+		for i := 0; i < want[bi].Len; i++ {
+			w, g := want[bi].Columns[0].Int64Data[i], got[bi].Columns[0].Int64Data[i]
+			if w != g {
+				t.Fatalf("batch %d row %d: id %d, want %d", bi, i, g, w)
+			}
+		}
+	}
+}
+
+// TestDecodeAheadIter_MatchesSerial: the consumer-facing contract is
+// byte-identical to RowGroupIter — same batches, same order — across
+// worker counts, including k exceeding the group count.
+func TestDecodeAheadIter_MatchesSerial(t *testing.T) {
+	data := manyRowGroupFile(t, 16, 50)
+	schema := []pqt.Column{{Name: "id", Type: pqt.TypeInt64}}
+
+	serial, err := OpenRowGroupIter(openFileReader(t, data), schema, nil, 0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serial.Close()
+	want, err := drainGroupIter(t, serial)
+	if err != nil {
+		t.Fatalf("serial drain: %v", err)
+	}
+	if len(want) != 16 {
+		t.Fatalf("fixture: serial yielded %d batches, want 16", len(want))
+	}
+
+	for _, workers := range []int{1, 2, 4, 32} {
+		it, err := OpenDecodeAheadIter(openFileReader(t, data), schema, nil, 0, 1,
+			DecodeAheadOpts{Workers: workers})
+		if err != nil {
+			t.Fatalf("workers=%d: %v", workers, err)
+		}
+		got, err := drainGroupIter(t, it)
+		if err != nil {
+			t.Fatalf("workers=%d drain: %v", workers, err)
+		}
+		requireSameBatches(t, want, got)
+		if groups, _ := it.Stats(); groups != 16 {
+			t.Errorf("workers=%d: groups read = %d, want 16", workers, groups)
+		}
+		// Post-exhaustion Next returns (nil, nil), like serial.
+		if b, err := it.Next(); err != nil || b != nil {
+			t.Errorf("workers=%d: Next after exhaustion = (%v, %v), want (nil, nil)", workers, b, err)
+		}
+		it.Close()
+	}
+}
+
+// TestDecodeAheadIter_TinyWindowStallsButDelivers: a window smaller than
+// any single group forces full serialization through the always-admit-
+// the-delivery-cursor rule — output stays identical, no deadlock, and
+// the stall counter proves the window actually gated.
+func TestDecodeAheadIter_TinyWindowStallsButDelivers(t *testing.T) {
+	data := manyRowGroupFile(t, 8, 50)
+	schema := []pqt.Column{{Name: "id", Type: pqt.TypeInt64}}
+
+	serial, err := OpenRowGroupIter(openFileReader(t, data), schema, nil, 0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serial.Close()
+	want, _ := drainGroupIter(t, serial)
+
+	it, err := OpenDecodeAheadIter(openFileReader(t, data), schema, nil, 0, 1,
+		DecodeAheadOpts{Workers: 4, WindowBytes: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer it.Close()
+	got, err := drainGroupIter(t, it)
+	if err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	requireSameBatches(t, want, got)
+	if _, stalls := it.Stats(); stalls == 0 {
+		t.Error("WindowBytes=1 with 4 workers never stalled — window is not gating admission")
+	}
+}
+
+// TestDecodeAheadIter_RespectsShard mirrors the serial shard test: the
+// union of all shards covers every row exactly once.
+func TestDecodeAheadIter_RespectsShard(t *testing.T) {
+	data := manyRowGroupFile(t, 4, 100)
+	schema := []pqt.Column{{Name: "id", Type: pqt.TypeInt64}}
+
+	const shardCount = 4
+	seen := make(map[int64]bool)
+	totalRows := 0
+	for shardIdx := 0; shardIdx < shardCount; shardIdx++ {
+		it, err := OpenDecodeAheadIter(openFileReader(t, data), schema, nil, shardIdx, shardCount,
+			DecodeAheadOpts{Workers: 2})
+		if err != nil {
+			t.Fatalf("shard %d: %v", shardIdx, err)
+		}
+		batches, err := drainGroupIter(t, it)
+		if err != nil {
+			t.Fatalf("shard %d drain: %v", shardIdx, err)
+		}
+		for _, b := range batches {
+			for i := 0; i < b.Len; i++ {
+				id := b.Columns[0].Int64Data[i]
+				if seen[id] {
+					t.Errorf("shard %d: duplicate id %d", shardIdx, id)
+				}
+				seen[id] = true
+				totalRows++
+			}
+		}
+		it.Close()
+	}
+	if totalRows != 4*100 {
+		t.Errorf("union of shards: %d rows, want %d", totalRows, 4*100)
+	}
+}
+
+// TestDecodeAheadIter_OutOfRangeShardYieldsNothing mirrors the serial
+// empty-shard sentinel.
+func TestDecodeAheadIter_OutOfRangeShardYieldsNothing(t *testing.T) {
+	data := manyRowGroupFile(t, 4, 100)
+	schema := []pqt.Column{{Name: "id", Type: pqt.TypeInt64}}
+	it, err := OpenDecodeAheadIter(openFileReader(t, data), schema, nil, 5, 4, DecodeAheadOpts{})
+	if err != nil {
+		t.Fatalf("expected nil err for out-of-range shard, got %v", err)
+	}
+	defer it.Close()
+	if b, err := it.Next(); err != nil || b != nil {
+		t.Errorf("Next on empty shard = (%v, %v), want (nil, nil)", b, err)
+	}
+}
+
+// TestDecodeAheadIter_ErrorAtSerialPosition: corrupting row group 2's
+// first data page makes the serial iterator deliver groups 0 and 1 and
+// then error; decode-ahead must surface the same error at the same
+// position even though later groups may have decoded fine already.
+func TestDecodeAheadIter_ErrorAtSerialPosition(t *testing.T) {
+	data := manyRowGroupFile(t, 6, 50)
+	schema := []pqt.Column{{Name: "id", Type: pqt.TypeInt64}}
+
+	// Locate group 2's first data page and stomp it.
+	fr := openFileReader(t, data).FileReader()
+	rg := fr.RowGroupMeta(2)
+	if rg == nil || rg.Columns[0].MetaData == nil {
+		t.Fatal("fixture: no metadata for row group 2")
+	}
+	off := rg.Columns[0].MetaData.DataPageOffset
+	if dict := rg.Columns[0].MetaData.DictionaryPageOffset; dict > 0 && dict < off {
+		off = dict
+	}
+	corrupted := append([]byte(nil), data...)
+	for i := int64(0); i < 16 && off+i < int64(len(corrupted)); i++ {
+		corrupted[off+i] ^= 0xFF
+	}
+
+	serial, err := OpenRowGroupIter(openFileReader(t, corrupted), schema, nil, 0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serial.Close()
+	serialBatches, serialErr := drainGroupIter(t, serial)
+	if serialErr == nil {
+		t.Fatal("fixture: corruption did not produce a serial decode error")
+	}
+	if len(serialBatches) != 2 {
+		t.Fatalf("fixture: serial delivered %d batches before erroring, want 2", len(serialBatches))
+	}
+
+	it, err := OpenDecodeAheadIter(openFileReader(t, corrupted), schema, nil, 0, 1,
+		DecodeAheadOpts{Workers: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer it.Close()
+	gotBatches, gotErr := drainGroupIter(t, it)
+	if gotErr == nil {
+		t.Fatal("decode-ahead did not surface the decode error")
+	}
+	if len(gotBatches) != 2 {
+		t.Fatalf("decode-ahead delivered %d batches before erroring, want 2 (serial parity)", len(gotBatches))
+	}
+	requireSameBatches(t, serialBatches, gotBatches)
+	// Dead after error, like a failed task expects.
+	if b, err := it.Next(); err != nil || b != nil {
+		t.Errorf("Next after error = (%v, %v), want (nil, nil)", b, err)
+	}
+}
+
+// TestDecodeAheadIter_PruneParity: dynamic-filter row-group pruning must
+// skip the same groups as serial and report the same counters.
+func TestDecodeAheadIter_PruneParity(t *testing.T) {
+	data := manyRowGroupFile(t, 8, 50)
+	schema := []pqt.Column{{Name: "id", Type: pqt.TypeInt64}}
+	// Groups tag ids as g*1000+i — a range of [3000, 4049] covers exactly
+	// groups 3 and 4; the other six groups prune.
+	ranges := []exec.DynamicRange{{Column: "id", MinValue: int64(3000), MaxValue: int64(4049)}}
+
+	serial, err := OpenRowGroupIter(openFileReader(t, data), schema, nil, 0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serial.Close()
+	serial.SetDynamicFilters(ranges, nil)
+	want, err := drainGroupIter(t, serial)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, wantPrunedRange, wantRead := serial.PruneStats()
+
+	it, err := OpenDecodeAheadIter(openFileReader(t, data), schema, nil, 0, 1,
+		DecodeAheadOpts{Workers: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer it.Close()
+	it.SetDynamicFilters(ranges, nil)
+	got, err := drainGroupIter(t, it)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireSameBatches(t, want, got)
+	_, gotPrunedRange, gotRead := it.PruneStats()
+	if gotPrunedRange != wantPrunedRange || gotRead != wantRead {
+		t.Errorf("prune stats: (range=%d, read=%d), want (range=%d, read=%d)",
+			gotPrunedRange, gotRead, wantPrunedRange, wantRead)
+	}
+	if wantRead != 2 {
+		t.Errorf("fixture: serial read %d groups, want 2", wantRead)
+	}
+}
+
+// TestDecodeAheadIter_CloseMidStreamJoinsWorkers: Close after a partial
+// read must stop delivery and return only after in-flight decodes are
+// joined — the caller munmaps the underlying bytes immediately after.
+// The -race build is the real assertion here.
+func TestDecodeAheadIter_CloseMidStreamJoinsWorkers(t *testing.T) {
+	data := manyRowGroupFile(t, 16, 50)
+	schema := []pqt.Column{{Name: "id", Type: pqt.TypeInt64}}
+	it, err := OpenDecodeAheadIter(openFileReader(t, data), schema, nil, 0, 1,
+		DecodeAheadOpts{Workers: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := it.Next(); err != nil {
+		t.Fatal(err)
+	}
+	if err := it.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if b, err := it.Next(); err != nil || b != nil {
+		t.Errorf("Next after Close = (%v, %v), want (nil, nil)", b, err)
+	}
+	// Close before first Next (workers never started) must not hang.
+	it2, err := OpenDecodeAheadIter(openFileReader(t, data), schema, nil, 0, 1, DecodeAheadOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := it2.Close(); err != nil {
+		t.Fatalf("Close before Next: %v", err)
+	}
+}

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -115,6 +115,15 @@ type Executor struct {
 	shuffleStreamReads       atomic.Int64
 	shuffleStreamFallbacks   atomic.Int64
 	shuffleStreamSkipResumes atomic.Int64
+
+	// Scan decode pipelining (docs/design/scan-decode-pipelining.md):
+	// parquet scan sources decode row groups ahead of consumption with a
+	// bounded window instead of one group per Next. Counters are the §5
+	// rollout markers, aggregated across sources on iterator close.
+	scanDecodeAhead            bool
+	scanDecodeAheadBytes       int64
+	scanDecodeAheadGroups      atomic.Int64
+	scanDecodeAheadWindowFulls atomic.Int64
 }
 
 // SetStreamingShuffleRead enables streaming decode of shuffle inputs
@@ -125,6 +134,20 @@ func (e *Executor) SetStreamingShuffleRead(on bool) { e.streamingShuffleRead = o
 // streaming opens, staged fallbacks, and batches skipped by fallbacks.
 func (e *Executor) ShuffleStreamStats() (reads, fallbacks, skipResumes int64) {
 	return e.shuffleStreamReads.Load(), e.shuffleStreamFallbacks.Load(), e.shuffleStreamSkipResumes.Load()
+}
+
+// SetScanDecodeAhead enables decode-ahead on parquet scan sources
+// (--scan-decode-ahead). windowBytes <= 0 selects the default. Call
+// before Worker.Start.
+func (e *Executor) SetScanDecodeAhead(on bool, windowBytes int64) {
+	e.scanDecodeAhead = on
+	e.scanDecodeAheadBytes = windowBytes
+}
+
+// ScanDecodeAheadStats returns the decode-ahead counters: row groups
+// decoded ahead and worker stalls on a full window.
+func (e *Executor) ScanDecodeAheadStats() (groups, windowFulls int64) {
+	return e.scanDecodeAheadGroups.Load(), e.scanDecodeAheadWindowFulls.Load()
 }
 
 // NewExecutor creates a new task executor.

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -120,10 +120,12 @@ type Executor struct {
 	// parquet scan sources decode row groups ahead of consumption with a
 	// bounded window instead of one group per Next. Counters are the §5
 	// rollout markers, aggregated across sources on iterator close.
-	scanDecodeAhead            bool
-	scanDecodeAheadBytes       int64
-	scanDecodeAheadGroups      atomic.Int64
-	scanDecodeAheadWindowFulls atomic.Int64
+	scanDecodeAhead               bool
+	scanDecodeAheadBytes          int64
+	scanDecodeAheadGroups         atomic.Int64
+	scanDecodeAheadWindowFulls    atomic.Int64
+	scanDecodeAheadPressureStalls atomic.Int64
+	scanDecodeAheadTokenDegrades  atomic.Int64
 }
 
 // SetStreamingShuffleRead enables streaming decode of shuffle inputs
@@ -145,9 +147,12 @@ func (e *Executor) SetScanDecodeAhead(on bool, windowBytes int64) {
 }
 
 // ScanDecodeAheadStats returns the decode-ahead counters: row groups
-// decoded ahead and worker stalls on a full window.
-func (e *Executor) ScanDecodeAheadStats() (groups, windowFulls int64) {
-	return e.scanDecodeAheadGroups.Load(), e.scanDecodeAheadWindowFulls.Load()
+// decoded ahead, worker stalls on a full window, admissions refused
+// under heap pressure, and sources that got fewer decode workers than
+// the default because the cpuToken pool was drawn down.
+func (e *Executor) ScanDecodeAheadStats() (groups, windowFulls, pressureStalls, tokenDegrades int64) {
+	return e.scanDecodeAheadGroups.Load(), e.scanDecodeAheadWindowFulls.Load(),
+		e.scanDecodeAheadPressureStalls.Load(), e.scanDecodeAheadTokenDegrades.Load()
 }
 
 // NewExecutor creates a new task executor.

--- a/internal/worker/scan_prefetch.go
+++ b/internal/worker/scan_prefetch.go
@@ -393,6 +393,40 @@ func (p *filePrefetcher) take(ctx context.Context, idx int) *prefetchResult {
 	}
 }
 
+// tryTake is take's non-blocking sibling for the decode-ahead pre-open
+// path (docs/design/scan-decode-pipelining.md S2): it never waits on a
+// download. Returns (res, true) when idx resolved to a usable local file
+// (ownership transfers to the caller), (nil, true) when idx resolved to
+// skipped/err — the result is PUT BACK for the authoritative take() in
+// openNextFile, which must still observe it — and (nil, false) when the
+// download is simply not done yet (poll again later).
+func (p *filePrefetcher) tryTake(idx int) (*prefetchResult, bool) {
+	p.mu.Lock()
+	if idx+1 > p.nextNeeded {
+		p.nextNeeded = idx + 1
+	}
+	close(p.windowFree)
+	p.windowFree = make(chan struct{})
+	p.mu.Unlock()
+
+	select {
+	case res := <-p.results[idx]:
+		if res.skipped || res.err != nil {
+			// Put back (cap-1 channel, single producer per idx — the
+			// send cannot block) so take() reaps it and releases any
+			// window bytes exactly once, there.
+			p.results[idx] <- res
+			return nil, true
+		}
+		if res.windowBytes > 0 {
+			p.releaseWindow(res.windowBytes)
+		}
+		return res, true
+	default:
+		return nil, false
+	}
+}
+
 // Close cancels outstanding downloads, waits for workers to exit, and
 // removes any downloaded-but-never-taken temp files. Idempotent.
 func (p *filePrefetcher) Close() {

--- a/internal/worker/stream_source.go
+++ b/internal/worker/stream_source.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -132,6 +133,18 @@ type cachedFileStreamSource struct {
 	prefetch         *filePrefetcher
 	prefetchStarted  bool
 	prefetchDisabled bool
+
+	// Cross-file decode continuation (--scan-decode-ahead, memo S2): the
+	// next parquet file, pre-opened once the current file's row groups
+	// are all assigned, so its head decodes while the current tail
+	// delivers. decodeWin is the one byte window every file of this
+	// source draws from. preOpenSkip is (fileIdx+1) of an index whose
+	// prefetch resolved unusable — stop polling it; the tiered
+	// openNextFile path is authoritative there (0 = none).
+	nextParquet *pendingParquet
+	decodeWin   *scan.DecodeWindow
+	preOpenSkip int
+	preOpens    int // files pre-opened by the continuation (tests + DEBUG log)
 }
 
 // shuffleBatchIter is the common face of the mmap-backed and streaming
@@ -224,15 +237,28 @@ func (s *cachedFileStreamSource) Next(ctx context.Context) (*batch.RecordBatch, 
 		}
 
 		// Yield next decoded row group from the active Parquet iterator.
-		// The iterator decodes lazily — only one row group's worth of
-		// memory is live at a time per source.
+		// Serial: only one row group's worth of memory is live at a time
+		// per source. Decode-ahead: bounded by the source's DecodeWindow.
 		if s.parquetIter != nil {
 			b, err := s.parquetIter.Next()
 			if err != nil {
 				return nil, err
 			}
 			if b != nil {
+				s.tryPreOpenNextParquet()
 				return b, nil
+			}
+			// Cross-file continuation: the next file was pre-opened and
+			// its head is already decoding — swap it in without touching
+			// the tiered open path. Release order matters exactly as in
+			// the serial branch below: iterator (quiesces decode), then
+			// reader ref, then mmap.
+			if s.nextParquet != nil {
+				s.releaseParquetIter()
+				s.releaseCurrentFile()
+				s.installParquet(s.nextParquet)
+				s.nextParquet = nil
+				continue
 			}
 			// Iterator exhausted — release reader and the mmap/local file it
 			// was reading from before opening the next file. Order matters:
@@ -279,7 +305,13 @@ func (s *cachedFileStreamSource) Next(ctx context.Context) (*batch.RecordBatch, 
 }
 
 func (s *cachedFileStreamSource) Close() error {
-	// Stop the download-ahead workers first and reap any temp files they
+	// Pre-opened next file first: its iterator joins in-flight decodes
+	// before the mmap drops (same invariant as the current file below).
+	if s.nextParquet != nil {
+		s.nextParquet.release(s.executor.logger)
+		s.nextParquet = nil
+	}
+	// Stop the download-ahead workers and reap any temp files they
 	// downloaded that were never consumed.
 	if s.prefetch != nil {
 		s.prefetch.Close()
@@ -567,25 +599,14 @@ func (s *cachedFileStreamSource) openNextFile(ctx context.Context) error {
 // open tail. On any failure the temp file is removed and the caller
 // falls back to the normal tiered path.
 func (s *cachedFileStreamSource) openPrefetchedParquet(localPath, filePath string) error {
-	f, err := os.Open(localPath)
-	if err != nil {
-		_ = os.Remove(localPath)
-		return fmt.Errorf("opening prefetched file %s: %w", localPath, err)
-	}
-	defer f.Close()
-	fi, err := f.Stat()
-	if err != nil || fi.Size() == 0 {
-		_ = os.Remove(localPath)
-		return fmt.Errorf("prefetched file %s unusable (err=%v)", localPath, err)
-	}
-	mmapData, err := syscall.Mmap(int(f.Fd()), 0, int(fi.Size()), syscall.PROT_READ, syscall.MAP_SHARED)
-	if err != nil {
-		_ = os.Remove(localPath)
-		return fmt.Errorf("mmap prefetched file %s: %w", localPath, err)
-	}
-	// finishOpenParquet unwinds mmap+file itself if the payload isn't
+	// buildParquetFromLocal unwinds mmap+file itself if the payload isn't
 	// valid parquet (e.g. a legacy shuffle object under a .parquet key).
-	return s.finishOpenParquet(filePath, mmapData, mmapData, localPath)
+	p, err := s.buildParquetFromLocal(localPath, filePath, localPath)
+	if err != nil {
+		return err
+	}
+	s.installParquet(p)
+	return nil
 }
 
 // progressReadCloser reports each successful Read to the per-task
@@ -703,22 +724,14 @@ func (s *cachedFileStreamSource) fallbackFromStream(ctx context.Context, cause e
 // cache owns the file, so neither releaseCurrentFile nor the open-failure
 // unwind may unlink it.
 func (s *cachedFileStreamSource) openParquetFromBaseCache(cachePath, filePath string) error {
-	f, err := os.Open(cachePath)
+	// ownedPath "" — the cache owns the file; only the mmap unwinds on a
+	// bad payload.
+	p, err := s.buildParquetFromLocal(cachePath, filePath, "")
 	if err != nil {
-		return fmt.Errorf("opening base-cache file %s: %w", cachePath, err)
+		return err
 	}
-	defer f.Close()
-	fi, err := f.Stat()
-	if err != nil || fi.Size() == 0 {
-		return fmt.Errorf("base-cache file %s unusable (err=%v)", cachePath, err)
-	}
-	mmapData, err := syscall.Mmap(int(f.Fd()), 0, int(fi.Size()), syscall.PROT_READ, syscall.MAP_SHARED)
-	if err != nil {
-		return fmt.Errorf("mmap base-cache file %s: %w", cachePath, err)
-	}
-	// finishOpenParquet unwinds the mmap itself on a bad payload; its
-	// os.Remove of the empty localPath is a no-op.
-	return s.finishOpenParquet(filePath, mmapData, mmapData, "")
+	s.installParquet(p)
+	return nil
 }
 
 // openPrefetchedShuffle opens a shuffle file the prefetcher already landed
@@ -760,21 +773,85 @@ func (s *cachedFileStreamSource) openPrefetchedShuffle(localPath, filePath strin
 // column projection guard, and set up the row-group iterator (or the
 // eager fallback for Array/Map schemas). mmapData/localPath may be
 // nil/empty for the in-memory path.
+// pendingParquet is a fully-opened parquet file (reader + iterator +
+// mmap/file ownership) not yet installed as the source's current file.
+// The cross-file continuation holds at most one while the current file
+// drains, so its head decodes into the shared window early.
+type pendingParquet struct {
+	iter            parquetGroupIter
+	reader          *parquet.Reader
+	mmapData        []byte
+	mmapRegion      *mmapRegion
+	localPath       string
+	fallbackBatches []*batch.RecordBatch
+}
+
+// release drops a never-installed pending file: quiesce decode first
+// (iter.Close joins in-flight workers), then the reader ref, then the
+// mmap — same order Close documents for the current file.
+func (p *pendingParquet) release(logger *slog.Logger) {
+	if p == nil {
+		return
+	}
+	if p.iter != nil {
+		_ = p.iter.Close()
+		p.iter = nil
+	}
+	p.reader = nil
+	if p.mmapData != nil {
+		unregisterMmap(p.mmapRegion)
+		p.mmapRegion = nil
+		_ = syscall.Munmap(p.mmapData)
+		p.mmapData = nil
+	}
+	if p.localPath != "" {
+		if rmErr := os.Remove(p.localPath); rmErr != nil && !os.IsNotExist(rmErr) && logger != nil {
+			logger.Warn("pending parquet cleanup failed", "path", p.localPath, "error", rmErr)
+		}
+		p.localPath = ""
+	}
+}
+
+// installParquet makes a pending file the source's current file. The
+// caller must have released the previous current file already.
+func (s *cachedFileStreamSource) installParquet(p *pendingParquet) {
+	s.mmapData = p.mmapData
+	s.mmapRegion = p.mmapRegion
+	s.localPath = p.localPath
+	s.parquetIter = p.iter
+	s.parquetReader = p.reader
+	s.fallbackBatches = p.fallbackBatches
+	s.fallbackBatchIdx = 0
+}
+
 func (s *cachedFileStreamSource) finishOpenParquet(filePath string, data, mmapData []byte, localPath string) error {
+	p, err := s.buildParquetState(filePath, data, mmapData, localPath)
+	if err != nil {
+		return err
+	}
+	s.installParquet(p)
+	return nil
+}
+
+// buildParquetState opens a parquet payload into a pendingParquet without
+// touching the source's current-file fields. On error the mmap/local file
+// are unwound (empty localPath = caller-owned file, not unlinked).
+func (s *cachedFileStreamSource) buildParquetState(filePath string, data, mmapData []byte, localPath string) (*pendingParquet, error) {
 	reader, err := parquet.NewReaderFromBytes(data)
 	if err != nil {
 		if mmapData != nil {
 			_ = syscall.Munmap(mmapData)
 			_ = os.Remove(localPath)
 		}
-		return fmt.Errorf("opening parquet file %s: %w", filePath, err)
+		return nil, fmt.Errorf("opening parquet file %s: %w", filePath, err)
 	}
-	// Transfer mmap/file ownership to the source so Next()/Close()
-	// release them when the iterator exhausts. nil/empty are fine for
-	// the in-memory fallback.
-	s.mmapData = mmapData
-	s.mmapRegion = registerMmap(mmapData) // nil when relief disabled
-	s.localPath = localPath
+	// nil/empty mmap/localPath are fine for the in-memory fallback.
+	p := &pendingParquet{
+		reader:     reader,
+		mmapData:   mmapData,
+		mmapRegion: registerMmap(mmapData), // nil when relief disabled
+		localPath:  localPath,
+	}
 	projCols := reader.Schema().Columns
 	// Apply column projection only when EVERY requested column is present
 	// in the file schema. If any requested name is missing (likely a
@@ -819,33 +896,137 @@ func (s *cachedFileStreamSource) finishOpenParquet(filePath string, data, mmapDa
 	if scan.HasUnsupportedColumnarTypes(projCols) {
 		batches, err := scan.ReadFileBatchesShard(reader, projCols, nil, shardIdx, shardCount)
 		if err != nil {
-			return fmt.Errorf("reading parquet file %s (fallback): %w", filePath, err)
+			p.release(s.executor.logger)
+			return nil, fmt.Errorf("reading parquet file %s (fallback): %w", filePath, err)
 		}
-		s.fallbackBatches = batches
-		s.fallbackBatchIdx = 0
-		return nil
+		p.fallbackBatches = batches
+		return p, nil
 	}
 	var iter parquetGroupIter
 	if s.executor.scanDecodeAhead {
+		if s.decodeWin == nil {
+			// One window per source, shared across every file it opens —
+			// the cross-file continuation draws the next file's head from
+			// the same budget as the current file's tail.
+			s.decodeWin = scan.NewDecodeWindow(s.executor.scanDecodeAheadBytes)
+		}
 		da, err := scan.OpenDecodeAheadIter(reader, projCols, nil, shardIdx, shardCount,
-			scan.DecodeAheadOpts{WindowBytes: s.executor.scanDecodeAheadBytes})
+			scan.DecodeAheadOpts{Window: s.decodeWin})
 		if err != nil {
-			return fmt.Errorf("opening decode-ahead iterator for %s: %w", filePath, err)
+			p.release(s.executor.logger)
+			return nil, fmt.Errorf("opening decode-ahead iterator for %s: %w", filePath, err)
 		}
 		iter = &decodeAheadStatsIter{DecodeAheadIter: da, executor: s.executor}
 	} else {
 		rgIter, err := scan.OpenRowGroupIter(reader, projCols, nil, shardIdx, shardCount)
 		if err != nil {
-			return fmt.Errorf("opening row-group iterator for %s: %w", filePath, err)
+			p.release(s.executor.logger)
+			return nil, fmt.Errorf("opening row-group iterator for %s: %w", filePath, err)
 		}
 		iter = rgIter
 	}
 	if len(s.dynamicRanges) > 0 || len(s.bloomFilters) > 0 {
 		iter.SetDynamicFilters(s.dynamicRanges, s.bloomFilters)
 	}
-	s.parquetIter = iter
-	s.parquetReader = reader
-	return nil
+	p.iter = iter
+	return p, nil
+}
+
+// tryPreOpenNextParquet pre-opens the next file for the cross-file decode
+// continuation. Called after every delivered parquet batch; all guards
+// are cheap. Only the non-blocking local tiers pre-open (base-table cache
+// hit, completed prefetch download) — anything else falls back to the
+// tiered openNextFile at the boundary, keeping this strictly best-effort:
+// it can never change results and never blocks the consumer.
+func (s *cachedFileStreamSource) tryPreOpenNextParquet() {
+	if !s.executor.scanDecodeAhead || s.nextParquet != nil || s.fileIdx >= len(s.files) {
+		return
+	}
+	idx := s.fileIdx
+	if s.preOpenSkip == idx+1 {
+		return
+	}
+	filePath := s.files[idx]
+	if !strings.HasSuffix(filePath, ".parquet") {
+		return
+	}
+	da, ok := s.parquetIter.(*decodeAheadStatsIter)
+	if !ok || !da.AssignmentDrained() {
+		return
+	}
+
+	// Base-table cache tier: map lookup + local open, never blocks.
+	if lps, ok := s.executor.store.(objstore.LocalPathStore); ok {
+		if cached, ok := lps.CachedLocalPath(s.bucket, filePath); ok {
+			if p, err := s.buildParquetFromLocal(cached, filePath, ""); err == nil {
+				s.adoptPending(p, idx)
+				return
+			} else if s.executor.logger != nil {
+				s.executor.logger.Debug("decode-ahead pre-open fell through",
+					"key", filePath, "path", cached, "error", err)
+			}
+		}
+	}
+	// Prefetch tier: consume the download only if it already finished.
+	if s.prefetch != nil {
+		res, resolved := s.prefetch.tryTake(idx)
+		if !resolved {
+			return // still downloading — poll again on the next batch
+		}
+		if res == nil {
+			s.preOpenSkip = idx + 1 // skipped/err — openNextFile owns it
+			return
+		}
+		if p, err := s.buildParquetFromLocal(res.localPath, filePath, res.localPath); err == nil {
+			s.adoptPending(p, idx)
+			return
+		}
+		// buildParquetFromLocal removed the temp; the tiered path
+		// re-resolves this index from the durable copy.
+		s.preOpenSkip = idx + 1
+	}
+}
+
+// buildParquetFromLocal mmaps a local parquet file and builds its pending
+// state. ownedPath is "" when the file belongs to a cache (must not be
+// unlinked) and the file's own path when ownership transfers to us.
+func (s *cachedFileStreamSource) buildParquetFromLocal(localPath, filePath, ownedPath string) (*pendingParquet, error) {
+	f, err := os.Open(localPath)
+	if err != nil {
+		if ownedPath != "" {
+			_ = os.Remove(ownedPath)
+		}
+		return nil, fmt.Errorf("opening local parquet %s: %w", localPath, err)
+	}
+	defer f.Close()
+	fi, err := f.Stat()
+	if err != nil || fi.Size() == 0 {
+		if ownedPath != "" {
+			_ = os.Remove(ownedPath)
+		}
+		return nil, fmt.Errorf("local parquet %s unusable (err=%v)", localPath, err)
+	}
+	mmapData, err := syscall.Mmap(int(f.Fd()), 0, int(fi.Size()), syscall.PROT_READ, syscall.MAP_SHARED)
+	if err != nil {
+		if ownedPath != "" {
+			_ = os.Remove(ownedPath)
+		}
+		return nil, fmt.Errorf("mmap local parquet %s: %w", localPath, err)
+	}
+	// buildParquetState unwinds mmap (and unlinks ownedPath when set) on a
+	// bad payload.
+	return s.buildParquetState(filePath, mmapData, mmapData, ownedPath)
+}
+
+// adoptPending records a pre-opened next file and starts its decode
+// workers so the head decodes into the shared window immediately.
+func (s *cachedFileStreamSource) adoptPending(p *pendingParquet, idx int) {
+	s.nextParquet = p
+	s.fileIdx = idx + 1
+	s.preOpens++
+	if da, ok := p.iter.(*decodeAheadStatsIter); ok {
+		da.Start()
+	}
 }
 
 // decodeAheadStatsIter folds a DecodeAheadIter's engagement counters into

--- a/internal/worker/stream_source.go
+++ b/internal/worker/stream_source.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 
@@ -145,6 +146,11 @@ type cachedFileStreamSource struct {
 	decodeWin   *scan.DecodeWindow
 	preOpenSkip int
 	preOpens    int // files pre-opened by the continuation (tests + DEBUG log)
+	// Decode width for this source (decided with decodeWin) and the
+	// cpuTokens held for its extra workers — released exactly once, in
+	// Close.
+	decodeAheadK     int
+	decodeTokensHeld int
 }
 
 // shuffleBatchIter is the common face of the mmap-backed and streaming
@@ -324,6 +330,10 @@ func (s *cachedFileStreamSource) Close() error {
 	// reader holding dangling mmap bytes if any caller still has a handle.
 	s.releaseParquetIter()
 	s.releaseCurrentFile()
+	if s.decodeTokensHeld > 0 {
+		s.executor.cpuTokens.Release(s.decodeTokensHeld)
+		s.decodeTokensHeld = 0
+	}
 	for i := s.fallbackBatchIdx; i < len(s.fallbackBatches); i++ {
 		s.fallbackBatches[i] = nil
 	}
@@ -907,11 +917,33 @@ func (s *cachedFileStreamSource) buildParquetState(filePath string, data, mmapDa
 		if s.decodeWin == nil {
 			// One window per source, shared across every file it opens —
 			// the cross-file continuation draws the next file's head from
-			// the same budget as the current file's tail.
+			// the same budget as the current file's tail. Decode width is
+			// also decided once per source, from the same cpuToken pool
+			// the morsel consumers draw on (nil pool = morsels disabled =
+			// serial consumers, so the fixed default width is safe);
+			// non-blocking, degrades toward serial under token exhaustion
+			// exactly like morselFragmentWorkers.
 			s.decodeWin = scan.NewDecodeWindow(s.executor.scanDecodeAheadBytes)
+			k := scan.DefaultDecodeAheadWorkers
+			if gp := runtime.GOMAXPROCS(0); k > gp {
+				k = gp
+			}
+			if s.executor.cpuTokens != nil {
+				got := s.executor.cpuTokens.TryAcquire(k - 1)
+				s.decodeTokensHeld = got
+				if got < k-1 {
+					s.executor.scanDecodeAheadTokenDegrades.Add(1)
+					if s.executor.logger != nil {
+						s.executor.logger.Debug("scan decode-ahead degraded on cpu tokens",
+							"want_workers", k, "got_workers", got+1)
+					}
+				}
+				k = got + 1
+			}
+			s.decodeAheadK = k
 		}
 		da, err := scan.OpenDecodeAheadIter(reader, projCols, nil, shardIdx, shardCount,
-			scan.DecodeAheadOpts{Window: s.decodeWin})
+			scan.DecodeAheadOpts{Window: s.decodeWin, Workers: s.decodeAheadK, Pressure: heapPressureActive})
 		if err != nil {
 			p.release(s.executor.logger)
 			return nil, fmt.Errorf("opening decode-ahead iterator for %s: %w", filePath, err)
@@ -1041,9 +1073,10 @@ type decodeAheadStatsIter struct {
 func (d *decodeAheadStatsIter) Close() error {
 	if !d.folded {
 		d.folded = true
-		groups, windowFulls := d.Stats()
+		groups, windowFulls, pressureStalls := d.Stats()
 		d.executor.scanDecodeAheadGroups.Add(groups)
 		d.executor.scanDecodeAheadWindowFulls.Add(windowFulls)
+		d.executor.scanDecodeAheadPressureStalls.Add(pressureStalls)
 	}
 	return d.DecodeAheadIter.Close()
 }

--- a/internal/worker/stream_source.go
+++ b/internal/worker/stream_source.go
@@ -102,9 +102,12 @@ type cachedFileStreamSource struct {
 
 	// Streaming row-group iterator for the current Parquet file. Yields one
 	// decoded RecordBatch per Next() call; the previous batch is GC-eligible
-	// once the consumer Releases it. Bounds Parquet-side live memory to one
-	// decoded row group at a time per source.
-	parquetIter *scan.RowGroupIter
+	// once the consumer Releases it. Serial (RowGroupIter) bounds
+	// Parquet-side live memory to one decoded row group at a time per
+	// source; decode-ahead (DecodeAheadIter, --scan-decode-ahead) to its
+	// byte window. Close MUST fully quiesce decode before returning —
+	// releaseCurrentFile munmaps the bytes the iterator reads.
+	parquetIter parquetGroupIter
 	// parquetReader is held alongside the iterator so its underlying buffer
 	// (the whole-file byte slice) stays live for the iterator's row-group
 	// reads. Released alongside parquetIter when the file is exhausted.
@@ -135,6 +138,14 @@ type cachedFileStreamSource struct {
 // WSHF chunk readers.
 type shuffleBatchIter interface {
 	Next() (*batch.RecordBatch, error)
+}
+
+// parquetGroupIter is the common face of the serial (scan.RowGroupIter)
+// and decode-ahead (scan.DecodeAheadIter) parquet row-group iterators.
+type parquetGroupIter interface {
+	Next() (*batch.RecordBatch, error)
+	SetDynamicFilters(ranges []exec.DynamicRange, blooms []*exec.BloomScanFilter)
+	Close() error
 }
 
 // SetDynamicFilters attaches dynamic-filter pushdowns to this source.
@@ -814,9 +825,20 @@ func (s *cachedFileStreamSource) finishOpenParquet(filePath string, data, mmapDa
 		s.fallbackBatchIdx = 0
 		return nil
 	}
-	iter, err := scan.OpenRowGroupIter(reader, projCols, nil, shardIdx, shardCount)
-	if err != nil {
-		return fmt.Errorf("opening row-group iterator for %s: %w", filePath, err)
+	var iter parquetGroupIter
+	if s.executor.scanDecodeAhead {
+		da, err := scan.OpenDecodeAheadIter(reader, projCols, nil, shardIdx, shardCount,
+			scan.DecodeAheadOpts{WindowBytes: s.executor.scanDecodeAheadBytes})
+		if err != nil {
+			return fmt.Errorf("opening decode-ahead iterator for %s: %w", filePath, err)
+		}
+		iter = &decodeAheadStatsIter{DecodeAheadIter: da, executor: s.executor}
+	} else {
+		rgIter, err := scan.OpenRowGroupIter(reader, projCols, nil, shardIdx, shardCount)
+		if err != nil {
+			return fmt.Errorf("opening row-group iterator for %s: %w", filePath, err)
+		}
+		iter = rgIter
 	}
 	if len(s.dynamicRanges) > 0 || len(s.bloomFilters) > 0 {
 		iter.SetDynamicFilters(s.dynamicRanges, s.bloomFilters)
@@ -824,6 +846,25 @@ func (s *cachedFileStreamSource) finishOpenParquet(filePath string, data, mmapDa
 	s.parquetIter = iter
 	s.parquetReader = reader
 	return nil
+}
+
+// decodeAheadStatsIter folds a DecodeAheadIter's engagement counters into
+// the executor-wide markers when the iterator closes (a source opens one
+// iterator per parquet file; per-file granularity is noise).
+type decodeAheadStatsIter struct {
+	*scan.DecodeAheadIter
+	executor *Executor
+	folded   bool
+}
+
+func (d *decodeAheadStatsIter) Close() error {
+	if !d.folded {
+		d.folded = true
+		groups, windowFulls := d.Stats()
+		d.executor.scanDecodeAheadGroups.Add(groups)
+		d.executor.scanDecodeAheadWindowFulls.Add(windowFulls)
+	}
+	return d.DecodeAheadIter.Close()
 }
 
 // openShuffleFile streams the (possibly compressed) shuffle body from rc to a

--- a/internal/worker/stream_source_decode_ahead_test.go
+++ b/internal/worker/stream_source_decode_ahead_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/citc-tech/wadjet/internal/storage/objstore"
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
@@ -313,16 +314,22 @@ func TestFilePrefetcher_TryTakePutsBackFailures(t *testing.T) {
 
 	// Poll tryTake on the missing file's index until its download resolves
 	// to an error; every resolved observation must report unusable (nil).
+	// Deadline-based — a count-bounded spin finishes before the prefetch
+	// worker even runs on a slow CI runner.
 	var resolved bool
-	for i := 0; i < 2000 && !resolved; i++ {
+	deadline := time.Now().Add(15 * time.Second)
+	for !resolved && time.Now().Before(deadline) {
 		var res *prefetchResult
 		res, resolved = p.tryTake(1)
 		if resolved && res != nil {
 			t.Fatalf("tryTake returned a usable result for a missing object: %+v", res)
 		}
+		if !resolved {
+			time.Sleep(time.Millisecond)
+		}
 	}
 	if !resolved {
-		t.Fatal("prefetch of missing object never resolved")
+		t.Fatal("prefetch of missing object never resolved within deadline")
 	}
 	// The authoritative take must still observe the buffered failure
 	// immediately (put-back happened) rather than blocking.

--- a/internal/worker/stream_source_decode_ahead_test.go
+++ b/internal/worker/stream_source_decode_ahead_test.go
@@ -1,0 +1,282 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// writeMultiGroupFixture writes n parquet files with groupsPerFile row
+// groups of rowsPerGroup rows each ("id", "val" int64) and returns the
+// keys and expected val-sum. Small row groups so decode-ahead has real
+// in-file parallelism to exercise.
+func writeMultiGroupFixture(t *testing.T, store objstore.Store, bucket string, n, groupsPerFile, rowsPerGroup int) ([]string, int64) {
+	t.Helper()
+	if err := store.MakeBucket(context.Background(), bucket); err != nil {
+		t.Fatal(err)
+	}
+	schema := parquet.Schema{Columns: []parquet.Column{
+		{Name: "id", Type: parquet.TypeInt64},
+		{Name: "val", Type: parquet.TypeInt64},
+	}}
+	cfg := parquet.DefaultWriterConfig()
+	cfg.RowGroupSize = rowsPerGroup
+
+	keys := make([]string, 0, n)
+	var wantSum int64
+	rowID := 0
+	for f := 0; f < n; f++ {
+		var buf bytes.Buffer
+		w, err := parquet.NewWriter(&buf, schema, cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for g := 0; g < groupsPerFile; g++ {
+			rows := make([]map[string]any, rowsPerGroup)
+			for r := range rows {
+				v := int64(rowID * 7)
+				rows[r] = map[string]any{"id": int64(rowID), "val": v}
+				wantSum += v
+				rowID++
+			}
+			if err := w.WriteRows(rows); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		key := fmt.Sprintf("tables/t/part-%04d.parquet", f)
+		if _, err := store.Put(context.Background(), bucket, key, bytes.NewReader(buf.Bytes()), int64(buf.Len()), "application/octet-stream"); err != nil {
+			t.Fatal(err)
+		}
+		keys = append(keys, key)
+	}
+	return keys, wantSum
+}
+
+// TestScanDecodeAhead_MultiFileParity: with --scan-decode-ahead on, a
+// multi-file multi-row-group scan over the prefetcher path yields exactly
+// the rows the serial path yields, and the engagement counter moves.
+func TestScanDecodeAhead_MultiFileParity(t *testing.T) {
+	ctx := context.Background()
+	store := objstore.NewMemStore()
+	keys, wantSum := writeMultiGroupFixture(t, store, "b", 5, 4, 32)
+
+	e := &Executor{store: store, spillDir: t.TempDir()}
+	e.SetScanDecodeAhead(true, 0)
+	src := newCachedFileStreamSource(e, "", "b", keys)
+	if err := src.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	sum, rows := drainValSum(t, ctx, src)
+	if err := src.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if sum != wantSum || rows != 5*4*32 {
+		t.Fatalf("decode-ahead read: sum=%d rows=%d, want sum=%d rows=%d", sum, rows, wantSum, 5*4*32)
+	}
+	if groups, _ := e.ScanDecodeAheadStats(); groups != 5*4 {
+		t.Errorf("decode-ahead groups = %d, want %d", groups, 5*4)
+	}
+
+	// Serial control on the same objects.
+	e2 := &Executor{store: store, spillDir: t.TempDir()}
+	src2 := newCachedFileStreamSource(e2, "", "b", keys)
+	if err := src2.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer src2.Close()
+	sum2, rows2 := drainValSum(t, ctx, src2)
+	if sum2 != sum || rows2 != rows {
+		t.Fatalf("serial control disagrees: sum=%d rows=%d vs decode-ahead sum=%d rows=%d", sum2, rows2, sum, rows)
+	}
+}
+
+// localPathTestStore serves every object from a local directory via the
+// LocalPathStore interface — the deterministic base-cache stand-in for
+// pre-open tests (no download timing involved).
+type localPathTestStore struct {
+	objstore.Store
+	paths map[string]string // bucket+"/"+key -> local file
+}
+
+func (s *localPathTestStore) CachedLocalPath(bucket, key string) (string, bool) {
+	p, ok := s.paths[bucket+"/"+key]
+	return p, ok
+}
+func (s *localPathTestStore) HasCachedPath(bucket, key string) bool {
+	_, ok := s.paths[bucket+"/"+key]
+	return ok
+}
+
+// TestScanDecodeAhead_CrossFileContinuation: with every file resident in
+// the local-path tier, the continuation must pre-open every file after
+// the first (deterministically — no download races), deliver identical
+// rows, and leave the cache-owned files on disk.
+func TestScanDecodeAhead_CrossFileContinuation(t *testing.T) {
+	ctx := context.Background()
+	inner := objstore.NewMemStore()
+	keys, wantSum := writeMultiGroupFixture(t, inner, "b", 4, 3, 32)
+
+	// Materialize every object as a local file for the LocalPathStore tier.
+	dir := t.TempDir()
+	paths := make(map[string]string, len(keys))
+	for i, k := range keys {
+		rc, _, err := inner.Get(ctx, "b", k)
+		if err != nil {
+			t.Fatal(err)
+		}
+		local := filepath.Join(dir, fmt.Sprintf("cached-%d.parquet", i))
+		data := make([]byte, 0)
+		buf := make([]byte, 32<<10)
+		for {
+			n, rerr := rc.Read(buf)
+			data = append(data, buf[:n]...)
+			if rerr != nil {
+				break
+			}
+		}
+		rc.Close()
+		if err := os.WriteFile(local, data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		paths["b/"+k] = local
+	}
+	store := &localPathTestStore{Store: inner, paths: paths}
+
+	e := &Executor{store: store, spillDir: t.TempDir()}
+	e.SetScanDecodeAhead(true, 0)
+	src := newCachedFileStreamSource(e, "", "b", keys)
+	src.prefetchDisabled = true // isolate the local-path pre-open tier
+	if err := src.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	sum, rows := drainValSum(t, ctx, src)
+	if sum != wantSum || rows != 4*3*32 {
+		t.Fatalf("continuation read: sum=%d rows=%d, want sum=%d rows=%d", sum, rows, wantSum, 4*3*32)
+	}
+	if src.preOpens != len(keys)-1 {
+		t.Errorf("pre-opened %d files, want %d (every file after the first)", src.preOpens, len(keys)-1)
+	}
+	if err := src.Close(); err != nil {
+		t.Fatal(err)
+	}
+	// Cache-owned files must survive the scan (localPath stays empty).
+	for _, p := range paths {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("cache-owned file removed by scan: %s (%v)", p, err)
+		}
+	}
+}
+
+// TestScanDecodeAhead_CloseWithPendingFile: closing the source while a
+// pre-opened next file is still pending must quiesce its decode workers
+// and release its resources without touching delivered data. The -race
+// build is the real assertion.
+func TestScanDecodeAhead_CloseWithPendingFile(t *testing.T) {
+	ctx := context.Background()
+	inner := objstore.NewMemStore()
+	keys, _ := writeMultiGroupFixture(t, inner, "b", 3, 2, 32)
+
+	dir := t.TempDir()
+	paths := make(map[string]string, len(keys))
+	for i, k := range keys {
+		rc, _, err := inner.Get(ctx, "b", k)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var data []byte
+		buf := make([]byte, 32<<10)
+		for {
+			n, rerr := rc.Read(buf)
+			data = append(data, buf[:n]...)
+			if rerr != nil {
+				break
+			}
+		}
+		rc.Close()
+		local := filepath.Join(dir, fmt.Sprintf("cached-%d.parquet", i))
+		if err := os.WriteFile(local, data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		paths["b/"+k] = local
+	}
+	store := &localPathTestStore{Store: inner, paths: paths}
+
+	e := &Executor{store: store, spillDir: t.TempDir()}
+	e.SetScanDecodeAhead(true, 0)
+	src := newCachedFileStreamSource(e, "", "b", keys)
+	src.prefetchDisabled = true
+	if err := src.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	// Pull batches until a pending file exists, then close mid-stream.
+	for i := 0; i < 100 && src.nextParquet == nil; i++ {
+		b, err := src.Next(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if b == nil {
+			break
+		}
+	}
+	if src.nextParquet == nil {
+		t.Fatal("fixture never produced a pending pre-opened file")
+	}
+	if err := src.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if src.nextParquet != nil {
+		t.Error("Close left the pending file live")
+	}
+}
+
+// TestFilePrefetcher_TryTakePutsBackFailures: a tryTake that observes an
+// err/skipped result must put it back so the authoritative take() still
+// receives it — consuming it would leave take() blocked forever on the
+// cap-1 channel.
+func TestFilePrefetcher_TryTakePutsBackFailures(t *testing.T) {
+	ctx := context.Background()
+	store := objstore.NewMemStore()
+	keys, _ := writeMultiGroupFixture(t, store, "b", 2, 1, 8)
+	missing := "tables/t/missing.parquet"
+	files := []string{keys[0], missing, keys[1]}
+
+	e := &Executor{store: store, spillDir: t.TempDir()}
+	src := newCachedFileStreamSource(e, "", "b", files)
+	p := startFilePrefetcher(ctx, src)
+	defer p.Close()
+
+	// Poll tryTake on the missing file's index until its download resolves
+	// to an error; every resolved observation must report unusable (nil).
+	var resolved bool
+	for i := 0; i < 2000 && !resolved; i++ {
+		var res *prefetchResult
+		res, resolved = p.tryTake(1)
+		if resolved && res != nil {
+			t.Fatalf("tryTake returned a usable result for a missing object: %+v", res)
+		}
+	}
+	if !resolved {
+		t.Fatal("prefetch of missing object never resolved")
+	}
+	// The authoritative take must still observe the buffered failure
+	// immediately (put-back happened) rather than blocking.
+	done := make(chan *prefetchResult, 1)
+	go func() { done <- p.take(ctx, 1) }()
+	select {
+	case res := <-done:
+		if res.err == nil && !res.skipped {
+			t.Fatalf("take after tryTake put-back: unexpected success %+v", res)
+		}
+	case <-ctx.Done():
+		t.Fatal("ctx done")
+	}
+}

--- a/internal/worker/stream_source_decode_ahead_test.go
+++ b/internal/worker/stream_source_decode_ahead_test.go
@@ -82,7 +82,7 @@ func TestScanDecodeAhead_MultiFileParity(t *testing.T) {
 	if sum != wantSum || rows != 5*4*32 {
 		t.Fatalf("decode-ahead read: sum=%d rows=%d, want sum=%d rows=%d", sum, rows, wantSum, 5*4*32)
 	}
-	if groups, _ := e.ScanDecodeAheadStats(); groups != 5*4 {
+	if groups, _, _, _ := e.ScanDecodeAheadStats(); groups != 5*4 {
 		t.Errorf("decode-ahead groups = %d, want %d", groups, 5*4)
 	}
 
@@ -235,6 +235,63 @@ func TestScanDecodeAhead_CloseWithPendingFile(t *testing.T) {
 	}
 	if src.nextParquet != nil {
 		t.Error("Close left the pending file live")
+	}
+}
+
+// TestScanDecodeAhead_TokenDegradeAndRelease: with a drained cpuToken
+// pool the source degrades to one decode worker (counter fires) and
+// still yields identical rows; with an ample pool the extra-worker
+// tokens are held for the source's lifetime and released exactly once
+// on Close.
+func TestScanDecodeAhead_TokenDegradeAndRelease(t *testing.T) {
+	ctx := context.Background()
+	store := objstore.NewMemStore()
+	keys, wantSum := writeMultiGroupFixture(t, store, "b", 3, 3, 32)
+
+	// Drained pool: degrade to serial width.
+	e := &Executor{store: store, spillDir: t.TempDir()}
+	e.SetScanDecodeAhead(true, 0)
+	e.cpuTokens = newCPUTokens(0)
+	src := newCachedFileStreamSource(e, "", "b", keys)
+	if err := src.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	sum, rows := drainValSum(t, ctx, src)
+	if err := src.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if sum != wantSum || rows != 3*3*32 {
+		t.Fatalf("degraded read: sum=%d rows=%d, want sum=%d rows=%d", sum, rows, wantSum, 3*3*32)
+	}
+	if src.decodeAheadK != 1 {
+		t.Errorf("decode width under drained pool = %d, want 1", src.decodeAheadK)
+	}
+	if _, _, _, degrades := e.ScanDecodeAheadStats(); degrades == 0 {
+		t.Error("token-degrade counter did not fire under a drained pool")
+	}
+
+	// Ample pool: extra workers hold tokens until Close releases them.
+	e2 := &Executor{store: store, spillDir: t.TempDir()}
+	e2.SetScanDecodeAhead(true, 0)
+	e2.cpuTokens = newCPUTokens(16)
+	src2 := newCachedFileStreamSource(e2, "", "b", keys)
+	if err := src2.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := src2.Next(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if src2.decodeAheadK < 2 {
+		t.Fatalf("decode width under ample pool = %d, want >= 2", src2.decodeAheadK)
+	}
+	if held := e2.cpuTokens.InUse(); held != int64(src2.decodeTokensHeld) || held == 0 {
+		t.Fatalf("tokens in use = %d, want %d (source's held count)", held, src2.decodeTokensHeld)
+	}
+	if err := src2.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if held := e2.cpuTokens.InUse(); held != 0 {
+		t.Errorf("tokens in use after Close = %d, want 0", held)
 	}
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -566,8 +566,40 @@ func (w *Worker) Start(ctx context.Context) error {
 	if w.config.StreamingShuffleRead {
 		w.startShuffleStreamMarkerLoop(ctx)
 	}
+	if w.config.ScanDecodeAhead {
+		w.startScanDecodeAheadMarkerLoop(ctx)
+	}
 
 	return nil
+}
+
+// startScanDecodeAheadMarkerLoop runs the scan-decode-ahead stats marker
+// (docs/design/scan-decode-pipelining.md §5) on bgWG — same contract as
+// startShuffleStreamMarkerLoop below: ctx-bound loops must never join
+// w.wg or they deadlock Drain.
+func (w *Worker) startScanDecodeAheadMarkerLoop(ctx context.Context) {
+	w.bgWG.Add(1)
+	go func() {
+		defer w.bgWG.Done()
+		var last [4]int64
+		t := time.NewTicker(60 * time.Second)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				groups, windowFulls, pressureStalls, tokenDegrades := w.executor.ScanDecodeAheadStats()
+				cur := [4]int64{groups, windowFulls, pressureStalls, tokenDegrades}
+				if cur != last {
+					last = cur
+					w.logger.Info("scan decode-ahead stats",
+						"groups", groups, "window_fulls", windowFulls,
+						"pressure_stalls", pressureStalls, "token_degrades", tokenDegrades)
+				}
+			}
+		}
+	}()
 }
 
 // startShuffleStreamMarkerLoop runs the streaming-shuffle-read stats marker

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -71,6 +71,14 @@ type Config struct {
 	// Default on at the CLI (SF100-validated); false is the kill switch.
 	StreamingShuffleRead bool
 
+	// ScanDecodeAhead decodes parquet row groups ahead of scan consumption
+	// with a bounded window instead of one group per pull
+	// (docs/design/scan-decode-pipelining.md). Default false pending SF100
+	// validation. ScanDecodeAheadBytes bounds decoded-but-unconsumed bytes
+	// per scan source; <= 0 selects the engine default (256 MiB).
+	ScanDecodeAhead      bool
+	ScanDecodeAheadBytes int64
+
 	// MmapRelief enables the Phase-5 MADV_DONTNEED relief of cold mmap'd cache
 	// files under heap pressure. Default false: fully dormant (no region
 	// tracking, no per-Next cost, no syscall). Deploy-gated.
@@ -232,6 +240,7 @@ func New(cfg Config, store objstore.Store, nc *nats.Conn, js jetstream.JetStream
 	executor.SetNATSConn(nc)
 	executor.SetMorselWorkers(cfg.MorselWorkers)
 	executor.SetStreamingShuffleRead(cfg.StreamingShuffleRead)
+	executor.SetScanDecodeAhead(cfg.ScanDecodeAhead, cfg.ScanDecodeAheadBytes)
 	// Phase 3: wire the system-reservoir registry for ACCOUNTING (Available()/
 	// drift) — this does NOT activate the floating spill threshold; that stays
 	// gated on FloatingBudgetActive (default false → tuned static 40%/90% path).

--- a/internal/worker/worker_drain_test.go
+++ b/internal/worker/worker_drain_test.go
@@ -165,6 +165,30 @@ func TestWorkerDrain_StreamingShuffleMarkerLoop(t *testing.T) {
 	}
 }
 
+// TestWorkerDrain_ScanDecodeAheadMarkerLoop: the scan-decode-ahead stats
+// marker loop must ride bgWG, not w.wg — the same drain-deadlock class as
+// the streaming-shuffle marker loop above.
+func TestWorkerDrain_ScanDecodeAheadMarkerLoop(t *testing.T) {
+	store := objstore.NewMemStore()
+	ctx, cancel := context.WithCancel(context.Background())
+	w := &Worker{
+		config:   Config{WorkerID: "drain-scan-marker-test", ScanDecodeAhead: true},
+		logger:   slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn})),
+		drainCh:  make(chan struct{}),
+		cancel:   cancel,
+		executor: NewExecutor(store, NewLRUCache(1024), nil),
+	}
+	w.startScanDecodeAheadMarkerLoop(ctx)
+
+	done := make(chan struct{})
+	go func() { w.Drain(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Drain did not complete: scan-decode-ahead marker loop blocks drain (wg vs bgWG)")
+	}
+}
+
 // TestWorkerDrain_TimeoutEscalatesToStop: with DrainTimeout set and a task
 // that never finishes, Drain must give up and hard-stop (cancel) instead of
 // hanging past the platform's kill window.


### PR DESCRIPTION
## Summary
Implements docs/design/scan-decode-pipelining.md (memo PR #227) behind `--scan-decode-ahead` (default **off** pending SF100 validation). Three slices, one commit each:

- **S1 — DecodeAheadIter** (`internal/engine/scan/decode_ahead.go`): k decode workers pull row-group indices in file order, results deliver strictly in source order — consumer contract byte-identical to the serial RowGroupIter (same batches, same error position, same prune behavior). Byte-bounded window (default 256 MiB) with per-group estimates from projected columns' `TotalUncompressedSize`; the delivery-cursor group is always admitted (no deadlock on oversized groups). `Close` joins in-flight decodes before the caller munmaps.
- **S2 — cross-file continuation**: once the current file's groups are all assigned, the source pre-opens the next file from the non-blocking local tiers only (base-cache hit / completed prefetch via new `filePrefetcher.tryTake`) and starts its decode workers — removes the per-file boundary bubble. One shared `DecodeWindow` per source; `tryTake` puts skipped/err results back so the authoritative `take()` still observes them.
- **S3 — cpuTokens + pressure collapse**: decode width drawn from the same token pool as morsel consumers (non-blocking, degrades toward serial); `heapPressureActive` gates admission beyond the delivery cursor so the window drains under memory pressure. Markers: `scan decode-ahead stats` loop (on `bgWG` — drain-regression-tested) + `ScanDecodeAheadGroups/WindowFulls/PressureStalls/TokenDegrades`.

## Gates (memo §6, all green)
- Full unit suite; worker + scan packages under `-race` (S1-S3 tests ×2)
- TPC-H SF0.01: 22/22 PASS (incl. SMJ-forced variant)
- `tpch-harness --mode=local` arms **off / on / on+DAG-forced**: 25/25 PASS each, rows + checksums identical across arms
- **SF1 engagement arm** (flag on, DAG-forced): 25/25 PASS, no zero-row queries; both workers logged `scan decode-ahead stats groups=1086/1089 window_fulls=0 pressure_stalls=0 token_degrades=0`

## Next
SF100 same-window pair per memo §6 (benchmark_runs=2 both arms, block+CPU profiling; markers order: utilization vs 2.9/16 ref → engagement counters → scan band → wall LAST). Needs deploy approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)