### PR TITLE
feat(coordinator): projected-tail gate for eager consumer clearance

### DIFF
--- a/docs/design/eager-consumer-dispatch.md
+++ b/docs/design/eager-consumer-dispatch.md
@@ -302,3 +302,60 @@ overlap achieved, and worker utilization rises above 2.5/16 cores on
 multi-stage queries. If the SF100 pair shows no movement in those two
 markers, the thesis is wrong and the flag stays off — no threshold
 tuning to force it.
+
+### 10.1 Q08 outlier root-caused (2026-07-20): known pressure-floor
+### variance, not an eager defect
+
+The +93% came from ONE join-6 probe-split task (b87311e0, worker
+i-0e39…): 62.1s for ~1.37M rows while its two siblings did the same
+volume in ~24s. Fragment progress lines show uniform ~22k rows/s from
+start (siblings ~55k rows/s), pool at 1% — no stall, no queueing, no
+spill, and the worker ran nothing else for the task's last 53s. The
+worker's decode-ahead stats in that window show the refault pressure
+sensor active (refault_rate ≈ 22k/s, activations climbing): the fused
+probe scan inside the join task was pinned to the 2-deep pressure
+floor for its whole run — the same partial-residency background-
+refault mechanism documented as Q05's 117-165s cross-window band
+(scan-decode-pipelining.md §9.4). Eager only reshuffled scheduling so
+the collapse landed on Q08 in this pair (control's Q05 drew the short
+straw at 165.1s that evening; the eager arm's Q05 ran 116.9s).
+No eager-specific defect found.
+
+## 11. Projected-tail clearance gate (implemented 2026-07-20; flag
+## still OFF pending the gated SF100 pair)
+
+§10's split verdict is conditional convergence: clearance converts
+exactly when the producer still has a long completion tail to overlap.
+The gate encodes that:
+
+- `eagerFeed` timestamps successful producer-task completions
+  (firstDone/lastDone in noteCompletion).
+- At clearance, EVERY eager consumer — C1 non-join included — now
+  holds for `decisionReady` (a full wave + a quarter of producer
+  tasks), so a wave of arrival stats exists. The eagerness lost is the
+  first wave, the population §9 predicted and §10 measured as yielding
+  nothing.
+- `projectedTailSeconds()` = mean observed inter-arrival × tasks
+  remaining; fewer than two completions or nothing remaining → 0
+  (decline toward the barrier, never toward a wrong clearance).
+- Clearance requires `max(tail over the stage's eager feeds) ≥
+  eagerMinTailSeconds` (default 12, the §10 envelope: every measured
+  edge ≥ ~12s converted, every edge ≤ ~10s paid tax;
+  WADJET_EAGER_MIN_TAIL_SECONDS overrides, 0 restores ungated C3
+  behavior for A/B). Below the floor the stage logs
+  "projected tail below floor — keeping barrier" and takes the
+  barrier — byte-identical to flag-off planning.
+
+Acceptance for the gated SF100 pair, derived from §10's table: the
+gate must clear Q05/Q21/Q18/Q04/Q03-class edges (their steady wins
+summed ≈ 100s ≈ 6-7% of suite) and keep the barrier on the
+Q02/Q07/Q09/Q10/Q14/Q15/Q16/Q20 population (whose §10 taxes summed to
+the cancellation). Success = suite steady meaningfully below the
+25.45m reference with no query outside its documented variance band;
+failure = flag stays off and §10's verdict stands as final.
+
+Gates run at implementation time: unit (projectedTailSeconds math,
+TestEagerTailGate barrier contract), full coordinator suite, TPC-H
+SF0.01, SF1 harness with eager on at the default floor (gate declines
+everywhere at SF1 scale — plans byte-identical to flag-off) and at
+floor 0 (ungated clearance engages; rows identical).

--- a/internal/coordinator/eager_dispatch_e2e_test.go
+++ b/internal/coordinator/eager_dispatch_e2e_test.go
@@ -176,6 +176,15 @@ func assertEagerArmsIdentical(t *testing.T, control, treatment map[string]int) {
 // fencing needs). Asserts flag-on results are identical to flag-off and
 // that the mechanism markers engaged (memo §8).
 func TestEagerDispatchE2E(t *testing.T) {
+	// SF001 producers complete in milliseconds, so the projected-tail
+	// gate (eager-consumer-dispatch.md §10/§11) would keep the barrier
+	// and the engagement assertions below could never fire. Disable the
+	// floor: this test gates clearance MECHANISM correctness, not the
+	// SF100 conversion policy (TestEagerTailGate covers the gate).
+	restoreTail := eagerMinTailSeconds
+	eagerMinTailSeconds = 0
+	t.Cleanup(func() { eagerMinTailSeconds = restoreTail })
+
 	ctx, newCoord := setupEagerE2E(t, []string{"part", "supplier", "partsupp", "nation", "region"})
 	sql := tpch.TPCHQueries[2].SQL
 
@@ -206,6 +215,15 @@ func TestEagerDispatchE2E(t *testing.T) {
 // SF001 data is uniform, so the projected decision is no-split and eager
 // clearance proceeds; results must be row-identical to the barrier arm.
 func TestEagerJoinDispatchE2E(t *testing.T) {
+	// SF001 producers complete in milliseconds, so the projected-tail
+	// gate (eager-consumer-dispatch.md §10/§11) would keep the barrier
+	// and the engagement assertions below could never fire. Disable the
+	// floor: this test gates clearance MECHANISM correctness, not the
+	// SF100 conversion policy (TestEagerTailGate covers the gate).
+	restoreTail := eagerMinTailSeconds
+	eagerMinTailSeconds = 0
+	t.Cleanup(func() { eagerMinTailSeconds = restoreTail })
+
 	ctx, newCoord := setupEagerE2E(t, []string{"lineitem", "orders"})
 	const sql = `SELECT l_orderkey, COUNT(*) AS cnt, SUM(l_quantity) AS qty
 		FROM lineitem JOIN orders ON l_orderkey = o_orderkey
@@ -224,4 +242,30 @@ func TestEagerJoinDispatchE2E(t *testing.T) {
 	}
 	t.Logf("C2 join eager engaged: edges=%d, %d groups identical",
 		EagerEdgesPlanned.Load()-edgesBefore, len(control))
+}
+
+// TestEagerTailGate: with the projected-tail floor in force (set high so
+// SF001's millisecond producers can never satisfy it), an eager-flagged
+// run must keep the barrier on every edge — zero early clearances — and
+// stay row-identical. This is the §11 gate contract: below-floor tails
+// degrade to exactly the flag-off plan, never to a wrong clearance.
+func TestEagerTailGate(t *testing.T) {
+	ctx, newCoord := setupEagerE2E(t, []string{"part", "supplier", "partsupp", "nation", "region"})
+	sql := tpch.TPCHQueries[2].SQL
+
+	restoreTail := eagerMinTailSeconds
+	eagerMinTailSeconds = 1e9
+	t.Cleanup(func() { eagerMinTailSeconds = restoreTail })
+
+	control := runEagerE2EQuery(ctx, t, newCoord(false), sql, "control")
+	if len(control) == 0 {
+		t.Fatal("control returned no rows")
+	}
+	edgesBefore := EagerEdgesPlanned.Load()
+	treatment := runEagerE2EQuery(ctx, t, newCoord(true), sql, "eager-gated")
+
+	assertEagerArmsIdentical(t, control, treatment)
+	if got := EagerEdgesPlanned.Load() - edgesBefore; got != 0 {
+		t.Errorf("gate floor in force but %d consumers cleared early — gate not applied", got)
+	}
 }

--- a/internal/coordinator/eager_feed.go
+++ b/internal/coordinator/eager_feed.go
@@ -1,6 +1,8 @@
 package coordinator
 
 import (
+	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -61,6 +63,14 @@ type eagerFeed struct {
 	replay    []distributed.ProducerTaskManifest // manifests published so far
 	closed    bool                               // query finished; republisher must stop
 	completed int                                // producer tasks at successful terminal
+	// firstDone/lastDone timestamp the first and most recent successful
+	// producer-task completions. Feed the projected-tail eager gate
+	// (projectedTailSeconds): the C3 SF100 pair (design doc §10) showed
+	// eager clearance only converts when the producer still has a long
+	// completion tail at clearance time, and costs slot occupancy when
+	// it does not.
+	firstDone time.Time
+	lastDone  time.Time
 	// observedPartBytes accumulates worker-reported per-partition output
 	// bytes element-wise over completed tasks. nil until the first task
 	// reports a vector; stays nil for legacy workers (skew decision
@@ -117,6 +127,11 @@ func (f *eagerFeed) appendReplay(m distributed.ProducerTaskManifest) {
 func (f *eagerFeed) noteCompletion(partBytes []int64) {
 	f.mu.Lock()
 	f.completed++
+	now := time.Now()
+	if f.firstDone.IsZero() {
+		f.firstDone = now
+	}
+	f.lastDone = now
 	if len(partBytes) > 0 {
 		if f.observedPartBytes == nil {
 			f.observedPartBytes = make([]int64, f.numPartitions)
@@ -154,6 +169,42 @@ func (f *eagerFeed) projectedPartitionBytes() []int64 {
 	}
 	return out
 }
+
+// projectedTailSeconds estimates the wall remaining until the producer's
+// last task completes, from the completions observed so far: mean
+// inter-arrival × tasks remaining. Called at consumer clearance time
+// (after decisionReady, so at least a full wave of completions exists).
+// Returns 0 when nothing remains or when fewer than two completions have
+// landed (single-task producers, threshold==1) — no measurable tail means
+// nothing worth overlapping, so the gate declines toward the barrier,
+// never toward a wrong clearance.
+//
+// The C3 SF100 pair (eager-consumer-dispatch.md §10) is the calibration:
+// every edge whose measured producer spread was ≥ ~12s converted under
+// eager clearance (Q05 −29%, Q21, Q18, Q04, Q03); every edge below ~10s
+// paid a slot-occupancy tax instead. eagerMinTailSeconds encodes that
+// envelope; WADJET_EAGER_MIN_TAIL_SECONDS overrides it (0 = gate off,
+// restoring the ungated C3 behavior for A/B).
+func (f *eagerFeed) projectedTailSeconds() float64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	total := len(f.producerTaskIDs)
+	remaining := total - f.completed
+	if remaining <= 0 || f.completed < 2 || f.lastDone.Equal(f.firstDone) {
+		return 0
+	}
+	meanGap := f.lastDone.Sub(f.firstDone).Seconds() / float64(f.completed-1)
+	return meanGap * float64(remaining)
+}
+
+var eagerMinTailSeconds = func() float64 {
+	if v := os.Getenv("WADJET_EAGER_MIN_TAIL_SECONDS"); v != "" {
+		if n, err := strconv.ParseFloat(v, 64); err == nil && n >= 0 {
+			return n
+		}
+	}
+	return 12.0
+}()
 
 // replaySnapshot returns a copy of the manifests published so far.
 func (f *eagerFeed) replaySnapshot() []distributed.ProducerTaskManifest {

--- a/internal/coordinator/eager_tail_gate_test.go
+++ b/internal/coordinator/eager_tail_gate_test.go
@@ -1,0 +1,68 @@
+package coordinator
+
+import (
+	"testing"
+	"time"
+)
+
+// TestProjectedTailSeconds verifies the eager tail projection: mean
+// inter-arrival of observed completions extrapolated over remaining tasks,
+// with conservative zeros for unmeasurable feeds (fewer than two
+// completions, nothing remaining) so the gate declines toward the barrier.
+func TestProjectedTailSeconds(t *testing.T) {
+	mk := func(total, completed int, first, last time.Time) *eagerFeed {
+		f := newEagerFeed()
+		f.producerTaskIDs = make([]string, total)
+		f.completed = completed
+		f.firstDone = first
+		f.lastDone = last
+		return f
+	}
+	t0 := time.Now()
+
+	cases := []struct {
+		name string
+		f    *eagerFeed
+		want float64
+	}{
+		{
+			// 4 of 12 done over 6s → mean gap 2s → 8 remaining → 16s tail.
+			name: "long_tail",
+			f:    mk(12, 4, t0, t0.Add(6*time.Second)),
+			want: 16.0,
+		},
+		{
+			// all done → nothing to overlap.
+			name: "complete",
+			f:    mk(12, 12, t0, t0.Add(22*time.Second)),
+			want: 0,
+		},
+		{
+			// single completion → no measurable gap → conservative 0.
+			name: "one_completion",
+			f:    mk(3, 1, t0, t0),
+			want: 0,
+		},
+		{
+			// single-task producer, threshold==1: remaining 0 → 0.
+			name: "single_task_producer",
+			f:    mk(1, 1, t0, t0),
+			want: 0,
+		},
+		{
+			// two completions at the same instant (degenerate clock) → 0,
+			// never NaN/negative.
+			name: "zero_gap",
+			f:    mk(6, 2, t0, t0),
+			want: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.f.projectedTailSeconds()
+			if got < tc.want-0.01 || got > tc.want+0.01 {
+				t.Fatalf("projectedTailSeconds() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -472,24 +472,53 @@ func (c *Coordinator) executeStageDAG(
 					return gctx.Err()
 				}
 			}
-			// C2 join clearance: hold until both feeds cross the decision
-			// threshold (decisionReady always closes at or before producer
+			// Decision-point hold: EVERY eager consumer (C1 and C2) waits
+			// for its feeds to cross the decision threshold before
+			// clearing (decisionReady always closes at or before producer
 			// completion, so this cannot outwait a healthy producer; a
-			// failed producer cancels gctx), then apply the projected skew
-			// decision. Would-split → barrier.
+			// failed producer cancels gctx). Joins needed this for the
+			// projected skew decision from the start; C1 consumers now
+			// hold too, because the projected-tail gate below needs a
+			// wave of completion timestamps. The eagerness lost is the
+			// first producer wave — exactly the population §9 predicted
+			// (and the C3 pair measured) as yielding nothing.
+			if !eagerBroken {
+				for _, f := range eagerFeeds {
+					select {
+					case <-f.decisionReady:
+					case <-gctx.Done():
+						return gctx.Err()
+					}
+				}
+			}
+			// Projected-tail gate (C3 pair, eager-consumer-dispatch.md
+			// §10): eager clearance converts only when a producer still
+			// has a long completion tail to overlap — every measured edge
+			// with spread ≥ ~12s won, every edge below ~10s paid slot-
+			// occupancy tax. Gate on the LONGEST projected tail across
+			// the stage's eager feeds; below the floor, take the barrier.
+			if !eagerBroken {
+				maxTail := 0.0
+				for _, f := range eagerFeeds {
+					if t := f.projectedTailSeconds(); t > maxTail {
+						maxTail = t
+					}
+				}
+				if maxTail < eagerMinTailSeconds {
+					c.logger.Info("eager dispatch: projected tail below floor — keeping barrier",
+						"query", queryID, "stage_id", s.ID,
+						"projected_tail_s", maxTail, "floor_s", eagerMinTailSeconds)
+					eagerBroken = true
+				}
+			}
+			// C2 join clearance: apply the projected skew decision.
+			// Would-split → barrier.
 			if !eagerBroken && eagerJoin {
 				numTasks := 1
 				if s.Distribution.Kind == physical.DistHashPartitioned {
 					numTasks = s.Distribution.Count
 					if numTasks <= 0 {
 						numTasks = workerCount
-					}
-				}
-				for _, f := range eagerFeeds {
-					select {
-					case <-f.decisionReady:
-					case <-gctx.Done():
-						return gctx.Err()
 					}
 				}
 				probeDep, buildDep := joinPrimaryDeps(s)


### PR DESCRIPTION
## Context

The C3 SF100 pair (design doc §10, PR #244) turned eager dispatch's flat suite into a **conditional** verdict: clearance converts only on long-tail producers (every measured edge ≥ ~12s spread won: Q05 −29%, Q18 −9%, Q04 −12%, Q21, Q03; every edge ≤ ~10s paid a slot-occupancy tax that cancelled the wins). The Q08 +93% outlier is root-caused in §10.1: the known refault pressure-floor variance mechanism (Q05's 117-165s band), not an eager defect.

## The gate (§11)

- `eagerFeed` timestamps producer-task completions.
- Every eager consumer (C1 included) holds for `decisionReady` so a wave of arrival stats exists — the eagerness lost is the first wave, the population §9 predicted and §10 measured as yielding nothing.
- Clearance requires the longest **projected tail** (mean inter-arrival × tasks remaining) across the stage's feeds ≥ `eagerMinTailSeconds` (default 12s = the measured envelope; `WADJET_EAGER_MIN_TAIL_SECONDS` overrides, 0 restores ungated C3 behavior for A/B).
- Below-floor → logged barrier keep, byte-identical to flag-off planning. Unmeasurable tails decline toward the barrier, never toward a wrong clearance.

`--eager-dispatch` stays **default OFF**. §11 carries the acceptance criteria for the gated SF100 pair (clear the Q05/Q21/Q18/Q04/Q03 class ≈ 100s of measured wins; keep the barrier on the taxed population).

## Gates

- Unit: tail projection math (5 cases incl. degenerate clocks); `TestEagerTailGate` (floor in force → zero clearances, rows identical)
- Existing C1/C2 E2E tests updated to zero the floor (they gate mechanism correctness; SF001 producers finish in ms)
- `go test ./internal/...` green; TPC-H SF0.01 green
- SF1 harness eager-on twice: default floor PASS, floor=0 PASS (11 clearances engage, rows identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRLkDz9MVaSoFP5kEJSRQD