### PR TITLE
perf(planner): defer all uncorrelated scalar subqueries to producer stages

### DIFF
--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/citc-tech/wadjet/internal/config"
 	"github.com/citc-tech/wadjet/internal/engine/batch"
@@ -592,6 +593,13 @@ func (p *Planner) executeSubquery(ctx context.Context, sql string) ([]map[string
 	return collectSink.ToRows(), nil
 }
 
+// scalarDeferAll gates deferring ALL uncorrelated scalar filter subqueries
+// to distributed producer stages (not only CTE-referencing ones).
+// Kill switch: WADJET_SCALAR_DEFER=0 reverts non-CTE subqueries to eager
+// plan-time execution on the coordinator's single-process pipeline
+// (mirrors WADJET_EXCHANGE_ELIDE / WADJET_SCAN_COL_SANITIZE).
+var scalarDeferAll = os.Getenv("WADJET_SCALAR_DEFER") != "0"
+
 // deferredScalar carries a single CTE-referencing subquery whose resolution
 // has been deferred until coordinator dispatch. The placeholder is a colon-
 // prefixed identifier rendered into the serialized filter expression; the
@@ -675,16 +683,24 @@ func (p *Planner) resolveSubqueryAST(ctx context.Context, node plansql.Node, def
 
 	switch n := node.(type) {
 	case *plansql.SubqueryNode:
-		// If the subquery references a CTE we must defer evaluation so it
-		// shares the distributed accumulation path rather than running as a
-		// single-process pipeline over the cteCache (which floats-drifts vs
-		// the outer query's distributed aggregate).
-		if p.subqueryReferencesCTE(n.SQL) {
+		// Defer scalar subqueries to producer stages so they share the
+		// distributed accumulation path instead of running as a silent
+		// single-process pipeline on the coordinator at plan time (Q11's
+		// partsupp⨝supplier⨝nation subquery cost ~39s/query at SF100 this
+		// way, Q22's customer avg ~10s). CTE-referencing subqueries MUST
+		// defer regardless of the kill switch — eager evaluation over the
+		// cteCache floats-drifts vs the outer query's distributed
+		// aggregate (the Q15 SF0.1 0-row bug).
+		if scalarDeferAll || p.subqueryReferencesCTE(n.SQL) {
 			name := p.allocScalarPlaceholder()
 			*deferred = append(*deferred, deferredScalar{Placeholder: name, SubquerySQL: n.SQL})
 			return &plansql.LiteralPlaceholder{Name: name}
 		}
+		start := time.Now()
 		rows, err := p.executeSubquery(ctx, n.SQL)
+		slog.Info("plan-time scalar subquery executed on coordinator",
+			"duration", time.Since(start).Round(time.Millisecond),
+			"rows", len(rows), "error", err != nil)
 		if err != nil || len(rows) == 0 {
 			return node
 		}
@@ -3608,13 +3624,26 @@ func (p *Planner) walkStages(node *logical.Node, stages *[]Stage, parentID *stri
 						// a literal in place of the placeholder. Loses
 						// correctness for CTE-drift cases but keeps the query
 						// running rather than failing outright.
+						start := time.Now()
 						rows, sErr := p.executeSubquery(p.planCtx, d.SubquerySQL)
+						slog.Warn("scalar producer emission failed; executed subquery on coordinator",
+							"duration", time.Since(start).Round(time.Millisecond),
+							"emit_error", err, "exec_error", sErr)
+						spliced := false
 						if sErr == nil && len(rows) > 0 {
 							for _, v := range rows[0] {
 								lit := scalarToLiteral(v).String()
 								resolvedExpr = strings.ReplaceAll(resolvedExpr, ":"+d.Placeholder, lit)
+								spliced = true
 								break
 							}
+						}
+						if !spliced {
+							// Both paths failed: restore the original subquery
+							// text so downstream sees what it saw before
+							// deferral existed, not a dangling :scalar_N.
+							resolvedExpr = strings.ReplaceAll(resolvedExpr,
+								":"+d.Placeholder, "("+d.SubquerySQL+")")
 						}
 						continue
 					}

--- a/internal/planner/physical/scalar_defer_all_test.go
+++ b/internal/planner/physical/scalar_defer_all_test.go
@@ -1,0 +1,136 @@
+package physical
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/planner/logical"
+	plansql "github.com/citc-tech/wadjet/internal/planner/sql"
+)
+
+// TestScalarDeferAll_Q11_Q22 verifies that non-CTE uncorrelated scalar
+// subqueries are deferred to distributed producer stages instead of being
+// executed eagerly on the coordinator's single-process pipeline at plan
+// time. Before this change Q11 spent ~39s and Q22 ~10s per SF100 execution
+// inside resolveSubqueryAST→executeSubquery, silently, before "stage-DAG
+// dispatch" — the DAG saw none of it. Deferral routes the subquery through
+// the same producer-stage/ScalarDependencies path built for Q15's
+// CTE-referencing case.
+func TestScalarDeferAll_Q11_Q22(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		qNum int
+	}{
+		{"Q11_having_sum_threshold", 11},
+		{"Q22_where_avg_acctbal", 22},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cat, ctx := setupTPCHCatalog(t)
+
+			sql := tpchPlanQueryMap[tc.qNum]
+			parsed, err := plansql.Parse(sql)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			info, err := plansql.ExtractSelect(parsed)
+			if err != nil {
+				t.Fatalf("extract: %v", err)
+			}
+			logicalPlan, err := logical.BuildFromSelect(info)
+			if err != nil {
+				t.Fatalf("logical plan: %v", err)
+			}
+			scanAnnotator := func(plan *logical.Node) {
+				NewPlanner(cat).AnnotateScanColumns(ctx, plan)
+			}
+			scanAnnotator(logicalPlan)
+			logicalPlan = logical.Optimize(logicalPlan, scanAnnotator)
+
+			planner := NewPlanner(cat)
+			planner.WorkerCount = 4
+
+			stages, err := planner.PlanDistributed(ctx, logicalPlan)
+			if err != nil {
+				t.Fatalf("PlanDistributed: %v", err)
+			}
+
+			var filterStage *Stage
+			for i := range stages {
+				if len(stages[i].ScalarDependencies) > 0 {
+					filterStage = &stages[i]
+					break
+				}
+			}
+			if filterStage == nil {
+				t.Fatal("expected a stage with ScalarDependencies — scalar subquery was resolved eagerly at plan time instead of deferred")
+			}
+
+			stageByID := make(map[string]*Stage, len(stages))
+			for i := range stages {
+				stageByID[stages[i].ID] = &stages[i]
+			}
+			var sawPlaceholder bool
+			for ph, producerID := range filterStage.ScalarDependencies {
+				prod, ok := stageByID[producerID]
+				if !ok {
+					t.Fatalf("stage %s: placeholder %q references missing producer %q", filterStage.ID, ph, producerID)
+				}
+				if prod.Tasks != 1 {
+					t.Errorf("producer stage %s: want Tasks=1 for singleton scalar output, got %d", producerID, prod.Tasks)
+				}
+				for _, expr := range filterStage.FilterExprs {
+					if strings.Contains(expr, ":"+ph) {
+						sawPlaceholder = true
+					}
+				}
+			}
+			if !sawPlaceholder {
+				t.Errorf("stage %s: no FilterExpr contains the placeholder; FilterExprs=%v",
+					filterStage.ID, filterStage.FilterExprs)
+			}
+		})
+	}
+}
+
+// TestScalarDeferAll_KillSwitch verifies WADJET_SCALAR_DEFER=0 restores the
+// legacy eager path for non-CTE subqueries (no ScalarDependencies emitted;
+// the filter carries an inlined literal or the original subquery text).
+func TestScalarDeferAll_KillSwitch(t *testing.T) {
+	old := scalarDeferAll
+	scalarDeferAll = false
+	defer func() { scalarDeferAll = old }()
+
+	cat, ctx := setupTPCHCatalog(t)
+	sql := tpchPlanQueryMap[22]
+	parsed, err := plansql.Parse(sql)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	info, err := plansql.ExtractSelect(parsed)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	logicalPlan, err := logical.BuildFromSelect(info)
+	if err != nil {
+		t.Fatalf("logical plan: %v", err)
+	}
+	scanAnnotator := func(plan *logical.Node) {
+		NewPlanner(cat).AnnotateScanColumns(ctx, plan)
+	}
+	scanAnnotator(logicalPlan)
+	logicalPlan = logical.Optimize(logicalPlan, scanAnnotator)
+
+	planner := NewPlanner(cat)
+	planner.WorkerCount = 4
+	stages, err := planner.PlanDistributed(ctx, logicalPlan)
+	if err != nil {
+		t.Fatalf("PlanDistributed: %v", err)
+	}
+	for i := range stages {
+		for ph := range stages[i].ScalarDependencies {
+			if strings.HasPrefix(ph, "scalar_") {
+				t.Errorf("kill switch off: stage %s still defers scalar %q", stages[i].ID, ph)
+			}
+		}
+	}
+}

