### PR TITLE
perf(coordinator): same-stage placement spread + stall-duration/phase instrumentation

### DIFF
--- a/internal/coordinator/scheduler.go
+++ b/internal/coordinator/scheduler.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -193,8 +195,16 @@ func (s *Scheduler) PublishTasks(ctx context.Context, tasks []distributed.Task) 
 // backpressure to the scheduler. The full set is rejected if no worker
 // is connected — there is no NATS fallback in gRPC mode.
 func (s *Scheduler) publishViaDataPlane(batch []preparedTask, deadlineNano int64) error {
+	// batchAssigned counts this call's placements per worker. Bin-packed
+	// tasks spread across it first (same-stage anti-affinity): one
+	// PublishTasks call is one stage's fan-out, and stale heartbeats used
+	// to let "most free pool" put an entire fan-out on one worker
+	// (2026-07-20 Q20 diagnosis: 3×18M-row final-aggregate tasks on one
+	// worker, +24s serialization; clump lotteries visible in every run).
+	batchAssigned := make(map[string]int)
+	methods := make(map[string]int)
 	for _, p := range batch {
-		workerID, ok := s.pickWorkerFor(p.task)
+		workerID, method, ok := s.pickWorkerFor(p.task, batchAssigned)
 		if !ok {
 			return fmt.Errorf("dispatching task %s: %w", p.task.ID, dataplane.ErrNoWorkers)
 		}
@@ -207,6 +217,8 @@ func (s *Scheduler) publishViaDataPlane(batch []preparedTask, deadlineNano int64
 				if ok2 && workerID2 != workerID {
 					if err2 := s.dpSrv.SendTaskDispatch(workerID2, p.task.ID, p.task.QueryID, p.task.StageID, p.data, deadlineNano); err2 == nil {
 						s.noteInflight(p.task, workerID2)
+						batchAssigned[workerID2]++
+						methods[method]++
 						continue
 					}
 				}
@@ -214,9 +226,30 @@ func (s *Scheduler) publishViaDataPlane(batch []preparedTask, deadlineNano int64
 			return fmt.Errorf("dispatching task %s to %s: %w", p.task.ID, workerID, err)
 		}
 		s.noteInflight(p.task, workerID)
+		batchAssigned[workerID]++
+		methods[method]++
 	}
-	s.logger.Info("published tasks", "count", len(batch), "transport", "grpc")
+	s.logger.Info("published tasks", "count", len(batch), "transport", "grpc",
+		"spread", formatCounts(batchAssigned), "placement", formatCounts(methods))
 	return nil
+}
+
+// formatCounts renders a count map as "k1:v1,k2:v2" with sorted keys —
+// compact enough for one log attr, stable enough to grep.
+func formatCounts(m map[string]int) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, "%s:%d", k, m[k])
+	}
+	return b.String()
 }
 
 // pickWorkerFor selects a worker for one task. Memory-aware bin-packing
