### PR TITLE
feat(worker): per-query/stage attribution of scan decode-ahead stalls

### DIFF
--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -127,6 +127,28 @@ type Executor struct {
 	scanDecodeAheadPressureStalls atomic.Int64
 	scanDecodeAheadTokenStalls    atomic.Int64
 	scanDecodeAheadLedgerStalls   atomic.Int64
+	// scanDecodeAheadByQuery attributes the counters above per source
+	// identity — the task's QueryID, which on stage-input sources is
+	// stage-scoped (e.g. "st-join-10-<query>"), so SF100 logs separate a
+	// query's scan legs from its exchange-repartition legs (memo §9.3:
+	// Q05's collapse-vs-width tension is phase-local and invisible in
+	// worker-lifetime totals). Entries are emitted and deleted by
+	// sweepScanDecodeAheadQueryStats once idle, so the map stays bounded
+	// on long-running workers.
+	scanDecodeAheadByQuery sync.Map // task QueryID string -> *decodeAheadQueryStats
+}
+
+// decodeAheadQueryStats is one query's decode-ahead counter slice.
+// emitted holds the counter snapshot at the last sweep; a sweep that
+// finds the counters unchanged emits the final line and drops the entry.
+type decodeAheadQueryStats struct {
+	groups, windowFulls, pressureStalls, tokenStalls, ledgerStalls atomic.Int64
+	emitted                                                        [5]int64
+}
+
+func (s *decodeAheadQueryStats) snapshot() [5]int64 {
+	return [5]int64{s.groups.Load(), s.windowFulls.Load(), s.pressureStalls.Load(),
+		s.tokenStalls.Load(), s.ledgerStalls.Load()}
 }
 
 // SetStreamingShuffleRead enables streaming decode of shuffle inputs
@@ -145,6 +167,50 @@ func (e *Executor) ShuffleStreamStats() (reads, fallbacks, skipResumes int64) {
 func (e *Executor) SetScanDecodeAhead(on bool, windowBytes int64) {
 	e.scanDecodeAhead = on
 	e.scanDecodeAheadBytes = windowBytes
+}
+
+// foldScanDecodeAheadQueryStats adds one closed iterator's counters to
+// the per-query accumulator. queryID may be empty (embedded callers);
+// those fold under the "-" bucket rather than being dropped.
+func (e *Executor) foldScanDecodeAheadQueryStats(queryID string, groups, windowFulls, pressureStalls, tokenStalls, ledgerStalls int64) {
+	if queryID == "" {
+		queryID = "-"
+	}
+	v, _ := e.scanDecodeAheadByQuery.LoadOrStore(queryID, &decodeAheadQueryStats{})
+	qs := v.(*decodeAheadQueryStats)
+	qs.groups.Add(groups)
+	qs.windowFulls.Add(windowFulls)
+	qs.pressureStalls.Add(pressureStalls)
+	qs.tokenStalls.Add(tokenStalls)
+	qs.ledgerStalls.Add(ledgerStalls)
+}
+
+// sweepScanDecodeAheadQueryStats emits per-query decode-ahead stats
+// lines. A query whose counters are unchanged since the previous sweep
+// is finished (sources fold on close): its line is emitted and the
+// entry dropped. Queries still accumulating are held for the next
+// sweep. final=true emits and drops everything — the worker is
+// stopping and there is no next sweep.
+func (e *Executor) sweepScanDecodeAheadQueryStats(final bool) {
+	logger := e.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	e.scanDecodeAheadByQuery.Range(func(k, v any) bool {
+		qs := v.(*decodeAheadQueryStats)
+		cur := qs.snapshot()
+		if !final && cur != qs.emitted {
+			qs.emitted = cur
+			return true // still moving — hold for the next sweep
+		}
+		e.scanDecodeAheadByQuery.Delete(k)
+		logger.Info("scan decode-ahead query stats",
+			"query", k,
+			"groups", cur[0], "window_fulls", cur[1],
+			"pressure_stalls", cur[2], "token_stalls", cur[3],
+			"ledger_stalls", cur[4])
+		return true
+	})
 }
 
 // ScanDecodeAheadStats returns the decode-ahead counters: row groups

--- a/internal/worker/stream_source.go
+++ b/internal/worker/stream_source.go
@@ -944,7 +944,7 @@ func (s *cachedFileStreamSource) buildParquetState(filePath string, data, mmapDa
 			p.release(s.executor.logger)
 			return nil, fmt.Errorf("opening decode-ahead iterator for %s: %w", filePath, err)
 		}
-		iter = &decodeAheadStatsIter{DecodeAheadIter: da, executor: s.executor}
+		iter = &decodeAheadStatsIter{DecodeAheadIter: da, executor: s.executor, queryID: s.queryID}
 	} else {
 		rgIter, err := scan.OpenRowGroupIter(reader, projCols, nil, shardIdx, shardCount)
 		if err != nil {
@@ -1058,11 +1058,13 @@ func (s *cachedFileStreamSource) adoptPending(p *pendingParquet, idx int) {
 }
 
 // decodeAheadStatsIter folds a DecodeAheadIter's engagement counters into
-// the executor-wide markers when the iterator closes (a source opens one
-// iterator per parquet file; per-file granularity is noise).
+// the executor-wide markers — and the per-query attribution map — when
+// the iterator closes (a source opens one iterator per parquet file;
+// per-file granularity is noise).
 type decodeAheadStatsIter struct {
 	*scan.DecodeAheadIter
 	executor *Executor
+	queryID  string
 	folded   bool
 }
 
@@ -1075,6 +1077,8 @@ func (d *decodeAheadStatsIter) Close() error {
 		d.executor.scanDecodeAheadPressureStalls.Add(pressureStalls)
 		d.executor.scanDecodeAheadTokenStalls.Add(tokenStalls)
 		d.executor.scanDecodeAheadLedgerStalls.Add(ledgerStalls)
+		d.executor.foldScanDecodeAheadQueryStats(d.queryID,
+			groups, windowFulls, pressureStalls, tokenStalls, ledgerStalls)
 	}
 	return d.DecodeAheadIter.Close()
 }

--- a/internal/worker/stream_source_decode_ahead_test.go
+++ b/internal/worker/stream_source_decode_ahead_test.go
@@ -397,3 +397,64 @@ func TestScanDecodeAhead_LedgerWiring(t *testing.T) {
 		t.Errorf("ample pool used after close = %d, want 0", used)
 	}
 }
