### PR TITLE
fix(planner): keep Row-field dotted paths through scan-needs sanitization

### DIFF
--- a/internal/planner/logical/optimizer.go
+++ b/internal/planner/logical/optimizer.go
@@ -131,6 +131,16 @@ func sanitizeScanNeeds(n *Node, needs map[string]bool) []string {
 		if alias, col, ok := strings.Cut(name, "."); ok {
 			if strings.EqualFold(alias, n.TableAlias) || strings.EqualFold(alias, n.TableName) {
 				keep[col] = true
+				continue
+			}
+			// "attrs.score" where attrs is a ROW-typed column of THIS
+			// scan is a field path, not an alias qualifier — keep it
+			// verbatim (the expression compiler resolves the field, and
+			// the scan must read the base column). Dropping it broke
+			// every dotted Row access (filter column "attrs.score" does
+			// not exist) when sanitization landed in #249.
+			if inSchema[strings.ToLower(alias)] {
+				keep[name] = true
 			}
 			continue // other relation's qualified column: drop
 		}

--- a/internal/planner/logical/sanitize_scan_needs_test.go
+++ b/internal/planner/logical/sanitize_scan_needs_test.go
@@ -59,6 +59,20 @@ func TestSanitizeScanNeeds(t *testing.T) {
 			[]string{"l_quantity", "o_orderkey"},
 		},
 		{
+			// "attrs.score" where attrs is a ROW-typed column of THIS scan
+			// is a field path, not an alias qualifier — kept verbatim.
+			// Dropping it broke every dotted Row access when sanitization
+			// landed in #249 (filter column "attrs.score" does not exist).
+			"row field path kept",
+			&Node{
+				Type:        NodeScan,
+				TableName:   "events",
+				ScanColumns: []string{"id", "attrs"},
+			},
+			[]string{"id", "attrs.score", "other.col"},
+			[]string{"attrs.score", "id"},
+		},
+		{
 			// Table name works as the alias when no explicit alias exists.
 			"table name as alias",
 			&Node{Type: NodeScan, TableName: "orders", ScanColumns: []string{"o_orderkey"}},


### PR DESCRIPTION
## Problem

`sanitizeScanNeeds` (#249 A1) treats every `x.y` need as an alias-qualified column and drops it when `x` isn't this scan's alias/table name. But `attrs.score` where `attrs` is a **Row-typed column** of the scan is a field path, not a qualifier — dropping it broke every dotted Row access in the embeddable engine (`filter column "attrs.score" does not exist`; dotted SELECTs silently NULL).

This is a **main regression from this morning's #249 merge**, surfaced by `TestRowFieldResolutionAndFilterStrictness` in `wadjet/` failing on PR CI — that package sits outside `./internal/...`, which is why local suites and the pre-push hook missed it.

## Fix

Keep `x.y` verbatim when `x` names a column in the scan's schema. Regression case added to `TestSanitizeScanNeeds`; the existing wadjet/ test passes again.

`./internal/planner/... ./wadjet/` green, TPC-H SF0.01 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)