### PR TITLE
perf(planner): narrow shuffle payloads — sanitize scan columns, carry projection through absorbed shuffles

### DIFF
--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -971,11 +971,21 @@ func (c *Coordinator) dispatchShuffleStage(
 	// Synthesize a source stage for runShuffleSide. EstimatedBytes carries
 	// the upstream's worker-reported output size so the shuffle tasks get
 	// per-task admission estimates (runShuffleSide splits it per task).
+	// ScanTable/ScanColumns ride along when the upstream is a pass-through
+	// leaf scan, so runShuffleSide's prunedScanColumns can narrow the
+	// shuffle tasks' parquet reads — otherwise scan-absorbed legs shuffle
+	// every column of the base table (memo §2 A2). Chained shuffles leave
+	// both empty: WSHF inputs ignore column projection.
+	synthTable := stage.TableName
+	if synthTable == "" {
+		synthTable = upstream.ScanTable
+	}
 	synthetic := physical.Stage{
 		ID:             stage.ID + "-src",
 		Type:           physical.StageScan,
 		ScanFiles:      sourceFiles,
-		TableName:      stage.TableName, // may be empty for chained shuffles; worker falls back to generic scan
+		TableName:      synthTable,
+		Columns:        upstream.ScanColumns,
 		EstimatedBytes: upstream.Bytes,
 	}
 	numParts := stage.Exchange.Count
@@ -1323,9 +1333,11 @@ func (c *Coordinator) dispatchPipelineStage(
 		}
 		files := append([]string(nil), stage.ScanFiles...)
 		out := StageOutput{
-			Kind:  OutputSinglePart,
-			Files: [][]string{files},
-			Bytes: stage.EstimatedBytes, // catalog-true file sizes
+			Kind:        OutputSinglePart,
+			Files:       [][]string{files},
+			Bytes:       stage.EstimatedBytes, // catalog-true file sizes
+			ScanTable:   stage.TableName,
+			ScanColumns: append([]string(nil), stage.Columns...),
 		}
 		// Materialize Consume specs into wire form so downstream shuffle/
 		// stage dispatchers can ship them in their task descriptors

--- a/internal/coordinator/shuffle_projection_test.go
+++ b/internal/coordinator/shuffle_projection_test.go
@@ -1,0 +1,239 @@
+package coordinator
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/benchmarks/tpch"
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/storage/catalog"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+	"github.com/citc-tech/wadjet/internal/worker"
+)
+
+// TestShuffleProjectionNarrowsAbsorbedScans is the end-to-end regression
+// test for docs/design/exchange-reuse.md §2 A2: a repartition whose
+// dependency is a pass-through leaf scan (unfiltered, file count >
+// workerCount so fuseScanShuffle skips it) must shuffle only the scan's
+// required columns, not the full table width. Before the fix the
+// synthetic source stage handed to runShuffleSide carried no column
+// list, and Q21/Q18's raw lineitem legs shipped all 16 columns
+// (85.69 GB vs ~12 GB needed at SF100).
+//
+// The assertion reads the WSHF partition headers the shuffle tasks
+// actually wrote: no repartition output may carry lineitem's full width.
+func TestShuffleProjectionNarrowsAbsorbedScans(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	t.Cleanup(cancel)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	natsCfg := distributed.DefaultNATSConfig()
+	natsCfg.Port = -1
+	natsCfg.StoreDir = t.TempDir()
+	embeddedNATS, err := distributed.NewEmbeddedNATS(natsCfg, logger)
+	if err != nil {
+		t.Fatalf("starting NATS: %v", err)
+	}
+	t.Cleanup(embeddedNATS.Shutdown)
+
+	nc, err := distributed.ConnectInProcess(embeddedNATS.Server())
+	if err != nil {
+		t.Fatalf("connecting to NATS: %v", err)
+	}
+	t.Cleanup(func() { nc.Close() })
+
+	js, err := distributed.NewJetStream(nc)
+	if err != nil {
+		t.Fatalf("creating JetStream: %v", err)
+	}
+	if err := distributed.SetupStreams(ctx, js); err != nil {
+		t.Fatalf("setting up streams: %v", err)
+	}
+
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(ctx, "test"); err != nil {
+		t.Fatal(err)
+	}
+	kv, err := catalog.NewNATSKV(js)
+	if err != nil {
+		t.Fatalf("creating NATS KV: %v", err)
+	}
+	cat := catalog.New(kv, store, "test")
+	if err := cat.Init(ctx); err != nil {
+		t.Fatalf("catalog init: %v", err)
+	}
+
+	// Write each table; lineitem in 5 chunks so its scan stays above the
+	// fuseScanShuffle workerCount cap and the repartition absorbs it (the
+	// pass-through + dispatchShuffleStage path under test).
+	data := tpch.Generate(tpch.SF001)
+	for tableName, schema := range tpch.AllTables {
+		if err := cat.CreateTable(ctx, tableName, schema, nil); err != nil {
+			t.Fatalf("creating table %s: %v", tableName, err)
+		}
+		rows := data[tableName]
+		if len(rows) == 0 {
+			continue
+		}
+		chunks := 1
+		if tableName == "lineitem" {
+			chunks = 5
+		}
+		per := (len(rows) + chunks - 1) / chunks
+		for ci := 0; ci < chunks; ci++ {
+			lo, hi := ci*per, (ci+1)*per
+			if hi > len(rows) {
+				hi = len(rows)
+			}
+			if lo >= hi {
+				break
+			}
+			var buf bytes.Buffer
+			pw, err := parquet.NewWriter(&buf, schema, parquet.DefaultWriterConfig())
+			if err != nil {
+				t.Fatalf("parquet writer for %s: %v", tableName, err)
+			}
+			if err := pw.WriteRows(rows[lo:hi]); err != nil {
+				t.Fatalf("writing %s rows: %v", tableName, err)
+			}
+			if err := pw.Close(); err != nil {
+				t.Fatalf("closing %s writer: %v", tableName, err)
+			}
+			filePath := fmt.Sprintf("tables/%s/chunk_%04d.parquet", tableName, ci+1)
+			pdata := buf.Bytes()
+			if _, err := store.Put(ctx, "test", filePath, bytes.NewReader(pdata), int64(len(pdata)), "application/octet-stream"); err != nil {
+				t.Fatalf("storing %s parquet: %v", tableName, err)
+			}
+			if err := cat.AddFiles(ctx, tableName, map[string]string{}, "tables/"+tableName+"/", []catalog.FileEntry{{
+				Path:      filePath,
+				SizeBytes: int64(len(pdata)),
+				NumRows:   int64(hi - lo),
+				CreatedAt: time.Now(),
+			}}); err != nil {
+				t.Fatalf("adding %s to manifest: %v", tableName, err)
+			}
+		}
+	}
+
+	for i := 0; i < 3; i++ {
+		w := worker.New(worker.Config{
+			NATSUrl:       embeddedNATS.ClientURL(),
+			MaxConcurrent: 4,
+			CacheBytes:    64 * 1024 * 1024,
+		}, store, nc, js, logger)
+		workerCtx, workerCancel := context.WithCancel(context.Background())
+		t.Cleanup(workerCancel)
+		if err := w.Start(workerCtx); err != nil {
+			t.Fatalf("starting worker %d: %v", i, err)
+		}
+		t.Cleanup(w.Stop)
+	}
+
+	coord := New(Config{
+		NATSUrl:      embeddedNATS.ClientURL(),
+		ResultBucket: "test",
+		// Force hash joins with real repartition exchanges: at SF0.01
+		// every table fits the broadcast threshold and the path under
+		// test (scan-absorbed repartition) would never run.
+		BroadcastBytesOverride: 1024,
+	}, cat, nc, js, logger)
+	for i := 0; i < 3; i++ {
+		coord.workers.record(distributed.WorkerHeartbeat{
+			WorkerID:  fmt.Sprintf("fake-worker-%d", i),
+			Timestamp: time.Now(),
+		})
+	}
+
+	// Q21: two of its lineitem legs shuffle straight from base parquet.
+	q := tpch.TPCHQueries[21]
+	result, err := coord.ExecuteSQL(ctx, q.SQL)
+	if err != nil {
+		t.Fatalf("Q21 ExecuteSQL: %v", err)
+	}
+	if result.Error != "" {
+		t.Fatalf("Q21 error: %s", result.Error)
+	}
+	if rows := mustRows(t, result); len(rows) != 1 {
+		t.Fatalf("Q21 rows = %d, want 1 (SF0.01 reference)", len(rows))
+	}
+
+	fullWidth := len(tpch.AllTables["lineitem"].Columns)
+	infos, err := store.List(ctx, "test", objstore.ListOptions{Prefix: "queries/"})
+	if err != nil {
+		t.Fatalf("listing scratch: %v", err)
+	}
+	checked := 0
+	seen := map[string]int{}
+	for _, info := range infos {
+		if i := strings.Index(info.Key, "/"); i > 0 {
+			if j := strings.Index(info.Key[i+1:], "/"); j > 0 {
+				seen[info.Key[i+1:i+1+j]]++
+			}
+		}
+		if !strings.Contains(info.Key, "exchange-repartition") || !strings.Contains(info.Key, ".wshf") {
+			continue
+		}
+		cols, err := readWSHFColCount(ctx, store, "test", info.Key)
+		if err != nil {
+			t.Fatalf("reading %s: %v", info.Key, err)
+		}
+		if cols == 0 {
+			continue // empty partition file with no header
+		}
+		checked++
+		if cols >= fullWidth {
+			t.Errorf("shuffle partition %s has %d columns (full lineitem width %d) — absorbed-scan projection lost", info.Key, cols, fullWidth)
+		}
+	}
+	if checked == 0 {
+		t.Fatalf("no repartition partition files found in scratch — the path under test did not run (plan shape changed or scratch purged?); scratch dirs: %v (total %d keys); keys: %v", seen, len(infos), keyNames(infos))
+	}
+	t.Logf("checked %d repartition partitions, all narrower than %d columns", checked, fullWidth)
+}
+
+func keyNames(infos []objstore.ObjectInfo) []string {
+	out := make([]string, 0, len(infos))
+	for _, i := range infos {
+		out = append(out, i.Key)
+	}
+	return out
+}
+
+// readWSHFColCount parses a WSHF header's NumCols, transparently
+// decompressing s2-compressed bodies.
+func readWSHFColCount(ctx context.Context, store objstore.Store, bucket, key string) (int, error) {
+	rc, _, err := store.Get(ctx, bucket, key)
+	if err != nil {
+		return 0, err
+	}
+	defer rc.Close()
+	raw, err := io.ReadAll(rc)
+	if err != nil {
+		return 0, err
+	}
+	if len(raw) == 0 {
+		return 0, nil
+	}
+	if !bytes.HasPrefix(raw, []byte("WSHF")) {
+		if raw, err = worker.DecompressShuffleData(raw); err != nil {
+			return 0, fmt.Errorf("neither raw WSHF nor s2: %w", err)
+		}
+		if !bytes.HasPrefix(raw, []byte("WSHF")) {
+			return 0, fmt.Errorf("decompressed body is not WSHF")
+		}
+	}
+	if len(raw) < 10 {
+		return 0, fmt.Errorf("truncated WSHF header (%d bytes)", len(raw))
+	}
+	return int(binary.LittleEndian.Uint16(raw[8:10])), nil
+}

