### PR TITLE
build(benchmark): refault_pressure_rate tfvar for the §9.4 sensor A/B

### DIFF
--- a/deploy/benchmark/terraform/main.tf
+++ b/deploy/benchmark/terraform/main.tf
@@ -653,6 +653,7 @@ resource "aws_instance" "worker" {
           --scope -p "MemoryMax=$PER_PROC_BYTES" -p "MemoryHigh=$PER_PROC_GOMEMLIMIT" \
           --setenv="GOMEMLIMIT=$PER_PROC_GOMEMLIMIT" \
           --setenv="WADJET_GOGC=100" \
+          --setenv="WADJET_REFAULT_PRESSURE_RATE=${var.refault_pressure_rate}" \
           /usr/local/bin/wadjet serve \
             --mode=worker \
             --nats-url="nats://$COORD_IP:4222" \

--- a/deploy/benchmark/terraform/variables.tf
+++ b/deploy/benchmark/terraform/variables.tf
@@ -288,6 +288,12 @@ variable "streaming_shuffle_read" {
   default     = true
 }
 
+variable "refault_pressure_rate" {
+  description = "WADJET_REFAULT_PRESSURE_RATE for workers: page-cache pressure sensor activation threshold in refaulted pages/sec (docs/design/scan-decode-pipelining.md §9). Empty = binary default (1000); 0 = sensor OFF (the §9.4 sensor-off A/B arm)."
+  type        = string
+  default     = ""
+}
+
 variable "scan_decode_ahead" {
   description = "Scan decode pipelining (docs/design/scan-decode-pipelining.md): workers decode parquet row groups ahead of scan consumption — k decode workers with in-order delivery, pool-ledger-charged byte window, refault-sensor collapse, cross-file continuation. Worker-side flag only. Default true (SF100 pair 2026-07-17: steady-state -7.3%, 0/44 mismatches); set false as the kill switch."
   type        = bool


### PR DESCRIPTION
Threads WADJET_REFAULT_PRESSURE_RATE into the worker systemd-run scope. Empty = binary default; 0 = sensor off (the §9.4 off arm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)