### PR TITLE
fix(coordinator): cap partial-aggregate fan-out at workerCount with size floor

### DIFF
--- a/cmd/tpch-bench/main.go
+++ b/cmd/tpch-bench/main.go
@@ -409,6 +409,9 @@ func setupDistributed(ctx context.Context, logger *slog.Logger, endpoint, region
 		// as the kill switch. Coordinator-side decision only — workers
 		// always report the per-partition accounting it consumes.
 		SkewSplit: os.Getenv("WADJET_SKEW_SPLIT") != "0" && !strings.EqualFold(os.Getenv("WADJET_SKEW_SPLIT"), "false"),
+		// Partial-aggregate fan-out (aggregatePartialSplit): default ON,
+		// matching the wadjet CLI default; set 0/false as the kill switch.
+		AggPartialSplit: os.Getenv("WADJET_AGG_PARTIAL_SPLIT") != "0" && !strings.EqualFold(os.Getenv("WADJET_AGG_PARTIAL_SPLIT"), "false"),
 		// Broadcast threshold override: <0 = never broadcast. 0/unset =
 		// cluster-derived default.
 		BroadcastBytesOverride: envInt64("WADJET_BROADCAST_BYTES"),

--- a/cmd/wadjet/main.go
+++ b/cmd/wadjet/main.go
@@ -101,6 +101,7 @@ var (
 	sortMergeJoinBytes    int64
 	lateMaterialization   bool
 	skewSplit             bool
+	aggPartialSplit       bool
 	bushyJoinReorder      bool
 	broadcastBytes        int64
 	streamingExchange     bool
@@ -174,6 +175,7 @@ func main() {
 	rootCmd.PersistentFlags().Int64Var(&sortMergeJoinBytes, "sort-merge-join-bytes", 0, "Inner equi-joins whose sides BOTH exceed this estimated size run as sort-merge joins (both sides sort to spill-friendly runs and stream a merge) instead of hash joins, bounding join memory at merge-cursor state instead of a resident build table. Applies to both the local single-process paths and the distributed stage DAG (the join stage swaps operator; its exchange children are identical). 0 = disabled (default). See docs/design/sort-merge-join.md.")
 	rootCmd.PersistentFlags().BoolVar(&lateMaterialization, "late-materialization", true, "Emit inner/left hash-join output as view (dictionary) columns over the probe input and build batches, deferring the column gather to the first consumer that needs owned storage — join chains compose the indirection so a column is copied once, at its final consumer or the shuffle encode. Default true (validated 2026-07-09: SF10 −6.2%, SF100 −4.9% suite wall, Q08 −36%/−44%, row-identical both scales); --late-materialization=false restores eager join-output gather. See docs/design/late-materialization.md.")
 	rootCmd.PersistentFlags().BoolVar(&skewSplit, "skew-split", true, "Adaptive skew-aware shuffle layout: when a shuffled hash join's per-partition input bytes (reported by the shuffle stages) show a hot partition group (over the absolute floor AND >=2x the mean group), split it into k sub-tasks that divide the group's probe files and replicate its build files, bounding the straggler task's input and memory footprint. Default true (validated 2026-07-11: SF10 hot-key fixture -41% straggler wall, row-identical; plan-identical on uniform workloads via the ratio gate); --skew-split=false is the kill switch. See docs/design/skew-aware-shuffle.md.")
+	rootCmd.PersistentFlags().BoolVar(&aggPartialSplit, "agg-partial-split", true, "Fan out partial (pre-merge) aggregate stages over a non-trivial multi-file upstream into at most workerCount tasks aggregating disjoint file slices, instead of one task reading the entire upstream. Gated on the upstream's worker-reported output size so trivial aggregates stay single-task (per-task scheduling overhead otherwise dominates). --agg-partial-split=false is the kill switch.")
 	rootCmd.PersistentFlags().BoolVar(&bushyJoinReorder, "bushy-join-reorder", false, "Let the cost-based join reorder emit BUSHY plans (joins of two composite intermediates — e.g. pre-joining a snowflake dimension chain before it meets the fact stream) when strictly cheaper than every left-deep order. Cost ties keep the left-deep shape. Process-wide, default false. See docs/design/bushy-join-cbo.md.")
 	rootCmd.PersistentFlags().Int64Var(&localFastPathBytes, "local-fastpath-bytes", coordinator.DefaultLocalFastPathBytes, "Queries whose post-pruning catalog scan bytes stay under this threshold execute in-process on the coordinator (skipping the distributed stage DAG and its per-stage object-store round trips). 0 = disabled.")
 	rootCmd.PersistentFlags().BoolVar(&streamingExchange, "streaming-exchange", true, "Streaming exchange: consumers fetch stage outputs from the producing workers' local disk over gRPC with async S3 upload; every failure falls through to the durable S3 path. Default true (validated 2026-07-02: SF10 −10%, SF100 −23% suite wall, row-identical, zero fault-tolerance events); --streaming-exchange=false restores synchronous S3-only shuffle. See docs/design/streaming-exchange.md.")
@@ -955,6 +957,7 @@ func runStandalone(ctx context.Context, store objstore.Store, logger *slog.Logge
 		SortMergeJoinBytes:     sortMergeJoinBytes,
 		LateMaterialization:    lateMaterialization,
 		SkewSplit:              skewSplit,
+		AggPartialSplit:        aggPartialSplit,
 		StreamingExchange:      streamingExchange,
 		EagerDispatch:          eagerDispatch,
 	}, cat, nc, js, logger)
@@ -1257,6 +1260,7 @@ func runCoordinator(ctx context.Context, store objstore.Store, logger *slog.Logg
 		SortMergeJoinBytes:     sortMergeJoinBytes,
 		LateMaterialization:    lateMaterialization,
 		SkewSplit:              skewSplit,
+		AggPartialSplit:        aggPartialSplit,
 		StreamingExchange:      streamingExchange,
 		EagerDispatch:          eagerDispatch,
 	}, cat, nc, js, logger)

--- a/internal/coordinator/aggregate_partial_split_test.go
+++ b/internal/coordinator/aggregate_partial_split_test.go
@@ -10,8 +10,11 @@ import (
 // TestAggregatePartialSplit_Trigger verifies the dispatcher's decision to
 // fan out a DistRoundRobin partial aggregate: triggers only for the
 // partial "aggregate" stage type with the RoundRobin label, spare workers,
-// the 1-task default, a single non-eager dep, and a divisible upstream.
-// Mirrors the conditions enforced in dispatchComputeStage.
+// the 1-task default, a single non-eager dep, a non-trivial upstream
+// (>= aggSplitMinBytes reported bytes), and >= 2 upstream files. Task
+// count caps at workerCount (probe-split shape) — the 2026-07-19 SF100
+// run showed per-partition granularity produces swarms of ~2ms tasks
+// whose scheduling overhead regresses the whole suite.
 func TestAggregatePartialSplit_Trigger(t *testing.T) {
 	rrStage := physical.Stage{
 		Type:         physical.StageAggregate,
@@ -19,12 +22,14 @@ func TestAggregatePartialSplit_Trigger(t *testing.T) {
 		Dependencies: []string{"join-1"},
 		Distribution: physical.Distribution{Kind: physical.DistRoundRobin},
 	}
+	big := int64(aggSplitMinBytes)
 	partitioned := map[string]StageOutput{
-		"join-1": {Kind: OutputPartitioned, NumPartitions: 4,
+		"join-1": {Kind: OutputPartitioned, NumPartitions: 4, Bytes: big,
 			Files: [][]string{{"p0a", "p0b"}, {"p1"}, nil, {"p3"}}},
 	}
 	singlePart := map[string]StageOutput{
-		"join-1": {Kind: OutputSinglePart, Files: [][]string{{"f0", "f1", "f2", "f3"}}},
+		"join-1": {Kind: OutputSinglePart, Bytes: big,
+			Files: [][]string{{"f0", "f1", "f2", "f3"}}},
 	}
 
 	withField := func(mut func(*physical.Stage)) physical.Stage {
@@ -43,11 +48,11 @@ func TestAggregatePartialSplit_Trigger(t *testing.T) {
 		wantGroups [][]string
 	}{
 		{
-			// Partitioned upstream: one group per NON-EMPTY partition, so
-			// no task is dispatched with zero input files.
-			name: "partitioned_upstream_group_per_partition", stage: rrStage,
-			inputs: partitioned, workers: 3, curTasks: 1, wantOK: true,
-			wantGroups: [][]string{{"p0a", "p0b"}, {"p1"}, {"p3"}},
+			// Partitioned upstream: flattened files split across at most
+			// workerCount tasks — NOT one task per partition.
+			name: "partitioned_upstream_capped_at_workers", stage: rrStage,
+			inputs: partitioned, workers: 2, curTasks: 1, wantOK: true,
+			wantGroups: [][]string{{"p0a", "p0b"}, {"p1", "p3"}},
 		},
 		{
 			// Single-part multi-file upstream: even split capped at workerCount.
@@ -55,13 +60,34 @@ func TestAggregatePartialSplit_Trigger(t *testing.T) {
 			inputs: singlePart, workers: 2, curTasks: 1, wantOK: true,
 			wantGroups: [][]string{{"f0", "f1"}, {"f2", "f3"}},
 		},
+		{
+			// More workers than files: one task per file, no empty tasks.
+			name: "more_workers_than_files", stage: rrStage,
+			inputs: singlePart, workers: 8, curTasks: 1, wantOK: true,
+			wantGroups: [][]string{{"f0"}, {"f1"}, {"f2"}, {"f3"}},
+		},
+		{
+			// Below the bytes floor the single-task partial is already cheap;
+			// splitting is pure scheduling overhead (the 2ms-task swarm).
+			name: "small_upstream_excluded", stage: rrStage,
+			inputs: map[string]StageOutput{
+				"join-1": {Kind: OutputPartitioned, NumPartitions: 2, Bytes: aggSplitMinBytes - 1,
+					Files: [][]string{{"p0"}, {"p1"}}},
+			}, workers: 3, curTasks: 1, wantOK: false,
+		},
+		{
+			// Unknown bytes (legacy worker) declines — degrade to the
+			// pre-split shape, never to a regression.
+			name: "unknown_bytes_excluded", stage: rrStage,
+			inputs: map[string]StageOutput{
+				"join-1": {Kind: OutputPartitioned, NumPartitions: 2,
+					Files: [][]string{{"p0"}, {"p1"}}},
+			}, workers: 3, curTasks: 1, wantOK: false,
+		},
 		{name: "single_worker", stage: rrStage, inputs: partitioned, workers: 1, curTasks: 1, wantOK: false},
 		{name: "already_parallel", stage: rrStage, inputs: partitioned, workers: 3, curTasks: 4, wantOK: false},
 		{name: "single_file_upstream", stage: rrStage, inputs: map[string]StageOutput{
-			"join-1": {Kind: OutputSinglePart, Files: [][]string{{"f0"}}},
-		}, workers: 3, curTasks: 1, wantOK: false},
-		{name: "one_nonempty_partition", stage: rrStage, inputs: map[string]StageOutput{
-			"join-1": {Kind: OutputPartitioned, NumPartitions: 2, Files: [][]string{{"p0"}, nil}},
+			"join-1": {Kind: OutputSinglePart, Bytes: big, Files: [][]string{{"f0"}}},
 		}, workers: 3, curTasks: 1, wantOK: false},
 		{name: "missing_dep_output", stage: rrStage, inputs: map[string]StageOutput{}, workers: 3, curTasks: 1, wantOK: false},
 		{
@@ -128,7 +154,7 @@ func TestAggregatePartialSplit_EagerExcluded(t *testing.T) {
 		Distribution: physical.Distribution{Kind: physical.DistRoundRobin},
 	}
 	inputs := map[string]StageOutput{
-		"join-1": {Kind: OutputPartitioned, NumPartitions: 2,
+		"join-1": {Kind: OutputPartitioned, NumPartitions: 2, Bytes: aggSplitMinBytes,
 			Files: [][]string{{"p0"}, {"p1"}}, eager: &eagerFeed{}},
 	}
 	if _, _, ok := aggregatePartialSplit(stage, inputs, 3, 1); ok {

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -93,6 +93,14 @@ type Config struct {
 	// the ratio gate); this struct field's zero value stays false so
 	// embedded/test constructors opt in explicitly.
 	SkewSplit bool
+	// AggPartialSplit enables the round-robin partial-aggregate fan-out
+	// (aggregatePartialSplit in execute_stage_dag.go): partial "aggregate"
+	// stages over a non-trivial multi-file upstream split into at most
+	// workerCount tasks aggregating disjoint file slices. The wadjet CLI
+	// and tpch-bench default this ON; --agg-partial-split=false is the
+	// kill switch. Zero value stays false so embedded/test constructors
+	// opt in explicitly (mirrors SkewSplit).
+	AggPartialSplit bool
 	// EagerDispatch enables eager consumer dispatch (docs/design/
 	// eager-consumer-dispatch.md): the coordinator republishes per-
 	// producer-task file manifests on EagerManifestSubject as shuffle

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -3,6 +3,8 @@ package coordinator
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -2040,9 +2042,11 @@ func (c *Coordinator) dispatchComputeStage(
 	// Mutually exclusive with probe-split and skew-split by stage type.
 	var rrAggGroups [][]string
 	rrAggDep := ""
-	if dep, groups, ok := aggregatePartialSplit(stage, inputs, workerCount, numTasks); ok {
-		rrAggDep, rrAggGroups = dep, groups
-		numTasks = len(groups)
+	if c.config.AggPartialSplit {
+		if dep, groups, ok := aggregatePartialSplit(stage, inputs, workerCount, numTasks); ok {
+			rrAggDep, rrAggGroups = dep, groups
+			numTasks = len(groups)
+		}
 	}
 	// Adaptive skew split (--skew-split, docs/design/skew-aware-shuffle.md):
 	// a shuffled hash join whose deps report per-partition bytes may split
@@ -3495,9 +3499,24 @@ func broadcastJoinProbeSplit(
 // from EnsureDistribution, or dispatchFinalAggregateFanout for Singleton
 // finals) merge the partials.
 //
-// Slicing: one task per non-empty partition group for OutputPartitioned
-// upstreams (matches the per-partition granularity join stages already
-// dispatch at), an even file split capped at workerCount otherwise.
+// Slicing: an even split of the flattened upstream file list across at
+// most workerCount tasks — the same shape as probe-split. The first cut
+// of this fan-out used one task PER upstream partition (24-way at SF100)
+// with no size gate; the 2026-07-19 SF100 validation run showed why the
+// probe-split precedent caps at workerCount: small aggregates became
+// swarms of ~2ms tasks whose per-task dispatch/result overhead (~0.5-1s)
+// dwarfed the work, serialized through max_concurrent worker slots, and
+// queued the NEXT query's scan tasks behind the swarm (+18% suite task
+// count, steady pass +28% — slower than its own cold pass). Chunky
+// tasks or no split.
+//
+// aggSplitMinBytes is the same "fanout only wins when each task performs
+// non-trivial work" reasoning as finalAggregateFanoutCandidate's
+// K > workerCount gate: below it, the single-task partial is already
+// cheap and the split is pure scheduling overhead. Bytes are the
+// worker-reported on-disk size of the upstream output; 0 (unknown,
+// legacy worker) declines the split — degrade to the pre-split shape,
+// never to a regression.
 //
 // Guards: SortKeys/Limit/FilterExprs never appear on a partial today
 // (fuseSortIntoPredecessor folds into finals only; HAVING lands on the
@@ -3506,6 +3525,19 @@ func broadcastJoinProbeSplit(
 // merge has seen all partials. Eager provisional inputs are excluded the
 // same way probe-split/skew slicing is: their manifest-fed partition-range
 // convention does not match custom file groups.
+//
+// WADJET_AGG_SPLIT_MIN_BYTES overrides the floor (small-scale harness runs
+// force the split path everywhere with =1 so the correctness gate actually
+// exercises it; SF1 upstreams are all under the production floor).
+var aggSplitMinBytes = func() int64 {
+	if v := os.Getenv("WADJET_AGG_SPLIT_MIN_BYTES"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 64 << 20
+}()
+
 func aggregatePartialSplit(
 	stage physical.Stage,
 	inputs map[string]StageOutput,
@@ -3531,20 +3563,18 @@ func aggregatePartialSplit(
 	if !present || in.eager != nil {
 		return "", nil, false
 	}
-	if in.Kind == OutputPartitioned {
-		for _, part := range in.Files {
-			if len(part) > 0 {
-				groups = append(groups, part)
-			}
-		}
-	} else if len(in.Files) > 0 && len(in.Files[0]) >= 2 {
-		files := in.Files[0]
-		n := workerCount
-		if n > len(files) {
-			n = len(files)
-		}
-		groups = splitFilesEvenly(files, n)
+	if in.Bytes < aggSplitMinBytes {
+		return "", nil, false
 	}
+	files := flattenStageFiles(in)
+	if len(files) < 2 {
+		return "", nil, false
+	}
+	n := workerCount
+	if n > len(files) {
+		n = len(files)
+	}
+	groups = splitFilesEvenly(files, n)
 	if len(groups) < 2 {
 		return "", nil, false
 	}


### PR DESCRIPTION
## What happened

The SF100 validation run of #242's fan-out (results/20260719-191904, vs same-day control 20260719-105312) **regressed the steady pass +28.1%** (32.9m vs 25.7m; rows 44/44 identical; the treatment's steady pass was slower than its own cold pass — within-run degradation).

## Root cause

Established from worker logs + the per-task arrival lines #242 itself added: per-**partition** task granularity (t=24) with no size gate turned small partial aggregates into swarms of **~2ms tasks**. Per-task dispatch/result overhead (~0.5-1s) dwarfed the work, serialized through `max_concurrent=4` worker slots, and queued the *next* query's scan tasks behind the swarm — untouched queries regressed too (Q06 +187%, Q16 +208%, Q19 +145%; +640 tasks/suite, +18%).

## Fix — follow the probe-split shape exactly

- Split the **flattened** upstream file list across **at most workerCount** tasks, never per-partition.
- **64 MiB floor** on the upstream's worker-reported bytes (unknown → decline): below it the single-task partial is already cheap; same reasoning as `finalAggregateFanoutCandidate`'s K > workerCount gate. `WADJET_AGG_SPLIT_MIN_BYTES` overrides for small-scale gating.
- **`--agg-partial-split` kill switch** (default true; `WADJET_AGG_PARTIAL_SPLIT` for tpch-bench), mirroring `--skew-split` — the convention v1 skipped.

## Gates

- Unit tests: cap + floor + unknown-bytes decline + all v1 guards
- `go test ./internal/...` green; TPC-H SF0.01 green
- SF1 harness PASS twice: default floor (split declines everywhere at SF1 scale — validating the off path) and floor=1 (split fires on all 15 partial stages, **every one capped at num_tasks=3**, rows identical, no zero-row queries)
- SF100 revalidation pending (needs deploy approval)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRLkDz9MVaSoFP5kEJSRQD