### PR TITLE
fix(worker): per-row-group cpuToken accounting for scan decode-ahead

### DIFF
--- a/docs/design/scan-decode-pipelining.md
+++ b/docs/design/scan-decode-pipelining.md
@@ -1,6 +1,13 @@
 # Scan decode pipelining (parallel row-group decode-ahead)
 
-Status: PROPOSED. Follow-up predicted by
+Status: IMPLEMENTED (PR #228, flag default off). First SF100 pair
+(2026-07-16, §8) validated correctness + the scan-band mechanism but
+came out WALL-FLAT: source-lifetime cpuToken holds starved concurrent
+join fragments (Q20 +54%, Q05 +17%) and ate the scan wins (Q16 −63%,
+Q01 −32%). Fixed by per-row-group token accounting (§8.1);
+single-arm revalidation pending.
+
+Originally: PROPOSED. Follow-up predicted by
 `docs/design/scan-decompress-parallelism.md` §5 ("scan decode becomes
 CPU-parallel instead of slot-serial" fixed the *decoder*; the *producer*
 stayed serial) and by the morsel cap comment itself
@@ -194,3 +201,38 @@ decoded ahead of consumption":
   fragments×window inside the envelope on c7gd.4xlarge; a
   memory-pressure collapse hook (drop to k=1, drain window) is listed
   in S3 and must be in place before default-ON is proposed.
+
+## 8. SF100 pair results (2026-07-16) and the token fix
+
+Same-window pair on main 983d1ae (control `results/20260716-222612`,
+treatment `results/20260716-232648`), benchmark_runs=2 both arms,
+block+CPU profiling both arms, 3× c7gd.4xlarge, base cache 150 GB.
+
+- **Correctness**: 0 row mismatches across all 88 query executions.
+- **Engagement**: groups ≈ 38-40k/worker/2 suites; fallback-free.
+- **Scan band moved exactly as designed** (steady-state run 2):
+  Q16 −63%, Q01 −32%, Q06 −27%, Q12 −24%, Q15 −22%, Q02 −20%.
+- **Join-legged regressions ate the wins**: Q20 +54%, Q05 +17%,
+  Q22 +11%, Q07 +9%, Q03 +8%. Suite wall FLAT (26m53s → 27m13s,
+  +1.2%); utilization FLAT (2.85 → 2.84 of 16 cores).
+- **Conviction**: `window_fulls ≈ 35-41k` on ≈ 40k groups — decode
+  workers spent most of their lives stalled on a full window while
+  HOLDING source-lifetime cpuTokens (`token_degrades 211-235/worker`
+  = the pool was drained), narrowing concurrent join fragments'
+  morsel width. Decode-ahead moved wall between bands instead of
+  adding compute.
+
+### 8.1 Fix: per-row-group token accounting
+
+Tokens are acquired per DECODE, not per worker lifetime: a worker
+takes one token at admission of a non-cursor group and releases it
+when the decoded group parks. Workers stalled on the window, on
+pressure, or between groups hold nothing; the delivery-cursor group
+stays token-exempt (serial progress always allowed — the morsel
+"first consumer free" rule). Hoarding is structurally impossible;
+decode width becomes adaptive to actual token availability per group.
+Marker `token_degrades` is replaced by `token_stalls` (per-group
+admissions deferred; the group still decodes, serially at worst).
+
+Revalidation: single treatment-only SF100 run (control reference =
+`results/20260716-222612`), per the cost call on full A/Bs.

--- a/internal/engine/scan/decode_ahead.go
+++ b/internal/engine/scan/decode_ahead.go
@@ -48,6 +48,7 @@ type DecodeAheadIter struct {
 
 	workers  int
 	pressure func() bool
+	tokens   TokenPool
 
 	dynamicRanges []exec.DynamicRange
 	bloomFilters  []*exec.BloomScanFilter
@@ -75,6 +76,7 @@ type DecodeAheadIter struct {
 	rgRead           atomic.Int64
 	windowFullStalls atomic.Int64
 	pressureStalls   atomic.Int64
+	tokenStalls      atomic.Int64
 }
 
 // decodeSlot is one row group's outcome, parked until the delivery
@@ -103,6 +105,25 @@ type DecodeAheadOpts struct {
 	// the consumer takes — the memory-pressure collapse hook. Must be
 	// safe to call from multiple goroutines.
 	Pressure func() bool
+	// Tokens, when set, budgets decode CPU per ROW GROUP: a worker
+	// acquires one token at admission and releases it when the decoded
+	// group parks, so a worker stalled on the window (or between groups)
+	// holds nothing. The delivery-cursor group is token-exempt — serial
+	// progress is always allowed, mirroring the morsel "first consumer is
+	// free" rule. The 2026-07-16 SF100 pair convicted the previous
+	// source-lifetime acquisition: decode workers sat window-stalled
+	// holding tokens (~35k stalls/40k groups), starving concurrent join
+	// fragments' morsel width (Q20 +54%, Q05 +17%) while utilization
+	// stayed flat.
+	Tokens TokenPool
+}
+
+// TokenPool is the compute-budget seam shared with the caller's pool
+// (the worker's cpuTokens). Both methods must be safe for concurrent
+// use; TryAcquire must not block.
+type TokenPool interface {
+	TryAcquire(n int) int
+	Release(n int)
 }
 
 // DecodeWindow is a byte budget shared by one or more DecodeAheadIters.
@@ -168,6 +189,7 @@ func OpenDecodeAheadIter(reader *pqt.Reader, schema []pqt.Column, selectedCols [
 		workers:  opts.Workers,
 		win:      opts.Window,
 		pressure: opts.Pressure,
+		tokens:   opts.Tokens,
 	}
 	if it.win == nil {
 		it.win = NewDecodeWindow(opts.WindowBytes)
@@ -268,13 +290,14 @@ func (it *DecodeAheadIter) PruneStats() (bloom, rangeP, read int) {
 }
 
 // Stats returns the decode-ahead engagement counters (memo §5 markers):
-// row groups decoded, worker stalls on a full window, and admissions
-// refused under memory pressure.
-func (it *DecodeAheadIter) Stats() (groupsRead, windowFullStalls, pressureStalls int64) {
+// row groups decoded, worker stalls on a full window, admissions refused
+// under memory pressure, and admissions deferred for lack of a cpu
+// token (the group still decodes later — serially at worst).
+func (it *DecodeAheadIter) Stats() (groupsRead, windowFullStalls, pressureStalls, tokenStalls int64) {
 	if it == nil {
-		return 0, 0, 0
+		return 0, 0, 0, 0
 	}
-	return it.rgRead.Load(), it.windowFullStalls.Load(), it.pressureStalls.Load()
+	return it.rgRead.Load(), it.windowFullStalls.Load(), it.pressureStalls.Load(), it.tokenStalls.Load()
 }
 
 // Next returns the next decoded row group in source order, or (nil, nil)
@@ -326,16 +349,18 @@ func (it *DecodeAheadIter) decodeLoop() {
 		}
 		idx := it.nextIdx
 		est := it.estimateGroupBytes(idx)
-		// The delivery-cursor group is always admitted: the consumer is
-		// (or will be) waiting on precisely this index, so reserving past
-		// the window here cannot grow it further, and refusing would
-		// deadlock on any single group larger than the window. (Under a
-		// shared window this bounds transient overshoot to one group per
-		// chained iterator.) Memory pressure gates admission the same way
-		// — cursor-only progress until it clears, undelivered bytes drain
-		// as the consumer takes. Wakeups: every delivery broadcasts, and
+		// The delivery-cursor group is always admitted — token-free and
+		// past any window/pressure gate: the consumer is (or will be)
+		// waiting on precisely this index, so reserving past the window
+		// here cannot grow it further, and refusing would deadlock on any
+		// single group larger than the window. (Under a shared window
+		// this bounds transient overshoot to one group per chained
+		// iterator.) Every non-cursor group must clear the window, the
+		// pressure hook, AND acquire a cpu token held only for the decode
+		// itself. Wakeups: every delivery and every park broadcasts, and
 		// the cursor group is always decodable, so a stalled worker is
 		// re-checked at least once per delivered group.
+		var holdsToken bool
 		if idx != it.deliver {
 			if it.win.inflight+est > it.win.limit {
 				it.windowFullStalls.Add(1)
@@ -346,6 +371,14 @@ func (it *DecodeAheadIter) decodeLoop() {
 				it.pressureStalls.Add(1)
 				it.win.cond.Wait()
 				continue
+			}
+			if it.tokens != nil {
+				if it.tokens.TryAcquire(1) == 0 {
+					it.tokenStalls.Add(1)
+					it.win.cond.Wait()
+					continue
+				}
+				holdsToken = true
 			}
 		}
 		it.nextIdx++
@@ -364,6 +397,9 @@ func (it *DecodeAheadIter) decodeLoop() {
 					it.rgRead.Add(1)
 				}
 			}
+		}
+		if holdsToken {
+			it.tokens.Release(1)
 		}
 
 		it.win.mu.Lock()

--- a/internal/engine/scan/decode_ahead_test.go
+++ b/internal/engine/scan/decode_ahead_test.go
@@ -2,6 +2,7 @@ package scan
 
 import (
 	"bytes"
+	"sync"
 	"testing"
 
 	"github.com/citc-tech/wadjet/internal/engine/batch"
@@ -119,7 +120,7 @@ func TestDecodeAheadIter_MatchesSerial(t *testing.T) {
 			t.Fatalf("workers=%d drain: %v", workers, err)
 		}
 		requireSameBatches(t, want, got)
-		if groups, _, _ := it.Stats(); groups != 16 {
+		if groups, _, _, _ := it.Stats(); groups != 16 {
 			t.Errorf("workers=%d: groups read = %d, want 16", workers, groups)
 		}
 		// Post-exhaustion Next returns (nil, nil), like serial.
@@ -156,7 +157,7 @@ func TestDecodeAheadIter_TinyWindowStallsButDelivers(t *testing.T) {
 		t.Fatalf("drain: %v", err)
 	}
 	requireSameBatches(t, want, got)
-	if _, stalls, _ := it.Stats(); stalls == 0 {
+	if _, stalls, _, _ := it.Stats(); stalls == 0 {
 		t.Error("WindowBytes=1 with 4 workers never stalled — window is not gating admission")
 	}
 }
@@ -187,8 +188,107 @@ func TestDecodeAheadIter_PressureDegradesToSerial(t *testing.T) {
 		t.Fatalf("drain: %v", err)
 	}
 	requireSameBatches(t, want, got)
-	if _, _, stalls := it.Stats(); stalls == 0 {
+	if _, _, stalls, _ := it.Stats(); stalls == 0 {
 		t.Error("permanent pressure with 4 workers never stalled — hook is not gating admission")
+	}
+}
+
+// countingTokenPool counts acquire/release and enforces a capacity, so
+// tests can prove per-group hold semantics: peak holds bounded, zero
+// residual after drain, and progress with capacity 0.
+type countingTokenPool struct {
+	mu       sync.Mutex
+	capacity int
+	inUse    int
+	peak     int
+	acquires int
+}
+
+func (p *countingTokenPool) TryAcquire(n int) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	avail := p.capacity - p.inUse
+	if avail <= 0 {
+		return 0
+	}
+	if n > avail {
+		n = avail
+	}
+	p.inUse += n
+	p.acquires += n
+	if p.inUse > p.peak {
+		p.peak = p.inUse
+	}
+	return n
+}
+
+func (p *countingTokenPool) Release(n int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.inUse -= n
+}
+
+// TestDecodeAheadIter_PerGroupTokens: tokens are held per decode, not
+// per worker lifetime — capacity 0 still drains the file (cursor group
+// is token-exempt) with stalls counted; an ample pool ends with zero
+// residual holds and per-group acquires.
+func TestDecodeAheadIter_PerGroupTokens(t *testing.T) {
+	data := manyRowGroupFile(t, 12, 50)
+	schema := []pqt.Column{{Name: "id", Type: pqt.TypeInt64}}
+
+	serial, err := OpenRowGroupIter(openFileReader(t, data), schema, nil, 0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serial.Close()
+	want, _ := drainGroupIter(t, serial)
+
+	// Capacity 0: every non-cursor admission stalls, yet the iterator
+	// must still deliver everything (serial via the cursor exemption).
+	starved := &countingTokenPool{capacity: 0}
+	it, err := OpenDecodeAheadIter(openFileReader(t, data), schema, nil, 0, 1,
+		DecodeAheadOpts{Workers: 4, Tokens: starved})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer it.Close()
+	got, err := drainGroupIter(t, it)
+	if err != nil {
+		t.Fatalf("starved drain: %v", err)
+	}
+	requireSameBatches(t, want, got)
+	if _, _, _, stalls := it.Stats(); stalls == 0 {
+		t.Error("capacity-0 pool never produced a token stall")
+	}
+	if starved.acquires != 0 {
+		t.Errorf("capacity-0 pool recorded %d acquires, want 0", starved.acquires)
+	}
+
+	// Ample pool: acquires happen per group, peak bounded by workers-ish,
+	// and nothing is held after the drain (no hoarding).
+	ample := &countingTokenPool{capacity: 16}
+	it2, err := OpenDecodeAheadIter(openFileReader(t, data), schema, nil, 0, 1,
+		DecodeAheadOpts{Workers: 4, Tokens: ample})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer it2.Close()
+	got2, err := drainGroupIter(t, it2)
+	if err != nil {
+		t.Fatalf("ample drain: %v", err)
+	}
+	requireSameBatches(t, want, got2)
+	ample.mu.Lock()
+	inUse, peak, acquires := ample.inUse, ample.peak, ample.acquires
+	ample.mu.Unlock()
+	if inUse != 0 {
+		t.Errorf("tokens still held after drain: %d, want 0 (hoarding)", inUse)
+	}
+	if peak > 4 {
+		t.Errorf("peak concurrent holds = %d, want <= workers (4)", peak)
+	}
+	if acquires == 0 {
+		t.Error("ample pool saw no acquires — tokens not engaged")
 	}
 }
 

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -125,7 +125,7 @@ type Executor struct {
 	scanDecodeAheadGroups         atomic.Int64
 	scanDecodeAheadWindowFulls    atomic.Int64
 	scanDecodeAheadPressureStalls atomic.Int64
-	scanDecodeAheadTokenDegrades  atomic.Int64
+	scanDecodeAheadTokenStalls    atomic.Int64
 }
 
 // SetStreamingShuffleRead enables streaming decode of shuffle inputs
@@ -148,11 +148,11 @@ func (e *Executor) SetScanDecodeAhead(on bool, windowBytes int64) {
 
 // ScanDecodeAheadStats returns the decode-ahead counters: row groups
 // decoded ahead, worker stalls on a full window, admissions refused
-// under heap pressure, and sources that got fewer decode workers than
-// the default because the cpuToken pool was drawn down.
-func (e *Executor) ScanDecodeAheadStats() (groups, windowFulls, pressureStalls, tokenDegrades int64) {
+// under heap pressure, and per-group admissions deferred for lack of a
+// cpu token (each affected group still decodes, serially at worst).
+func (e *Executor) ScanDecodeAheadStats() (groups, windowFulls, pressureStalls, tokenStalls int64) {
 	return e.scanDecodeAheadGroups.Load(), e.scanDecodeAheadWindowFulls.Load(),
-		e.scanDecodeAheadPressureStalls.Load(), e.scanDecodeAheadTokenDegrades.Load()
+		e.scanDecodeAheadPressureStalls.Load(), e.scanDecodeAheadTokenStalls.Load()
 }
 
 // NewExecutor creates a new task executor.

--- a/internal/worker/stream_source.go
+++ b/internal/worker/stream_source.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"syscall"
 
@@ -146,11 +145,6 @@ type cachedFileStreamSource struct {
 	decodeWin   *scan.DecodeWindow
 	preOpenSkip int
 	preOpens    int // files pre-opened by the continuation (tests + DEBUG log)
-	// Decode width for this source (decided with decodeWin) and the
-	// cpuTokens held for its extra workers — released exactly once, in
-	// Close.
-	decodeAheadK     int
-	decodeTokensHeld int
 }
 
 // shuffleBatchIter is the common face of the mmap-backed and streaming
@@ -330,10 +324,6 @@ func (s *cachedFileStreamSource) Close() error {
 	// reader holding dangling mmap bytes if any caller still has a handle.
 	s.releaseParquetIter()
 	s.releaseCurrentFile()
-	if s.decodeTokensHeld > 0 {
-		s.executor.cpuTokens.Release(s.decodeTokensHeld)
-		s.decodeTokensHeld = 0
-	}
 	for i := s.fallbackBatchIdx; i < len(s.fallbackBatches); i++ {
 		s.fallbackBatches[i] = nil
 	}
@@ -917,33 +907,23 @@ func (s *cachedFileStreamSource) buildParquetState(filePath string, data, mmapDa
 		if s.decodeWin == nil {
 			// One window per source, shared across every file it opens —
 			// the cross-file continuation draws the next file's head from
-			// the same budget as the current file's tail. Decode width is
-			// also decided once per source, from the same cpuToken pool
-			// the morsel consumers draw on (nil pool = morsels disabled =
-			// serial consumers, so the fixed default width is safe);
-			// non-blocking, degrades toward serial under token exhaustion
-			// exactly like morselFragmentWorkers.
+			// the same budget as the current file's tail.
 			s.decodeWin = scan.NewDecodeWindow(s.executor.scanDecodeAheadBytes)
-			k := scan.DefaultDecodeAheadWorkers
-			if gp := runtime.GOMAXPROCS(0); k > gp {
-				k = gp
-			}
-			if s.executor.cpuTokens != nil {
-				got := s.executor.cpuTokens.TryAcquire(k - 1)
-				s.decodeTokensHeld = got
-				if got < k-1 {
-					s.executor.scanDecodeAheadTokenDegrades.Add(1)
-					if s.executor.logger != nil {
-						s.executor.logger.Debug("scan decode-ahead degraded on cpu tokens",
-							"want_workers", k, "got_workers", got+1)
-					}
-				}
-				k = got + 1
-			}
-			s.decodeAheadK = k
 		}
-		da, err := scan.OpenDecodeAheadIter(reader, projCols, nil, shardIdx, shardCount,
-			scan.DecodeAheadOpts{Window: s.decodeWin, Workers: s.decodeAheadK, Pressure: heapPressureActive})
+		// CPU is budgeted per ROW GROUP inside the iterator (one token
+		// held only for the duration of one decode, cursor group exempt)
+		// — never per source lifetime: the 2026-07-16 SF100 pair showed
+		// window-stalled decode workers hoarding source-held tokens and
+		// starving concurrent join fragments' morsel width. A nil pool
+		// (morsels disabled → serial consumers) leaves decode unbudgeted
+		// at the default width. NOTE: the nil check must happen here — a
+		// nil *cpuTokens wrapped in the interface would read as non-nil
+		// and silently serialize decode.
+		opts := scan.DecodeAheadOpts{Window: s.decodeWin, Pressure: heapPressureActive}
+		if s.executor.cpuTokens != nil {
+			opts.Tokens = s.executor.cpuTokens
+		}
+		da, err := scan.OpenDecodeAheadIter(reader, projCols, nil, shardIdx, shardCount, opts)
 		if err != nil {
 			p.release(s.executor.logger)
 			return nil, fmt.Errorf("opening decode-ahead iterator for %s: %w", filePath, err)
@@ -1073,10 +1053,11 @@ type decodeAheadStatsIter struct {
 func (d *decodeAheadStatsIter) Close() error {
 	if !d.folded {
 		d.folded = true
-		groups, windowFulls, pressureStalls := d.Stats()
+		groups, windowFulls, pressureStalls, tokenStalls := d.Stats()
 		d.executor.scanDecodeAheadGroups.Add(groups)
 		d.executor.scanDecodeAheadWindowFulls.Add(windowFulls)
 		d.executor.scanDecodeAheadPressureStalls.Add(pressureStalls)
+		d.executor.scanDecodeAheadTokenStalls.Add(tokenStalls)
 	}
 	return d.DecodeAheadIter.Close()
 }

--- a/internal/worker/stream_source_decode_ahead_test.go
+++ b/internal/worker/stream_source_decode_ahead_test.go
@@ -239,17 +239,18 @@ func TestScanDecodeAhead_CloseWithPendingFile(t *testing.T) {
 	}
 }
 
-// TestScanDecodeAhead_TokenDegradeAndRelease: with a drained cpuToken
-// pool the source degrades to one decode worker (counter fires) and
-// still yields identical rows; with an ample pool the extra-worker
-// tokens are held for the source's lifetime and released exactly once
-// on Close.
-func TestScanDecodeAhead_TokenDegradeAndRelease(t *testing.T) {
+// TestScanDecodeAhead_PerGroupTokens: the source's decode CPU is
+// budgeted per row group against the executor's cpuToken pool — a
+// drained pool still yields identical rows (cursor-exempt serial
+// progress, token-stall counter fires), and with an ample pool NOTHING
+// remains held after the scan drains mid-source or closes: no
+// source-lifetime hoarding (the 2026-07-16 SF100 regression class).
+func TestScanDecodeAhead_PerGroupTokens(t *testing.T) {
 	ctx := context.Background()
 	store := objstore.NewMemStore()
 	keys, wantSum := writeMultiGroupFixture(t, store, "b", 3, 3, 32)
 
-	// Drained pool: degrade to serial width.
+	// Drained pool: still correct, stall counter fires.
 	e := &Executor{store: store, spillDir: t.TempDir()}
 	e.SetScanDecodeAhead(true, 0)
 	e.cpuTokens = newCPUTokens(0)
@@ -262,16 +263,17 @@ func TestScanDecodeAhead_TokenDegradeAndRelease(t *testing.T) {
 		t.Fatal(err)
 	}
 	if sum != wantSum || rows != 3*3*32 {
-		t.Fatalf("degraded read: sum=%d rows=%d, want sum=%d rows=%d", sum, rows, wantSum, 3*3*32)
+		t.Fatalf("starved read: sum=%d rows=%d, want sum=%d rows=%d", sum, rows, wantSum, 3*3*32)
 	}
-	if src.decodeAheadK != 1 {
-		t.Errorf("decode width under drained pool = %d, want 1", src.decodeAheadK)
+	if _, _, _, stalls := e.ScanDecodeAheadStats(); stalls == 0 {
+		t.Error("token-stall counter did not fire under a drained pool")
 	}
-	if _, _, _, degrades := e.ScanDecodeAheadStats(); degrades == 0 {
-		t.Error("token-degrade counter did not fire under a drained pool")
+	if held := e.cpuTokens.InUse(); held != 0 {
+		t.Errorf("tokens in use after starved scan = %d, want 0", held)
 	}
 
-	// Ample pool: extra workers hold tokens until Close releases them.
+	// Ample pool: after every delivered batch, held tokens can only be
+	// the ones inside active decodes — and after Close, exactly zero.
 	e2 := &Executor{store: store, spillDir: t.TempDir()}
 	e2.SetScanDecodeAhead(true, 0)
 	e2.cpuTokens = newCPUTokens(16)
@@ -279,20 +281,15 @@ func TestScanDecodeAhead_TokenDegradeAndRelease(t *testing.T) {
 	if err := src2.Init(ctx); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := src2.Next(ctx); err != nil {
-		t.Fatal(err)
-	}
-	if src2.decodeAheadK < 2 {
-		t.Fatalf("decode width under ample pool = %d, want >= 2", src2.decodeAheadK)
-	}
-	if held := e2.cpuTokens.InUse(); held != int64(src2.decodeTokensHeld) || held == 0 {
-		t.Fatalf("tokens in use = %d, want %d (source's held count)", held, src2.decodeTokensHeld)
+	sum2, rows2 := drainValSum(t, ctx, src2)
+	if sum2 != wantSum || rows2 != rows {
+		t.Fatalf("ample read: sum=%d rows=%d, want sum=%d rows=%d", sum2, rows2, wantSum, rows)
 	}
 	if err := src2.Close(); err != nil {
 		t.Fatal(err)
 	}
 	if held := e2.cpuTokens.InUse(); held != 0 {
-		t.Errorf("tokens in use after Close = %d, want 0", held)
+		t.Errorf("tokens in use after Close = %d, want 0 (hoarding)", held)
 	}
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -589,13 +589,13 @@ func (w *Worker) startScanDecodeAheadMarkerLoop(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case <-t.C:
-				groups, windowFulls, pressureStalls, tokenDegrades := w.executor.ScanDecodeAheadStats()
-				cur := [4]int64{groups, windowFulls, pressureStalls, tokenDegrades}
+				groups, windowFulls, pressureStalls, tokenStalls := w.executor.ScanDecodeAheadStats()
+				cur := [4]int64{groups, windowFulls, pressureStalls, tokenStalls}
 				if cur != last {
 					last = cur
 					w.logger.Info("scan decode-ahead stats",
 						"groups", groups, "window_fulls", windowFulls,
-						"pressure_stalls", pressureStalls, "token_degrades", tokenDegrades)
+						"pressure_stalls", pressureStalls, "token_stalls", tokenStalls)
 				}
 			}
 		}


### PR DESCRIPTION
## Why
The SF100 pair (control `results/20260716-222612` vs treatment `-232648`, main 983d1ae) validated correctness (0 row mismatches / 88 executions) and the scan-band mechanism (Q16 −63%, Q01 −32%, Q06 −27%, Q12 −24%, Q15 −22%, Q02 −20%) — but the suite wall was FLAT (+1.2%) and utilization flat (2.85→2.84/16): join-legged queries regressed (Q20 +54%, Q05 +17%, Q07 +9%) and ate the wins.

**Conviction**: `window_fulls ≈ 35-41k` on ≈40k groups/worker — decode workers spent most of their lives stalled on a full window while **holding source-lifetime cpuTokens** (`token_degrades` 211-235/worker = pool drained), narrowing concurrent join fragments' morsel width.

## Fix
Tokens are acquired **per decode**: one token at admission of a non-cursor group, released when the decoded group parks. Stalled workers (window/pressure/tokens) hold nothing; the delivery-cursor group is token-exempt, so serial progress is always guaranteed (the morsel first-consumer-free rule). Hoarding is structurally impossible and decode width adapts per group. Marker `token_degrades` → `token_stalls`. Memo §8 records the pair + fix.

## Gates
- scan+worker `-race` ×2 incl. new per-group token tests (capacity-0 pool still drains serially with stalls counted and zero acquires; ample pool ends with zero residual holds after drain and Close)
- Full unit suite; harness DAG-forced flag-on arm PASS; SF1 engagement arm PASS (`groups≈1077/worker`, no zero-row queries)

## Next
Single treatment-only SF100 revalidation (control reference = today's `20260716-222612`), per the cost call on full A/Bs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)