### PR TITLE
fix(worker): ledger-charged decode-ahead window + page-cache refault sensor (memo §9)

### DIFF
--- a/cmd/refault-probe/main.go
+++ b/cmd/refault-probe/main.go
@@ -1,0 +1,78 @@
+// Command refault-probe is a field diagnostic for the §9 page-cache
+// pressure sensor (internal/engine/memory/pressure_os.go). It prints,
+// once per second, the raw workingset_refault counter this process can
+// see next to the sensor's sampled rate and active state — same
+// process, same instant, so a moving counter with a flat sensor rate
+// indicts the sensor, not the environment.
+//
+// With --thrash <file> it also generates workingset refaults itself:
+// the file is mmap'd and pages are touched in a random order, twice per
+// sweep, so pages join the kernel's workingset before eviction — run it
+// inside a memory-capped cgroup smaller than the file and the
+// eviction/re-touch cycle registers as refaults (a sequential cat loop
+// does not: streamed pages never activate).
+package main
+
+import (
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/engine/memory"
+)
+
+func main() {
+	thrash := flag.String("thrash", "", "file to mmap and randomly re-touch to generate workingset refaults")
+	secs := flag.Int("secs", 30, "seconds to run")
+	flag.Parse()
+
+	if *thrash != "" {
+		go thrashLoop(*thrash)
+	}
+
+	for i := 0; i < *secs; i++ {
+		active := memory.PageCachePressureActive()
+		rate, act := memory.PageCachePressureStats()
+		raw, ok := memory.ReadRefaultCounterForDiagnostics()
+		fmt.Printf("t=%02d raw=%d raw_ok=%v active=%v rate=%.0f activations=%d\n",
+			i, raw, ok, active, rate, act)
+		time.Sleep(1 * time.Second)
+	}
+}
+
+func thrashLoop(path string) {
+	f, err := os.Open(path)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "thrash open:", err)
+		return
+	}
+	st, err := f.Stat()
+	if err != nil || st.Size() == 0 {
+		fmt.Fprintln(os.Stderr, "thrash stat:", err)
+		return
+	}
+	data, err := syscall.Mmap(int(f.Fd()), 0, int(st.Size()), syscall.PROT_READ, syscall.MAP_SHARED)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "thrash mmap:", err)
+		return
+	}
+	const page = 4096
+	pages := len(data) / page
+	order := rand.Perm(pages)
+	var sink byte
+	for {
+		// Two touches per sweep in random order: the first faults the
+		// page in, the second (same sweep, different position) marks it
+		// referenced so eviction comes off the active list — the
+		// workingset shape the refault counter detects.
+		for _, p := range order {
+			sink += data[p*page]
+		}
+		for _, p := range order {
+			sink += data[(pages-1-p)*page]
+		}
+	}
+}

--- a/docs/design/scan-decode-pipelining.md
+++ b/docs/design/scan-decode-pipelining.md
@@ -338,3 +338,19 @@ full window — the sensor would trade scan-band width for cache relief.
 The SF100 pair remains the test; watch scan-band retention
 (Q16/Q06/Q12) alongside Q05/Q07, `refault_activations`, and
 `ledger_stalls`.
+
+**Sensor visibility bound (measured 2026-07-17)**: cgroup-v1 memcg
+reclaim does not feed the global `workingset_refault` counters on the
+WSL2 5.15 kernel — a capped v1 container thrashing 1.5 GiB of its own
+file pages through a 512 MiB limit moved the counter by ~0
+(`cmd/refault-probe --thrash` reproduces this). The sensor is therefore
+blind to v1-container-INTERNAL displacement, which is exactly the
+cap-wrapper simulator's shape — so the capped rig cannot fire it
+end-to-end. This is a simulator artifact, not a product gap: SF100
+workers run bare on cgroup-v2 AL2023 (host-level reclaim feeds
+/proc/vmstat AND the v2 memory.stat both), and real edge boxes are
+bare small machines or v2 containers. Fail-safe by construction:
+counter source absent or silent → sensor inactive → current behavior.
+`cmd/refault-probe` prints raw counter + sensor state side by side and
+generates workingset-shaped thrash for field diagnosis; the sensor
+logs its bound source at init.

--- a/docs/design/scan-decode-pipelining.md
+++ b/docs/design/scan-decode-pipelining.md
@@ -285,3 +285,56 @@ re-reads vs GC-cycle frequency) is not isolated — the capped repro
 cannot distinguish them. The fix's SF100 pair is the test; markers to
 watch: decode-ahead ledger charges/denials, GC cycle counts, scan-band
 retention, Q05/Q07 vs the 20260716-222612 control.
+
+### 9.2 Implementation and what the capped repro falsified (2026-07-17)
+
+Both §9.1 pieces are implemented on `fix/decode-ahead-ledger-window`:
+
+**Ledger charge (e2e80a6).** `DecodeWindow` carries an optional
+`scan.WindowLedger` (satisfied directly by `*memory.Tracker`); the
+worker attaches its shared pool tracker. Non-cursor admission must
+clear the window ceiling, the pressure hook, `ledger.Reserve`, and a
+cpu token (token denial rolls the reserve back); the delivery-cursor
+group is force-charged but never denied. Inflight and ledger move in
+lockstep, balancing to zero per source on delivery and Close. New
+marker: `ledger_stalls`.
+
+**What the same-window capped repro then falsified**: §9.1's claim
+that the ledger route subsumes a page-cache sensor. Interleaved arms
+(A = off, B = main + flag, C = ledger + flag; EDGE_CAP_MB=2048):
+A 36.9 s, B 55.2 s (+49 %, regression reproduced), C 48.5 s (+31 % —
+partial) with `ledger_stalls=0`. The pool auto-sizes to
+goMemLimit − cache = 1.45 GiB under the cap, so a 256 MiB window never
+draws a denial: the pool bounds OPERATOR co-tenancy (its real job, and
+the charge stays — at SF100 the 5.4 GiB pool carries multi-GB join
+builds, a topology the capped rig cannot reproduce), but no Go-side
+ledger sees the kernel-level displacement.
+
+**Refault-rate sensor (5a35fdf).** The kernel publishes the
+displacement directly: `workingset_refault` counts faults on
+recently-evicted pages — thrash by definition; cold sequential reads
+are first-touch faults and do not count. Measured: ~0/s quiet baseline
+vs 15k–95k pages/s during capped thrash — four orders of magnitude.
+`memory.PageCachePressureActive()` samples the process's cgroup-v2
+`memory.stat` (host `/proc/vmstat` fallback; source absence disables)
+at 1 s cadence; active when the rate exceeds 1000 pages/s (~4 MB/s,
+env-overridable) on two consecutive samples. Decode-ahead admission
+consults it alongside the Go-heap gauge — no iterator changes; the
+existing pressure path collapses to the cursor-exempt serial floor.
+Safe on both ends: under thrash, width is worthless anyway (the
+I/O-bound repro logged `window_fulls=0` — decode cannot outrun a
+saturated disk); on a healthy box the sensor is silent. Markers:
+`refault_rate`, `refault_activations`.
+
+**Environment caveat for future capped repros**: the rig only
+discriminates when the flag-off arm shows a LOW refault rate (dataset
+host-cache-warm). After a host reboot every arm ran ~90k refaults/s
+and A ≈ B ≈ C — saturated disk thrash masks the window effect
+entirely. Check the flag-off refault rate before trusting any arm.
+
+**Residual honest bound** (one cell no local rig can test): SF100
+partial-residency background refaults co-occurring with a productively
+full window — the sensor would trade scan-band width for cache relief.
+The SF100 pair remains the test; watch scan-band retention
+(Q16/Q06/Q12) alongside Q05/Q07, `refault_activations`, and
+`ledger_stalls`.

