### PR TITLE
build(bench): terraform var scan_decode_ahead (default false)

### DIFF
--- a/deploy/benchmark/terraform/main.tf
+++ b/deploy/benchmark/terraform/main.tf
@@ -680,6 +680,7 @@ resource "aws_instance" "worker" {
             --morsel-workers=${var.morsel_workers} \
             --base-table-cache-bytes=${var.base_table_cache_bytes} \
             --streaming-shuffle-read=${var.streaming_shuffle_read} \
+            --scan-decode-ahead=${var.scan_decode_ahead} \
             %{if var.spill_floating_budget~}
             --spill-floating-budget \
             %{endif~}

--- a/deploy/benchmark/terraform/variables.tf
+++ b/deploy/benchmark/terraform/variables.tf
@@ -288,6 +288,12 @@ variable "streaming_shuffle_read" {
   default     = true
 }
 
+variable "scan_decode_ahead" {
+  description = "Scan decode pipelining (docs/design/scan-decode-pipelining.md): workers decode parquet row groups ahead of scan consumption — k decode workers with in-order delivery, byte-bounded window, cross-file continuation — instead of one row group per pull on the consumer goroutine. Worker-side flag only. Default false pending SF100 validation — set true for the treatment arm."
+  type        = bool
+  default     = false
+}
+
 variable "peer_exchange_port" {
   description = "Worker↔worker peer-exchange (FetchShuffle) port; SG opens it intra-cluster whenever streaming_exchange is set."
   type        = number


### PR DESCRIPTION
Worker-side flag pass-through for the SF100 A/B pair (docs/design/scan-decode-pipelining.md §6). Mirrors streaming_shuffle_read (5820244). `tofu validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)