--- a/internal/planner/physical/testdata/ensure_distribution/q11.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q11.golden
@@ -4,5 +4,12 @@ scan-3	scan	Singleton
 join-4	broadcast_join	Singleton	deps=scan-0,exchange-replicate-join-4-3,scan-1
 aggregate-5	aggregate	RoundRobin	deps=join-4
 final_aggregate-6	final_aggregate	Singleton	deps=aggregate-5
+scan-7	scan	Singleton
+scan-8	scan	Singleton
+scan-10	scan	Singleton
+join-11	broadcast_join	Singleton	deps=scan-7,exchange-replicate-join-11-9,scan-8
+aggregate-12	aggregate	Singleton	deps=join-11
+final_aggregate-13	final_aggregate	Singleton	deps=aggregate-12
 exchange-replicate-join-4-3	exchange-replicate	Broadcast	deps=scan-3
+exchange-replicate-join-11-9	exchange-replicate	Broadcast	deps=scan-10
 exchange-gather-final_aggregate-6	exchange-gather	Singleton	deps=final_aggregate-6

--- a/internal/planner/physical/testdata/ensure_distribution/q22.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q22.golden
@@ -3,6 +3,8 @@ scan-1	scan	Singleton
 exchange-repartition-2	exchange-repartition	Hash(c_custkey)/32	deps=scan-0
 exchange-repartition-3	exchange-repartition	Hash(o_custkey)/32	deps=scan-1
 join-4	hash_join	Hash(c_custkey)/32	deps=exchange-repartition-2,exchange-repartition-3
