### PR TITLE
perf(worker): work-conserving morsel width — yield CPU tokens while input-starved

### DIFF
--- a/docs/design/morsel-execution.md
+++ b/docs/design/morsel-execution.md
@@ -319,6 +319,43 @@ goroutines) bounds Σ(k) across concurrent tasks *and* is taken by the
 existing errgroup bursts, so the process never schedules more compute
 goroutines than cores.
 
+### 4.2.1 Work-conserving width (2026-07-21)
+
+Fixed-lifetime width acquisition turned out to self-starve: a fragment's
+consumers held their width tokens THROUGH input stalls, and the pool they
+exhausted is the same pool decode-ahead draws from — so on probe-split
+scan stages the decode that would have fed the idle consumers collapsed to
+cursor-only. The SF100 2026-07-21 ref run showed the shape suite-wide:
+every 3-task lineitem broadcast/probe-split stage bottomed out at a ~45 s
+floor (Q09 join-6 47.3 s with 126 s cumulative decode token-stall on one
+worker; Q17's two legs 74 s each; Q18 scan-9 130 s) while workers averaged
+~17 % CPU.
+
+The fix inverts the holding rule: **a consumer owns width only while it
+owns a morsel.** `morselFragmentWorkers` no longer takes tokens; it
+returns the policy target plus a per-fragment `widthGate`. Consumers
+claim before processing — fragment baseline slot first (the "first
+consumer is free" rule, now a slot any consumer may hold rather than
+goroutine #0's identity), then a pool token — hold the slot across
+back-to-back morsels (steady flow pays no per-morsel pool traffic), and
+yield it before blocking on an empty dispenser. Starved width returns to
+the pool, decode-ahead widens, the channel refills, consumers re-claim:
+tokens flow to whichever side has work.
+
+Claiming may BLOCK (a queued FIFO waiter on `cpuTokens`), which the
+original §4.2 design ruled out. The rejection targeted waits on capacity
+that only the waiter's own progress would release; here every token
+holder is actively computing with bounded hold time (one row-group
+decode, one morsel), releases are continuous, and the baseline slot
+guarantees each fragment a runnable consumer regardless of the pool — no
+cycle, no wedge. Queued waiters take strict priority over `TryAcquire`
+(they hold admitted morsels; feeding them beats widening decode). A side
+effect fixes a second rigidity: width is no longer frozen at start-time
+token availability, so a fragment that began under a transient burst can
+widen when the burst passes.
+
+Kill switch: `WADJET_MORSEL_YIELD=0` restores fixed-lifetime acquisition.
+
 ### 4.3 Pipeline breakers
 
 - **HashAggregate / Sort:** per-worker `CloneSink` partials merged at the

--- a/internal/worker/cpu_tokens.go
+++ b/internal/worker/cpu_tokens.go
@@ -2,7 +2,7 @@ package worker
 
 import (
 	"runtime"
-	"sync/atomic"
+	"sync"
 )
 
 // cpuTokens is a worker-wide counting semaphore over EXTRA compute
@@ -12,15 +12,35 @@ import (
 // Σ(extra widths) across concurrent tasks never schedules more compute
 // goroutines than the reserved core budget.
 //
-// Acquisition is non-blocking BY DESIGN: a fragment that cannot get tokens
-// degrades to a narrower width (ultimately serial) instead of waiting.
+// TryAcquire is non-blocking BY DESIGN: a fragment or decode worker that
+// cannot get tokens degrades to a narrower width instead of waiting.
 // Blocking here would recreate the parked-waiter admission shape rejected in
 // project_admission_control_rejected_2026-05-18 — a goroutine holding
 // upstream resources while gated on capacity that only its own progress
 // would release.
+//
+// enqueueWaiter is the one deliberate exception (work-conserving width,
+// §4.2.1): a morsel consumer that already HOLDS work may park for a token,
+// because the capacity it waits on is released by OTHER goroutines' bounded
+// progress (per-row-group decode holds, other consumers' per-morsel holds)
+// and every fragment's baseline slot guarantees a token-free consumer is
+// always runnable — the waiter's own progress is never what frees the pool.
+// Waiters are FIFO and take strict priority over TryAcquire: a queued
+// consumer holds an admitted morsel, so feeding it beats widening decode.
 type cpuTokens struct {
+	mu       sync.Mutex
 	capacity int64
-	used     atomic.Int64
+	used     int64
+	// waiters is the FIFO grant queue. Granted waiters get used pre-charged
+	// and their channel closed; cancellation returns the charge.
+	waiters []*tokenWaiter
+}
+
+// tokenWaiter is one parked blocking acquisition. granted flips exactly once,
+// under the pool lock, together with the channel close.
+type tokenWaiter struct {
+	ch      chan struct{}
+	granted bool
 }
 
 // newCPUTokens creates a token pool of the given capacity. Capacity 0 (or
@@ -42,33 +62,87 @@ func defaultCPUTokenCapacity() int {
 }
 
 // TryAcquire claims up to n tokens without blocking and returns how many it
-// got (0..n). Callers must Release exactly that many when done.
+// got (0..n). Callers must Release exactly that many when done. Returns 0
+// while blocking waiters are queued: those hold admitted work already, and
+// granting around them would starve it.
 func (t *cpuTokens) TryAcquire(n int) int {
 	if t == nil || n <= 0 {
 		return 0
 	}
-	for {
-		cur := t.used.Load()
-		avail := t.capacity - cur
-		if avail <= 0 {
-			return 0
-		}
-		take := int64(n)
-		if take > avail {
-			take = avail
-		}
-		if t.used.CompareAndSwap(cur, cur+take) {
-			return int(take)
-		}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.waiters) > 0 {
+		return 0
 	}
+	avail := t.capacity - t.used
+	if avail <= 0 {
+		return 0
+	}
+	take := int64(n)
+	if take > avail {
+		take = avail
+	}
+	t.used += take
+	return int(take)
 }
 
-// Release returns n previously acquired tokens to the pool.
+// Release returns n previously acquired tokens to the pool and hands as many
+// as possible straight to queued waiters, FIFO.
 func (t *cpuTokens) Release(n int) {
 	if t == nil || n <= 0 {
 		return
 	}
-	t.used.Add(-int64(n))
+	t.mu.Lock()
+	t.used -= int64(n)
+	t.grantLocked()
+	t.mu.Unlock()
+}
+
+// grantLocked moves tokens to queued waiters while capacity allows. Caller
+// holds t.mu.
+func (t *cpuTokens) grantLocked() {
+	for len(t.waiters) > 0 && t.used < t.capacity {
+		w := t.waiters[0]
+		t.waiters = t.waiters[1:]
+		t.used++
+		w.granted = true
+		close(w.ch)
+	}
+}
+
+// enqueueWaiter registers a blocking single-token acquisition and returns
+// its waiter. The caller selects on w.ch (closed = one token now owned) and
+// MUST call cancelWaiter if it stops waiting for any reason — including
+// after a successful receive it chooses not to use.
+//
+// If a token is free (and no earlier waiter is queued), the grant happens
+// immediately and the returned waiter's channel is already closed.
+func (t *cpuTokens) enqueueWaiter() *tokenWaiter {
+	w := &tokenWaiter{ch: make(chan struct{})}
+	t.mu.Lock()
+	t.waiters = append(t.waiters, w)
+	t.grantLocked()
+	t.mu.Unlock()
+	return w
+}
+
+// cancelWaiter withdraws a waiter registered by enqueueWaiter. If the grant
+// already happened (or races in), the token is returned to the pool.
+func (t *cpuTokens) cancelWaiter(w *tokenWaiter) {
+	t.mu.Lock()
+	if w.granted {
+		t.used--
+		t.grantLocked()
+		t.mu.Unlock()
+		return
+	}
+	for i, q := range t.waiters {
+		if q == w {
+			t.waiters = append(t.waiters[:i], t.waiters[i+1:]...)
+			break
+		}
+	}
+	t.mu.Unlock()
 }
 
 // InUse reports the number of tokens currently held (instrumentation).
@@ -76,7 +150,9 @@ func (t *cpuTokens) InUse() int64 {
 	if t == nil {
 		return 0
 	}
-	return t.used.Load()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.used
 }
 
 // Capacity reports the pool size (instrumentation).

--- a/internal/worker/executor_fragment.go
+++ b/internal/worker/executor_fragment.go
@@ -426,10 +426,10 @@ func buildDynamicFilterEmitOps(specs []distributed.DynamicFilterEmit) ([]*exec.D
 // pause) lives in the consumer so the pause reflects the full pipeline state.
 func (e *Executor) runFragmentLinear(ctx context.Context, task distributed.Task, src exec.Source, ops []exec.UnaryOperator, sink fragmentSink, result *distributed.ResultNotification) error {
 	// Morsel-driven parallel path (docs/design/morsel-execution.md §4). k > 1
-	// only when the flag allows it, every op is Cloneable, the fragment
-	// clears the size gate, and CPU tokens are available. Tokens are held for
-	// the duration of the fragment.
-	if k, release := e.morselFragmentWorkers(task, ops); k > 1 {
+	// only when the flag allows it, every op is Cloneable, and the fragment
+	// clears the size gate. Active width is metered by the gate (§4.2.1);
+	// in legacy mode tokens are held for the duration of the fragment.
+	if k, gate, release := e.morselFragmentWorkers(task, ops); k > 1 {
 		defer release()
 		e.logger.Debug("morsel parallel fragment",
 			"task_id", task.ID,
@@ -438,7 +438,7 @@ func (e *Executor) runFragmentLinear(ctx context.Context, task distributed.Task,
 			"estimated_bytes", task.EstimatedBytes,
 			"cpu_tokens_in_use", e.cpuTokens.InUse(),
 			"cpu_tokens_cap", e.cpuTokens.Capacity())
-		return e.runFragmentLinearParallel(ctx, task, src, ops, sink, result, k)
+		return e.runFragmentLinearParallel(ctx, task, src, ops, sink, result, k, gate)
 	}
 	progress := exec.ProgressReporterFromContext(ctx)
 	fp := newFragmentProgress(e.logger, task, e)
@@ -580,31 +580,38 @@ var morselMinFragmentBytes int64 = 64 << 20
 // bottleneck and extra clones only add merge/scratch overhead.
 const morselFragmentParallelismCap = 8
 
-// morselFragmentWorkers decides the parallel width for a linear fragment and
-// acquires CPU tokens for the extra consumers. Returns k and a release
-// function (call exactly once, after the fragment finishes). k == 1 means
-// serial — the returned release is a no-op.
+// morselFragmentWorkers decides the parallel width for a linear fragment.
+// Returns the consumer count k, the width gate metering their ACTIVE
+// concurrency, and a release function (call exactly once, after the
+// fragment finishes). k == 1 means serial — gate is nil and release a no-op.
 //
-// The first consumer is free (the serial baseline is always allowed); each
-// extra consumer takes one token. Acquisition is non-blocking: under token
-// exhaustion the fragment degrades toward serial rather than queueing.
-func (e *Executor) morselFragmentWorkers(task distributed.Task, ops []exec.UnaryOperator) (int, func()) {
+// Work-conserving mode (default): no tokens are taken here at all. k is the
+// policy target and the returned widthGate admits consumers morsel-by-morsel
+// — one fragment baseline slot is free, extras claim pool tokens only while
+// processing and yield them when the dispenser runs dry, so input-starved
+// width never starves the decode that would feed it (§4.2.1).
+//
+// Legacy mode (WADJET_MORSEL_YIELD=0): the first consumer is free, each
+// extra consumer takes one token at fragment start and holds it for the
+// fragment's lifetime; under token exhaustion the fragment degrades toward
+// serial. gate is nil.
+func (e *Executor) morselFragmentWorkers(task distributed.Task, ops []exec.UnaryOperator) (int, *widthGate, func()) {
 	noop := func() {}
 	policy := e.morselWorkers
 	if policy == 0 || policy == 1 || e.cpuTokens == nil {
-		return 1, noop
+		return 1, nil, noop
 	}
 	// Every op must be Cloneable — non-cloneable ops (e.g. the
 	// DynamicFilterEmitOp accumulator) keep the fragment serial.
 	for _, op := range ops {
 		if _, ok := op.(exec.Cloneable); !ok {
-			return 1, noop
+			return 1, nil, noop
 		}
 	}
 	target := policy
 	if policy < 0 { // auto: size-gated, width up to core count
 		if task.EstimatedBytes < morselMinFragmentBytes {
-			return 1, noop
+			return 1, nil, noop
 		}
 		target = runtime.GOMAXPROCS(0)
 	}
@@ -612,13 +619,70 @@ func (e *Executor) morselFragmentWorkers(task distributed.Task, ops []exec.Unary
 		target = morselFragmentParallelismCap
 	}
 	if target <= 1 {
-		return 1, noop
+		return 1, nil, noop
+	}
+	if morselWidthYield {
+		return target, newWidthGate(e.cpuTokens), noop
 	}
 	got := e.cpuTokens.TryAcquire(target - 1)
 	if got == 0 {
-		return 1, noop
+		return 1, nil, noop
 	}
-	return 1 + got, func() { e.cpuTokens.Release(got) }
+	return 1 + got, nil, func() { e.cpuTokens.Release(got) }
+}
+
+// consumeMorsels is one consumer goroutine's loop, shared by the linear and
+// breaker parallel paths. process must retire the morsel on every path and
+// is called while the consumer holds its width slot; stop (nil-safe) is
+// checked after each morsel to end the parallel section early (pressure
+// collapse). A nil gate reproduces the fixed-width shape: the consumer's
+// concurrency is pre-paid, so it just drains the channel.
+//
+// The slot dance is the work-conserving core: hold a slot across
+// back-to-back morsels (the steady-flow fast path — no per-morsel pool
+// traffic), yield it before blocking on an empty channel, re-claim on the
+// next morsel.
+func consumeMorsels(ctx context.Context, d *morselDispenser, gate *widthGate, process func(m morsel) error, stop func() bool) error {
+	slot := slotNone
+	defer func() {
+		if gate != nil {
+			gate.yield(slot)
+		}
+	}()
+	for {
+		var m morsel
+		var ok bool
+		select {
+		case m, ok = <-d.ch:
+		default:
+			if gate != nil && slot != slotNone {
+				gate.yield(slot)
+				slot = slotNone
+			}
+			select {
+			case m, ok = <-d.ch:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		if !ok {
+			return nil
+		}
+		if gate != nil && slot == slotNone {
+			s, err := gate.claim(ctx)
+			if err != nil {
+				m.retire()
+				return err
+			}
+			slot = s
+		}
+		if err := process(m); err != nil {
+			return err
+		}
+		if stop != nil && stop() {
+			return nil
+		}
+	}
 }
 
 // runFragmentLinearParallel is the morsel-driven variant of
@@ -654,7 +718,7 @@ func (e *Executor) morselFragmentWorkers(task distributed.Task, ops []exec.Unary
 // expr.ColRef's sync.Once). The warmup batch completes those writes while
 // the chain is still single-threaded; clones then only read the resolved
 // caches.
-func (e *Executor) runFragmentLinearParallel(ctx context.Context, task distributed.Task, src exec.Source, ops []exec.UnaryOperator, sink fragmentSink, result *distributed.ResultNotification, k int) error {
+func (e *Executor) runFragmentLinearParallel(ctx context.Context, task distributed.Task, src exec.Source, ops []exec.UnaryOperator, sink fragmentSink, result *distributed.ResultNotification, k int, gate *widthGate) error {
 	progress := exec.ProgressReporterFromContext(ctx)
 	fp := newFragmentProgress(e.logger, task, e)
 	src = fp.timeSource(src)
@@ -766,7 +830,7 @@ func (e *Executor) runFragmentLinearParallel(ctx context.Context, task distribut
 		for i := 0; i < k; i++ {
 			chain := chains[i]
 			g.Go(func() error {
-				for m := range d.ch {
+				return consumeMorsels(gctx, d, gate, func(m morsel) error {
 					if err := fp.applyBackpressure(gctx); err != nil {
 						m.retire()
 						return err
@@ -783,15 +847,17 @@ func (e *Executor) runFragmentLinearParallel(ctx context.Context, task distribut
 						}
 					}
 					m.retire()
+					return nil
+				}, func() bool {
 					if collapsed.Load() {
-						return nil
+						return true
 					}
 					if heapPressureActive() {
 						collapsed.Store(true)
-						return nil
+						return true
 					}
-				}
-				return nil
+					return false
+				})
 			})
 		}
 		if err := g.Wait(); err != nil {
@@ -828,8 +894,11 @@ func (e *Executor) runFragmentLinearParallel(ctx context.Context, task distribut
 		if err := <-prodErr; err != nil {
 			return fmt.Errorf("fragment task %s: %w", task.ID, err)
 		}
-		e.logger.Debug("morsel parallel fragment done",
-			append([]any{"task_id", task.ID, "k", k}, d.logAttrs()...)...)
+		attrs := append([]any{"task_id", task.ID, "k", k}, d.logAttrs()...)
+		if gate != nil {
+			attrs = append(attrs, gate.logAttrs()...)
+		}
+		e.logger.Debug("morsel parallel fragment done", attrs...)
 	}
 
 	// Spilled-partition flush, over EVERY chain. Clone probes share the
@@ -873,7 +942,7 @@ func (e *Executor) runFragmentLinearParallel(ctx context.Context, task distribut
 // (Sort stores them) while upstream Filters reuse per-instance Sel scratch —
 // same rule as drainThroughBreaker. Finalize on the primary is called here,
 // matching the serial Pipeline.Run contract for the j==0 phase.
-func (e *Executor) runBreakerConsumeParallel(ctx context.Context, task distributed.Task, src exec.Source, ops []exec.UnaryOperator, sink exec.MergeableSink, k int) error {
+func (e *Executor) runBreakerConsumeParallel(ctx context.Context, task distributed.Task, src exec.Source, ops []exec.UnaryOperator, sink exec.MergeableSink, k int, gate *widthGate) error {
 	fp := newFragmentProgress(e.logger, task, e)
 
 	consumeInto := func(ctx context.Context, dst exec.Sink, b *batch.RecordBatch) error {
@@ -1018,7 +1087,7 @@ func (e *Executor) runBreakerConsumeParallel(ctx context.Context, task distribut
 	for i := 0; i < k; i++ {
 		chain, wsink := chains[i], sinks[i]
 		g.Go(func() error {
-			for m := range d.ch {
+			return consumeMorsels(gctx, d, gate, func(m morsel) error {
 				if err := fp.applyBackpressure(gctx); err != nil {
 					m.retire()
 					return err
@@ -1035,15 +1104,17 @@ func (e *Executor) runBreakerConsumeParallel(ctx context.Context, task distribut
 					}
 				}
 				m.retire()
+				return nil
+			}, func() bool {
 				if collapsed.Load() {
-					return nil
+					return true
 				}
 				if e.sharedSpill != nil && e.sharedSpill.ShouldSpillFor(memory.SpillCheap) {
 					collapsed.Store(true)
-					return nil
+					return true
 				}
-			}
-			return nil
+				return false
+			})
 		})
 	}
 	if err := g.Wait(); err != nil {
@@ -1089,8 +1160,11 @@ func (e *Executor) runBreakerConsumeParallel(ctx context.Context, task distribut
 	if err := <-prodErr; err != nil {
 		return err
 	}
-	e.logger.Debug("morsel parallel breaker consume done",
-		append([]any{"task_id", task.ID, "k", k}, d.logAttrs()...)...)
+	doneAttrs := append([]any{"task_id", task.ID, "k", k}, d.logAttrs()...)
+	if gate != nil {
+		doneAttrs = append(doneAttrs, gate.logAttrs()...)
+	}
+	e.logger.Debug("morsel parallel breaker consume done", doneAttrs...)
 
 	// Spilled-partition flush over every chain (shared spillState; the first
 	// drain clears it, later chains no-op — same rule as the linear path),
@@ -1237,8 +1311,9 @@ func (e *Executor) runFragmentWithBreakers(ctx context.Context, task distributed
 			// serial Pipeline.
 			mergeable, isMergeable := breakers[j].Op.(exec.MergeableSink)
 			k, release := 1, func() {}
+			var gate *widthGate
 			if isMergeable {
-				k, release = e.morselFragmentWorkers(task, phaseOps)
+				k, gate, release = e.morselFragmentWorkers(task, phaseOps)
 			}
 			if k > 1 {
 				err = func() error {
@@ -1251,7 +1326,7 @@ func (e *Executor) runFragmentWithBreakers(ctx context.Context, task distributed
 						"estimated_bytes", task.EstimatedBytes,
 						"cpu_tokens_in_use", e.cpuTokens.InUse(),
 						"cpu_tokens_cap", e.cpuTokens.Capacity())
-					return e.runBreakerConsumeParallel(ctx, task, currentSrc, phaseOps, mergeable, k)
+					return e.runBreakerConsumeParallel(ctx, task, currentSrc, phaseOps, mergeable, k, gate)
 				}()
 				if err != nil {
 					return fmt.Errorf("fragment task %s: %s consume: %w", task.ID, breakers[j].Label, err)

--- a/internal/worker/morsel_fragment_test.go
+++ b/internal/worker/morsel_fragment_test.go
@@ -24,7 +24,19 @@ func (nonCloneableOp) Execute(_ context.Context, b *batch.RecordBatch) (*batch.R
 }
 func (nonCloneableOp) Close() error { return nil }
 
+// pinWidthYield pins the work-conserving-width mode for a test and restores
+// it at cleanup. The fixed-width subtests below pin false: they encode the
+// legacy WADJET_MORSEL_YIELD=0 semantics (width frozen at start-time token
+// availability).
+func pinWidthYield(tb testing.TB, on bool) {
+	tb.Helper()
+	prev := morselWidthYield
+	morselWidthYield = on
+	tb.Cleanup(func() { morselWidthYield = prev })
+}
+
 func TestMorselFragmentWorkers_Gates(t *testing.T) {
+	pinWidthYield(t, false)
 	newExec := func(policy, tokens int) *Executor {
 		e := NewExecutor(objstore.NewMemStore(), NewLRUCache(1024*1024), nil)
 		e.SetMorselWorkers(policy)
@@ -39,19 +51,19 @@ func TestMorselFragmentWorkers_Gates(t *testing.T) {
 
 	t.Run("zero value stays serial", func(t *testing.T) {
 		e := NewExecutor(objstore.NewMemStore(), NewLRUCache(1024*1024), nil)
-		if k, _ := e.morselFragmentWorkers(bigTask, cloneable); k != 1 {
+		if k, _, _ := e.morselFragmentWorkers(bigTask, cloneable); k != 1 {
 			t.Fatalf("k = %d, want 1", k)
 		}
 	})
 	t.Run("explicit 1 stays serial", func(t *testing.T) {
 		e := newExec(1, 8)
-		if k, _ := e.morselFragmentWorkers(bigTask, cloneable); k != 1 {
+		if k, _, _ := e.morselFragmentWorkers(bigTask, cloneable); k != 1 {
 			t.Fatalf("k = %d, want 1", k)
 		}
 	})
 	t.Run("fixed width acquires extras and releases", func(t *testing.T) {
 		e := newExec(4, 8)
-		k, release := e.morselFragmentWorkers(smallTask, cloneable) // fixed bypasses size gate
+		k, _, release := e.morselFragmentWorkers(smallTask, cloneable) // fixed bypasses size gate
 		if k != 4 {
 			t.Fatalf("k = %d, want 4", k)
 		}
@@ -65,7 +77,7 @@ func TestMorselFragmentWorkers_Gates(t *testing.T) {
 	})
 	t.Run("token scarcity narrows width", func(t *testing.T) {
 		e := newExec(4, 1)
-		k, release := e.morselFragmentWorkers(bigTask, cloneable)
+		k, _, release := e.morselFragmentWorkers(bigTask, cloneable)
 		if k != 2 {
 			t.Fatalf("k = %d, want 2 (1 free + 1 token)", k)
 		}
@@ -73,7 +85,7 @@ func TestMorselFragmentWorkers_Gates(t *testing.T) {
 	})
 	t.Run("token exhaustion degrades to serial", func(t *testing.T) {
 		e := newExec(4, 0)
-		k, release := e.morselFragmentWorkers(bigTask, cloneable)
+		k, _, release := e.morselFragmentWorkers(bigTask, cloneable)
 		if k != 1 {
 			t.Fatalf("k = %d, want 1", k)
 		}
@@ -85,7 +97,7 @@ func TestMorselFragmentWorkers_Gates(t *testing.T) {
 	t.Run("non-cloneable op stays serial without taking tokens", func(t *testing.T) {
 		e := newExec(4, 8)
 		ops := append([]exec.UnaryOperator{nonCloneableOp{}}, cloneable...)
-		k, _ := e.morselFragmentWorkers(bigTask, ops)
+		k, _, _ := e.morselFragmentWorkers(bigTask, ops)
 		if k != 1 {
 			t.Fatalf("k = %d, want 1", k)
 		}
@@ -95,10 +107,10 @@ func TestMorselFragmentWorkers_Gates(t *testing.T) {
 	})
 	t.Run("auto respects size gate", func(t *testing.T) {
 		e := newExec(-1, 8)
-		if k, _ := e.morselFragmentWorkers(smallTask, cloneable); k != 1 {
+		if k, _, _ := e.morselFragmentWorkers(smallTask, cloneable); k != 1 {
 			t.Fatalf("small fragment k = %d, want 1", k)
 		}
-		k, release := e.morselFragmentWorkers(bigTask, cloneable)
+		k, _, release := e.morselFragmentWorkers(bigTask, cloneable)
 		want := runtime.GOMAXPROCS(0)
 		if want > morselFragmentParallelismCap {
 			want = morselFragmentParallelismCap
@@ -113,12 +125,37 @@ func TestMorselFragmentWorkers_Gates(t *testing.T) {
 	})
 	t.Run("fixed width capped", func(t *testing.T) {
 		e := newExec(64, 64)
-		k, release := e.morselFragmentWorkers(bigTask, cloneable)
+		k, _, release := e.morselFragmentWorkers(bigTask, cloneable)
 		if k != morselFragmentParallelismCap {
 			t.Fatalf("k = %d, want cap %d", k, morselFragmentParallelismCap)
 		}
 		release()
 	})
+}
+
+// TestMorselFragmentWorkers_YieldMode: work-conserving mode takes no tokens
+// up front and returns the full policy target even on an exhausted pool —
+// active width is metered per-morsel by the gate instead of frozen at
+// start-time availability.
+func TestMorselFragmentWorkers_YieldMode(t *testing.T) {
+	pinWidthYield(t, true)
+	e := NewExecutor(objstore.NewMemStore(), NewLRUCache(1024*1024), nil)
+	e.SetMorselWorkers(4)
+	e.cpuTokens = newCPUTokens(0) // exhausted pool must not narrow k
+	cloneable := []exec.UnaryOperator{exec.NewFilter(func(*batch.RecordBatch, int) bool { return true })}
+	task := distributed.Task{EstimatedBytes: morselMinFragmentBytes}
+
+	k, gate, release := e.morselFragmentWorkers(task, cloneable)
+	if k != 4 {
+		t.Fatalf("k = %d, want policy target 4", k)
+	}
+	if gate == nil {
+		t.Fatal("gate = nil, want a width gate in yield mode")
+	}
+	if got := e.cpuTokens.InUse(); got != 0 {
+		t.Fatalf("tokens taken up front = %d, want 0", got)
+	}
+	release()
 }
 
 // TestExecuteFragment_MorselParallel_FilterParity runs the same

--- a/internal/worker/width_gate.go
+++ b/internal/worker/width_gate.go
@@ -1,0 +1,105 @@
+package worker
+
+import (
+	"context"
+	"os"
+	"sync/atomic"
+	"time"
+)
+
+// morselWidthYield gates work-conserving morsel width (docs/design/
+// morsel-execution.md §4.2.1). Default on; WADJET_MORSEL_YIELD=0 restores
+// the fixed-width shape (tokens acquired once at fragment start and held for
+// the fragment's lifetime, width frozen at whatever was free at that
+// moment). Package var so tests can pin either mode.
+var morselWidthYield = os.Getenv("WADJET_MORSEL_YIELD") != "0"
+
+// widthSlot is what one morsel consumer currently holds: nothing, the
+// fragment's free baseline slot, or one worker-pool cpu token.
+type widthSlot uint8
+
+const (
+	slotNone widthSlot = iota
+	slotBaseline
+	slotToken
+)
+
+// widthGate meters a parallel fragment's ACTIVE consumer width against the
+// worker-wide cpuTokens pool, work-conservingly: a consumer holds its slot
+// only while it is actually processing a morsel and yields it whenever the
+// dispenser runs dry. The fixed-width shape this replaces held width tokens
+// through input stalls, which starved the very token takers producing that
+// input — decode-ahead collapsed to cursor-only under two concurrent
+// probe-split fragments (SF100 2026-07-21 ref: 45s lineitem-stage floor,
+// 126s cumulative token-stall on Q09 join-6, workers ~17% CPU-utilized).
+//
+// One baseline slot per fragment is always claimable token-free (the
+// "first consumer is free" rule), which is also the progress guarantee that
+// makes blocking claims safe: token holders are always actively computing
+// and release in bounded time, and no fragment can wedge with work queued
+// because the baseline cannot be held by an idle consumer.
+type widthGate struct {
+	tokens *cpuTokens
+	// baseline carries the fragment's one free slot; buffered cap 1, primed
+	// at construction.
+	baseline chan struct{}
+
+	// Stats for the fragment-completion log line.
+	claimWaitNs atomic.Int64
+	yields      atomic.Int64
+}
+
+func newWidthGate(tokens *cpuTokens) *widthGate {
+	g := &widthGate{tokens: tokens, baseline: make(chan struct{}, 1)}
+	g.baseline <- struct{}{}
+	return g
+}
+
+// claim blocks until the consumer may process a morsel, preferring the
+// fragment baseline, then a free pool token, then parking FIFO for either.
+// The caller holds an admitted morsel; see cpuTokens.enqueueWaiter for why
+// parking here cannot deadlock.
+func (g *widthGate) claim(ctx context.Context) (widthSlot, error) {
+	select {
+	case <-g.baseline:
+		return slotBaseline, nil
+	default:
+	}
+	if g.tokens.TryAcquire(1) == 1 {
+		return slotToken, nil
+	}
+	t0 := time.Now()
+	defer func() { g.claimWaitNs.Add(time.Since(t0).Nanoseconds()) }()
+	w := g.tokens.enqueueWaiter()
+	select {
+	case <-g.baseline:
+		g.tokens.cancelWaiter(w)
+		return slotBaseline, nil
+	case <-w.ch:
+		return slotToken, nil
+	case <-ctx.Done():
+		g.tokens.cancelWaiter(w)
+		return slotNone, ctx.Err()
+	}
+}
+
+// yield returns a held slot. Safe to call with slotNone.
+func (g *widthGate) yield(s widthSlot) {
+	switch s {
+	case slotBaseline:
+		g.baseline <- struct{}{}
+	case slotToken:
+		g.tokens.Release(1)
+	default:
+		return
+	}
+	g.yields.Add(1)
+}
+
+// logAttrs summarizes the gate's activity for the fragment-completion line.
+func (g *widthGate) logAttrs() []any {
+	return []any{
+		"width_wait_ms", g.claimWaitNs.Load() / 1e6,
+		"width_yields", g.yields.Load(),
+	}
+}

--- a/internal/worker/width_gate_test.go
+++ b/internal/worker/width_gate_test.go
@@ -1,0 +1,252 @@
+package worker
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestCPUTokens_WaiterFIFOAndPriority(t *testing.T) {
+	tok := newCPUTokens(1)
+	if got := tok.TryAcquire(1); got != 1 {
+		t.Fatalf("TryAcquire = %d, want 1", got)
+	}
+
+	w1 := tok.enqueueWaiter()
+	w2 := tok.enqueueWaiter()
+	select {
+	case <-w1.ch:
+		t.Fatal("w1 granted while pool exhausted")
+	default:
+	}
+	// Queued waiters block TryAcquire even though nothing is free anyway;
+	// the load-bearing case is after Release: the token must go to w1, not
+	// to a TryAcquire racing in.
+	tok.Release(1)
+	select {
+	case <-w1.ch:
+	case <-time.After(time.Second):
+		t.Fatal("w1 not granted after Release")
+	}
+	if got := tok.TryAcquire(1); got != 0 {
+		t.Fatalf("TryAcquire = %d, want 0 while w2 still queued", got)
+	}
+	tok.cancelWaiter(w1) // held a granted token: cancel returns it → w2 gets it
+	select {
+	case <-w2.ch:
+	case <-time.After(time.Second):
+		t.Fatal("w2 not granted after w1's token returned")
+	}
+	tok.cancelWaiter(w2)
+	if got := tok.InUse(); got != 0 {
+		t.Fatalf("InUse = %d, want 0 after both waiters cancelled", got)
+	}
+	if got := tok.TryAcquire(1); got != 1 {
+		t.Fatalf("TryAcquire = %d, want 1 with queue drained", got)
+	}
+}
+
+func TestCPUTokens_CancelUngrantedWaiter(t *testing.T) {
+	tok := newCPUTokens(1)
+	tok.TryAcquire(1)
+	w := tok.enqueueWaiter()
+	tok.cancelWaiter(w)
+	tok.Release(1)
+	if got := tok.InUse(); got != 0 {
+		t.Fatalf("InUse = %d, want 0 (cancelled waiter must not hold a grant)", got)
+	}
+}
+
+func TestCPUTokens_EnqueueGrantsImmediatelyWhenFree(t *testing.T) {
+	tok := newCPUTokens(2)
+	w := tok.enqueueWaiter()
+	select {
+	case <-w.ch:
+	default:
+		t.Fatal("waiter not granted despite free capacity")
+	}
+	tok.cancelWaiter(w)
+	if got := tok.InUse(); got != 0 {
+		t.Fatalf("InUse = %d, want 0", got)
+	}
+}
+
+func TestWidthGate_BaselineAlwaysClaimable(t *testing.T) {
+	// Zero-capacity pool: only the fragment baseline exists. A serial
+	// claim/yield cycle must never block.
+	g := newWidthGate(newCPUTokens(0))
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		s, err := g.claim(ctx)
+		if err != nil || s != slotBaseline {
+			t.Fatalf("claim %d = (%v, %v), want baseline", i, s, err)
+		}
+		g.yield(s)
+	}
+}
+
+func TestWidthGate_TokenThenBaselineThenBlock(t *testing.T) {
+	tok := newCPUTokens(1)
+	g := newWidthGate(tok)
+	ctx := context.Background()
+
+	s1, _ := g.claim(ctx) // baseline
+	s2, _ := g.claim(ctx) // pool token
+	if s1 != slotBaseline || s2 != slotToken {
+		t.Fatalf("claims = %v, %v; want baseline, token", s1, s2)
+	}
+
+	// Third claim parks until a slot frees.
+	done := make(chan widthSlot, 1)
+	go func() {
+		s, err := g.claim(ctx)
+		if err != nil {
+			t.Errorf("claim: %v", err)
+		}
+		done <- s
+	}()
+	select {
+	case s := <-done:
+		t.Fatalf("third claim returned %v with both slots held", s)
+	case <-time.After(50 * time.Millisecond):
+	}
+	g.yield(s2)
+	select {
+	case s := <-done:
+		g.yield(s)
+	case <-time.After(time.Second):
+		t.Fatal("parked claim not woken by yield")
+	}
+	g.yield(s1)
+	if got := tok.InUse(); got != 0 {
+		t.Fatalf("tokens leaked: %d", got)
+	}
+}
+
+func TestWidthGate_ClaimHonorsContextCancel(t *testing.T) {
+	tok := newCPUTokens(0)
+	g := newWidthGate(tok)
+	base, _ := g.claim(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := g.claim(ctx)
+		errCh <- err
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("claim returned nil error after cancel")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("claim did not return after cancel")
+	}
+	g.yield(base)
+	if got := tok.InUse(); got != 0 {
+		t.Fatalf("tokens leaked: %d", got)
+	}
+}
+
+// TestConsumeMorsels_YieldsWidthWhileStarved is the regression test for the
+// 2026-07-21 decode-starvation diagnosis: consumers parked on an empty
+// dispenser must hold ZERO pool tokens, so a concurrent token taker (decode-
+// ahead standing in as `TryAcquire`) can widen. Under the legacy fixed-width
+// shape the fragment held its width tokens through exactly this stall and
+// the pool stayed exhausted.
+func TestConsumeMorsels_YieldsWidthWhileStarved(t *testing.T) {
+	const capacity = 4
+	tok := newCPUTokens(capacity)
+	g := newWidthGate(tok)
+	d := newMorselDispenser(4, false)
+
+	var processed atomic.Int64
+	release := make(chan struct{})
+	var wg sync.WaitGroup
+	ctx := context.Background()
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = consumeMorsels(ctx, d, g, func(m morsel) error {
+				<-release // hold the slot while "processing"
+				processed.Add(1)
+				m.retire()
+				return nil
+			}, nil)
+		}()
+	}
+
+	// Feed one round so every consumer processes concurrently, then starve.
+	for i := 0; i < 4; i++ {
+		d.ch <- morsel{b: nil, retire: func() {}}
+	}
+	deadline := time.After(2 * time.Second)
+	for tok.InUse() != capacity-1 { // 4 active = 1 baseline + 3 tokens
+		select {
+		case <-deadline:
+			t.Fatalf("active width tokens = %d, want %d", tok.InUse(), capacity-1)
+		case <-time.After(time.Millisecond):
+		}
+	}
+	close(release)
+	for processed.Load() != 4 {
+		select {
+		case <-deadline:
+			t.Fatalf("processed = %d, want 4", processed.Load())
+		case <-time.After(time.Millisecond):
+		}
+	}
+	// Channel now empty: every consumer must yield its slot while parked.
+	for tok.InUse() != 0 {
+		select {
+		case <-deadline:
+			t.Fatalf("starved consumers still hold %d tokens (legacy shape)", tok.InUse())
+		case <-time.After(time.Millisecond):
+		}
+	}
+	// The decode-side probe: a non-blocking taker gets the full pool.
+	if got := tok.TryAcquire(capacity); got != capacity {
+		t.Fatalf("TryAcquire during consumer starvation = %d, want %d", got, capacity)
+	}
+	tok.Release(capacity)
+
+	close(d.ch)
+	wg.Wait()
+	if got := tok.InUse(); got != 0 {
+		t.Fatalf("tokens leaked after close: %d", got)
+	}
+}
+
+// TestConsumeMorsels_SerialUnderZeroCapacity: with an empty pool the loop
+// still makes progress on the baseline slot alone.
+func TestConsumeMorsels_SerialUnderZeroCapacity(t *testing.T) {
+	tok := newCPUTokens(0)
+	g := newWidthGate(tok)
+	d := newMorselDispenser(2, false)
+
+	var processed atomic.Int64
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = consumeMorsels(context.Background(), d, g, func(m morsel) error {
+				processed.Add(1)
+				m.retire()
+				return nil
+			}, nil)
+		}()
+	}
+	for i := 0; i < 32; i++ {
+		d.ch <- morsel{b: nil, retire: func() {}}
+	}
+	close(d.ch)
+	wg.Wait()
+	if got := processed.Load(); got != 32 {
+		t.Fatalf("processed = %d, want 32", got)
+	}
+}


### PR DESCRIPTION
## Problem

Morsel-parallel fragments acquire their width tokens once at fragment start and hold them for the fragment's lifetime — **including while blocked on an empty morsel channel**. Decode-ahead draws from the same worker-wide pool (`cpuTokens`, GOMAXPROCS−2). Two concurrent probe-split tasks × up to 7 extra consumers each exhaust the pool, so the decode that would feed those idle consumers gets zero tokens and collapses to cursor-only. The consumers wait on the channel; the decoder waits on the consumers' tokens.

Evidence from the 2026-07-21 SF100 steady ref (results/20260721-232107):

- Every 3-task lineitem broadcast/probe-split stage bottoms out at a ~45 s floor: Q09 `join-6` 47.3 s (126 s cumulative decode token-stall on one worker), Q17 `join-2`/`join-5` 74 s stall each, Q18 `scan-9` 130 s stall — all with `pressure_stalls=0 window_fulls=0 ledger_stalls=0`, i.e. tokens are the only closed gate.
- Whole-run worker CPU profiles: 260–276 % of 1600 % available (~17 % utilization). The cluster is starved, not saturated.

## Fix

A consumer owns width **only while it owns a morsel**:

- `morselFragmentWorkers` no longer takes tokens; it returns the policy target `k` plus a per-fragment `widthGate`.
- Consumers claim before processing — fragment **baseline slot** first (the "first consumer is free" rule, now a slot any consumer may hold), then a pool token — hold the slot across back-to-back morsels (steady flow pays no per-morsel pool traffic), and **yield it before blocking on an empty dispenser**. Starved width returns to the pool; decode-ahead widens; the channel refills; consumers re-claim.
- `cpuTokens` gains a FIFO waiter queue with strict priority over `TryAcquire`: queued claimers hold admitted morsels, so feeding them beats widening decode.
- Side effect: width is no longer frozen at start-time token availability — a fragment that started under a transient burst can widen when the burst passes.

Blocking claims are deadlock-free by construction: every token holder is actively computing with bounded hold time (one row-group decode, one morsel), and the baseline slot keeps one consumer per fragment runnable regardless of the pool. This differs from the parked-waiter admission shape rejected in May: the awaited capacity is released by other goroutines' bounded progress, never the waiter's own. Design record: `docs/design/morsel-execution.md` §4.2.1.

**Kill switch:** `WADJET_MORSEL_YIELD=0` restores fixed-lifetime acquisition.

## Tests & gates

- Regression: `TestConsumeMorsels_YieldsWidthWhileStarved` — parked consumers hold zero tokens; a concurrent `TryAcquire` (decode-ahead stand-in) gets the full pool. Fails by design under the legacy holding rule.
- New: cpuTokens FIFO/cancel/immediate-grant, widthGate baseline/park/ctx-cancel, zero-capacity serial progress, yield-mode width decision.
- `go test -race` worker + exec + scan; `./internal/...`; `./wadjet/...`; TPC-H SF0.01 22/22.
- `tpch-harness --mode=local` at SF0.01 **and SF1**, both flag states: row counts identical, zero hangs (SF1 local suite wall 39.7 s yield-on vs 45.4 s off — directional only).
- Race-built `wadjet` through forced-parallel harness (`--morsel-workers=4,--log-level=debug`): 0 race reports; `width_yields`/`width_wait_ms` visible in fragment-done lines.

## Validation plan

Same-window SF100 A/B (main baseline first, then this branch) — watch the decode-ahead `token_stall_ms` collapse on Q09/Q17/Q18 big stages, the known grace-join probe serialization cluster (Q17/Q20/Q12), and heap headroom (active width can now reach target more often).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015wewUJXsvVAouAthWFKxWM