--- a/internal/engine/memory/pressure_os.go
+++ b/internal/engine/memory/pressure_os.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"log/slog"
 	"os"
 	"strconv"
 	"strings"
@@ -132,20 +133,21 @@ func (s *refaultSensor) Stats() (lastRate float64, activations int64) {
 }
 
 // readRefaultCounter returns a reader for the best available refault
-// counter: the process's cgroup v2 memory.stat if one exists, else the
-// host-wide /proc/vmstat. Returns nil when neither source has a
-// workingset_refault field (e.g. pre-4.20 kernels, PSI-less builds).
-func readRefaultCounter() func() (int64, bool) {
+// counter and the source it bound, for the init log: the process's
+// cgroup v2 memory.stat if one exists, else the host-wide /proc/vmstat.
+// Returns nil when neither source has a workingset_refault field (e.g.
+// pre-4.20 kernels, PSI-less builds).
+func readRefaultCounter() (func() (int64, bool), string) {
 	if path := cgroupV2StatPath(); path != "" {
 		if _, ok := parseRefaultFile(path); ok {
-			return func() (int64, bool) { return parseRefaultFile(path) }
+			return func() (int64, bool) { return parseRefaultFile(path) }, path
 		}
 	}
 	const vmstat = "/proc/vmstat"
 	if _, ok := parseRefaultFile(vmstat); ok {
-		return func() (int64, bool) { return parseRefaultFile(vmstat) }
+		return func() (int64, bool) { return parseRefaultFile(vmstat) }, vmstat
 	}
-	return nil
+	return nil, "none"
 }
 
 // cgroupV2StatPath resolves this process's cgroup v2 memory.stat path,
@@ -204,7 +206,12 @@ func pageCachePressureSensor() *refaultSensor {
 				threshold = f
 			}
 		}
-		pageCacheSensor = newRefaultSensor(readRefaultCounter(), threshold, refaultSampleInterval)
+		read, source := readRefaultCounter()
+		pageCacheSensor = newRefaultSensor(read, threshold, refaultSampleInterval)
+		slog.Info("page-cache pressure sensor",
+			"source", source,
+			"threshold_pages_per_sec", threshold,
+			"enabled", !pageCacheSensor.disabled)
 	})
 	return pageCacheSensor
 }
@@ -222,4 +229,16 @@ func PageCachePressureActive() bool {
 // (pages/sec) and its lifetime activation count, for rollout markers.
 func PageCachePressureStats() (lastRate float64, activations int64) {
 	return pageCachePressureSensor().Stats()
+}
+
+// ReadRefaultCounterForDiagnostics reads the raw refault counter through
+// the same source-selection logic the sensor uses. cmd/refault-probe
+// prints it beside the sensor state to separate "counter not visible
+// here" from "sensor not sampling" in the field.
+func ReadRefaultCounterForDiagnostics() (int64, bool) {
+	read, _ := readRefaultCounter()
+	if read == nil {
+		return 0, false
+	}
+	return read()
 }

--- a/internal/engine/memory/pressure_os.go
+++ b/internal/engine/memory/pressure_os.go
@@ -1,0 +1,225 @@
+package memory
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Page-cache pressure sensor (docs/design/scan-decode-pipelining.md §9).
+//
+// The Go-heap pressure hooks above are blind to the failure mode that
+// convicted the decode-ahead window: held heap bytes displace the page
+// cache holding the file pages a scan is about to read, the kernel
+// absorbs the squeeze silently, and Go-side accounting never crosses any
+// threshold. The kernel DOES publish the displacement as it happens:
+// workingset_refault counts faults on pages that were recently evicted —
+// cache thrash by definition. Cold sequential reads are first-touch
+// faults, not refaults, so a healthy streaming scan reads ~0/s while
+// genuine displacement measured 15k-95k pages/s on the 2 GiB capped
+// repro (2026-07-17) — four orders of magnitude of separation.
+//
+// The counter is read from the process's own cgroup v2 memory.stat when
+// available (attributes pressure to this container), falling back to the
+// host-wide /proc/vmstat (correct on dedicated workers; on shared hosts
+// it may fire from a co-tenant's thrash, which only costs decode-ahead
+// width at a moment when the disk is contended anyway — width is
+// worthless mid-thrash: the capped repro measured window_fulls=0 once
+// I/O-bound). No readable source disables the sensor permanently.
+//
+// A sample is taken at most once per second; the rate must exceed the
+// threshold on two consecutive samples before the sensor reports active
+// (one-burst damping), and one quiet sample deactivates it.
+
+// refaultPressureRatePerSec is the default activation threshold in
+// refaulted pages/sec (≈4 MB/s of cache re-reads). Quiet-box baseline is
+// ~0/s and measured thrash is 15k+/s, so the constant sits well clear of
+// both; it is a floor against incidental bursts, not a tuning point.
+// Overridable via WADJET_REFAULT_PRESSURE_RATE (pages/sec, 0 disables).
+const refaultPressureRatePerSec = 1000.0
+
+// refaultSampleInterval is the minimum time between counter reads. Rate
+// estimation over sub-second windows is noise; the sensor is consulted
+// per row-group admission (~ms cadence) and must stay near-free.
+const refaultSampleInterval = time.Second
+
+// refaultSensor computes a refault rate from a monotonic counter source
+// and applies two-sample activation damping. The zero value is unusable;
+// construct with newRefaultSensor.
+type refaultSensor struct {
+	mu        sync.Mutex
+	read      func() (int64, bool) // monotonic page count; false = source gone
+	threshold float64              // pages/sec; <= 0 disables
+	interval  time.Duration
+
+	disabled   bool
+	lastCount  int64
+	lastSample time.Time
+	lastRate   float64
+	hotStreak  int // consecutive over-threshold samples
+	active     bool
+
+	activations int64 // inactive->active transitions, for markers
+}
+
+func newRefaultSensor(read func() (int64, bool), threshold float64, interval time.Duration) *refaultSensor {
+	s := &refaultSensor{read: read, threshold: threshold, interval: interval}
+	if read == nil || threshold <= 0 {
+		s.disabled = true
+		return s
+	}
+	// Prime the baseline so the first real sample measures a delta, not
+	// the counter's absolute value.
+	if c, ok := read(); ok {
+		s.lastCount = c
+		s.lastSample = time.Now()
+	} else {
+		s.disabled = true
+	}
+	return s
+}
+
+// Active reports whether the refault rate has exceeded the threshold on
+// the last two samples. Cheap between sampling intervals: one mutex and
+// a time check.
+func (s *refaultSensor) Active() bool {
+	if s == nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.disabled {
+		return false
+	}
+	now := time.Now()
+	elapsed := now.Sub(s.lastSample)
+	if elapsed < s.interval {
+		return s.active
+	}
+	c, ok := s.read()
+	if !ok {
+		s.disabled = true
+		s.active = false
+		return false
+	}
+	s.lastRate = float64(c-s.lastCount) / elapsed.Seconds()
+	s.lastCount = c
+	s.lastSample = now
+	if s.lastRate > s.threshold {
+		s.hotStreak++
+	} else {
+		s.hotStreak = 0
+	}
+	wasActive := s.active
+	s.active = s.hotStreak >= 2
+	if s.active && !wasActive {
+		s.activations++
+	}
+	return s.active
+}
+
+// Stats returns the last computed rate (pages/sec) and the number of
+// inactive->active transitions — the §9 rollout markers.
+func (s *refaultSensor) Stats() (lastRate float64, activations int64) {
+	if s == nil {
+		return 0, 0
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastRate, s.activations
+}
+
+// readRefaultCounter returns a reader for the best available refault
+// counter: the process's cgroup v2 memory.stat if one exists, else the
+// host-wide /proc/vmstat. Returns nil when neither source has a
+// workingset_refault field (e.g. pre-4.20 kernels, PSI-less builds).
+func readRefaultCounter() func() (int64, bool) {
+	if path := cgroupV2StatPath(); path != "" {
+		if _, ok := parseRefaultFile(path); ok {
+			return func() (int64, bool) { return parseRefaultFile(path) }
+		}
+	}
+	const vmstat = "/proc/vmstat"
+	if _, ok := parseRefaultFile(vmstat); ok {
+		return func() (int64, bool) { return parseRefaultFile(vmstat) }
+	}
+	return nil
+}
+
+// cgroupV2StatPath resolves this process's cgroup v2 memory.stat path,
+// or "" when the process is not in a non-root v2 cgroup. Mirrors the
+// hierarchy walk in detectV2ProcessLimit (detect.go).
+func cgroupV2StatPath() string {
+	data, err := os.ReadFile("/proc/self/cgroup")
+	if err != nil {
+		return ""
+	}
+	for line := range strings.SplitSeq(string(data), "\n") {
+		if p, ok := strings.CutPrefix(line, "0::"); ok {
+			if p == "" || p == "/" {
+				return ""
+			}
+			return "/sys/fs/cgroup" + p + "/memory.stat"
+		}
+	}
+	return ""
+}
+
+// parseRefaultFile reads workingset_refault_file (falling back to the
+// pre-5.9 unified workingset_refault) from a vmstat-format file.
+func parseRefaultFile(path string) (int64, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	var unified int64
+	var haveUnified bool
+	for line := range strings.SplitSeq(string(data), "\n") {
+		if v, ok := strings.CutPrefix(line, "workingset_refault_file "); ok {
+			if n, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64); err == nil {
+				return n, true
+			}
+		}
+		if v, ok := strings.CutPrefix(line, "workingset_refault "); ok {
+			if n, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64); err == nil {
+				unified, haveUnified = n, true
+			}
+		}
+	}
+	return unified, haveUnified
+}
+
+var (
+	pageCacheSensorOnce sync.Once
+	pageCacheSensor     *refaultSensor
+)
+
+func pageCachePressureSensor() *refaultSensor {
+	pageCacheSensorOnce.Do(func() {
+		threshold := refaultPressureRatePerSec
+		if v := os.Getenv("WADJET_REFAULT_PRESSURE_RATE"); v != "" {
+			if f, err := strconv.ParseFloat(v, 64); err == nil && f >= 0 {
+				threshold = f
+			}
+		}
+		pageCacheSensor = newRefaultSensor(readRefaultCounter(), threshold, refaultSampleInterval)
+	})
+	return pageCacheSensor
+}
+
+// PageCachePressureActive reports whether the kernel is currently
+// refaulting recently-evicted file pages faster than the threshold —
+// page-cache thrash the Go-heap hooks cannot see. Callers gate
+// DISCRETIONARY memory use (decode-ahead width, speculative prefetch)
+// on it; it must not gate correctness-bearing work.
+func PageCachePressureActive() bool {
+	return pageCachePressureSensor().Active()
+}
+
+// PageCachePressureStats returns the sensor's last sampled refault rate
+// (pages/sec) and its lifetime activation count, for rollout markers.
+func PageCachePressureStats() (lastRate float64, activations int64) {
+	return pageCachePressureSensor().Stats()
+}