--- a/internal/coordinator/skew_split_test.go
+++ b/internal/coordinator/skew_split_test.go
@@ -404,12 +404,19 @@ func TestSkewSplitParity(t *testing.T) {
 		return c
 	}
 
+	// Both queries aggregate over e.v so the fat pad column legitimately
+	// survives shuffle projection — before the 2026-07-21 projection fix
+	// (exchange-reuse memo A1/A2) the fixture leaned on the projection
+	// BUG to ship v: the queries never referenced it, but the polluted
+	// column list reverted the scan to full width. With real projection,
+	// k-only shuffles fall below the skew byte thresholds and the split
+	// never engages.
 	queries := []string{
 		// Inner join + aggregate over the hot key's dimension.
-		"SELECT d.name, count(*) AS cnt FROM events e JOIN dims d ON e.k = d.k GROUP BY d.name ORDER BY d.name",
+		"SELECT d.name, count(*) AS cnt, min(e.v) AS mv FROM events e JOIN dims d ON e.k = d.k GROUP BY d.name ORDER BY d.name",
 		// Left join: unmatched probe rows (keys >= 48) must survive the
 		// split exactly once each.
-		"SELECT count(*) AS total_rows, count(d.name) AS matched_rows FROM events e LEFT JOIN dims d ON e.k = d.k",
+		"SELECT count(*) AS total_rows, count(d.name) AS matched_rows, min(e.v) AS mv FROM events e LEFT JOIN dims d ON e.k = d.k",
 	}
 
 	run := func(c *Coordinator, sql string) string {

--- a/internal/coordinator/stage_output.go
+++ b/internal/coordinator/stage_output.go
@@ -62,6 +62,18 @@ type StageOutput struct {
 	// across pass-through leaf scans that don't dispatch tasks themselves.
 	DynamicFilters []distributed.DynamicFilterSpec
 
+	// ScanTable/ScanColumns identify a pass-through leaf scan's relation
+	// and (sanitized) projection. Set ONLY on the no-task pass-through
+	// path, where downstream shuffle tasks read base parquet directly —
+	// dispatchShuffleStage copies them onto its synthetic source stage so
+	// prunedScanColumns can narrow the shuffle payload. Without them the
+	// synthetic stage has no column list and every scan-absorbed shuffle
+	// leg ships full-width rows (85.69 GB vs ~12 GB needed on Q21's l2
+	// leg; docs/design/exchange-reuse.md §2 A2). Empty on all other
+	// outputs — WSHF inputs ignore column projection.
+	ScanTable   string
+	ScanColumns []string
+
 	// eager marks a PROVISIONAL output synthesized by an eagerly-cleared
 	// consumer (eagerFeed.provisionalOutput): the producer stage is still
 	// running, Files is the empty layout, and dispatchComputeStage must

--- a/internal/planner/logical/optimizer.go
+++ b/internal/planner/logical/optimizer.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 	"math"
 	"math/bits"
+	"os"
+	"sort"
 	"strings"
 	"sync/atomic"
 
@@ -39,6 +41,14 @@ func Optimize(plan *Node, annotators ...func(*Node)) *Node {
 	plan = rewriteDistinctAsGroupBy(plan)
 	plan = extractPartitionFilters(plan)
 	plan = pruneProjections(plan)
+	// Re-annotate before column pruning: scans created AFTER the first
+	// annotator pass (scalar-subquery decorrelation) have no ScanColumns,
+	// and sanitizeScanNeeds can only drop other-table pollution when it
+	// knows the scan's schema (it conservatively keeps everything
+	// otherwise). Annotators are idempotent.
+	for _, annotate := range annotators {
+		annotate(plan)
+	}
 	computeRequiredColumns(plan)
 	attachScanPredicates(plan)
 	return plan
@@ -74,6 +84,66 @@ func attachScanPredicates(n *Node) {
 // columns from storage.
 func computeRequiredColumns(n *Node) {
 	pushColumnNeeds(n, nil)
+}
+
+// scanColSanitize gates sanitizeScanNeeds (WADJET_SCAN_COL_SANITIZE=0
+// restores the pre-2026-07 polluted lists for A/B). Default on.
+var scanColSanitize = os.Getenv("WADJET_SCAN_COL_SANITIZE") != "0"
+
+// sanitizeScanNeeds turns the ancestor-accumulated needs set into a clean
+// RequiredColumns list for one scan. The accumulated set carries junk the
+// scan can never produce — alias-qualified duplicates ("l1.l_receiptdate"
+// next to "l_receiptdate") and the OTHER side's join-key columns
+// ("s_suppkey" landing on a lineitem scan via "s_suppkey = l1.l_suppkey").
+// Any such name trips the worker's all-or-nothing parquet projection guard
+// (cachedFileStreamSource.projectColumns) and silently reverts the scan —
+// and every shuffle fed by it — to full width: Q21's l1 leg measured
+// 143 B/row against the 25 B/row its clean sibling leg achieves
+// (docs/design/exchange-reuse.md §2 A1).
+//
+// Rules, conservative toward keeping:
+//   - "alias.col" where alias is THIS scan (TableAlias or TableName):
+//     rewritten to bare col. Other aliases: dropped — provably another
+//     relation's column.
+//   - bare names when ScanColumns (catalog schema, AnnotateScanColumns) is
+//     known: kept iff in the schema, EXCEPT "__"-prefixed derived names
+//     (e.g. __having_0), which are kept so the worker guard's
+//     derived-column semantics are preserved exactly.
+//   - bare names when ScanColumns is empty (no catalog at plan time):
+//     kept — we cannot judge, and full width is the safe failure mode.
+//
+// Output is sorted for deterministic plans.
+func sanitizeScanNeeds(n *Node, needs map[string]bool) []string {
+	if !scanColSanitize {
+		cols := make([]string, 0, len(needs))
+		for col := range needs {
+			cols = append(cols, col)
+		}
+		sort.Strings(cols)
+		return cols
+	}
+	inSchema := make(map[string]bool, len(n.ScanColumns))
+	for _, c := range n.ScanColumns {
+		inSchema[strings.ToLower(c)] = true
+	}
+	keep := make(map[string]bool, len(needs))
+	for name := range needs {
+		if alias, col, ok := strings.Cut(name, "."); ok {
+			if strings.EqualFold(alias, n.TableAlias) || strings.EqualFold(alias, n.TableName) {
+				keep[col] = true
+			}
+			continue // other relation's qualified column: drop
+		}
+		if len(inSchema) == 0 || inSchema[strings.ToLower(name)] || strings.HasPrefix(name, "__") {
+			keep[name] = true
+		}
+	}
+	cols := make([]string, 0, len(keep))
+	for col := range keep {
+		cols = append(cols, col)
+	}
+	sort.Strings(cols)
+	return cols
 }
 
 // pushColumnNeeds recursively pushes the set of needed columns from parent
@@ -137,11 +207,7 @@ func pushColumnNeeds(n *Node, parentNeeds map[string]bool) {
 
 	if n.Type == NodeScan {
 		if len(needs) > 0 {
-			cols := make([]string, 0, len(needs))
-			for col := range needs {
-				cols = append(cols, col)
-			}
-			n.RequiredColumns = cols
+			n.RequiredColumns = sanitizeScanNeeds(n, needs)
 		}
 		return
 	}

--- a/internal/planner/logical/sanitize_scan_needs_test.go
+++ b/internal/planner/logical/sanitize_scan_needs_test.go
@@ -1,0 +1,93 @@
+package logical
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestSanitizeScanNeeds(t *testing.T) {
+	lineitem := &Node{
+		Type:        NodeScan,
+		TableName:   "lineitem",
+		TableAlias:  "l1",
+		ScanColumns: []string{"l_orderkey", "l_suppkey", "l_receiptdate", "l_commitdate", "l_quantity"},
+	}
+	noSchema := &Node{Type: NodeScan, TableName: "lineitem", TableAlias: "l1"}
+
+	tests := []struct {
+		name  string
+		node  *Node
+		needs []string
+		want  []string
+	}{
+		{
+			// The Q21 l1 shape (memo §2 A1): alias-qualified dupes resolve
+			// to bare, the other side's join key drops.
+			"alias dupes and other-table key",
+			lineitem,
+			[]string{"l1.l_receiptdate", "l_receiptdate", "l1.l_commitdate", "l_commitdate", "s_suppkey", "l_suppkey", "l_orderkey"},
+			[]string{"l_commitdate", "l_orderkey", "l_receiptdate", "l_suppkey"},
+		},
+		{
+			// The Q18 outer-leg shape: bare other-table join key drops.
+			"bare other-table join key",
+			lineitem,
+			[]string{"l_quantity", "l_orderkey", "o_orderkey"},
+			[]string{"l_orderkey", "l_quantity"},
+		},
+		{
+			// Alias-qualified for a DIFFERENT alias drops even without schema.
+			"foreign alias drops without schema",
+			noSchema,
+			[]string{"s.s_suppkey", "l1.l_orderkey", "l_quantity"},
+			[]string{"l_orderkey", "l_quantity"},
+		},
+		{
+			// Derived names are kept: the worker guard's full-width
+			// fallback for unknown derivation inputs must stay reachable.
+			"derived __ names kept",
+			lineitem,
+			[]string{"l_quantity", "__having_0"},
+			[]string{"__having_0", "l_quantity"},
+		},
+		{
+			// No schema → bare names cannot be judged; keep all.
+			"no schema keeps bare names",
+			noSchema,
+			[]string{"l_quantity", "o_orderkey"},
+			[]string{"l_quantity", "o_orderkey"},
+		},
+		{
+			// Table name works as the alias when no explicit alias exists.
+			"table name as alias",
+			&Node{Type: NodeScan, TableName: "orders", ScanColumns: []string{"o_orderkey"}},
+			[]string{"orders.o_orderkey"},
+			[]string{"o_orderkey"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			needs := make(map[string]bool, len(tc.needs))
+			for _, n := range tc.needs {
+				needs[n] = true
+			}
+			got := sanitizeScanNeeds(tc.node, needs)
+			sort.Strings(got)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("sanitizeScanNeeds = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeScanNeedsKillSwitch(t *testing.T) {
+	old := scanColSanitize
+	scanColSanitize = false
+	defer func() { scanColSanitize = old }()
+	n := &Node{Type: NodeScan, TableName: "lineitem", ScanColumns: []string{"l_orderkey"}}
+	got := sanitizeScanNeeds(n, map[string]bool{"s_suppkey": true, "l_orderkey": true})
+	if len(got) != 2 {
+		t.Fatalf("kill switch off should keep raw set, got %v", got)
+	}
+}

--- a/internal/planner/physical/scan_columns_sanitize_test.go
+++ b/internal/planner/physical/scan_columns_sanitize_test.go
@@ -1,0 +1,43 @@
+package physical
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestScanColumnsSanitized is the plan-level regression test for memo
+// exchange-reuse.md §2 A1: scan stages must never carry alias-qualified
+// or other-table column names — one such name trips the worker's
+// all-or-nothing parquet projection guard and silently reverts the scan
+// (and every shuffle it feeds) to full width. Before the
+// sanitizeScanNeeds fix, Q21's l1 scan carried "l1.l_receiptdate" and
+// "s_suppkey" (143 B/row shuffled vs 25 B/row on the clean sibling leg).
+func TestScanColumnsSanitized(t *testing.T) {
+	cat, ctx := setupTPCHCatalog(t)
+	for name, sql := range tpchPlanQueries {
+		t.Run(name, func(t *testing.T) {
+			for _, s := range sqlToStages(t, cat, ctx, sql, 3) {
+				if s.Type != "scan" || s.TableName == "" {
+					continue
+				}
+				schema, ok := tpchSchemas[s.TableName]
+				if !ok {
+					continue
+				}
+				valid := make(map[string]bool, len(schema.Columns))
+				for _, c := range schema.Columns {
+					valid[strings.ToLower(c.Name)] = true
+				}
+				for _, col := range s.Columns {
+					if strings.Contains(col, ".") {
+						t.Errorf("stage %s (%s): alias-qualified column %q survived sanitization", s.ID, s.TableName, col)
+						continue
+					}
+					if !valid[strings.ToLower(col)] && !strings.HasPrefix(col, "__") {
+						t.Errorf("stage %s (%s): column %q is not in the table schema (other-table pollution)", s.ID, s.TableName, col)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/worker/stream_source.go
+++ b/internal/worker/stream_source.go
@@ -75,6 +75,11 @@ type cachedFileStreamSource struct {
 	// without needing to teach the source about derivation rules.
 	projectColumns []string
 
+	// projectionSkipWarned dedupes the once-per-source WARN emitted when
+	// projectColumns names a column absent from the file schema (the
+	// all-or-nothing guard reverting to full width).
+	projectionSkipWarned bool
+
 	// Row-group sharding. When shardCount > 1, parquet reads only row groups
 	// [idx*N/count, (idx+1)*N/count). Only applies to parquet inputs (.wshf
 	// shuffle outputs are unaffected — those are already partitioned by the
@@ -864,11 +869,23 @@ func (s *cachedFileStreamSource) buildParquetState(filePath string, data, mmapDa
 			schemaSet[c.Name] = true
 		}
 		allPresent := true
+		var missing []string
 		for _, name := range s.projectColumns {
 			if !schemaSet[name] {
 				allPresent = false
-				break
+				missing = append(missing, name)
 			}
+		}
+		if !allPresent && !s.projectionSkipWarned {
+			// Once per source, not per file: a 600-file scan reverting to
+			// full width is one event. Legitimate for derived columns
+			// (pre-project computes them); polluted planner lists were the
+			// silent 5-6x shuffle-byte amplifier of memo §2 A1 — this line
+			// is how the next regression of that class gets seen.
+			s.projectionSkipWarned = true
+			s.executor.logger.Warn("parquet projection skipped: requested columns missing from schema (reading full width)",
+				"query_id", s.queryID, "missing", strings.Join(missing, ","),
+				"requested", len(s.projectColumns))
 		}
 		if allPresent {
 			wanted := make(map[string]bool, len(s.projectColumns))


### PR DESCRIPTION
Implements levers **A1+A2** of `docs/design/exchange-reuse.md` (memo in #248): ~200GB of excess S3/network shuffle traffic per SF100 steady pass in Q18+Q21 alone, plus the same defect suite-wide on every scan-absorbed shuffle leg.

## A1 — planner: sanitize scan column lists
`pushColumnNeeds` dumped the ancestor-accumulated needs set onto every scan: alias-qualified duplicates (`l1.l_receiptdate`) and other-table join keys (`s_suppkey` on a lineitem scan) tripped the worker's all-or-nothing parquet projection guard → silent full-width scan and shuffle (Q21 l1 leg: 143B/row vs the 25B/row its clean sibling leg proves achievable). `sanitizeScanNeeds`: self-alias → bare, other-relation names dropped when the catalog schema is known, `__`-prefixed derived names kept (guard semantics preserved exactly). Scalar-subquery-decorrelated scans are re-annotated before pruning (they had no ScanColumns). Kill switch `WADJET_SCAN_COL_SANITIZE=0`.

## A2 — coordinator: absorbed shuffles keep the projection
`dispatchShuffleStage`'s synthetic source stage carried no `Columns`, so every scan-absorbed repartition shuffled full table width (Q21 r-11 ≡ Q18 r-7: byte-identical 85.69GB of full-width raw lineitem at SF100). Pass-through leaf-scan `StageOutput`s now carry `ScanTable`/`ScanColumns`; the synthetic stage forwards them through `prunedScanColumns` (catalog-intersected, junk can't leak). WSHF-input chained shuffles unchanged.

## Worker
The projection guard now WARNs once per source when it reverts to full width, naming the missing columns — this failure mode was invisible for months.

## Tests
- `TestSanitizeScanNeeds` — rules + kill switch.
- `TestScanColumnsSanitized` — plan-level, all TPC-H fixtures (fails pre-fix on Q02/Q21).
- `TestShuffleProjectionNarrowsAbsorbedScans` — e2e with real workers, lineitem in 5 chunks to force the absorbed path; reads the WSHF partition headers the shuffle actually wrote. Fails pre-fix with 16-column partitions; passes post-fix (384 partitions checked).
- `TestSkewSplitParity` fixture updated: it accidentally depended on the projection bug to ship its pad column (now referenced via `min(e.v)`; splits still engage, parity holds).

## Gates
Unit suite green (exit-code-verified), TPC-H SF0.01 pass, `tpch-harness --mode=local` 22/22 row-checksums identical to main.

SF100 validation pair: next (per memo §5, one pair covers the A batch; lever B rides separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRLkDz9MVaSoFP5kEJSRQD