### PR TITLE
fix(worker): occupancy-floored pressure collapse for scan decode-ahead (§9.5)

### DIFF
--- a/docs/design/scan-decode-pipelining.md
+++ b/docs/design/scan-decode-pipelining.md
@@ -441,3 +441,43 @@ non-trivial) was considered and rejected: the per-group estimate
 +37 %) shows even one extra group hurts the edge regime — the two
 regimes genuinely want different answers, and the discriminator is the
 envelope, not the occupancy.
+
+### 9.5 Sensor A/B (2026-07-18) and the occupancy-floored collapse
+
+Same-evening SF100 pair, bin 82d1ce3: sensor-on (the §9.4 attribution
+run, results/20260718-222535) vs sensor-off
+(`WADJET_REFAULT_PRESSURE_RATE=0`, results/20260719-004315). 0/44 row
+mismatches. **Sensor-off is a net loss: steady 26.6 m vs 25.7 m
+(+3.7 %).** The repartition-bound queries recover exactly as §9.4
+predicted (Q05 −12.7 %, Q12 −33 %, Q09 −13 %) but the scan band pays
+more than they gain (Q06 +46 %, Q14 +18 %, Q15 +15 %, Q17 +14 %,
+Q03/Q01 +12 %), and the counters show why: without the sensor,
+`window_fulls` jumps ~7 k → ~43 k — the 256 MiB window SATURATES and
+its held bytes displace page cache. The §9 displacement mechanism is
+live at SF100; the sensor was correctly suppressing it.
+
+Both regimes therefore coexist at SF100 query-by-query, and the
+discriminator is WINDOW OCCUPANCY:
+
+- decode outruns the consumer → window fills → held bytes displace
+  cache → collapse is right (Q06's win needs the sensor);
+- producer-bound repartition stages → window sits empty → cursor-only
+  collapse is pure serialization with nothing to shed (Q05's loss).
+
+**Fix (this section's implementation): occupancy-floored pressure
+collapse.** Under pressure, non-cursor admission is denied only while
+another non-cursor group is in flight or parked (shared-window `ahead`
+count) — a 2-deep pipeline holding at most ~one group-estimate of
+bytes, which is nothing to displace with, while keeping producer-bound
+stages pipelined. No new constants on big envelopes.
+`PressureStrict` restores cursor-only collapse and is set on
+edge-class envelopes (GOMEMLIMIT < 2 GiB, the GC-mode classification):
+the capped repro measured even one extra in-flight group as harmful
+there (32 MiB arm +37 % while cursor-only beat flag-off).
+
+Expected from the A/B arithmetic: keep the sensor-on scan band, recover
+most of the repartition-stage losses (Q05/Q09/Q12/Q02/Q07 ≈ 45 s of
+run-2 wall) → target ≈ 25.0 m steady. The validating pair watches:
+Q05 + Q06 TOGETHER (the two regimes must both hold), pressure_stalls
+(should drop on repartition stages, persist on scan band),
+`ahead`-floor correctness via row parity.

--- a/internal/engine/scan/decode_ahead.go
+++ b/internal/engine/scan/decode_ahead.go
@@ -46,9 +46,10 @@ type DecodeAheadIter struct {
 	// for window estimation, resolved once at Open.
 	estLeaves []int
 
-	workers  int
-	pressure func() bool
-	tokens   TokenPool
+	workers        int
+	pressure       func() bool
+	pressureStrict bool
+	tokens         TokenPool
 
 	dynamicRanges []exec.DynamicRange
 	bloomFilters  []*exec.BloomScanFilter
@@ -83,9 +84,10 @@ type DecodeAheadIter struct {
 // decodeSlot is one row group's outcome, parked until the delivery
 // cursor reaches its index.
 type decodeSlot struct {
-	batch  *batch.RecordBatch // nil when pruned or empty
-	err    error
-	est    int64 // window bytes reserved for this group
+	batch *batch.RecordBatch // nil when pruned or empty
+	err   error
+	est   int64 // window bytes reserved for this group
+	ahead bool  // admitted as non-cursor: delivery/drop decrements win.ahead
 }
 
 // DecodeAheadOpts sizes a DecodeAheadIter.
@@ -101,11 +103,27 @@ type DecodeAheadOpts struct {
 	// and the head of file F+1 draw from one budget.
 	Window *DecodeWindow
 	// Pressure, when set, is consulted before admitting any group beyond
-	// the delivery cursor. While it reports true the iterator degrades to
-	// effectively serial (one group in flight) and the window drains as
-	// the consumer takes — the memory-pressure collapse hook. Must be
+	// the delivery cursor — the memory-pressure collapse hook. Must be
 	// safe to call from multiple goroutines.
+	//
+	// While it reports true, admission is OCCUPANCY-FLOORED by default:
+	// one non-cursor group may be in flight or parked (a 2-deep
+	// pipeline), further admission waits. The 2026-07-18 SF100 sensor
+	// A/B (memo §9.5) split the pressure regime in two: when decode
+	// outruns the consumer the window fills and its held bytes displace
+	// page cache (collapse is right — Q06 +46 % without it), but on
+	// producer-bound repartition stages the window sits EMPTY and
+	// cursor-only collapse is pure serialization with nothing to shed
+	// (Q05 −12.7 % when spared). One group ahead holds ~one group-est of
+	// bytes — nothing to displace with — while keeping the producer
+	// pipelined.
 	Pressure func() bool
+	// PressureStrict restores cursor-only collapse under Pressure (no
+	// group ahead at all). Set on edge-class envelopes (< 2 GiB
+	// GOMEMLIMIT), where the capped repro measured even one extra
+	// in-flight group as harmful (32 MiB window arm +37 % vs cursor-only
+	// winning outright).
+	PressureStrict bool
 	// Tokens, when set, budgets decode CPU per ROW GROUP: a worker
 	// acquires one token at admission and releases it when the decoded
 	// group parks, so a worker stalled on the window (or between groups)
@@ -159,6 +177,10 @@ type DecodeWindow struct {
 	// with inflight, so the ledger balance returns to zero when every
 	// owning iterator has closed.
 	ledger WindowLedger
+	// ahead counts non-cursor groups admitted but not yet delivered (or
+	// dropped), across every iterator sharing this window — the
+	// occupancy floor the pressure hook gates on. Guarded by mu.
+	ahead int
 }
 
 // NewDecodeWindow returns a window bounding decoded-but-undelivered
@@ -183,12 +205,17 @@ func NewDecodeWindowWithLedger(bytes int64, ledger WindowLedger) *DecodeWindow {
 	return w
 }
 
-// credit returns a group's byte reservation — window and ledger — when
-// its slot is delivered or dropped. Caller holds w.mu.
-func (w *DecodeWindow) credit(est int64) {
-	w.inflight -= est
+// credit returns a slot's reservations — window bytes, ledger bytes,
+// and its occupancy-floor count — when it is delivered or dropped.
+// Caller holds w.mu.
+func (w *DecodeWindow) credit(slot *decodeSlot) {
+	w.inflight -= slot.est
+	if slot.ahead {
+		slot.ahead = false
+		w.ahead--
+	}
 	if w.ledger != nil {
-		w.ledger.Release(est)
+		w.ledger.Release(slot.est)
 	}
 }
 
@@ -231,10 +258,11 @@ func OpenDecodeAheadIter(reader *pqt.Reader, schema []pqt.Column, selectedCols [
 	}
 
 	it := &DecodeAheadIter{
-		workers:  opts.Workers,
-		win:      opts.Window,
-		pressure: opts.Pressure,
-		tokens:   opts.Tokens,
+		workers:        opts.Workers,
+		win:            opts.Window,
+		pressure:       opts.Pressure,
+		pressureStrict: opts.PressureStrict,
+		tokens:         opts.Tokens,
 	}
 	if it.win == nil {
 		it.win = NewDecodeWindow(opts.WindowBytes)
@@ -362,7 +390,7 @@ func (it *DecodeAheadIter) Next() (*batch.RecordBatch, error) {
 		if slot, ok := it.slots[it.deliver]; ok {
 			delete(it.slots, it.deliver)
 			it.deliver++
-			it.win.credit(slot.est)
+			it.win.credit(slot)
 			it.win.cond.Broadcast()
 			if slot.err != nil {
 				// Mirror serial semantics: the error surfaces exactly at
@@ -410,13 +438,18 @@ func (it *DecodeAheadIter) decodeLoop() {
 		// which is also why a ledger denial needs no external wakeup:
 		// deliveries keep crediting the ledger and re-running this check.
 		var holdsToken bool
-		if idx != it.deliver {
+		isAhead := idx != it.deliver
+		if isAhead {
 			if it.win.inflight+est > it.win.limit {
 				it.windowFullStalls.Add(1)
 				it.win.cond.Wait()
 				continue
 			}
-			if it.pressure != nil && it.pressure() {
+			// Occupancy-floored pressure collapse (memo §9.5): under
+			// pressure, one non-cursor group may be in flight or parked
+			// across the shared window; strict mode (edge envelopes)
+			// admits none.
+			if it.pressure != nil && (it.pressureStrict || it.win.ahead > 0) && it.pressure() {
 				it.pressureStalls.Add(1)
 				it.win.cond.Wait()
 				continue
@@ -444,10 +477,13 @@ func (it *DecodeAheadIter) decodeLoop() {
 		}
 		it.nextIdx++
 		it.win.inflight += est
+		if isAhead {
+			it.win.ahead++
+		}
 		ranges, blooms := it.dynamicRanges, it.bloomFilters
 		it.win.mu.Unlock()
 
-		slot := &decodeSlot{est: est}
+		slot := &decodeSlot{est: est, ahead: isAhead}
 		if pruned := it.pruneGroup(idx, ranges, blooms); !pruned {
 			b, err := ReadRowGroupNative(it.fr, idx, it.readSchema, nil)
 			if err != nil {
@@ -530,7 +566,7 @@ func (it *DecodeAheadIter) Close() error {
 	// Release this iterator's undelivered reservations so a chained
 	// iterator sharing the window doesn't inherit dead inflight bytes.
 	for idx, slot := range it.slots {
-		it.win.credit(slot.est)
+		it.win.credit(slot)
 		delete(it.slots, idx)
 	}
 	it.win.cond.Broadcast()
@@ -543,7 +579,7 @@ func (it *DecodeAheadIter) Close() error {
 	// those reservations too. No new slots can appear once closed.
 	it.win.mu.Lock()
 	for idx, slot := range it.slots {
-		it.win.credit(slot.est)
+		it.win.credit(slot)
 		delete(it.slots, idx)
 	}
 	it.win.cond.Broadcast()

--- a/internal/engine/scan/decode_ahead_test.go
+++ b/internal/engine/scan/decode_ahead_test.go
@@ -642,3 +642,97 @@ func TestDecodeAheadIter_LedgerBalancedOnAllPaths(t *testing.T) {
 		t.Errorf("ledger balance after mid-stream close = %d, want 0", balance)
 	}
 }
+
+// TestDecodeAheadIter_PressureOccupancyFloor: memo §9.5 — under
+// permanent pressure the default (non-strict) mode still pipelines
+// 2-deep (cursor + one ahead): output identical to serial, the ahead
+// count peaks at exactly 1, stalls fire once the floor is held, and
+// the count returns to zero on drain and on mid-stream Close. Strict
+// mode admits nothing ahead (peak 0), preserving the edge behavior.
+func TestDecodeAheadIter_PressureOccupancyFloor(t *testing.T) {
+	data := manyRowGroupFile(t, 12, 50)
+	schema := []pqt.Column{{Name: "id", Type: pqt.TypeInt64}}
+
+	serial, err := OpenRowGroupIter(openFileReader(t, data), schema, nil, 0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serial.Close()
+	want, _ := drainGroupIter(t, serial)
+
+	run := func(strict bool) (got []*batch.RecordBatch, stalls int64, aheadPeak int, it *DecodeAheadIter) {
+		t.Helper()
+		it, err := OpenDecodeAheadIter(openFileReader(t, data), schema, nil, 0, 1,
+			DecodeAheadOpts{Workers: 4, PressureStrict: strict, Pressure: func() bool { return true }})
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Sample the shared ahead count between deliveries; the mutex
+		// serializes reads with admission so peaks cannot be missed
+		// entirely (a worker may admit between samples, but the floor
+		// guarantee is that ahead never EXCEEDS the bound — asserting
+		// the sampled max <= bound is what matters).
+		for {
+			b, err := it.Next()
+			if err != nil {
+				t.Fatal(err)
+			}
+			it.win.mu.Lock()
+			if it.win.ahead > aheadPeak {
+				aheadPeak = it.win.ahead
+			}
+			it.win.mu.Unlock()
+			if b == nil {
+				break
+			}
+			got = append(got, b)
+		}
+		_, _, stalls, _, _ = it.Stats()
+		return got, stalls, aheadPeak, it
+	}
+
+	// Default (floored): 2-deep, correct, stalled, drained ahead == 0.
+	got, stalls, peak, it := run(false)
+	requireSameBatches(t, want, got)
+	if peak > 1 {
+		t.Errorf("floored mode ahead peak = %d, want <= 1", peak)
+	}
+	if stalls == 0 {
+		t.Error("floored mode never stalled — floor not gating past 1 ahead")
+	}
+	it.win.mu.Lock()
+	if it.win.ahead != 0 {
+		t.Errorf("ahead after drain = %d, want 0", it.win.ahead)
+	}
+	it.win.mu.Unlock()
+	it.Close()
+
+	// Strict: nothing ahead, ever.
+	got2, stalls2, peak2, it2 := run(true)
+	requireSameBatches(t, want, got2)
+	if peak2 != 0 {
+		t.Errorf("strict mode ahead peak = %d, want 0", peak2)
+	}
+	if stalls2 == 0 {
+		t.Error("strict mode never stalled")
+	}
+	it2.Close()
+
+	// Mid-stream Close drops parked ahead slots and zeroes the count.
+	it3, err := OpenDecodeAheadIter(openFileReader(t, data), schema, nil, 0, 1,
+		DecodeAheadOpts{Workers: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := it3.Next(); err != nil {
+		t.Fatal(err)
+	}
+	if err := it3.Close(); err != nil {
+		t.Fatal(err)
+	}
+	it3.win.mu.Lock()
+	if it3.win.ahead != 0 {
+		t.Errorf("ahead after mid-stream close = %d, want 0", it3.win.ahead)
+	}
+	it3.win.mu.Unlock()
+}

--- a/internal/worker/executor_fragment.go
+++ b/internal/worker/executor_fragment.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -463,6 +465,17 @@ var pageCachePressureActive = memory.PageCachePressureActive
 func scanDecodeAheadPressure() bool {
 	return heapPressureActive() || pageCachePressureActive()
 }
+
+// scanDecodeAheadStrictPressure reports whether pressure collapse should
+// be cursor-only (no group ahead) rather than occupancy-floored 2-deep
+// (memo §9.5): edge-class envelopes, mirroring the < 2 GiB GOMEMLIMIT
+// classification the GC mode uses — the capped repro measured even one
+// extra in-flight group as harmful there. Cached once: GOMEMLIMIT is
+// set at process start.
+var scanDecodeAheadStrictPressure = sync.OnceValue(func() bool {
+	lim := debug.SetMemoryLimit(-1)
+	return lim > 0 && lim != math.MaxInt64 && lim < 2<<30
+})
 
 // morselMinFragmentBytes is the auto-mode size gate: fragments whose
 // EstimatedBytes fall below it stay serial. Parallelism pays only above a

--- a/internal/worker/stream_source.go
+++ b/internal/worker/stream_source.go
@@ -935,7 +935,8 @@ func (s *cachedFileStreamSource) buildParquetState(filePath string, data, mmapDa
 		// thrash (memo §9: refault-rate sensor — the displacement channel
 		// the heap hook cannot see; the capped repro measured decode-ahead
 		// width as worthless-to-harmful precisely when refaults run hot).
-		opts := scan.DecodeAheadOpts{Window: s.decodeWin, Pressure: scanDecodeAheadPressure}
+		opts := scan.DecodeAheadOpts{Window: s.decodeWin, Pressure: scanDecodeAheadPressure,
+			PressureStrict: scanDecodeAheadStrictPressure()}
 		if s.executor.cpuTokens != nil {
 			opts.Tokens = s.executor.cpuTokens
 		}


### PR DESCRIPTION
The sensor A/B proved both pressure regimes coexist at SF100 and window occupancy discriminates them: empty-window producer stages lose to cursor-only collapse (Q05), filling windows need it (Q06 +46% without). Under pressure, admission now allows exactly one non-cursor group in flight (shared-window `ahead` count) — 2-deep pipeline, ~nothing held. Edge envelopes (<2GiB) keep strict cursor-only via `PressureStrict`. Full §9.5 in the memo, incl. the A/B table and target arithmetic (≈25.0m steady).

Validation: needs one SF100 arm vs tonight's sensor-on run — watch Q05 AND Q06 together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)