+
+// TestScanDecodeAhead_PerQueryAttribution: closed sources fold their
+// counters under their query id; the sweep emits-and-drops a query only
+// once its counters go idle, and final sweep drains everything.
+func TestScanDecodeAhead_PerQueryAttribution(t *testing.T) {
+	ctx := context.Background()
+	store := objstore.NewMemStore()
+	keys, wantSum := writeMultiGroupFixture(t, store, "b", 2, 3, 32)
+
+	e := &Executor{store: store, spillDir: t.TempDir()}
+	e.SetScanDecodeAhead(true, 0)
+
+	scanQuery := func(qid string) {
+		src := newCachedFileStreamSource(e, qid, "b", keys)
+		if err := src.Init(ctx); err != nil {
+			t.Fatal(err)
+		}
+		sum, _ := drainValSum(t, ctx, src)
+		if err := src.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if sum != wantSum {
+			t.Fatalf("query %s: sum=%d want %d", qid, sum, wantSum)
+		}
+	}
+	scanQuery("qa")
+	scanQuery("qb")
+
+	load := func(qid string) *decodeAheadQueryStats {
+		v, ok := e.scanDecodeAheadByQuery.Load(qid)
+		if !ok {
+			return nil
+		}
+		return v.(*decodeAheadQueryStats)
+	}
+	qa, qb := load("qa"), load("qb")
+	if qa == nil || qb == nil {
+		t.Fatal("per-query entries missing after source close")
+	}
+	if qa.groups.Load() != 2*3 || qb.groups.Load() != 2*3 {
+		t.Fatalf("per-query groups = %d/%d, want 6/6", qa.groups.Load(), qb.groups.Load())
+	}
+
+	// First sweep: counters moved since the zero snapshot — entries held.
+	e.sweepScanDecodeAheadQueryStats(false)
+	if load("qa") == nil || load("qb") == nil {
+		t.Fatal("first sweep dropped still-fresh entries")
+	}
+	// Second sweep: idle — emitted and dropped.
+	e.sweepScanDecodeAheadQueryStats(false)
+	if load("qa") != nil || load("qb") != nil {
+		t.Fatal("second sweep kept idle entries")
+	}
+
+	// Final sweep drains immediately, no idle wait.
+	scanQuery("qc")
+	e.sweepScanDecodeAheadQueryStats(true)
+	if load("qc") != nil {
+		t.Fatal("final sweep kept entry")
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -601,6 +601,7 @@ func (w *Worker) startScanDecodeAheadMarkerLoop(ctx context.Context) {
 						"refault_rate", int64(refaultRate),
 						"refault_activations", refaultActivations)
 				}
+				w.executor.sweepScanDecodeAheadQueryStats(false)
 			}
 		}
 	}()
@@ -861,6 +862,7 @@ func (w *Worker) Stop() {
 	// the 2026-07-17 capped repro lost every worker-side sample this way.
 	// Emitted after wg.Wait, so every source has folded its counters.
 	if w.config.ScanDecodeAhead {
+		w.executor.sweepScanDecodeAheadQueryStats(true)
 		groups, windowFulls, pressureStalls, tokenStalls, ledgerStalls := w.executor.ScanDecodeAheadStats()
 		refaultRate, refaultActivations := memory.PageCachePressureStats()
 		w.logger.Info("scan decode-ahead stats (final)",


### PR DESCRIPTION
Item 3 of the §9.3 follow-ups: closed decode-ahead iterators fold their counters under the task QueryID (stage-scoped on stage inputs), swept by the marker loop with emit-and-drop on idle — one greppable line per query/stage. Gives the Q05 repartition-phase attribution the next SF100 run needs. Race-tested; harness smoke shows per-stage lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)