--- a/internal/engine/memory/pressure_os_test.go
+++ b/internal/engine/memory/pressure_os_test.go
@@ -1,0 +1,146 @@
+package memory
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// fakeCounter drives a refaultSensor with a scripted monotonic counter.
+type fakeCounter struct {
+	value int64
+	ok    bool
+}
+
+func (f *fakeCounter) read() (int64, bool) { return f.value, f.ok }
+
+// sample advances the sensor past its interval and feeds the next count.
+// The sensor derives rate from wall elapsed time, so tests use a tiny
+// interval and real (short) sleeps.
+func sample(t *testing.T, s *refaultSensor, f *fakeCounter, next int64) bool {
+	t.Helper()
+	f.value = next
+	time.Sleep(2 * time.Millisecond)
+	return s.Active()
+}
+
+func TestRefaultSensor_TwoSampleActivationAndRelease(t *testing.T) {
+	f := &fakeCounter{value: 1000, ok: true}
+	// threshold 1000 pages/s; 1ms interval so 2ms sleeps always resample.
+	s := newRefaultSensor(f.read, 1000, time.Millisecond)
+
+	// One hot sample: not active yet (damping).
+	if got := sample(t, s, f, f.value+1_000_000); got {
+		t.Fatal("active after a single hot sample — damping missing")
+	}
+	// Second consecutive hot sample: active.
+	if got := sample(t, s, f, f.value+1_000_000); !got {
+		t.Fatal("not active after two consecutive hot samples")
+	}
+	if _, activations := s.Stats(); activations != 1 {
+		t.Fatalf("activations = %d, want 1", activations)
+	}
+	// One quiet sample releases immediately.
+	if got := sample(t, s, f, f.value); got {
+		t.Fatal("still active after a quiet sample")
+	}
+	// Hot again needs two samples again.
+	if got := sample(t, s, f, f.value+1_000_000); got {
+		t.Fatal("re-activated after a single hot sample")
+	}
+	if got := sample(t, s, f, f.value+1_000_000); !got {
+		t.Fatal("not re-activated after two hot samples")
+	}
+	if _, activations := s.Stats(); activations != 2 {
+		t.Fatalf("activations = %d, want 2", activations)
+	}
+}
+
+func TestRefaultSensor_BelowThresholdStaysQuiet(t *testing.T) {
+	f := &fakeCounter{value: 0, ok: true}
+	s := newRefaultSensor(f.read, 1000, time.Millisecond)
+	for range 5 {
+		// ~1 page per 2ms = 500/s < 1000/s threshold.
+		if got := sample(t, s, f, f.value+1); got {
+			t.Fatal("active below threshold")
+		}
+	}
+}
+
+func TestRefaultSensor_SourceLossDisables(t *testing.T) {
+	f := &fakeCounter{value: 0, ok: true}
+	s := newRefaultSensor(f.read, 1000, time.Millisecond)
+	sample(t, s, f, 1_000_000)
+	f.ok = false
+	if got := sample(t, s, f, 2_000_000); got {
+		t.Fatal("active after source loss")
+	}
+	// Disabled is sticky even if the source comes back.
+	f.ok = true
+	sample(t, s, f, 99_000_000)
+	if got := sample(t, s, f, 199_000_000); got {
+		t.Fatal("sensor resurrected after source loss — disable must be sticky")
+	}
+}
+
+func TestRefaultSensor_NilOrZeroThresholdDisabled(t *testing.T) {
+	if s := newRefaultSensor(nil, 1000, time.Millisecond); s.Active() {
+		t.Fatal("nil reader active")
+	}
+	f := &fakeCounter{value: 0, ok: true}
+	s := newRefaultSensor(f.read, 0, time.Millisecond)
+	if got := sample(t, s, f, 100_000_000); got {
+		t.Fatal("zero threshold active")
+	}
+}
+
+func TestParseRefaultFile(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, content string) string {
+		t.Helper()
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	// Modern split counters: file variant preferred.
+	p := write("modern", "nr_free_pages 1\nworkingset_refault_anon 5\nworkingset_refault_file 42\npgmajfault 9\n")
+	if n, ok := parseRefaultFile(p); !ok || n != 42 {
+		t.Fatalf("modern: got (%d, %v), want (42, true)", n, ok)
+	}
+	// Pre-5.9 unified counter.
+	p = write("legacy", "workingset_refault 17\npgmajfault 9\n")
+	if n, ok := parseRefaultFile(p); !ok || n != 17 {
+		t.Fatalf("legacy: got (%d, %v), want (17, true)", n, ok)
+	}
+	// No counter at all.
+	p = write("none", "nr_free_pages 1\npgmajfault 9\n")
+	if _, ok := parseRefaultFile(p); ok {
+		t.Fatal("file without workingset counters parsed ok")
+	}
+	if _, ok := parseRefaultFile(filepath.Join(dir, "missing")); ok {
+		t.Fatal("missing file parsed ok")
+	}
+}
+
+// TestPageCachePressureActive_Smoke exercises the real singleton path —
+// whatever the host provides, it must not panic and must be callable
+// concurrently (the -race build is the assertion).
+func TestPageCachePressureActive_Smoke(t *testing.T) {
+	done := make(chan struct{})
+	for range 4 {
+		go func() {
+			for range 100 {
+				PageCachePressureActive()
+			}
+			done <- struct{}{}
+		}()
+	}
+	for range 4 {
+		<-done
+	}
+	PageCachePressureStats()
+}

