### PR TITLE
perf(coordinator): fan out DistRoundRobin partial aggregates at dispatch

### DIFF
--- a/internal/coordinator/aggregate_partial_split_test.go
+++ b/internal/coordinator/aggregate_partial_split_test.go
@@ -1,0 +1,137 @@
+package coordinator
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/planner/physical"
+)
+
+// TestAggregatePartialSplit_Trigger verifies the dispatcher's decision to
+// fan out a DistRoundRobin partial aggregate: triggers only for the
+// partial "aggregate" stage type with the RoundRobin label, spare workers,
+// the 1-task default, a single non-eager dep, and a divisible upstream.
+// Mirrors the conditions enforced in dispatchComputeStage.
+func TestAggregatePartialSplit_Trigger(t *testing.T) {
+	rrStage := physical.Stage{
+		Type:         physical.StageAggregate,
+		GroupByCols:  []string{"k"},
+		Dependencies: []string{"join-1"},
+		Distribution: physical.Distribution{Kind: physical.DistRoundRobin},
+	}
+	partitioned := map[string]StageOutput{
+		"join-1": {Kind: OutputPartitioned, NumPartitions: 4,
+			Files: [][]string{{"p0a", "p0b"}, {"p1"}, nil, {"p3"}}},
+	}
+	singlePart := map[string]StageOutput{
+		"join-1": {Kind: OutputSinglePart, Files: [][]string{{"f0", "f1", "f2", "f3"}}},
+	}
+
+	withField := func(mut func(*physical.Stage)) physical.Stage {
+		s := rrStage
+		mut(&s)
+		return s
+	}
+
+	cases := []struct {
+		name       string
+		stage      physical.Stage
+		inputs     map[string]StageOutput
+		workers    int
+		curTasks   int
+		wantOK     bool
+		wantGroups [][]string
+	}{
+		{
+			// Partitioned upstream: one group per NON-EMPTY partition, so
+			// no task is dispatched with zero input files.
+			name: "partitioned_upstream_group_per_partition", stage: rrStage,
+			inputs: partitioned, workers: 3, curTasks: 1, wantOK: true,
+			wantGroups: [][]string{{"p0a", "p0b"}, {"p1"}, {"p3"}},
+		},
+		{
+			// Single-part multi-file upstream: even split capped at workerCount.
+			name: "single_part_even_split", stage: rrStage,
+			inputs: singlePart, workers: 2, curTasks: 1, wantOK: true,
+			wantGroups: [][]string{{"f0", "f1"}, {"f2", "f3"}},
+		},
+		{name: "single_worker", stage: rrStage, inputs: partitioned, workers: 1, curTasks: 1, wantOK: false},
+		{name: "already_parallel", stage: rrStage, inputs: partitioned, workers: 3, curTasks: 4, wantOK: false},
+		{name: "single_file_upstream", stage: rrStage, inputs: map[string]StageOutput{
+			"join-1": {Kind: OutputSinglePart, Files: [][]string{{"f0"}}},
+		}, workers: 3, curTasks: 1, wantOK: false},
+		{name: "one_nonempty_partition", stage: rrStage, inputs: map[string]StageOutput{
+			"join-1": {Kind: OutputPartitioned, NumPartitions: 2, Files: [][]string{{"p0"}, nil}},
+		}, workers: 3, curTasks: 1, wantOK: false},
+		{name: "missing_dep_output", stage: rrStage, inputs: map[string]StageOutput{}, workers: 3, curTasks: 1, wantOK: false},
+		{
+			name:   "not_roundrobin",
+			stage:  withField(func(s *physical.Stage) { s.Distribution = physical.Distribution{Kind: physical.DistSingleton} }),
+			inputs: partitioned, workers: 3, curTasks: 1, wantOK: false,
+		},
+		{
+			name:   "final_aggregate_excluded",
+			stage:  withField(func(s *physical.Stage) { s.Type = "final_aggregate" }),
+			inputs: partitioned, workers: 3, curTasks: 1, wantOK: false,
+		},
+		{
+			// A sort, limit, or post-filter applied per-slice would be wrong
+			// before the merge has seen all partials.
+			name:   "sort_keys_excluded",
+			stage:  withField(func(s *physical.Stage) { s.SortKeys = []physical.SortKeySpec{{Column: "k"}} }),
+			inputs: partitioned, workers: 3, curTasks: 1, wantOK: false,
+		},
+		{
+			name:   "limit_excluded",
+			stage:  withField(func(s *physical.Stage) { s.Limit = 10 }),
+			inputs: partitioned, workers: 3, curTasks: 1, wantOK: false,
+		},
+		{
+			name:   "post_filter_excluded",
+			stage:  withField(func(s *physical.Stage) { s.FilterExprs = []string{"cnt > 3"} }),
+			inputs: partitioned, workers: 3, curTasks: 1, wantOK: false,
+		},
+		{
+			name:   "multi_dep_excluded",
+			stage:  withField(func(s *physical.Stage) { s.Dependencies = []string{"join-1", "join-2"} }),
+			inputs: partitioned, workers: 3, curTasks: 1, wantOK: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dep, groups, ok := aggregatePartialSplit(tc.stage, tc.inputs, tc.workers, tc.curTasks)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if dep != "join-1" {
+				t.Errorf("depID = %q, want join-1", dep)
+			}
+			if !reflect.DeepEqual(groups, tc.wantGroups) {
+				t.Errorf("groups = %v, want %v", groups, tc.wantGroups)
+			}
+		})
+	}
+}
+
+// TestAggregatePartialSplit_EagerExcluded: provisional (eager) upstream
+// outputs use the manifest-fed partition-range convention, which does not
+// match custom file groups — the split must decline.
+func TestAggregatePartialSplit_EagerExcluded(t *testing.T) {
+	stage := physical.Stage{
+		Type:         physical.StageAggregate,
+		GroupByCols:  []string{"k"},
+		Dependencies: []string{"join-1"},
+		Distribution: physical.Distribution{Kind: physical.DistRoundRobin},
+	}
+	inputs := map[string]StageOutput{
+		"join-1": {Kind: OutputPartitioned, NumPartitions: 2,
+			Files: [][]string{{"p0"}, {"p1"}}, eager: &eagerFeed{}},
+	}
+	if _, _, ok := aggregatePartialSplit(stage, inputs, 3, 1); ok {
+		t.Fatal("split must decline eager provisional inputs")
+	}
+}

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -2036,6 +2036,14 @@ func (c *Coordinator) dispatchComputeStage(
 		numTasks = n
 		probeSplit = true
 	}
