### PR TITLE
fix(worker): replace polled task Fetch with persistent Messages iterator

### DIFF
--- a/internal/worker/task_intake_test.go
+++ b/internal/worker/task_intake_test.go
@@ -1,0 +1,105 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+)
+
+// TestTaskIntakeDeliversAllWithoutLoss is the regression test for the Q08
+// AckWait stall (2026-07-21): the old 500ms-polled Fetch intake could
+// discard server-delivered messages client-side at the request-expiry
+// boundary — unacked, invisible in logs, redelivered only after the
+// 10-minute AckWait. The persistent Messages() iterator must drain an
+// intake burst larger than the concurrency limit with every message
+// delivered exactly once: nothing pending, nothing ack-pending, nothing
+// redelivered.
+//
+// The burst uses undecodable payloads on purpose: handleTask Terms them
+// before touching the executor, so the test isolates the intake loop
+// (fetch → slot gate → handleTask → terminal ack) from task execution.
+func TestTaskIntakeDeliversAllWithoutLoss(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	cfg := distributed.DefaultNATSConfig()
+	cfg.Port = -1
+	cfg.StoreDir = t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	en, err := distributed.NewEmbeddedNATS(cfg, logger)
+	if err != nil {
+		t.Fatalf("embed NATS: %v", err)
+	}
+	t.Cleanup(en.Shutdown)
+
+	nc, err := distributed.ConnectInProcess(en.Server())
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(nc.Close)
+	js, err := distributed.NewJetStream(nc)
+	if err != nil {
+		t.Fatalf("jetstream: %v", err)
+	}
+	if err := distributed.SetupStreams(ctx, js); err != nil {
+		t.Fatalf("setup streams: %v", err)
+	}
+
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(ctx, "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	w := New(Config{
+		NATSUrl:       en.ClientURL(),
+		MaxConcurrent: 2,
+		CacheBytes:    16 * 1024 * 1024,
+	}, store, nc, js, logger)
+	workerCtx, workerCancel := context.WithCancel(context.Background())
+	t.Cleanup(workerCancel)
+	if err := w.Start(workerCtx); err != nil {
+		t.Fatalf("start worker: %v", err)
+	}
+	t.Cleanup(w.Stop)
+
+	const burst = 50
+	for i := 0; i < burst; i++ {
+		if _, err := js.Publish(ctx, distributed.SubjectTasksScan,
+			[]byte(fmt.Sprintf("not-a-task-%03d", i))); err != nil {
+			t.Fatalf("publish %d: %v", i, err)
+		}
+	}
+
+	consumer, err := js.Consumer(ctx, distributed.StreamTasks, "tasks")
+	if err != nil {
+		t.Fatalf("lookup consumer: %v", err)
+	}
+
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		info, err := consumer.Info(ctx)
+		if err != nil {
+			t.Fatalf("consumer info: %v", err)
+		}
+		if info.NumPending == 0 && info.NumAckPending == 0 {
+			if info.NumRedelivered != 0 {
+				t.Fatalf("intake redelivered %d messages — a first delivery was dropped unacked", info.NumRedelivered)
+			}
+			if got := info.Delivered.Consumer; got < burst {
+				t.Fatalf("consumer delivered %d < published %d", got, burst)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("intake did not drain: pending=%d ack_pending=%d redelivered=%d",
+				info.NumPending, info.NumAckPending, info.NumRedelivered)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -974,8 +975,44 @@ func sweepDirContents(dir string, logger *slog.Logger) (int, int64) {
 }
 
 func (w *Worker) taskLoop(ctx context.Context, consumer jetstream.Consumer, sem chan struct{}) {
-	// Batch fetch: pull up to available concurrency slots at once to
-	// amortize the NATS round-trip overhead.
+	// Persistent pull subscription with slot-gated Next() instead of a
+	// 500ms-polled one-shot Fetch. The polled Fetch churned ~2 pull
+	// requests/second/worker, and each request-expiry boundary is a race
+	// window: a message the server sends just as the client gives up on
+	// the request is discarded client-side WITHOUT ack, while the server
+	// has it counted as delivered — it re-appears only after the full
+	// 10-minute AckWait. Observed live 2026-07-21 (SF100 deploy 4): two
+	// Q08 join-14 task deliveries vanished with zero worker-log trace,
+	// were redelivered at exactly AckWait expiry, and executed in 137ms —
+	// a 650s query stall for 275ms of work. The managed Messages()
+	// iterator keeps one long-lived pull open (client renews it ahead of
+	// expiry and reconciles in-flight deliveries across renewals), so the
+	// expiry race is gone by construction.
+	//
+	// PullMaxMessages(1): at most one message is buffered client-side
+	// beyond the ones being executed, so a slot-starved worker holds at
+	// most one delivery aging toward AckWait (redelivery of that one is
+	// dedup-safe: task outputs are TaskID-idempotent and the coordinator's
+	// taskRetrier ignores duplicate terminal results). The old batch-fetch
+	// round-trip amortization is irrelevant against multi-second tasks.
+	it, err := consumer.Messages(jetstream.PullMaxMessages(1))
+	if err != nil {
+		w.logger.Error("task intake: creating messages iterator", "error", err)
+		return
+	}
+	defer it.Stop()
+	// Unblock Next() on shutdown or drain. Stop discards any client-side
+	// buffered delivery unacked — JetStream redelivers it to a surviving
+	// worker after AckWait, which is the desired hand-off for a departing
+	// worker.
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-w.drainCh:
+		}
+		it.Stop()
+	}()
+
 	for {
 		if ctx.Err() != nil {
 			return
@@ -1007,66 +1044,44 @@ func (w *Worker) taskLoop(ctx context.Context, consumer jetstream.Consumer, sem 
 			}
 		}
 
-		// Count available slots (non-blocking drain)
-		available := 0
-		for {
-			select {
-			case sem <- struct{}{}:
-				available++
-				if available >= w.config.MaxConcurrent {
-					goto fetch
-				}
-			default:
-				goto fetch
-			}
+		// Acquire ONE slot, then take one message. The drain case matters
+		// twice over: without it a saturated worker blocks here through
+		// the whole drain, and when a slot finally freed it would pull one
+		// MORE task past the Draining check at the loop top (intake leak
+		// during drain).
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.drainCh:
+			return
+		case sem <- struct{}{}:
 		}
-	fetch:
-		if available == 0 {
-			// All slots occupied — wait for one to free up. The drain case
-			// matters twice over: without it a saturated worker blocks here
-			// through the whole drain, and when a slot finally freed it
-			// would pull one MORE task past the Draining check at the loop
-			// top (intake leak during drain).
+
+		msg, err := it.Next()
+		if err != nil {
+			<-sem
+			if ctx.Err() != nil || w.Draining() ||
+				errors.Is(err, jetstream.ErrMsgIteratorClosed) {
+				return
+			}
+			// Transient iterator error (missed heartbeats during a NATS
+			// hiccup): surface it — silent intake failures are how the
+			// Q08 stall stayed invisible — and back off briefly.
+			w.logger.Warn("task intake: iterator error", "error", err)
 			select {
 			case <-ctx.Done():
 				return
-			case <-w.drainCh:
-				return
-			case sem <- struct{}{}:
-				available = 1
-			}
-		}
-
-		msgs, err := consumer.Fetch(available, jetstream.FetchMaxWait(500*time.Millisecond))
-		if err != nil {
-			for i := 0; i < available; i++ {
-				<-sem
-			}
-			if ctx.Err() != nil {
-				return
+			case <-time.After(time.Second):
 			}
 			continue
 		}
 
-		dispatched := 0
-		for msg := range msgs.Messages() {
-			dispatched++
-			w.wg.Add(1)
-			go func(m jetstream.Msg) {
-				defer w.wg.Done()
-				defer func() { <-sem }()
-				w.handleTask(ctx, m)
-			}(msg)
-		}
-
-		// Return unused slots
-		for i := dispatched; i < available; i++ {
-			<-sem
-		}
-
-		if msgs.Error() != nil && ctx.Err() == nil {
-			w.logger.Debug("fetch returned", "error", msgs.Error())
-		}
+		w.wg.Add(1)
+		go func(m jetstream.Msg) {
+			defer w.wg.Done()
+			defer func() { <-sem }()
+			w.handleTask(ctx, m)
+		}(msg)
 	}
 }
 
@@ -1112,6 +1127,18 @@ func (w *Worker) handleTask(ctx context.Context, msg jetstream.Msg) {
 		w.logger.Error("failed to unmarshal task", "error", err)
 		msg.Term()
 		return
+	}
+	// Redelivery is always an anomaly worth seeing: either a prior
+	// delivery was lost before any worker logged it (the Q08 AckWait
+	// stall class) or a prior attempt ran past AckWait without progress.
+	// Execution stays safe either way — task outputs are
+	// TaskID-idempotent and the coordinator ignores duplicate terminal
+	// results — but the event must not be silent.
+	if meta, mErr := msg.Metadata(); mErr == nil && meta.NumDelivered > 1 {
+		w.logger.Warn("task redelivered — prior delivery lost or unacked",
+			"task_id", task.ID, "query_id", task.QueryID,
+			"num_delivered", meta.NumDelivered,
+			"stream_seq", meta.Sequence.Stream)
 	}
 	w.executeIncomingTask(ctx, task, jetstreamAcker{msg: msg})
 }