--- a/internal/engine/scan/decode_ahead.go
+++ b/internal/engine/scan/decode_ahead.go
@@ -77,6 +77,7 @@ type DecodeAheadIter struct {
 	windowFullStalls atomic.Int64
 	pressureStalls   atomic.Int64
 	tokenStalls      atomic.Int64
+	ledgerStalls     atomic.Int64
 }
 
 // decodeSlot is one row group's outcome, parked until the delivery
@@ -126,6 +127,25 @@ type TokenPool interface {
 	Release(n int)
 }
 
+// WindowLedger is the memory-budget seam shared with the caller's task
+// ledger (the worker's shared pool tracker — *memory.Tracker satisfies
+// it directly). Decoded-but-undelivered window bytes are charged here so
+// they are visible to spill decisions and so admission collapses toward
+// the cursor-only serial floor as budget headroom vanishes — the memo §9
+// fix: under memory pressure the window's held batches displace page
+// cache and GC headroom that the Go-heap pressure hook cannot see, so
+// the byte cost must ride the same ledger as every other operator.
+//
+// Reserve returns a non-nil error to deny (nothing retained on denial);
+// ForceReserve charges unconditionally — used for the delivery-cursor
+// group, which is always admitted but whose bytes are still real.
+// All methods must be safe for concurrent use and must not block.
+type WindowLedger interface {
+	Reserve(n int64) error
+	ForceReserve(n int64)
+	Release(n int64)
+}
+
 // DecodeWindow is a byte budget shared by one or more DecodeAheadIters.
 // Its mutex doubles as the owning iterators' state lock.
 type DecodeWindow struct {
@@ -133,18 +153,43 @@ type DecodeWindow struct {
 	cond     *sync.Cond
 	inflight int64
 	limit    int64
+	// ledger, when non-nil, additionally charges every inflight byte to
+	// the task memory ledger: limit is the ceiling, ledger headroom is
+	// the floating bound below it. Reserved and released in lockstep
+	// with inflight, so the ledger balance returns to zero when every
+	// owning iterator has closed.
+	ledger WindowLedger
 }
 
 // NewDecodeWindow returns a window bounding decoded-but-undelivered
 // bytes across every iterator opened with it. bytes <= 0 selects
 // DefaultDecodeAheadWindowBytes.
 func NewDecodeWindow(bytes int64) *DecodeWindow {
+	return NewDecodeWindowWithLedger(bytes, nil)
+}
+
+// NewDecodeWindowWithLedger is NewDecodeWindow with a memory ledger
+// attached: beyond the fixed byte ceiling, non-cursor admission must
+// also clear ledger.Reserve, and every inflight byte is charged to the
+// ledger for its parked lifetime. A nil ledger yields the fixed-window
+// behavior. Callers passing a concrete pointer type must nil-check it
+// themselves — a nil *T wrapped in the interface reads as non-nil here.
+func NewDecodeWindowWithLedger(bytes int64, ledger WindowLedger) *DecodeWindow {
 	if bytes <= 0 {
 		bytes = DefaultDecodeAheadWindowBytes
 	}
-	w := &DecodeWindow{limit: bytes}
+	w := &DecodeWindow{limit: bytes, ledger: ledger}
 	w.cond = sync.NewCond(&w.mu)
 	return w
+}
+
+// credit returns a group's byte reservation — window and ledger — when
+// its slot is delivered or dropped. Caller holds w.mu.
+func (w *DecodeWindow) credit(est int64) {
+	w.inflight -= est
+	if w.ledger != nil {
+		w.ledger.Release(est)
+	}
 }
 
 const (
@@ -289,15 +334,16 @@ func (it *DecodeAheadIter) PruneStats() (bloom, rangeP, read int) {
 	return int(it.rgPrunedBloom.Load()), int(it.rgPrunedRange.Load()), int(it.rgRead.Load())
 }
 
-// Stats returns the decode-ahead engagement counters (memo §5 markers):
-// row groups decoded, worker stalls on a full window, admissions refused
-// under memory pressure, and admissions deferred for lack of a cpu
-// token (the group still decodes later — serially at worst).
-func (it *DecodeAheadIter) Stats() (groupsRead, windowFullStalls, pressureStalls, tokenStalls int64) {
+// Stats returns the decode-ahead engagement counters (memo §5/§9
+// markers): row groups decoded, worker stalls on a full window,
+// admissions refused under memory pressure, admissions deferred for
+// lack of a cpu token, and admissions denied by the memory ledger (the
+// group still decodes later — serially at worst, in every case).
+func (it *DecodeAheadIter) Stats() (groupsRead, windowFullStalls, pressureStalls, tokenStalls, ledgerStalls int64) {
 	if it == nil {
-		return 0, 0, 0, 0
+		return 0, 0, 0, 0, 0
 	}
-	return it.rgRead.Load(), it.windowFullStalls.Load(), it.pressureStalls.Load(), it.tokenStalls.Load()
+	return it.rgRead.Load(), it.windowFullStalls.Load(), it.pressureStalls.Load(), it.tokenStalls.Load(), it.ledgerStalls.Load()
 }
 
 // Next returns the next decoded row group in source order, or (nil, nil)
@@ -316,7 +362,7 @@ func (it *DecodeAheadIter) Next() (*batch.RecordBatch, error) {
 		if slot, ok := it.slots[it.deliver]; ok {
 			delete(it.slots, it.deliver)
 			it.deliver++
-			it.win.inflight -= slot.est
+			it.win.credit(slot.est)
 			it.win.cond.Broadcast()
 			if slot.err != nil {
 				// Mirror serial semantics: the error surfaces exactly at
@@ -350,16 +396,19 @@ func (it *DecodeAheadIter) decodeLoop() {
 		idx := it.nextIdx
 		est := it.estimateGroupBytes(idx)
 		// The delivery-cursor group is always admitted — token-free and
-		// past any window/pressure gate: the consumer is (or will be)
-		// waiting on precisely this index, so reserving past the window
-		// here cannot grow it further, and refusing would deadlock on any
-		// single group larger than the window. (Under a shared window
-		// this bounds transient overshoot to one group per chained
-		// iterator.) Every non-cursor group must clear the window, the
-		// pressure hook, AND acquire a cpu token held only for the decode
-		// itself. Wakeups: every delivery and every park broadcasts, and
-		// the cursor group is always decodable, so a stalled worker is
-		// re-checked at least once per delivered group.
+		// past any window/pressure/ledger gate: the consumer is (or will
+		// be) waiting on precisely this index, so reserving past the
+		// window here cannot grow it further, and refusing would deadlock
+		// on any single group larger than the window. Its bytes are still
+		// force-charged to the ledger — real bytes stay visible to spill
+		// decisions; overshoot is bounded to one group per chained
+		// iterator. Every non-cursor group must clear the window, the
+		// pressure hook, the memory ledger, AND acquire a cpu token held
+		// only for the decode itself. Wakeups: every delivery and every
+		// park broadcasts, and the cursor group is always decodable, so a
+		// stalled worker is re-checked at least once per delivered group —
+		// which is also why a ledger denial needs no external wakeup:
+		// deliveries keep crediting the ledger and re-running this check.
 		var holdsToken bool
 		if idx != it.deliver {
 			if it.win.inflight+est > it.win.limit {
@@ -372,14 +421,26 @@ func (it *DecodeAheadIter) decodeLoop() {
 				it.win.cond.Wait()
 				continue
 			}
+			if it.win.ledger != nil {
+				if err := it.win.ledger.Reserve(est); err != nil {
+					it.ledgerStalls.Add(1)
+					it.win.cond.Wait()
+					continue
+				}
+			}
 			if it.tokens != nil {
 				if it.tokens.TryAcquire(1) == 0 {
+					if it.win.ledger != nil {
+						it.win.ledger.Release(est)
+					}
 					it.tokenStalls.Add(1)
 					it.win.cond.Wait()
 					continue
 				}
 				holdsToken = true
 			}
+		} else if it.win.ledger != nil {
+			it.win.ledger.ForceReserve(est)
 		}
 		it.nextIdx++
 		it.win.inflight += est
@@ -469,7 +530,7 @@ func (it *DecodeAheadIter) Close() error {
 	// Release this iterator's undelivered reservations so a chained
 	// iterator sharing the window doesn't inherit dead inflight bytes.
 	for idx, slot := range it.slots {
-		it.win.inflight -= slot.est
+		it.win.credit(slot.est)
 		delete(it.slots, idx)
 	}
 	it.win.cond.Broadcast()
@@ -482,7 +543,7 @@ func (it *DecodeAheadIter) Close() error {
 	// those reservations too. No new slots can appear once closed.
 	it.win.mu.Lock()
 	for idx, slot := range it.slots {
-		it.win.inflight -= slot.est
+		it.win.credit(slot.est)
 		delete(it.slots, idx)
 	}
 	it.win.cond.Broadcast()

--- a/internal/engine/scan/decode_ahead_test.go
+++ b/internal/engine/scan/decode_ahead_test.go
@@ -2,6 +2,7 @@ package scan
 
 import (
 	"bytes"
+	"fmt"
 	"sync"
 	"testing"
 
@@ -120,7 +121,7 @@ func TestDecodeAheadIter_MatchesSerial(t *testing.T) {
 			t.Fatalf("workers=%d drain: %v", workers, err)
 		}
 		requireSameBatches(t, want, got)
-		if groups, _, _, _ := it.Stats(); groups != 16 {
+		if groups, _, _, _, _ := it.Stats(); groups != 16 {
 			t.Errorf("workers=%d: groups read = %d, want 16", workers, groups)
 		}
 		// Post-exhaustion Next returns (nil, nil), like serial.
@@ -157,7 +158,7 @@ func TestDecodeAheadIter_TinyWindowStallsButDelivers(t *testing.T) {
 		t.Fatalf("drain: %v", err)
 	}
 	requireSameBatches(t, want, got)
-	if _, stalls, _, _ := it.Stats(); stalls == 0 {
+	if _, stalls, _, _, _ := it.Stats(); stalls == 0 {
 		t.Error("WindowBytes=1 with 4 workers never stalled — window is not gating admission")
 	}
 }
@@ -188,7 +189,7 @@ func TestDecodeAheadIter_PressureDegradesToSerial(t *testing.T) {
 		t.Fatalf("drain: %v", err)
 	}
 	requireSameBatches(t, want, got)
-	if _, _, stalls, _ := it.Stats(); stalls == 0 {
+	if _, _, stalls, _, _ := it.Stats(); stalls == 0 {
 		t.Error("permanent pressure with 4 workers never stalled — hook is not gating admission")
 	}
 }
@@ -257,7 +258,7 @@ func TestDecodeAheadIter_PerGroupTokens(t *testing.T) {
 		t.Fatalf("starved drain: %v", err)
 	}
 	requireSameBatches(t, want, got)
-	if _, _, _, stalls := it.Stats(); stalls == 0 {
+	if _, _, _, stalls, _ := it.Stats(); stalls == 0 {
 		t.Error("capacity-0 pool never produced a token stall")
 	}
 	if starved.acquires != 0 {
@@ -470,5 +471,174 @@ func TestDecodeAheadIter_CloseMidStreamJoinsWorkers(t *testing.T) {
 	}
 	if err := it2.Close(); err != nil {
 		t.Fatalf("Close before Next: %v", err)
+	}
+}
+
+// countingLedger enforces a byte capacity and counts charge traffic so
+// tests can prove the memo-§9 ledger semantics: denial-driven collapse
+// to the cursor-only serial floor, forced cursor charges, and a zero
+// balance once every group is delivered or dropped.
+type countingLedger struct {
+	mu       sync.Mutex
+	capacity int64 // < 0 = unlimited
+	balance  int64
+	peak     int64
+	reserves int64 // successful Reserve calls
+	forced   int64 // ForceReserve calls
+}
+
+func (l *countingLedger) Reserve(n int64) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.capacity >= 0 && l.balance+n > l.capacity {
+		return fmt.Errorf("countingLedger: %d over capacity", n)
+	}
+	l.balance += n
+	l.reserves++
+	if l.balance > l.peak {
+		l.peak = l.balance
+	}
+	return nil
+}
+
+func (l *countingLedger) ForceReserve(n int64) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.balance += n
+	l.forced++
+	if l.balance > l.peak {
+		l.peak = l.balance
+	}
+}
+
+func (l *countingLedger) Release(n int64) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.balance -= n
+}
+
+func (l *countingLedger) snapshot() (balance, peak, reserves, forced int64) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.balance, l.peak, l.reserves, l.forced
+}
+
+// TestDecodeAheadIter_LedgerDeniedCollapsesToSerial: a ledger with zero
+// capacity denies every non-cursor admission, yet the iterator still
+// delivers everything through the cursor exemption — whose bytes are
+// force-charged, not skipped — and the ledger balance returns to zero.
+func TestDecodeAheadIter_LedgerDeniedCollapsesToSerial(t *testing.T) {
+	data := manyRowGroupFile(t, 8, 50)
+	schema := []pqt.Column{{Name: "id", Type: pqt.TypeInt64}}
+
+	serial, err := OpenRowGroupIter(openFileReader(t, data), schema, nil, 0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serial.Close()
+	want, _ := drainGroupIter(t, serial)
+
+	ledger := &countingLedger{capacity: 0}
+	it, err := OpenDecodeAheadIter(openFileReader(t, data), schema, nil, 0, 1,
+		DecodeAheadOpts{Workers: 4, Window: NewDecodeWindowWithLedger(0, ledger)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := drainGroupIter(t, it)
+	if err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	requireSameBatches(t, want, got)
+	if _, _, _, _, stalls := it.Stats(); stalls == 0 {
+		t.Error("capacity-0 ledger never produced a ledger stall")
+	}
+	if err := it.Close(); err != nil {
+		t.Fatal(err)
+	}
+	balance, _, reserves, forced := ledger.snapshot()
+	if balance != 0 {
+		t.Errorf("ledger balance after close = %d, want 0", balance)
+	}
+	if reserves != 0 {
+		t.Errorf("capacity-0 ledger recorded %d successful reserves, want 0", reserves)
+	}
+	if forced == 0 {
+		t.Error("cursor groups were never force-charged — real bytes invisible to the ledger")
+	}
+}
+
+// TestDecodeAheadIter_LedgerBalancedOnAllPaths: with an unlimited ledger
+// the balance returns to zero after a full drain, after a token-denial
+// rollback storm (capacity-0 token pool releases every ledger reserve it
+// cannot use), and after a mid-stream Close that drops parked slots.
+func TestDecodeAheadIter_LedgerBalancedOnAllPaths(t *testing.T) {
+	data := manyRowGroupFile(t, 12, 50)
+	schema := []pqt.Column{{Name: "id", Type: pqt.TypeInt64}}
+
+	serial, err := OpenRowGroupIter(openFileReader(t, data), schema, nil, 0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serial.Close()
+	want, _ := drainGroupIter(t, serial)
+
+	// Full drain.
+	ledger := &countingLedger{capacity: -1}
+	it, err := OpenDecodeAheadIter(openFileReader(t, data), schema, nil, 0, 1,
+		DecodeAheadOpts{Workers: 4, Window: NewDecodeWindowWithLedger(0, ledger)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := drainGroupIter(t, it)
+	if err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	requireSameBatches(t, want, got)
+	if err := it.Close(); err != nil {
+		t.Fatal(err)
+	}
+	balance, peak, reserves, _ := ledger.snapshot()
+	if balance != 0 {
+		t.Errorf("ledger balance after full drain = %d, want 0", balance)
+	}
+	if reserves == 0 || peak == 0 {
+		t.Errorf("unlimited ledger saw reserves=%d peak=%d — ledger not engaged", reserves, peak)
+	}
+
+	// Token denial must roll the ledger reserve back.
+	rollback := &countingLedger{capacity: -1}
+	it2, err := OpenDecodeAheadIter(openFileReader(t, data), schema, nil, 0, 1,
+		DecodeAheadOpts{Workers: 4, Tokens: &countingTokenPool{capacity: 0},
+			Window: NewDecodeWindowWithLedger(0, rollback)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got2, err := drainGroupIter(t, it2)
+	if err != nil {
+		t.Fatalf("rollback drain: %v", err)
+	}
+	requireSameBatches(t, want, got2)
+	if err := it2.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if balance, _, _, _ := rollback.snapshot(); balance != 0 {
+		t.Errorf("ledger balance after token-rollback drain = %d, want 0", balance)
+	}
+
+	// Mid-stream Close drops undelivered slots and credits their charges.
+	mid := &countingLedger{capacity: -1}
+	it3, err := OpenDecodeAheadIter(openFileReader(t, data), schema, nil, 0, 1,
+		DecodeAheadOpts{Workers: 4, Window: NewDecodeWindowWithLedger(0, mid)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := it3.Next(); err != nil {
+		t.Fatal(err)
+	}
+	if err := it3.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if balance, _, _, _ := mid.snapshot(); balance != 0 {
+		t.Errorf("ledger balance after mid-stream close = %d, want 0", balance)
 	}
 }

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -126,6 +126,7 @@ type Executor struct {
 	scanDecodeAheadWindowFulls    atomic.Int64
 	scanDecodeAheadPressureStalls atomic.Int64
 	scanDecodeAheadTokenStalls    atomic.Int64
+	scanDecodeAheadLedgerStalls   atomic.Int64
 }
 
 // SetStreamingShuffleRead enables streaming decode of shuffle inputs
@@ -148,11 +149,13 @@ func (e *Executor) SetScanDecodeAhead(on bool, windowBytes int64) {
 
 // ScanDecodeAheadStats returns the decode-ahead counters: row groups
 // decoded ahead, worker stalls on a full window, admissions refused
-// under heap pressure, and per-group admissions deferred for lack of a
-// cpu token (each affected group still decodes, serially at worst).
-func (e *Executor) ScanDecodeAheadStats() (groups, windowFulls, pressureStalls, tokenStalls int64) {
+// under heap pressure, per-group admissions deferred for lack of a cpu
+// token, and admissions denied by the shared memory pool ledger (each
+// affected group still decodes, serially at worst).
+func (e *Executor) ScanDecodeAheadStats() (groups, windowFulls, pressureStalls, tokenStalls, ledgerStalls int64) {
 	return e.scanDecodeAheadGroups.Load(), e.scanDecodeAheadWindowFulls.Load(),
-		e.scanDecodeAheadPressureStalls.Load(), e.scanDecodeAheadTokenStalls.Load()
+		e.scanDecodeAheadPressureStalls.Load(), e.scanDecodeAheadTokenStalls.Load(),
+		e.scanDecodeAheadLedgerStalls.Load()
 }
 
 // NewExecutor creates a new task executor.

--- a/internal/worker/executor_fragment.go
+++ b/internal/worker/executor_fragment.go
@@ -451,6 +451,19 @@ func (e *Executor) runFragmentLinear(ctx context.Context, task distributed.Task,
 // manipulating GOMEMLIMIT. Production never reassigns it.
 var heapPressureActive = memory.HeapBackpressureActive
 
+// pageCachePressureActive mirrors it for memory.PageCachePressureActive
+// (the §9 refault-rate sensor), same test-seam rationale.
+var pageCachePressureActive = memory.PageCachePressureActive
+
+// scanDecodeAheadPressure gates decode-ahead admission beyond the
+// delivery cursor: Go-heap tide gauge OR kernel page-cache thrash.
+// Discretionary decoded-ahead bytes are the first thing to yield under
+// either pressure channel; the cursor group is exempt inside the
+// iterator, so this can never stall delivery.
+func scanDecodeAheadPressure() bool {
+	return heapPressureActive() || pageCachePressureActive()
+}
+
 // morselMinFragmentBytes is the auto-mode size gate: fragments whose
 // EstimatedBytes fall below it stay serial. Parallelism pays only above a
 // size threshold — the parallel join build learned this the hard way

--- a/internal/worker/stream_source.go
+++ b/internal/worker/stream_source.go
@@ -931,7 +931,11 @@ func (s *cachedFileStreamSource) buildParquetState(filePath string, data, mmapDa
 		// at the default width. NOTE: the nil check must happen here — a
 		// nil *cpuTokens wrapped in the interface would read as non-nil
 		// and silently serialize decode.
-		opts := scan.DecodeAheadOpts{Window: s.decodeWin, Pressure: heapPressureActive}
+		// Admission pressure = Go-heap tide gauge OR kernel page-cache
+		// thrash (memo §9: refault-rate sensor — the displacement channel
+		// the heap hook cannot see; the capped repro measured decode-ahead
+		// width as worthless-to-harmful precisely when refaults run hot).
+		opts := scan.DecodeAheadOpts{Window: s.decodeWin, Pressure: scanDecodeAheadPressure}
 		if s.executor.cpuTokens != nil {
 			opts.Tokens = s.executor.cpuTokens
 		}

--- a/internal/worker/stream_source.go
+++ b/internal/worker/stream_source.go
@@ -907,8 +907,20 @@ func (s *cachedFileStreamSource) buildParquetState(filePath string, data, mmapDa
 		if s.decodeWin == nil {
 			// One window per source, shared across every file it opens —
 			// the cross-file continuation draws the next file's head from
-			// the same budget as the current file's tail.
-			s.decodeWin = scan.NewDecodeWindow(s.executor.scanDecodeAheadBytes)
+			// the same budget as the current file's tail. Window bytes are
+			// charged to the worker's shared memory pool (memo §9): the
+			// configured window is only the ceiling, actual occupancy is
+			// bounded by pool headroom, collapsing to the cursor-only
+			// serial floor when concurrent operators hold the budget. The
+			// held batches are real heap the Go-pressure hook cannot see
+			// displacing page cache — they must compete on the same ledger
+			// as everything else. NOTE: nil-check the tracker here — a nil
+			// *memory.Tracker wrapped in the interface reads as non-nil.
+			var ledger scan.WindowLedger
+			if s.executor.sharedTracker != nil {
+				ledger = s.executor.sharedTracker
+			}
+			s.decodeWin = scan.NewDecodeWindowWithLedger(s.executor.scanDecodeAheadBytes, ledger)
 		}
 		// CPU is budgeted per ROW GROUP inside the iterator (one token
 		// held only for the duration of one decode, cursor group exempt)
@@ -1053,11 +1065,12 @@ type decodeAheadStatsIter struct {
 func (d *decodeAheadStatsIter) Close() error {
 	if !d.folded {
 		d.folded = true
-		groups, windowFulls, pressureStalls, tokenStalls := d.Stats()
+		groups, windowFulls, pressureStalls, tokenStalls, ledgerStalls := d.Stats()
 		d.executor.scanDecodeAheadGroups.Add(groups)
 		d.executor.scanDecodeAheadWindowFulls.Add(windowFulls)
 		d.executor.scanDecodeAheadPressureStalls.Add(pressureStalls)
 		d.executor.scanDecodeAheadTokenStalls.Add(tokenStalls)
+		d.executor.scanDecodeAheadLedgerStalls.Add(ledgerStalls)
 	}
 	return d.DecodeAheadIter.Close()
 }

--- a/internal/worker/stream_source_decode_ahead_test.go
+++ b/internal/worker/stream_source_decode_ahead_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/citc-tech/wadjet/internal/engine/memory"
 	"github.com/citc-tech/wadjet/internal/storage/objstore"
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
 )
@@ -83,7 +84,7 @@ func TestScanDecodeAhead_MultiFileParity(t *testing.T) {
 	if sum != wantSum || rows != 5*4*32 {
 		t.Fatalf("decode-ahead read: sum=%d rows=%d, want sum=%d rows=%d", sum, rows, wantSum, 5*4*32)
 	}
-	if groups, _, _, _ := e.ScanDecodeAheadStats(); groups != 5*4 {
+	if groups, _, _, _, _ := e.ScanDecodeAheadStats(); groups != 5*4 {
 		t.Errorf("decode-ahead groups = %d, want %d", groups, 5*4)
 	}
 
@@ -265,7 +266,7 @@ func TestScanDecodeAhead_PerGroupTokens(t *testing.T) {
 	if sum != wantSum || rows != 3*3*32 {
 		t.Fatalf("starved read: sum=%d rows=%d, want sum=%d rows=%d", sum, rows, wantSum, 3*3*32)
 	}
-	if _, _, _, stalls := e.ScanDecodeAheadStats(); stalls == 0 {
+	if _, _, _, stalls, _ := e.ScanDecodeAheadStats(); stalls == 0 {
 		t.Error("token-stall counter did not fire under a drained pool")
 	}
 	if held := e.cpuTokens.InUse(); held != 0 {
@@ -339,5 +340,60 @@ func TestFilePrefetcher_TryTakePutsBackFailures(t *testing.T) {
 		}
 	case <-ctx.Done():
 		t.Fatal("ctx done")
+	}
+}
+
+// TestScanDecodeAhead_LedgerWiring: the source's decode window charges
+// the worker's shared memory pool (memo §9). A pool with no headroom
+// denies every non-cursor admission — the scan still completes serially
+// via the cursor exemption and the ledger-stall counter fires — and in
+// all cases the pool balance returns to zero once the source closes.
+func TestScanDecodeAhead_LedgerWiring(t *testing.T) {
+	ctx := context.Background()
+	store := objstore.NewMemStore()
+	keys, wantSum := writeMultiGroupFixture(t, store, "b", 3, 3, 32)
+
+	// 1-byte pool: every non-cursor Reserve is over budget.
+	e := &Executor{store: store, spillDir: t.TempDir()}
+	e.SetScanDecodeAhead(true, 0)
+	e.sharedTracker = memory.NewTracker("worker", 1)
+	src := newCachedFileStreamSource(e, "", "b", keys)
+	if err := src.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	sum, rows := drainValSum(t, ctx, src)
+	if err := src.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if sum != wantSum || rows != 3*3*32 {
+		t.Fatalf("ledger-starved read: sum=%d rows=%d, want sum=%d rows=%d", sum, rows, wantSum, 3*3*32)
+	}
+	if _, _, _, _, stalls := e.ScanDecodeAheadStats(); stalls == 0 {
+		t.Error("ledger-stall counter did not fire against a 1-byte pool")
+	}
+	if used := e.sharedTracker.Used(); used != 0 {
+		t.Errorf("shared pool used after close = %d, want 0", used)
+	}
+	if e.sharedTracker.Peak() == 0 {
+		t.Error("shared pool peak = 0 — cursor groups were never force-charged")
+	}
+
+	// Ample pool: full width, still balanced after close.
+	e2 := &Executor{store: store, spillDir: t.TempDir()}
+	e2.SetScanDecodeAhead(true, 0)
+	e2.sharedTracker = memory.NewTracker("worker", 1<<30)
+	src2 := newCachedFileStreamSource(e2, "", "b", keys)
+	if err := src2.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	sum2, rows2 := drainValSum(t, ctx, src2)
+	if err := src2.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if sum2 != wantSum || rows2 != rows {
+		t.Fatalf("ample read: sum=%d rows=%d, want sum=%d rows=%d", sum2, rows2, wantSum, rows)
+	}
+	if used := e2.sharedTracker.Used(); used != 0 {
+		t.Errorf("ample pool used after close = %d, want 0", used)
 	}
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -856,6 +856,21 @@ func (w *Worker) Stop() {
 	}
 	w.executor.uploads.Drain()
 
+	// Final decode-ahead stats: short runs end before the 60s marker
+	// ticker ever fires, leaving the fold-on-close counters unreported —
+	// the 2026-07-17 capped repro lost every worker-side sample this way.
+	// Emitted after wg.Wait, so every source has folded its counters.
+	if w.config.ScanDecodeAhead {
+		groups, windowFulls, pressureStalls, tokenStalls, ledgerStalls := w.executor.ScanDecodeAheadStats()
+		refaultRate, refaultActivations := memory.PageCachePressureStats()
+		w.logger.Info("scan decode-ahead stats (final)",
+			"groups", groups, "window_fulls", windowFulls,
+			"pressure_stalls", pressureStalls, "token_stalls", tokenStalls,
+			"ledger_stalls", ledgerStalls,
+			"refault_rate", int64(refaultRate),
+			"refault_activations", refaultActivations)
+	}
+
 	w.logger.Info("worker stopped", "worker_id", w.config.WorkerID)
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -581,7 +581,7 @@ func (w *Worker) startScanDecodeAheadMarkerLoop(ctx context.Context) {
 	w.bgWG.Add(1)
 	go func() {
 		defer w.bgWG.Done()
-		var last [4]int64
+		var last [5]int64
 		t := time.NewTicker(60 * time.Second)
 		defer t.Stop()
 		for {
@@ -589,13 +589,14 @@ func (w *Worker) startScanDecodeAheadMarkerLoop(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case <-t.C:
-				groups, windowFulls, pressureStalls, tokenStalls := w.executor.ScanDecodeAheadStats()
-				cur := [4]int64{groups, windowFulls, pressureStalls, tokenStalls}
+				groups, windowFulls, pressureStalls, tokenStalls, ledgerStalls := w.executor.ScanDecodeAheadStats()
+				cur := [5]int64{groups, windowFulls, pressureStalls, tokenStalls, ledgerStalls}
 				if cur != last {
 					last = cur
 					w.logger.Info("scan decode-ahead stats",
 						"groups", groups, "window_fulls", windowFulls,
-						"pressure_stalls", pressureStalls, "token_stalls", tokenStalls)
+						"pressure_stalls", pressureStalls, "token_stalls", tokenStalls,
+						"ledger_stalls", ledgerStalls)
 				}
 			}
 		}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -593,10 +593,13 @@ func (w *Worker) startScanDecodeAheadMarkerLoop(ctx context.Context) {
 				cur := [5]int64{groups, windowFulls, pressureStalls, tokenStalls, ledgerStalls}
 				if cur != last {
 					last = cur
+					refaultRate, refaultActivations := memory.PageCachePressureStats()
 					w.logger.Info("scan decode-ahead stats",
 						"groups", groups, "window_fulls", windowFulls,
 						"pressure_stalls", pressureStalls, "token_stalls", tokenStalls,
-						"ledger_stalls", ledgerStalls)
+						"ledger_stalls", ledgerStalls,
+						"refault_rate", int64(refaultRate),
+						"refault_activations", refaultActivations)
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Implements the memo §9 fix for the Q05/Q07 decode-ahead residual (window occupancy under memory pressure), in two complementary pieces — see `docs/design/scan-decode-pipelining.md` §9.2 for the full evidence trail:

1. **Ledger-charged window** — `DecodeWindow` carries an optional `scan.WindowLedger` (satisfied directly by `*memory.Tracker`); the worker attaches its shared pool tracker. Non-cursor admission must clear the window ceiling, the pressure hook, `ledger.Reserve`, and a cpu token (token denial rolls the reserve back). The delivery-cursor group is force-charged but never denied — the measured-safe serial floor. Window and ledger bytes move in lockstep, balancing to zero per source. Decoded-ahead bytes now compete with joins/sinks on the same pool and are visible to spill decisions.

2. **Page-cache refault-rate sensor** — the capped repro falsified §9.1's assumption that the ledger route subsumes an OS sensor: with the pool auto-sized to goMemLimit−cache (1.45 GiB under a 2 GiB cap), a 256 MiB window never draws a denial (`ledger_stalls=0`) while the kernel refaults 15k–95k pages/s. `memory.PageCachePressureActive()` reads `workingset_refault` (cgroup-v2 `memory.stat` preferred, `/proc/vmstat` fallback, source absence disables) at 1 s cadence; >1000 pages/s on two consecutive samples collapses decode-ahead admission to the cursor-only serial floor via the existing pressure path — no iterator changes. Refaults exclude cold streaming by construction (first-touch faults don't count), and width is worthless mid-thrash anyway (the I/O-bound repro logged `window_fulls=0`).

Also: final decode-ahead stats line at worker stop (short runs previously ended before the 60 s marker ever fired), sensor init-source log, and `cmd/refault-probe` for field diagnosis.

## Evidence

- Same-window capped repro (EDGE_CAP_MB=2048, SF10 Q05): off 36.9 s / main+flag 55.2 s (+49 %) / ledger+flag 48.5 s (+31 %, `ledger_stalls=0` → motivated the sensor).
- Prior 4-arm data: cost ∝ decoded-bytes-in-flight; window=1 (32.8 s) beats flag-off (36.2 s) even capped — the serial floor is safe.
- Measured bound: cgroup-v1 memcg reclaim is invisible to global workingset counters (WSL2 5.15) — the cap-wrapper simulator cannot fire the sensor end-to-end; SF100 workers (bare, cgroup-v2 AL2023) and real edge targets are visible. Documented in memo §9.2.

## Testing

- New regression tests: ledger denial collapses to serial with balanced charges; balance zero on full drain / token-rollback storm / mid-stream close; worker pool wiring end-to-end (1-byte pool → serial + `ledger_stalls`, ample pool → balanced); sensor rate/damping/source-loss/disable logic; parse fixtures for modern + legacy counter layouts.
- Full unit suite, scan+worker `-race` ×2, TPC-H SF0.01 22/22, full local harness gate flag-on 25/25 rows correct.
- Flag stays **opt-in** (`--scan-decode-ahead`). The SF100 pair (needs deploy approval) is the designated test for the Q05/Q07 residual: watch `ledger_stalls`, `refault_activations`, scan-band retention (Q16/Q06/Q12), Q05/Q07 vs the 20260716-222612 control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)