+	// Round-robin partial-aggregate fan-out (see aggregatePartialSplit).
+	// Mutually exclusive with probe-split and skew-split by stage type.
+	var rrAggGroups [][]string
+	rrAggDep := ""
+	if dep, groups, ok := aggregatePartialSplit(stage, inputs, workerCount, numTasks); ok {
+		rrAggDep, rrAggGroups = dep, groups
+		numTasks = len(groups)
+	}
 	// Adaptive skew split (--skew-split, docs/design/skew-aware-shuffle.md):
 	// a shuffled hash join whose deps report per-partition bytes may split
 	// hot partition groups into k sub-tasks (probe files divided, build
@@ -2057,6 +2065,7 @@ func (c *Coordinator) dispatchComputeStage(
 		"deps", stage.Dependencies, "num_tasks", numTasks,
 		"distribution_kind", stage.Distribution.Kind,
 		"distribution_count", stage.Distribution.Count,
+		"rr_agg_split", rrAggGroups != nil,
 		"probe_split", probeSplit,
 		"skew_split", skewAssign != nil,
 		"inputs_aliases", len(inputs),
@@ -2103,6 +2112,11 @@ func (c *Coordinator) dispatchComputeStage(
 		var err error
 		if probeSplit {
 			taskInputs, err = buildTaskInputsForBroadcastJoinSplitProbe(stage, inputs, w, numTasks)
+		} else if rrAggGroups != nil {
+			// Partial-aggregate fan-out: task w aggregates its disjoint
+			// file group; alias follows buildTaskInputsForStage's
+			// single-input convention (dep ID).
+			taskInputs = map[string][]string{rrAggDep: rrAggGroups[w]}
 		} else if skewAssign != nil {
 			taskInputs = skewAssign[w].inputs
 		} else {
@@ -2554,13 +2568,14 @@ func (c *Coordinator) dispatchComputeStage(
 	case physical.DistBroadcast:
 		kind = OutputReplicated
 	}
-	if probeSplit {
-		// Probe-split fan-out keeps the planner's DistSingleton labelling but
-		// produces N physical files (one per probe-slice task). Collapse all
-		// per-task files into Files[0] so OutputSinglePart consumers (which
-		// read only Files[0]) see the full join result. Downstream parallelism
-		// is preserved by finalAggregateFanoutCandidate / flattenStageFiles
-		// callers that iterate every Files[i].
+	if probeSplit || rrAggGroups != nil {
+		// Probe-split and partial-aggregate fan-out keep the planner's
+		// labelling (DistSingleton / DistRoundRobin) but produce N physical
+		// files (one per task). Collapse all per-task files into Files[0]
+		// so OutputSinglePart consumers (which read only Files[0]) see the
+		// full result. Downstream parallelism is preserved by
+		// finalAggregateFanoutCandidate / flattenStageFiles callers that
+		// iterate every Files[i].
 		flat := make([]string, 0)
 		for _, f := range files {
 			flat = append(flat, f...)
@@ -3459,6 +3474,81 @@ func broadcastJoinProbeSplit(
 		n = len(probeFiles)
 	}
 	return n, true
+}
+
+// aggregatePartialSplit reports whether a partial "aggregate" stage
+// qualifies for round-robin fan-out, returning the dep ID and per-task
+// input file groups when it does.
+//
+// The planner labels grouped partial aggregates DistRoundRobin when
+// workerCount > 1 (OutputDistribution, StageAggregate case) so the
+// property algebra forces a hash-shuffle ahead of the grouped final. The
+// dispatcher's task-count switch, however, had no DistRoundRobin arm — the
+// correctness-first default ran the partial as ONE task reading the entire
+// upstream (e.g. a 24-partition join output) while the rest of the cluster
+// idled. The 2026-07-19 arrival-waits evidence pass measured this as the
+// exclusive serial leg on Q10 (12.9s partial + downstream effects) and
+// Q13/Q02/Q03 at SF100. Partial aggregation is valid over any disjoint
+// cover of its input, so the fix is the same shape as the scan-fused
+// fan-out (dispatchScanAggregateStage): aggregate disjoint slices in
+// parallel, let the existing downstream machinery (exchange-repartition
+// from EnsureDistribution, or dispatchFinalAggregateFanout for Singleton
+// finals) merge the partials.
+//
+// Slicing: one task per non-empty partition group for OutputPartitioned
+// upstreams (matches the per-partition granularity join stages already
+// dispatch at), an even file split capped at workerCount otherwise.
+//
+// Guards: SortKeys/Limit/FilterExprs never appear on a partial today
+// (fuseSortIntoPredecessor folds into finals only; HAVING lands on the
+// final) — the guard keeps the split sound if that ever changes, since a
+// sort, limit, or post-filter applied per-slice would be wrong before the
+// merge has seen all partials. Eager provisional inputs are excluded the
+// same way probe-split/skew slicing is: their manifest-fed partition-range
+// convention does not match custom file groups.
+func aggregatePartialSplit(
+	stage physical.Stage,
+	inputs map[string]StageOutput,
+	workerCount, currentNumTasks int,
+) (depID string, groups [][]string, ok bool) {
+	if stage.Type != physical.StageAggregate {
+		return "", nil, false
+	}
+	if stage.Distribution.Kind != physical.DistRoundRobin {
+		return "", nil, false
+	}
+	if currentNumTasks != 1 || workerCount <= 1 {
+		return "", nil, false
+	}
+	if len(stage.Dependencies) != 1 || len(stage.FusedJoins) != 0 {
+		return "", nil, false
+	}
+	if len(stage.SortKeys) != 0 || stage.Limit != 0 || len(stage.FilterExprs) != 0 {
+		return "", nil, false
+	}
+	depID = stage.Dependencies[0]
+	in, present := inputs[depID]
+	if !present || in.eager != nil {
+		return "", nil, false
+	}
+	if in.Kind == OutputPartitioned {
+		for _, part := range in.Files {
+			if len(part) > 0 {
+				groups = append(groups, part)
+			}
+		}
+	} else if len(in.Files) > 0 && len(in.Files[0]) >= 2 {
+		files := in.Files[0]
+		n := workerCount
+		if n > len(files) {
+			n = len(files)
+		}
+		groups = splitFilesEvenly(files, n)
+	}
+	if len(groups) < 2 {
+		return "", nil, false
+	}
+	return depID, groups, true
 }
 
 // buildTaskInputsForBroadcastJoinSplitProbe is the probe-split variant of

--- a/internal/coordinator/task_retry.go
+++ b/internal/coordinator/task_retry.go
@@ -136,6 +136,17 @@ func (tr *taskRetrier) Observe(r distributed.ResultNotification) (allDone bool) 
 		attempt := st.attempts
 		onSuccess := tr.onSuccess
 		tr.mu.Unlock()
+		// Per-task arrival line: the only coordinator-side record of WHEN
+		// each task inside a stage finished. Within-stage completion spread
+		// read off these timestamps is what bounds task-granular
+		// consumer-start overlap (arrival-waits evidence pass 2026-07-19 —
+		// stage-level logs alone can't measure the spread).
+		if tr.logger != nil {
+			tr.logger.Info("task result",
+				"stage_id", tr.stageID, "task_id", r.TaskID,
+				"worker_id", r.WorkerID, "attempt", attempt,
+				"rows", r.NumRows, "bytes", r.SizeBytes)
+		}
 		if onSuccess != nil {
 			onSuccess(r.TaskID, attempt, r.ResultFiles, r.WorkerID, done, r.PartitionBytes)
 		}


### PR DESCRIPTION
## What

Two coordinator changes from the 2026-07-19 arrival-waits evidence pass:

**1. Partial-aggregate fan-out (perf).** The planner labels grouped partial aggregates over multi-task upstreams `DistRoundRobin`, but the dispatcher's task-count switch had no arm for it — the correctness-first default ran the partial as **one task** reading the entire upstream (e.g. a 24-partition join output) while the rest of the cluster idled. Measured as the exclusive serial leg on Q10 (12.9s partial → 17.5s singleton final), Q13, Q02, Q03 at SF100. Fix: fan out over disjoint input slices (per-partition groups for partitioned upstreams, even file split otherwise), collapsing results into `Files[0]` exactly like probe-split. The multi-file partial output also un-starves the existing `dispatchFinalAggregateFanout` for sort/limit-bearing Singleton finals (needs K > workerCount input files; a 1-task partial could never provide them).

**2. Per-task result-arrival log line (feat).** `taskRetrier.Observe` is the single funnel for every stage kind's result collection; one INFO line there makes within-stage completion spread measurable from coordinator logs — the quantity that bounds the task-granular eager-consumer-start lever (next arc).

## Gates

- Unit tests for the split candidate (all guards: sort/limit/post-filter, eager, multi-dep, single-file, already-parallel)
- `go test ./internal/...` green; TPC-H SF0.01 correctness green
- SF1 local harness (DAG-forced): **PASS**, no zero-row queries; split fired on 15 partial stages (t=3 / t=24); final-aggregate fanout newly fired 5×
- SF100 pair still to run (needs deploy approval) — expected: Q10/Q13/Q02/Q03 serial legs shrink; suite headline modest since Q18/Q21 are span-length-bound

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRLkDz9MVaSoFP5kEJSRQD