-aggregate-5	aggregate	RoundRobin	deps=join-4
-final_aggregate-6	final_aggregate	Singleton	deps=aggregate-5
-exchange-gather-final_aggregate-6	exchange-gather	Singleton	deps=final_aggregate-6
+scan-5	scan	Singleton
+final_aggregate-6	final_aggregate	Singleton	deps=scan-5
+aggregate-7	aggregate	RoundRobin	deps=join-4
+final_aggregate-8	final_aggregate	Singleton	deps=aggregate-7
+exchange-gather-final_aggregate-8	exchange-gather	Singleton	deps=final_aggregate-8


### PR DESCRIPTION
## Problem

Non-CTE scalar filter subqueries execute eagerly at plan time on the coordinator's single-process pipeline — silently, before `stage-DAG dispatch` is even logged. The 13.50m-baseline logs-only re-profile (merged/ run 20260721-175942) found:

- **Q11**: 38.5s/39.2s (run1/run2) of silent pre-dispatch time — the partsupp⨝supplier⨝nation SUM subquery on 8 coordinator cores. The DAG itself is only 8.6–11.3s of Q11's 50.4s wall.
- **Q22**: 9.7s/10.1s — avg over 15M customers, plus a +834MB coordinator heap spike.

Together ~49s/pass ≈ 6% of steady suite wall, invisible to stage timelines.

## Fix

Route all uncorrelated scalar subqueries through the `deferredScalar`/`ScalarDependencies` producer-stage path built for Q15's CTE case (`emitScalarProducerStages` already handled Q11's `SUM(...)*0.0001` wrapper via OutputRenames — only the `subqueryReferencesCTE` gate kept Q11/Q22 on the eager path). The subquery plans as ordinary distributed stages running concurrently with the rest of the DAG; the coordinator extracts the scalar and substitutes it before dispatching the filter-carrying stage.

Fallback chain: producer emission failure → eager execution (now logged with duration — the silent fallback is what hid this for months) → on total failure, the original subquery text is restored instead of a dangling `:scalar_N`.

**Kill switch**: `WADJET_SCALAR_DEFER=0` (CTE-referencing subqueries defer regardless — Q15 float-drift fix).

## Validation

- New structural tests: Q11/Q22 emit ScalarDependencies + singleton producers; kill-switch restores legacy.
- Golden plan diff surgical: Q11, Q22 only.
- Full `./internal/...` suite green; TPC-H SF0.01 correctness green.
- tpch-harness `--mode=local` (2-worker distributed): 25/25 PASS, rows identical (Q11=240, Q22=7).
- SF100 pair queued (deploying with #<lever-1 PR>).

🤖 Generated with [Claude Code](https://claude.com/claude-code)