### PR DESCRIPTION
## Problem — the intermittent Q08 stall, finally characterized

On the 2026-07-21 SF100 validation run, Q08's steady pass hit **650s** (vs its ~50s norm) with a bit-identical plan. Per-task evidence:

- `join-14`: 22/24 tasks completed within 3s of dispatch; the last two task results arrived at **+599.98s and +600.00s**.
- Those two tasks have **zero worker-log trace** before redelivery — their first `executing task` line is at t0+649s, followed by **137ms** of execution.
- `AckWait` is 10 minutes (`worker.go`), so: first delivery lost before any worker saw it → JetStream redelivery at exactly AckWait expiry → instant completion. A 650s stall for 275ms of work.

The intake pulled with `Fetch(available, FetchMaxWait(500ms))` in a tight loop — ~2 pull requests/second/worker. Each request-expiry boundary is a race window: a message the server sends just as the client abandons the request is discarded client-side **without ack**, while the server counts it delivered. Two tasks published in the same dispatch burst landing in one expiring fetch matches the incident exactly.

## Fix

`consumer.Messages(jetstream.PullMaxMessages(1))` with slot-gated `Next()`: one long-lived pull request the client renews ahead of expiry — the expiry race is gone by construction. Slot gating, pool-pressure gating, and drain semantics unchanged. At most one delivery buffers client-side beyond the executing tasks; redelivery of it is dedup-safe (task outputs are TaskID-idempotent; `taskRetrier` ignores duplicate terminal results).

Visibility (this failure class was invisible for months): redelivered tasks (`NumDelivered > 1`) now log at WARN with the delivery count; iterator errors log at WARN (the old fetch errors logged at Debug).

## Validation

- New regression test `TestTaskIntakeDeliversAllWithoutLoss`: 50-task burst through a real JetStream stream into a `MaxConcurrent=2` worker must fully drain with **zero redeliveries and zero stranded acks** — the invariant the polled Fetch violated.
- Full `./internal/... ./wadjet/` suites green; tpch-harness `--mode=local` 25/25 PASS.
- SF100 run queued (doubles as the fresh-window re-baseline after #251/#252).

🤖 Generated with [Claude Code](https://claude.com/claude-code)