@@ -226,22 +259,33 @@ func (s *Scheduler) publishViaDataPlane(batch []preparedTask, deadlineNano int64
 // would be static between heartbeats and pile every task of a fan-out
 // onto one worker.
 //
+// batchAssigned carries this publish call's placements so far: bin-packed
+// tasks are restricted to the workers with the fewest same-batch tasks
+// before "most free pool" ranks them. Without that restriction the same
+// staleness pathology hits estimated tasks — heartbeats lag 10s and the
+// per-task in-flight charge is small, so an entire fan-out lands on
+// whichever worker last reported the most free pool.
+//
 // Eager consumer tasks take their own placement path first: they can
 // block on producer manifests for the whole producer stage, so stacking
 // them on one worker starves that worker's producer lanes (targeted gRPC
 // dispatch has no work stealing).
-func (s *Scheduler) pickWorkerFor(t distributed.Task) (string, bool) {
+//
+// The returned method ("eager" | "binpack" | "rr") feeds the placement
+// attr on the "published tasks" line.
+func (s *Scheduler) pickWorkerFor(t distributed.Task, batchAssigned map[string]int) (workerID, method string, ok bool) {
 	if len(t.EagerInputs) > 0 {
 		if id, ok := s.pickEagerWorker(); ok {
-			return id, true
+			return id, "eager", true
 		}
 	}
 	if t.EstimatedBytes > 0 && s.registry != nil {
-		if id, ok := s.pickLeastLoaded(); ok {
-			return id, true
+		if id, ok := s.pickLeastLoadedSpread(batchAssigned); ok {
+			return id, "binpack", true
 		}
 	}
-	return s.dpSrv.PickWorker()
+	id, ok := s.dpSrv.PickWorker()
+	return id, "rr", ok
 }
 
 // pickEagerWorker places one eager consumer task: the connected worker
@@ -317,6 +361,37 @@ func (s *Scheduler) eagerInflightByWorker() map[string]int {
 // skipped; returns ok=false when none qualify so the caller round-robins.
 func (s *Scheduler) pickLeastLoaded() (string, bool) {
 	return pickLeastLoadedWorker(s.dpSrv.ConnectedWorkers(), s.registry.ActiveWorkers(), s.inflightByWorker())
+}
+
+// pickLeastLoadedSpread is pickLeastLoaded restricted to the workers with
+// the fewest tasks already placed by the current publish call — the
+// same-stage anti-affinity pass. Pool ranking then breaks ties among
+// them. Single-task publishes (retries, governed eager top-ups) see an
+// all-zero map and degrade to plain pickLeastLoaded.
+func (s *Scheduler) pickLeastLoadedSpread(batchAssigned map[string]int) (string, bool) {
+	connected := minBatchWorkers(s.dpSrv.ConnectedWorkers(), batchAssigned)
+	return pickLeastLoadedWorker(connected, s.registry.ActiveWorkers(), s.inflightByWorker())
+}
+
+// minBatchWorkers returns the subset of connected workers holding the
+// fewest same-batch placements. Order is preserved.
+func minBatchWorkers(connected []string, batchAssigned map[string]int) []string {
+	if len(connected) == 0 {
+		return connected
+	}
+	min := batchAssigned[connected[0]]
+	for _, id := range connected[1:] {
+		if n := batchAssigned[id]; n < min {
+			min = n
+		}
+	}
+	out := make([]string, 0, len(connected))
+	for _, id := range connected {
+		if batchAssigned[id] == min {
+			out = append(out, id)
+		}
+	}
+	return out
 }
 
 // pickLeastLoadedWorker is pickLeastLoaded's pure scoring core: max over

--- a/internal/coordinator/scheduler_binpack_test.go
+++ b/internal/coordinator/scheduler_binpack_test.go
@@ -166,3 +166,73 @@ func TestEstimateComputeTaskBytes(t *testing.T) {
 		})
 	}
 }
+
+func TestMinBatchWorkers(t *testing.T) {
+	tests := []struct {
+		name      string
+		connected []string
+		assigned  map[string]int
+		want      []string
+	}{
+		{"empty batch keeps all", []string{"w1", "w2", "w3"},
+			map[string]int{}, []string{"w1", "w2", "w3"}},
+		{"loaded worker drops out", []string{"w1", "w2", "w3"},
+			map[string]int{"w1": 1}, []string{"w2", "w3"}},
+		{"min-count subset survives", []string{"w1", "w2", "w3"},
+			map[string]int{"w1": 2, "w2": 1, "w3": 1}, []string{"w2", "w3"}},
+		{"no connected workers", nil, map[string]int{"w1": 1}, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := minBatchWorkers(tc.connected, tc.assigned)
+			if len(got) != len(tc.want) {
+				t.Fatalf("minBatchWorkers = %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("minBatchWorkers = %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// TestBinpackSpreadFanout replays the 2026-07-20 Q20 pathology: heartbeat
+// pool stats are stale for the whole fan-out (w3 reports most free the
+// entire time) and per-task estimates are too small to flip the ranking.
+// Without the same-batch restriction all 12 tasks land on w3; with it the
+// fan-out spreads 4/4/4 while w3 still wins each tie-break round.
+func TestBinpackSpreadFanout(t *testing.T) {
+	active := []*WorkerInfo{
+		{WorkerID: "w1", PoolBudget: 1000, PoolUsed: 500},
+		{WorkerID: "w2", PoolBudget: 1000, PoolUsed: 400},
+		{WorkerID: "w3", PoolBudget: 1000, PoolUsed: 100},
+	}
+	connected := []string{"w1", "w2", "w3"}
+	inflight := map[string]int64{} // estimates tiny: 1 byte per task
+	batchAssigned := map[string]int{}
+	counts := map[string]int{}
+	for i := 0; i < 12; i++ {
+		id, ok := pickLeastLoadedWorker(minBatchWorkers(connected, batchAssigned), active, inflight)
+		if !ok {
+			t.Fatalf("pick %d failed", i)
+		}
+		batchAssigned[id]++
+		counts[id]++
+		inflight[id]++ // per-task charge too small to matter
+	}
+	if counts["w1"] != 4 || counts["w2"] != 4 || counts["w3"] != 4 {
+		t.Fatalf("fan-out spread = %v, want 4/4/4", counts)
+	}
+	// Sanity: without the restriction, the stale ranking clumps.
+	clump := map[string]int{}
+	inflight = map[string]int64{}
+	for i := 0; i < 12; i++ {
+		id, _ := pickLeastLoadedWorker(connected, active, inflight)
+		clump[id]++
+		inflight[id]++
+	}
+	if clump["w3"] != 12 {
+		t.Fatalf("unrestricted control = %v, want all 12 on w3", clump)
+	}
+}

--- a/internal/engine/scan/decode_ahead.go
+++ b/internal/engine/scan/decode_ahead.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/citc-tech/wadjet/internal/engine/batch"
 	"github.com/citc-tech/wadjet/internal/engine/exec"
@@ -79,6 +80,23 @@ type DecodeAheadIter struct {
 	pressureStalls   atomic.Int64
 	tokenStalls      atomic.Int64
 	ledgerStalls     atomic.Int64
+
+	// Stall DURATIONS (ns), one per counter above. The 2026-07-20 Q08
+	// diagnosis showed counts alone cannot rank stall classes: slow and
+	// fast tasks logged near-identical counts while their wall time
+	// differed 3× — the time was in how long each wait lasted.
+	windowFullStallNs atomic.Int64
+	pressureStallNs   atomic.Int64
+	tokenStallNs      atomic.Int64
+	ledgerStallNs     atomic.Int64
+}
+
+// timedWait waits on the window condvar and adds the blocked span to ns.
+// Callers hold win.mu (cond.Wait's contract).
+func (it *DecodeAheadIter) timedWait(ns *atomic.Int64) {
+	t0 := time.Now()
+	it.win.cond.Wait()
+	ns.Add(time.Since(t0).Nanoseconds())
 }
 
 // decodeSlot is one row group's outcome, parked until the delivery
@@ -374,6 +392,16 @@ func (it *DecodeAheadIter) Stats() (groupsRead, windowFullStalls, pressureStalls
 	return it.rgRead.Load(), it.windowFullStalls.Load(), it.pressureStalls.Load(), it.tokenStalls.Load(), it.ledgerStalls.Load()
 }
 
+// StallDurations returns the total blocked time (ns) behind each Stats
+// counter, in the same order (window-full, pressure, token, ledger).
+// Counts say how often a gate closed; these say how much wall it cost.
+func (it *DecodeAheadIter) StallDurations() (windowFullNs, pressureNs, tokenNs, ledgerNs int64) {
+	if it == nil {
+		return 0, 0, 0, 0
+	}
+	return it.windowFullStallNs.Load(), it.pressureStallNs.Load(), it.tokenStallNs.Load(), it.ledgerStallNs.Load()
+}
+
 // Next returns the next decoded row group in source order, or (nil, nil)
 // when exhausted. Contract identical to RowGroupIter.Next.
 func (it *DecodeAheadIter) Next() (*batch.RecordBatch, error) {
@@ -442,7 +470,7 @@ func (it *DecodeAheadIter) decodeLoop() {
 		if isAhead {
 			if it.win.inflight+est > it.win.limit {
 				it.windowFullStalls.Add(1)
-				it.win.cond.Wait()
+				it.timedWait(&it.windowFullStallNs)
 				continue
 			}
 			// Occupancy-floored pressure collapse (memo §9.5): under
@@ -451,13 +479,13 @@ func (it *DecodeAheadIter) decodeLoop() {
 			// admits none.
 			if it.pressure != nil && (it.pressureStrict || it.win.ahead > 0) && it.pressure() {
 				it.pressureStalls.Add(1)
-				it.win.cond.Wait()
+				it.timedWait(&it.pressureStallNs)
 				continue
 			}
 			if it.win.ledger != nil {
 				if err := it.win.ledger.Reserve(est); err != nil {
 					it.ledgerStalls.Add(1)
-					it.win.cond.Wait()
+					it.timedWait(&it.ledgerStallNs)
 					continue
 				}
 			}
@@ -467,7 +495,7 @@ func (it *DecodeAheadIter) decodeLoop() {
 						it.win.ledger.Release(est)
 					}
 					it.tokenStalls.Add(1)
-					it.win.cond.Wait()
+					it.timedWait(&it.tokenStallNs)
 					continue
 				}
 				holdsToken = true

--- a/internal/engine/scan/decode_ahead_test.go
+++ b/internal/engine/scan/decode_ahead_test.go
@@ -161,6 +161,9 @@ func TestDecodeAheadIter_TinyWindowStallsButDelivers(t *testing.T) {
 	if _, stalls, _, _, _ := it.Stats(); stalls == 0 {
 		t.Error("WindowBytes=1 with 4 workers never stalled — window is not gating admission")
 	}
+	if wfNs, _, _, _ := it.StallDurations(); wfNs <= 0 {
+		t.Error("window-full stalls counted but zero blocked duration recorded")
+	}
 }
 
 // TestDecodeAheadIter_PressureDegradesToSerial: with the pressure hook
@@ -191,6 +194,9 @@ func TestDecodeAheadIter_PressureDegradesToSerial(t *testing.T) {
 	requireSameBatches(t, want, got)
 	if _, _, stalls, _, _ := it.Stats(); stalls == 0 {
 		t.Error("permanent pressure with 4 workers never stalled — hook is not gating admission")
+	}
+	if _, pNs, _, _ := it.StallDurations(); pNs <= 0 {
+		t.Error("pressure stalls counted but zero blocked duration recorded")
 	}
 }
 

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -127,6 +127,12 @@ type Executor struct {
 	scanDecodeAheadPressureStalls atomic.Int64
 	scanDecodeAheadTokenStalls    atomic.Int64
 	scanDecodeAheadLedgerStalls   atomic.Int64
+	// Stall durations (ns) behind the four stall counters above — counts
+	// rank frequency, these rank cost (2026-07-20 Q08 diagnosis).
+	scanDecodeAheadWindowFullNs atomic.Int64
+	scanDecodeAheadPressureNs   atomic.Int64
+	scanDecodeAheadTokenNs      atomic.Int64
+	scanDecodeAheadLedgerNs     atomic.Int64
 	// scanDecodeAheadByQuery attributes the counters above per source
 	// identity — the task's QueryID, which on stage-input sources is
 	// stage-scoped (e.g. "st-join-10-<query>"), so SF100 logs separate a
@@ -141,14 +147,17 @@ type Executor struct {
 // decodeAheadQueryStats is one query's decode-ahead counter slice.
 // emitted holds the counter snapshot at the last sweep; a sweep that
 // finds the counters unchanged emits the final line and drops the entry.
+// Indices 5-8 are the stall durations (ns) behind counters 1-4.
 type decodeAheadQueryStats struct {
 	groups, windowFulls, pressureStalls, tokenStalls, ledgerStalls atomic.Int64
-	emitted                                                        [5]int64
+	windowFullNs, pressureNs, tokenNs, ledgerNs                    atomic.Int64
+	emitted                                                        [9]int64
 }
 
-func (s *decodeAheadQueryStats) snapshot() [5]int64 {
-	return [5]int64{s.groups.Load(), s.windowFulls.Load(), s.pressureStalls.Load(),
-		s.tokenStalls.Load(), s.ledgerStalls.Load()}
+func (s *decodeAheadQueryStats) snapshot() [9]int64 {
+	return [9]int64{s.groups.Load(), s.windowFulls.Load(), s.pressureStalls.Load(),
+		s.tokenStalls.Load(), s.ledgerStalls.Load(),
+		s.windowFullNs.Load(), s.pressureNs.Load(), s.tokenNs.Load(), s.ledgerNs.Load()}
 }
 
 // SetStreamingShuffleRead enables streaming decode of shuffle inputs
@@ -172,7 +181,7 @@ func (e *Executor) SetScanDecodeAhead(on bool, windowBytes int64) {
 // foldScanDecodeAheadQueryStats adds one closed iterator's counters to
 // the per-query accumulator. queryID may be empty (embedded callers);
 // those fold under the "-" bucket rather than being dropped.
-func (e *Executor) foldScanDecodeAheadQueryStats(queryID string, groups, windowFulls, pressureStalls, tokenStalls, ledgerStalls int64) {
+func (e *Executor) foldScanDecodeAheadQueryStats(queryID string, groups, windowFulls, pressureStalls, tokenStalls, ledgerStalls, windowFullNs, pressureNs, tokenNs, ledgerNs int64) {
 	if queryID == "" {
 		queryID = "-"
 	}
@@ -183,6 +192,10 @@ func (e *Executor) foldScanDecodeAheadQueryStats(queryID string, groups, windowF
 	qs.pressureStalls.Add(pressureStalls)
 	qs.tokenStalls.Add(tokenStalls)
 	qs.ledgerStalls.Add(ledgerStalls)
+	qs.windowFullNs.Add(windowFullNs)
+	qs.pressureNs.Add(pressureNs)
+	qs.tokenNs.Add(tokenNs)
+	qs.ledgerNs.Add(ledgerNs)
 }
 
 // sweepScanDecodeAheadQueryStats emits per-query decode-ahead stats
@@ -208,7 +221,9 @@ func (e *Executor) sweepScanDecodeAheadQueryStats(final bool) {
 			"query", k,
 			"groups", cur[0], "window_fulls", cur[1],
 			"pressure_stalls", cur[2], "token_stalls", cur[3],
-			"ledger_stalls", cur[4])
+			"ledger_stalls", cur[4],
+			"window_full_ms", cur[5]/1e6, "pressure_stall_ms", cur[6]/1e6,
+			"token_stall_ms", cur[7]/1e6, "ledger_stall_ms", cur[8]/1e6)
 		return true
 	})
 }
@@ -222,6 +237,13 @@ func (e *Executor) ScanDecodeAheadStats() (groups, windowFulls, pressureStalls, 
 	return e.scanDecodeAheadGroups.Load(), e.scanDecodeAheadWindowFulls.Load(),
 		e.scanDecodeAheadPressureStalls.Load(), e.scanDecodeAheadTokenStalls.Load(),
 		e.scanDecodeAheadLedgerStalls.Load()
+}
+
+// ScanDecodeAheadStallNs returns the total blocked time (ns) behind the
+// four stall counters of ScanDecodeAheadStats, same order.
+func (e *Executor) ScanDecodeAheadStallNs() (windowFullNs, pressureNs, tokenNs, ledgerNs int64) {
+	return e.scanDecodeAheadWindowFullNs.Load(), e.scanDecodeAheadPressureNs.Load(),
+		e.scanDecodeAheadTokenNs.Load(), e.scanDecodeAheadLedgerNs.Load()
 }
 
 // NewExecutor creates a new task executor.

--- a/internal/worker/executor_fragment.go
+++ b/internal/worker/executor_fragment.go
@@ -62,6 +62,21 @@ type fragmentProgress struct {
 	backpressureCount   atomic.Int64
 	backpressurePauseMS atomic.Int64
 
+	// Phase timing (ns), fed by the fragment runners. Splits a slow task's
+	// wall into WHERE it went — the 2026-07-20 Q08 diagnosis had a task at
+	// uniform 1/3 speed and no counter that could say whether the source,
+	// the operator chain, or the sink was pacing it.
+	//   srcNs       time inside src.Next (decode + IO, incl. its stalls)
+	//   srcBlockedNs producer blocked handing a batch to the consumer
+	//   inputWaitNs consumer blocked waiting for the producer
+	//   opsNs       operator-chain Execute (join probe, filter, project)
+	//   sinkNs      sink consume (shuffle/output write)
+	srcNs        atomic.Int64
+	srcBlockedNs atomic.Int64
+	inputWaitNs  atomic.Int64
+	opsNs        atomic.Int64
+	sinkNs       atomic.Int64
+
 	mu                  sync.Mutex // guards the two log timestamps below
 	lastLog             time.Time
 	lastBackpressureLog time.Time
@@ -111,7 +126,69 @@ func (p *fragmentProgress) addRows(n int64) {
 			"bp_count", bp,
 			"bp_paused_ms", p.backpressurePauseMS.Load())
 	}
+	attrs = p.appendPhaseAttrs(attrs)
 	p.logger.Info("fragment task progress", attrs...)
+}
+
+// appendPhaseAttrs adds the nonzero phase-timing splits to a log line.
+func (p *fragmentProgress) appendPhaseAttrs(attrs []any) []any {
+	for _, ph := range []struct {
+		key string
+		ns  *atomic.Int64
+	}{
+		{"src_ms", &p.srcNs},
+		{"src_blocked_ms", &p.srcBlockedNs},
+		{"input_wait_ms", &p.inputWaitNs},
+		{"ops_ms", &p.opsNs},
+		{"sink_ms", &p.sinkNs},
+	} {
+		if v := ph.ns.Load(); v > 0 {
+			attrs = append(attrs, ph.key, v/1e6)
+		}
+	}
+	return attrs
+}
+
+// fragmentPhaseLogFloor gates the completion-time phase line: tasks
+// shorter than this log at Debug, keeping INFO volume flat for the
+// thousands of sub-second tasks per suite run.
+const fragmentPhaseLogFloor = 5 * time.Second
+
+// finish emits one "fragment task phases" line with the task's final
+// phase split. INFO for tasks long enough to matter, Debug otherwise.
+func (p *fragmentProgress) finish(totalRows int64) {
+	elapsed := time.Since(p.started)
+	attrs := p.appendPhaseAttrs([]any{
+		"task_id", p.taskID,
+		"stage_id", p.stageID,
+		"stage_type", p.stageType,
+		"elapsed_ms", elapsed.Milliseconds(),
+		"rows", totalRows,
+	})
+	if elapsed >= fragmentPhaseLogFloor {
+		p.logger.Info("fragment task phases", attrs...)
+		return
+	}
+	p.logger.Debug("fragment task phases", attrs...)
+}
+
+// timeSource wraps src so every Next is charged to p.srcNs.
+func (p *fragmentProgress) timeSource(src exec.Source) exec.Source {
+	return &timedSource{Source: src, ns: &p.srcNs}
+}
+
+// timedSource charges the wall spent inside the wrapped Source's Next to
+// an atomic counter. Init/Close pass through untimed.
+type timedSource struct {
+	exec.Source
+	ns *atomic.Int64
+}
+
+func (t *timedSource) Next(ctx context.Context) (*batch.RecordBatch, error) {
+	t0 := time.Now()
+	b, err := t.Source.Next(ctx)
+	t.ns.Add(time.Since(t0).Nanoseconds())
+	return b, err
 }
 
 // applyBackpressure pauses the consume loop briefly when the process heap
@@ -365,9 +442,13 @@ func (e *Executor) runFragmentLinear(ctx context.Context, task distributed.Task,
 	}
 	progress := exec.ProgressReporterFromContext(ctx)
 	fp := newFragmentProgress(e.logger, task, e)
+	src = fp.timeSource(src)
 	var totalRows int64
 	consume := func(ctx context.Context, b *batch.RecordBatch) error {
-		if err := sink.consume(ctx, b); err != nil {
+		t0 := time.Now()
+		err := sink.consume(ctx, b)
+		fp.sinkNs.Add(time.Since(t0).Nanoseconds())
+		if err != nil {
 			return err
 		}
 		n := int64(b.ActiveLen())
@@ -394,21 +475,30 @@ func (e *Executor) runFragmentLinear(ctx context.Context, task distributed.Task,
 			if b == nil {
 				return nil
 			}
+			t0 := time.Now()
 			select {
 			case <-gctx.Done():
 				return gctx.Err()
 			case ch <- b:
 			}
+			fp.srcBlockedNs.Add(time.Since(t0).Nanoseconds())
 		}
 	})
 	// Consumer: ops + sink. Drives backpressure (heap pause) and progress.
 	g.Go(func() error {
-		for b := range ch {
+		for {
+			t0 := time.Now()
+			b, ok := <-ch
+			fp.inputWaitNs.Add(time.Since(t0).Nanoseconds())
+			if !ok {
+				return nil
+			}
 			if err := fp.applyBackpressure(gctx); err != nil {
 				return err
 			}
 			cur := b
 			var err error
+			tOps := time.Now()
 			for _, op := range ops {
 				exec.FlattenForConsumer(cur, op)
 				cur, err = op.Execute(gctx, cur)
@@ -419,6 +509,7 @@ func (e *Executor) runFragmentLinear(ctx context.Context, task distributed.Task,
 					break
 				}
 			}
+			fp.opsNs.Add(time.Since(tOps).Nanoseconds())
 			if cur == nil || cur.ActiveLen() == 0 {
 				continue
 			}
@@ -426,11 +517,11 @@ func (e *Executor) runFragmentLinear(ctx context.Context, task distributed.Task,
 				return fmt.Errorf("sink consume: %w", err)
 			}
 		}
-		return nil
 	})
 	if err := g.Wait(); err != nil {
 		return fmt.Errorf("fragment task %s: %w", task.ID, err)
 	}
+	defer func() { fp.finish(totalRows) }() // closure: spill flush below still adds rows
 
 	// Spilled-partition flush. Grace Hash Join probes route rows whose hash
 	// partition was evicted to disk; without this drain, those probe rows
@@ -566,9 +657,14 @@ func (e *Executor) morselFragmentWorkers(task distributed.Task, ops []exec.Unary
 func (e *Executor) runFragmentLinearParallel(ctx context.Context, task distributed.Task, src exec.Source, ops []exec.UnaryOperator, sink fragmentSink, result *distributed.ResultNotification, k int) error {
 	progress := exec.ProgressReporterFromContext(ctx)
 	fp := newFragmentProgress(e.logger, task, e)
+	src = fp.timeSource(src)
 	var totalRows atomic.Int64
+	defer func() { fp.finish(totalRows.Load()) }()
 	consume := func(ctx context.Context, b *batch.RecordBatch) error {
-		if err := sink.consume(ctx, b); err != nil {
+		t0 := time.Now()
+		err := sink.consume(ctx, b)
+		fp.sinkNs.Add(time.Since(t0).Nanoseconds())
+		if err != nil {
 			return err
 		}
 		n := int64(b.ActiveLen())
@@ -648,6 +744,8 @@ func (e *Executor) runFragmentLinearParallel(ctx context.Context, task distribut
 		}()
 
 		runChain := func(ctx context.Context, chain []exec.UnaryOperator, b *batch.RecordBatch) (*batch.RecordBatch, error) {
+			t0 := time.Now()
+			defer func() { fp.opsNs.Add(time.Since(t0).Nanoseconds()) }()
 			cur := b
 			var err error
 			for _, op := range chain {
@@ -1088,6 +1186,10 @@ type fragmentBreaker struct {
 // stops emitting them as separate Sort stages).
 func (e *Executor) runFragmentWithBreakers(ctx context.Context, task distributed.Task, src exec.Source, middle []distributed.OpSpec, breakerIdxs []int, sink fragmentSink, result *distributed.ResultNotification, emitOps []*exec.DynamicFilterEmitOp) error {
 	progress := exec.ProgressReporterFromContext(ctx)
+	// Created up front (not at the final phase) so the elapsed clock and
+	// src timing cover the breaker-consume phases too.
+	fp := newFragmentProgress(e.logger, task, e)
+	src = fp.timeSource(src)
 
 	breakers := make([]*fragmentBreaker, len(breakerIdxs))
 	for i, idx := range breakerIdxs {
@@ -1185,10 +1287,13 @@ func (e *Executor) runFragmentWithBreakers(ctx context.Context, task distributed
 	defer finalCleanup()
 
 	last := breakers[len(breakers)-1]
-	fp := newFragmentProgress(e.logger, task, e)
 	var totalRows int64
+	defer func() { fp.finish(totalRows) }()
 	consume := func(ctx context.Context, b *batch.RecordBatch) error {
-		if err := sink.consume(ctx, b); err != nil {
+		t0 := time.Now()
+		err := sink.consume(ctx, b)
+		fp.sinkNs.Add(time.Since(t0).Nanoseconds())
+		if err != nil {
 			return err
 		}
 		n := int64(b.ActiveLen())
@@ -1208,12 +1313,14 @@ func (e *Executor) runFragmentWithBreakers(ctx context.Context, task distributed
 			break
 		}
 		cur := b
+		tOps := time.Now()
 		if last.DrainXform != nil {
 			cur, err = last.DrainXform(cur)
 			if err != nil {
 				return fmt.Errorf("fragment task %s: %s drain xform: %w", task.ID, last.Label, err)
 			}
 			if cur == nil {
+				fp.opsNs.Add(time.Since(tOps).Nanoseconds())
 				continue
 			}
 		}
@@ -1227,6 +1334,7 @@ func (e *Executor) runFragmentWithBreakers(ctx context.Context, task distributed
 				break
 			}
 		}
+		fp.opsNs.Add(time.Since(tOps).Nanoseconds())
 		if cur == nil || cur.ActiveLen() == 0 {
 			continue
 		}

--- a/internal/worker/fragment_phases_test.go
+++ b/internal/worker/fragment_phases_test.go
@@ -1,0 +1,72 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+)
+
+// sleepSource yields n empty-schema batches, sleeping per Next so the
+// timedSource wrapper has measurable wall to charge.
+type sleepSource struct {
+	n     int
+	sleep time.Duration
+}
+
+func (s *sleepSource) Init(context.Context) error { return nil }
+func (s *sleepSource) Close() error               { return nil }
+func (s *sleepSource) Next(context.Context) (*batch.RecordBatch, error) {
+	if s.n == 0 {
+		return nil, nil
+	}
+	s.n--
+	time.Sleep(s.sleep)
+	return batch.NewRecordBatch(nil, 0), nil
+}
+
+func TestTimedSourceChargesNextWall(t *testing.T) {
+	fp := newFragmentProgress(slog.Default(), distributed.Task{ID: "t", StageID: "s"}, nil)
+	src := fp.timeSource(&sleepSource{n: 3, sleep: 2 * time.Millisecond})
+	for {
+		b, err := src.Next(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if b == nil {
+			break
+		}
+	}
+	if got := fp.srcNs.Load(); got < (6 * time.Millisecond).Nanoseconds() {
+		t.Fatalf("srcNs = %d, want >= 6ms of charged Next wall", got)
+	}
+}
+
+func TestFragmentPhasesLine(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	fp := newFragmentProgress(logger, distributed.Task{ID: "t1", StageID: "join-6", StageType: "broadcast_join"}, nil)
+	fp.srcNs.Store((250 * time.Millisecond).Nanoseconds())
+	fp.opsNs.Store((100 * time.Millisecond).Nanoseconds())
+	fp.sinkNs.Store((50 * time.Millisecond).Nanoseconds())
+	fp.finish(1234)
+
+	out := buf.String()
+	if !strings.Contains(out, "fragment task phases") {
+		t.Fatalf("no phases line emitted: %q", out)
+	}
+	for _, want := range []string{"src_ms=250", "ops_ms=100", "sink_ms=50", "rows=1234"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("phases line missing %s: %q", want, out)
+		}
+	}
+	// Zero-valued phases stay off the line.
+	if strings.Contains(out, "input_wait_ms") || strings.Contains(out, "src_blocked_ms") {
+		t.Errorf("zero phases should be omitted: %q", out)
+	}
+}

--- a/internal/worker/stream_source.go
+++ b/internal/worker/stream_source.go
@@ -1073,13 +1073,19 @@ func (d *decodeAheadStatsIter) Close() error {
 	if !d.folded {
 		d.folded = true
 		groups, windowFulls, pressureStalls, tokenStalls, ledgerStalls := d.Stats()
+		windowFullNs, pressureNs, tokenNs, ledgerNs := d.StallDurations()
 		d.executor.scanDecodeAheadGroups.Add(groups)
 		d.executor.scanDecodeAheadWindowFulls.Add(windowFulls)
 		d.executor.scanDecodeAheadPressureStalls.Add(pressureStalls)
 		d.executor.scanDecodeAheadTokenStalls.Add(tokenStalls)
 		d.executor.scanDecodeAheadLedgerStalls.Add(ledgerStalls)
+		d.executor.scanDecodeAheadWindowFullNs.Add(windowFullNs)
+		d.executor.scanDecodeAheadPressureNs.Add(pressureNs)
+		d.executor.scanDecodeAheadTokenNs.Add(tokenNs)
+		d.executor.scanDecodeAheadLedgerNs.Add(ledgerNs)
 		d.executor.foldScanDecodeAheadQueryStats(d.queryID,
-			groups, windowFulls, pressureStalls, tokenStalls, ledgerStalls)
+			groups, windowFulls, pressureStalls, tokenStalls, ledgerStalls,
+			windowFullNs, pressureNs, tokenNs, ledgerNs)
 	}
 	return d.DecodeAheadIter.Close()
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -594,10 +594,13 @@ func (w *Worker) startScanDecodeAheadMarkerLoop(ctx context.Context) {
 				if cur != last {
 					last = cur
 					refaultRate, refaultActivations := memory.PageCachePressureStats()
+					windowFullNs, pressureNs, tokenNs, ledgerNs := w.executor.ScanDecodeAheadStallNs()
 					w.logger.Info("scan decode-ahead stats",
 						"groups", groups, "window_fulls", windowFulls,
 						"pressure_stalls", pressureStalls, "token_stalls", tokenStalls,
 						"ledger_stalls", ledgerStalls,
+						"window_full_ms", windowFullNs/1e6, "pressure_stall_ms", pressureNs/1e6,
+						"token_stall_ms", tokenNs/1e6, "ledger_stall_ms", ledgerNs/1e6,
 						"refault_rate", int64(refaultRate),
 						"refault_activations", refaultActivations)
 				}
@@ -865,10 +868,13 @@ func (w *Worker) Stop() {
 		w.executor.sweepScanDecodeAheadQueryStats(true)
 		groups, windowFulls, pressureStalls, tokenStalls, ledgerStalls := w.executor.ScanDecodeAheadStats()
 		refaultRate, refaultActivations := memory.PageCachePressureStats()
+		windowFullNs, pressureNs, tokenNs, ledgerNs := w.executor.ScanDecodeAheadStallNs()
 		w.logger.Info("scan decode-ahead stats (final)",
 			"groups", groups, "window_fulls", windowFulls,
 			"pressure_stalls", pressureStalls, "token_stalls", tokenStalls,
 			"ledger_stalls", ledgerStalls,
+			"window_full_ms", windowFullNs/1e6, "pressure_stall_ms", pressureNs/1e6,
+			"token_stall_ms", tokenNs/1e6, "ledger_stall_ms", ledgerNs/1e6,
 			"refault_rate", int64(refaultRate),
 			"refault_activations", refaultActivations)
 	}


### PR DESCRIPTION
## Summary

Three changes from the 2026-07-20 Q08/Q20/Q18 saved-log diagnosis (no-deploy pass over the reval/eager/gated SF100 runs):

1. **Same-stage placement anti-affinity** (`scheduler.go`): bin-packed tasks now spread across the workers with the fewest same-batch placements before "most free pool" ranks them. Stale heartbeats + tiny per-task estimates let an entire fan-out land on one worker (Q20 gated steady: all three 18M-row final-aggregate tasks on one worker, third +24s; placement clumps observed in every saved run, control included). Single-task publishes (retries, eager top-ups) degrade to the old behavior.
2. **Decode-ahead stall durations** (`decode_ahead.go` + worker fold): window-full/pressure/token/ledger blocked-time (ns) alongside the existing counts, per worker and per query. The Q08 diagnosis dead-ended precisely because slow and fast tasks logged near-identical stall *counts* while wall differed 3×.
3. **Fragment phase timing** (`executor_fragment.go`): per-task src / src-blocked / input-wait / ops / sink split on the 30s progress line, plus a completion-time `fragment task phases` line (INFO ≥5s, Debug below). Placement decisions now logged on `published tasks` (`spread=`, `placement=`).

Items 2–3 are the §12 eager-revival precondition-1 instrumentation (eager-consumer-dispatch.md).

## Validation

- `go test ./internal/...` green; new unit tests: `TestMinBatchWorkers`, `TestBinpackSpreadFanout` (replays the Q20 clump and proves 4/4/4 with the fix, 12/0/0 without), `TestTimedSourceChargesNextWall`, `TestFragmentPhasesLine`, duration assertions in the two decode-ahead stall tests.
- TPC-H SF0.01 correctness: pass.
- tpch-harness --mode=local: 22/22 row-checksums identical to main @ 8787fdf (q18=0 rows is slice-inherent, identical on main; the two micro checksum diffs are pre-existing row-order nondeterminism, unstable on main run-to-run).
- SF100 pair: pending (binaries staged at `bin/d484147`, cluster not yet applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRLkDz9MVaSoFP5kEJSRQD