### PR TITLE
perf(planner): dedupe filtered scan-exchanges subsumed by a raw sibling

### DIFF
--- a/internal/coordinator/exchange_subsume_e2e_test.go
+++ b/internal/coordinator/exchange_subsume_e2e_test.go
@@ -1,0 +1,191 @@
+package coordinator
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/benchmarks/tpch"
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/planner/physical"
+	"github.com/citc-tech/wadjet/internal/storage/catalog"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+	"github.com/citc-tech/wadjet/internal/worker"
+)
+
+// TestExchangeSubsumeQ21Shape is the e2e regression for exchange
+// subsumption dedup: the Q21 EXISTS/NOT-EXISTS pair whose NOT-EXISTS build
+// (filtered lineitem shuffle) is subsumed by the EXISTS build's raw shuffle
+// of the same table. Both arms (subsume on / kill switch off) must return
+// identical rows; ground truth pins the semantics. Multi-chunk data ensures
+// every group's rows span several scan/shuffle tasks.
+func TestExchangeSubsumeQ21Shape(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	t.Cleanup(cancel)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	natsCfg := distributed.DefaultNATSConfig()
+	natsCfg.Port = -1
+	natsCfg.StoreDir = t.TempDir()
+	embeddedNATS, err := distributed.NewEmbeddedNATS(natsCfg, logger)
+	if err != nil {
+		t.Fatalf("nats: %v", err)
+	}
+	t.Cleanup(embeddedNATS.Shutdown)
+	nc, err := distributed.ConnectInProcess(embeddedNATS.Server())
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { nc.Close() })
+	js, err := distributed.NewJetStream(nc)
+	if err != nil {
+		t.Fatalf("js: %v", err)
+	}
+	if err := distributed.SetupStreams(ctx, js); err != nil {
+		t.Fatalf("streams: %v", err)
+	}
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(ctx, "test"); err != nil {
+		t.Fatal(err)
+	}
+	kv, err := catalog.NewNATSKV(js)
+	if err != nil {
+		t.Fatalf("kv: %v", err)
+	}
+	cat := catalog.New(kv, store, "test")
+	if err := cat.Init(ctx); err != nil {
+		t.Fatalf("cat init: %v", err)
+	}
+
+	data := tpch.Generate(tpch.SF001)
+	for _, tbl := range []string{"lineitem", "supplier"} {
+		schema := tpch.AllTables[tbl]
+		rows := data[tbl]
+		if err := cat.CreateTable(ctx, tbl, schema, nil); err != nil {
+			t.Fatal(err)
+		}
+		const chunks = 3
+		per := (len(rows) + chunks - 1) / chunks
+		for c := 0; c < chunks; c++ {
+			lo, hi := c*per, c*per+per
+			if hi > len(rows) {
+				hi = len(rows)
+			}
+			if lo >= hi {
+				break
+			}
+			var buf bytes.Buffer
+			pw, _ := parquet.NewWriter(&buf, schema, parquet.DefaultWriterConfig())
+			if err := pw.WriteRows(rows[lo:hi]); err != nil {
+				t.Fatal(err)
+			}
+			pw.Close()
+			fp := fmt.Sprintf("tables/%s/chunk_%04d.parquet", tbl, c)
+			pd := buf.Bytes()
+			store.Put(ctx, "test", fp, bytes.NewReader(pd), int64(len(pd)), "application/octet-stream")
+			cat.AddFiles(ctx, tbl, map[string]string{}, "tables/"+tbl+"/", []catalog.FileEntry{{
+				Path: fp, SizeBytes: int64(len(pd)), NumRows: int64(hi - lo), CreatedAt: time.Now(),
+			}})
+		}
+	}
+
+	for i := 0; i < 3; i++ {
+		w := worker.New(worker.Config{NATSUrl: embeddedNATS.ClientURL(), MaxConcurrent: 4, CacheBytes: 64 << 20}, store, nc, js, logger)
+		wctx, wcancel := context.WithCancel(context.Background())
+		t.Cleanup(wcancel)
+		if err := w.Start(wctx); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(w.Stop)
+	}
+	coord := New(Config{NATSUrl: embeddedNATS.ClientURL(), ResultBucket: "test"}, cat, nc, js, logger)
+	for i := 0; i < 3; i++ {
+		coord.workers.record(distributed.WorkerHeartbeat{WorkerID: fmt.Sprintf("fake-%d", i), Timestamp: time.Now()})
+	}
+
+	// Ground truth from source rows: suppliers with a "waiting" line
+	// (receipt > commit) on a multi-supplier order where no OTHER supplier
+	// also has a late line on that order — the Q21 core.
+	type line struct {
+		order, supp int64
+		late        bool
+	}
+	var lines []line
+	for _, r := range data["lineitem"] {
+		lines = append(lines, line{
+			order: toInt64(r["l_orderkey"]),
+			supp:  toInt64(r["l_suppkey"]),
+			late:  fmt.Sprint(r["l_receiptdate"]) > fmt.Sprint(r["l_commitdate"]),
+		})
+	}
+	byOrder := map[int64][]line{}
+	for _, l := range lines {
+		byOrder[l.order] = append(byOrder[l.order], l)
+	}
+	truthCount := 0
+	for _, l := range lines {
+		if !l.late {
+			continue
+		}
+		otherSupp, otherLate := false, false
+		for _, o := range byOrder[l.order] {
+			if o.supp != l.supp {
+				otherSupp = true
+				if o.late {
+					otherLate = true
+				}
+			}
+		}
+		if otherSupp && !otherLate {
+			truthCount++
+		}
+	}
+
+	sql := `SELECT COUNT(*) AS numwait
+FROM supplier
+JOIN lineitem l1 ON s_suppkey = l1.l_suppkey
+WHERE l1.l_receiptdate > l1.l_commitdate
+AND EXISTS (
+  SELECT 1 FROM lineitem l2
+  WHERE l2.l_orderkey = l1.l_orderkey AND l2.l_suppkey != l1.l_suppkey
+)
+AND NOT EXISTS (
+  SELECT 1 FROM lineitem l3
+  WHERE l3.l_orderkey = l1.l_orderkey AND l3.l_suppkey != l1.l_suppkey
+    AND l3.l_receiptdate > l3.l_commitdate
+)`
+
+	prev := physical.ExchangeSubsume.Load()
+	t.Cleanup(func() { physical.ExchangeSubsume.Store(prev) })
+	for _, arm := range []struct {
+		name string
+		on   bool
+	}{
+		{"subsume", true},
+		{"kill-switch", false},
+	} {
+		t.Run(arm.name, func(t *testing.T) {
+			physical.ExchangeSubsume.Store(arm.on)
+			res, err := coord.ExecuteSQL(ctx, sql)
+			if err != nil {
+				t.Fatalf("ExecuteSQL: %v", err)
+			}
+			if res.Error != "" {
+				t.Fatalf("query error: %s", res.Error)
+			}
+			rows := mustRows(t, res)
+			if len(rows) != 1 {
+				t.Fatalf("got %d rows, want 1", len(rows))
+			}
+			got := toInt64(rows[0]["numwait"])
+			if got != int64(truthCount) {
+				t.Errorf("numwait = %d, want ground truth %d", got, truthCount)
+			}
+		})
+	}
+}

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -1000,7 +1000,16 @@ func (c *Coordinator) dispatchShuffleStage(
 	// consumers can clear their barrier once the shuffle tasks are built.
 	// nil when the flag is off. The empty-source early return above never
 	// dispatches the feed — consumers just fall through on done[dep].
-	shards, shardStats, err := c.runShuffleSide(ctx, queryID, "stage-"+stage.ID, synthetic, stage.Exchange.Keys, numParts, workerCount, upstream.DynamicFilters, c.eagerFeedHandle(queryID, stage.ID))
+	var computedCols []distributed.ComputedColSpec
+	for _, cc := range stage.Exchange.ComputedCols {
+		computedCols = append(computedCols, distributed.ComputedColSpec{Name: cc.Name, Expr: cc.Expr})
+	}
+	// Widen the parquet read with the flag expressions' input columns; the
+	// worker drops them from the payload after computing the flags.
+	if len(stage.Exchange.ExtraReadCols) > 0 && len(synthetic.Columns) > 0 {
+		synthetic.Columns = append(append([]string(nil), synthetic.Columns...), stage.Exchange.ExtraReadCols...)
+	}
+	shards, shardStats, err := c.runShuffleSide(ctx, queryID, "stage-"+stage.ID, synthetic, stage.Exchange.Keys, numParts, workerCount, upstream.DynamicFilters, computedCols, stage.Exchange.ExtraReadCols, c.eagerFeedHandle(queryID, stage.ID))
 	if err != nil {
 		return StageOutput{}, err
 	}
@@ -2225,6 +2234,7 @@ func (c *Coordinator) dispatchComputeStage(
 			QualifyAllBuildCols: stage.QualifyAllBuildCols,
 			BuildColOrigins:     stage.BuildColOrigins,
 			JoinFilter:          stage.JoinFilter,
+			BuildFilterExprs:    append([]string(nil), stage.BuildFilterExprs...),
 			FusedJoins:          wireFused,
 			GroupByCols:         stage.GroupByCols,
 			Aggregates:          aggs,
@@ -2720,6 +2730,7 @@ func buildJoinFragment(
 		JoinFilter:          t.JoinFilter,
 		BuildRowHint:        t.BuildRowHint,
 		SemiAntiKeyOnly:     t.SemiAntiKeyOnly,
+		BuildFilterExprs:    append([]string(nil), t.BuildFilterExprs...),
 		QualifyAllBuildCols: t.QualifyAllBuildCols,
 		BuildColOrigins:     t.BuildColOrigins,
 		OutputColumns:       append([]string(nil), t.Columns...),

--- a/internal/coordinator/orchestrate_repartition.go
+++ b/internal/coordinator/orchestrate_repartition.go
@@ -103,7 +103,7 @@ func (c *Coordinator) orchestrateRepartition(
 	g, gctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		shards, stats, err := c.runShuffleSide(gctx, queryID, "build", buildStage, cand.BuildKeys, numParts, workerCount, nil, nil)
+		shards, stats, err := c.runShuffleSide(gctx, queryID, "build", buildStage, cand.BuildKeys, numParts, workerCount, nil, nil, nil, nil)
 		if err != nil {
 			return fmt.Errorf("build-side shuffle for %s: %w", cand.BuildAlias, err)
 		}
@@ -112,7 +112,7 @@ func (c *Coordinator) orchestrateRepartition(
 	})
 
 	g.Go(func() error {
-		shards, stats, err := c.runShuffleSide(gctx, queryID, "probe", probeStage, cand.ProbeKeys, numParts, workerCount, nil, nil)
+		shards, stats, err := c.runShuffleSide(gctx, queryID, "probe", probeStage, cand.ProbeKeys, numParts, workerCount, nil, nil, nil, nil)
 		if err != nil {
 			return fmt.Errorf("probe-side shuffle for %s: %w", cand.ProbeAlias, err)
 		}
@@ -169,6 +169,8 @@ func (c *Coordinator) runShuffleSide(
 	numParts int,
 	workerCount int,
 	dynamicFilters []distributed.DynamicFilterSpec, // resolved bloom/range pushdowns from upstream build stat
+	computedCols []distributed.ComputedColSpec, // appended payload expression columns (exchange subsumption)
+	dropCols []string, // read-only flag-input columns dropped post-compute
 	eagerFeed *eagerFeed,
 ) ([][]string, shuffleSideStats, error) {
 	ctx, cancel := context.WithTimeout(ctx, shuffleStageTimeout)
@@ -247,6 +249,8 @@ func (c *Coordinator) runShuffleSide(
 			ResultPrefix:   resultPrefix,
 			CreatedAt:      time.Now(),
 			DynamicFilters: dynamicFilters,
+			ComputedCols:   computedCols,
+			DropCols:       dropCols,
 		}
 		if clusterID := c.catalog.ClusterID(); clusterID != "" {
 			t.ClusterID = clusterID

--- a/internal/distributed/messages.go
+++ b/internal/distributed/messages.go
@@ -126,6 +126,9 @@ type Task struct {
 	// owning alias instead of BuildTableAlias.
 	BuildColOrigins map[string]string `json:"build_col_origins,omitempty"`
 	JoinFilter      string            `json:"join_filter,omitempty"` // semi/anti join inequality filter expression
+	// BuildFilterExprs filter the build input rows before hash-table
+	// insertion (exchange subsumption dedup).
+	BuildFilterExprs []string `json:"build_filter_exprs,omitempty"`
 
 	// Fused join: additional broadcast joins absorbed into a single task.
 	// The worker builds hash tables for each fused join, then chains probes
@@ -138,6 +141,13 @@ type Task struct {
 	// Shuffle-specific
 	ShuffleKeys   []string `json:"shuffle_keys,omitempty"`   // columns to hash-partition on
 	NumPartitions int      `json:"num_partitions,omitempty"` // number of output partitions
+	// ComputedCols are expression columns appended to the shuffle payload
+	// after the projected scan columns (exchange subsumption dedup: a
+	// dropped filtered sibling's filter ships as a computed flag).
+	ComputedCols []ComputedColSpec `json:"computed_cols,omitempty"`
+	// DropCols are read-only helper columns (ComputedCols expression
+	// inputs) removed from the payload after the flags are computed.
+	DropCols []string `json:"drop_cols,omitempty"`
 	PartitionID   int      `json:"partition_id,omitempty"`   // which partition this join task handles
 
 	// Dynamic filters carried at the top level for non-fragment task shapes
@@ -324,6 +334,10 @@ type OpSpec struct {
 	JoinFilter          string   `json:"join_filter,omitempty"`
 	BuildRowHint        int64    `json:"build_row_hint,omitempty"`
 	SemiAntiKeyOnly     bool     `json:"semi_anti_key_only,omitempty"`
+	// BuildFilterExprs filter the BUILD input rows before hash-table
+	// insertion (exchange subsumption dedup: the dropped exchange's scan
+	// filter — or its computed flag column — applied at build read).
+	BuildFilterExprs []string `json:"build_filter_exprs,omitempty"`
 	QualifyAllBuildCols bool              `json:"qualify_all_build_cols,omitempty"`
 	BuildColOrigins     map[string]string `json:"build_col_origins,omitempty"` // bare build col → owning scan alias (multi-table builds only)
 	OutputColumns       []string          `json:"output_columns,omitempty"`    // OutputFilter for primary probe
@@ -669,4 +683,11 @@ func Unmarshal(data []byte, v any) error {
 		return gob.NewDecoder(bytes.NewReader(data[1:])).Decode(v)
 	}
 	return json.Unmarshal(data, v)
+}
+
+// ComputedColSpec is one appended expression column on a shuffle payload
+// (exchange subsumption dedup).
+type ComputedColSpec struct {
+	Name string `json:"name"`
+	Expr string `json:"expr"`
 }

--- a/internal/planner/physical/exchange.go
+++ b/internal/planner/physical/exchange.go
@@ -42,4 +42,21 @@ type ExchangeStage struct {
 	BuildAlias string        // Repartition, Replicate
 	ProbeAlias string        // Repartition, Replicate
 	BuildBytes int64         // Repartition (for logging / threshold checks)
+	// ComputedCols are expression columns APPENDED to the shuffle payload
+	// (after the projected scan columns). Set by dedupeSubsumedScanExchanges
+	// so one raw exchange can serve a dropped filtered sibling: the
+	// sibling's scan filter ships as a cheap computed flag (1 byte/row)
+	// instead of a second full scan+shuffle of the table. Workers evaluate
+	// Expr per batch and append the result under Name.
+	ComputedCols []ComputedCol
+	// ExtraReadCols are columns the shuffle's source scan must READ so the
+	// ComputedCols expressions can evaluate, but which are NOT part of the
+	// shipped payload — the worker drops them after computing the flags.
+	ExtraReadCols []string
+}
+
+// ComputedCol is one appended expression column on a shuffle payload.
+type ComputedCol struct {
+	Name string
+	Expr string
 }

--- a/internal/planner/physical/exchange_subsume.go
+++ b/internal/planner/physical/exchange_subsume.go
@@ -1,0 +1,234 @@
+package physical
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"sync/atomic"
+)
+
+// ExchangeSubsume gates dedupeSubsumedScanExchanges. Kill switch
+// WADJET_EXCHANGE_SUBSUME=0. Exported atomic.Bool (ScalarAggSemijoin
+// pattern) so tests can pin either arm.
+var ExchangeSubsume atomic.Bool
+
+func init() {
+	ExchangeSubsume.Store(os.Getenv("WADJET_EXCHANGE_SUBSUME") != "0")
+}
+
+// dedupeSubsumedScanExchanges drops an exchange-repartition whose payload is
+// a filtered subset of a sibling exchange over the same base table, rewiring
+// its consumer to the subsuming exchange.
+//
+// The Q21 shape that motivates it: l2 scans lineitem RAW and shuffles
+// (l_orderkey, l_suppkey) by l_orderkey for the EXISTS build; l3 scans the
+// SAME table with σ(l_receiptdate > l_commitdate), same payload columns,
+// same keys and partition count, for the NOT-EXISTS build. At SF100 the l3
+// leg pays a full scan-filter materialization plus a 300 M-row shuffle for
+// rows that are, exactly, a subset of what l2 already shipped.
+//
+// Because the filter's columns are deliberately NOT part of the shipped
+// payload (shuffle projection), the residual cannot run on the subsuming
+// exchange's rows as-is. Instead the raw exchange APPENDS the filter as a
+// computed boolean column (~1 byte/row on the raw payload — vs a second
+// full scan+shuffle), and the dropped exchange's consumer filters its build
+// input on that flag at read time (Stage.BuildFilterExprs). Filtering build
+// rows at read is semantically identical to filtering them at the dropped
+// scan.
+//
+// Conservative eligibility (v1):
+//   - A and B are exchange-repartition stages whose sole deps are SCAN
+//     stages of the same table; A's scan is filter-free, B's carries
+//     FilterExprs.
+//   - Same Exchange.Keys (exact) and Count.
+//   - B has exactly ONE consumer, which uses B as its build side
+//     (RightDepStage) and carries no pre-existing BuildFilterExprs.
+//   - Every payload column of B's scan is either in A's scan columns or
+//     referenced only by the residual filter; and the consumer's build-side
+//     references (join RightKeys + JoinFilter identifiers) are all present
+//     in A's payload.
+func dedupeSubsumedScanExchanges(stages []Stage) []Stage {
+	if !ExchangeSubsume.Load() {
+		return stages
+	}
+	idIndex := make(map[string]int, len(stages))
+	consumers := make(map[string][]int) // stage ID -> indexes of stages depending on it
+	for i := range stages {
+		idIndex[stages[i].ID] = i
+		for _, d := range stages[i].Dependencies {
+			consumers[d] = append(consumers[d], i)
+		}
+	}
+	scanOf := func(s *Stage) *Stage {
+		if s.Type != StageExchangeRepartition || s.Exchange == nil || len(s.Dependencies) != 1 {
+			return nil
+		}
+		idx, ok := idIndex[s.Dependencies[0]]
+		if !ok || stages[idx].Type != StageScan {
+			return nil
+		}
+		return &stages[idx]
+	}
+
+	dropped := make(map[string]bool) // dropped stage IDs (exchange + its scan)
+	flagSeq := 0
+	for bi := range stages {
+		b := &stages[bi]
+		scanB := scanOf(b)
+		if scanB == nil || len(scanB.FilterExprs) == 0 || len(consumers[scanB.ID]) != 1 {
+			continue
+		}
+		// Sole consumer of B must use it as the build side.
+		bCons := consumers[b.ID]
+		if len(bCons) != 1 {
+			continue
+		}
+		cons := &stages[bCons[0]]
+		if cons.RightDepStage != b.ID || len(cons.BuildFilterExprs) > 0 {
+			continue
+		}
+		for ai := range stages {
+			a := &stages[ai]
+			if ai == bi || dropped[a.ID] {
+				continue
+			}
+			scanA := scanOf(a)
+			if scanA == nil || len(scanA.FilterExprs) > 0 || scanA.TableName != scanB.TableName {
+				continue
+			}
+			if !keysEqual(a.Exchange.Keys, b.Exchange.Keys) || a.Exchange.Count != b.Exchange.Count {
+				continue
+			}
+			if !subsumePayloadCovered(scanA, scanB, cons) {
+				continue
+			}
+			// Rewrite: flag col on A, consumer build reads A + filter.
+			flag := fmt.Sprintf("__subsume_f%d", flagSeq)
+			flagSeq++
+			residual := conjoin(scanB.FilterExprs)
+			a.Exchange.ComputedCols = append(a.Exchange.ComputedCols, ComputedCol{
+				Name: flag,
+				Expr: residual,
+			})
+			// The flag's inputs must be READ by A's scan without joining
+			// the shipped payload: list them so the dispatcher widens the
+			// parquet read and the worker drops them post-compute.
+			aColSet := make(map[string]bool, len(scanA.Columns))
+			for _, c := range scanA.Columns {
+				aColSet[c] = true
+			}
+			for _, c := range scanB.Columns {
+				if !aColSet[c] && identifierInExpr(residual, c) && !hasColumn(a.Exchange.ExtraReadCols, c) {
+					a.Exchange.ExtraReadCols = append(a.Exchange.ExtraReadCols, c)
+				}
+			}
+			cons.BuildFilterExprs = []string{flag}
+			cons.RightDepStage = a.ID
+			for i, d := range cons.Dependencies {
+				if d == b.ID {
+					cons.Dependencies[i] = a.ID
+				}
+			}
+			dropped[b.ID] = true
+			dropped[scanB.ID] = true
+			break
+		}
+	}
+	if len(dropped) == 0 {
+		return stages
+	}
+	out := make([]Stage, 0, len(stages)-len(dropped))
+	for _, s := range stages {
+		if !dropped[s.ID] {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// subsumePayloadCovered checks the column-coverage conditions: B's payload
+// columns are each either shipped by A or referenced only by B's residual
+// filter, and the consumer's build-side references resolve against A's
+// payload.
+func subsumePayloadCovered(scanA, scanB, cons *Stage) bool {
+	aCols := make(map[string]bool, len(scanA.Columns))
+	for _, c := range scanA.Columns {
+		aCols[c] = true
+	}
+	residual := conjoin(scanB.FilterExprs)
+	for _, c := range scanB.Columns {
+		if !aCols[c] && !identifierInExpr(residual, c) {
+			return false
+		}
+	}
+	// Residual must be evaluable at B's scan (its identifiers come from
+	// scanB's own columns) — guaranteed by construction (planner pushed it
+	// onto scanB). The consumer's build references must exist in A's
+	// payload.
+	for _, k := range cons.JoinRightKeys {
+		if !aCols[baseColName(k)] {
+			return false
+		}
+	}
+	if cons.JoinFilter != "" {
+		for _, id := range extractIdentifiers(cons.JoinFilter) {
+			base := baseColName(id)
+			// Build-side references must be shipped; probe-side identifiers
+			// resolve against the probe schema, so only reject identifiers
+			// that look like B's table columns and are missing from A.
+			if hasColumn(scanB.Columns, base) && !aCols[base] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func conjoin(exprs []string) string {
+	if len(exprs) == 1 {
+		return exprs[0]
+	}
+	out := ""
+	for i, e := range exprs {
+		if i > 0 {
+			out += " AND "
+		}
+		out += "(" + e + ")"
+	}
+	return out
+}
+
+var identRe = regexp.MustCompile(`[A-Za-z_][A-Za-z0-9_.]*`)
+
+// identifierInExpr reports whether col appears as a whole identifier (or
+// the trailing segment of a qualified identifier) in expr.
+func identifierInExpr(expr, col string) bool {
+	for _, id := range extractIdentifiers(expr) {
+		if baseColName(id) == col {
+			return true
+		}
+	}
+	return false
+}
+
+func extractIdentifiers(expr string) []string {
+	return identRe.FindAllString(expr, -1)
+}
+
+func baseColName(id string) string {
+	for i := len(id) - 1; i >= 0; i-- {
+		if id[i] == '.' {
+			return id[i+1:]
+		}
+	}
+	return id
+}
+
+func hasColumn(cols []string, c string) bool {
+	for _, x := range cols {
+		if x == c {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -89,6 +89,13 @@ type Stage struct {
 	// build columns with the OWNING alias instead of BuildTableAlias.
 	BuildColOrigins map[string]string
 	JoinFilter      string // semi/anti join inequality filter (e.g., "l2.l_suppkey != l1.l_suppkey")
+	// BuildFilterExprs are row predicates applied to the BUILD input before
+	// hash-table insertion. Set by dedupeSubsumedScanExchanges when this
+	// join's build was rewired from a filtered exchange to a subsuming raw
+	// exchange: the dropped exchange's scan filter (or its computed
+	// __subsume flag) must now run at build-read time. Semantically
+	// identical to filtering at the dropped scan.
+	BuildFilterExprs []string
 
 	// Fused broadcast joins absorbed into this stage (avoids separate
 	// shuffle+join stages for small dimension tables like nation, region).
@@ -1765,6 +1772,12 @@ func (p *Planner) PlanDistributed(ctx context.Context, node *logical.Node) ([]St
 		// valid labels because the elided exchange's output distribution
 		// was by definition its input's. Kill switch WADJET_EXCHANGE_ELIDE=0.
 		stages = elideCoPartitionedExchanges(stages)
+		// Drop filtered scan-exchanges fully subsumed by a raw sibling over
+		// the same table (Q21 l3 ⊂ l2): the raw exchange ships the filter
+		// as a computed flag column and the dropped exchange's consumer
+		// filters its build input on it. Kill switch
+		// WADJET_EXCHANGE_SUBSUME=0.
+		stages = dedupeSubsumedScanExchanges(stages)
 		// Fragment fusion passes are intentionally NOT called here.
 		//
 		// fuseScanShuffle / fuseJoinShuffle absorb a downstream

--- a/internal/planner/physical/subsume_shape_test.go
+++ b/internal/planner/physical/subsume_shape_test.go
@@ -1,0 +1,36 @@
+package physical
+
+import "testing"
+
+// TestExchangeSubsume_Q21ShapeApplies pins that the dedup fires on the
+// EXISTS/NOT-EXISTS lineitem pair (the e2e test's query shape): the plan
+// must contain exactly ONE lineitem-scan-fed exchange with a computed flag
+// col, and a consumer carrying BuildFilterExprs.
+func TestExchangeSubsume_Q21ShapeApplies(t *testing.T) {
+	prev := ExchangeSubsume.Load()
+	t.Cleanup(func() { ExchangeSubsume.Store(prev) })
+	ExchangeSubsume.Store(true)
+	cat, ctx := setupTPCHCatalog(t)
+	sql := `SELECT COUNT(*) AS numwait
+FROM supplier
+JOIN lineitem l1 ON s_suppkey = l1.l_suppkey
+WHERE l1.l_receiptdate > l1.l_commitdate
+AND EXISTS (SELECT 1 FROM lineitem l2 WHERE l2.l_orderkey = l1.l_orderkey AND l2.l_suppkey != l1.l_suppkey)
+AND NOT EXISTS (SELECT 1 FROM lineitem l3 WHERE l3.l_orderkey = l1.l_orderkey AND l3.l_suppkey != l1.l_suppkey AND l3.l_receiptdate > l3.l_commitdate)`
+	stages := sqlToStages(t, cat, ctx, sql, 3)
+	flagged, buildFiltered := 0, 0
+	for _, s := range stages {
+		if s.Exchange != nil && len(s.Exchange.ComputedCols) > 0 {
+			flagged++
+		}
+		if len(s.BuildFilterExprs) > 0 {
+			buildFiltered++
+		}
+	}
+	if flagged != 1 || buildFiltered != 1 {
+		for _, s := range stages {
+			t.Logf("id=%s type=%s deps=%v", s.ID, s.Type, s.Dependencies)
+		}
+		t.Fatalf("flagged exchanges = %d, build-filtered consumers = %d; want 1 and 1 (dedup did not fire)", flagged, buildFiltered)
+	}
+}

--- a/internal/planner/physical/testdata/ensure_distribution/q21.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q21.golden
@@ -11,9 +11,7 @@ scan-9	scan	Singleton
 exchange-repartition-10	exchange-repartition	Hash(l_orderkey)/32	deps=join-8
 exchange-repartition-11	exchange-repartition	Hash(l_orderkey)/32	deps=scan-9
 join-12	hash_join	Hash(l_orderkey)/32	deps=exchange-repartition-10,exchange-repartition-11
-scan-13	scan	Singleton
-exchange-repartition-15	exchange-repartition	Hash(l_orderkey)/32	deps=scan-13
-join-16	hash_join	Hash(l_orderkey)/32	deps=join-12,exchange-repartition-15
+join-16	hash_join	Hash(l_orderkey)/32	deps=join-12,exchange-repartition-11
 aggregate-17	aggregate	RoundRobin	deps=join-16
 final_aggregate-18	final_aggregate	Hash(s_name)/4	deps=exchange-repartition-final_aggregate-18-18
 sort-19	sort	Singleton	deps=final_aggregate-18

--- a/internal/worker/broadcast_join_cache.go
+++ b/internal/worker/broadcast_join_cache.go
@@ -60,6 +60,11 @@ func computeBroadcastJoinKey(queryID string, spec distributed.OpSpec) string {
 	for _, k := range spec.RightKeys {
 		fmt.Fprintf(h, "\x00R:%s", k)
 	}
+	// Build-input filters change the built hash table: two joins over the
+	// same files with different BuildFilterExprs must not share a build.
+	for _, f := range spec.BuildFilterExprs {
+		fmt.Fprintf(h, "\x00BF:%s", f)
+	}
 	files := append([]string(nil), spec.BuildFiles...)
 	sort.Strings(files)
 	for _, f := range files {

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -1049,6 +1049,14 @@ func (e *Executor) executeShuffle(ctx context.Context, task distributed.Task, re
 	}
 	defer src.Close()
 
+	// Appended expression columns (exchange subsumption dedup): compiled
+	// once, evaluated per batch, appended ahead of the partitioning sink so
+	// the flag ships inside every partition file.
+	computedAppenders, err := newComputedColAppenders(task.ComputedCols)
+	if err != nil {
+		return fmt.Errorf("shuffle task %s: %w", task.ID, err)
+	}
+
 	// Set up the spill directory for the sink's partition files.
 	spillDir := filepath.Join(e.spillDir, "shuffle-"+task.ID)
 	if e.spillDir == "" {
@@ -1115,6 +1123,7 @@ func (e *Executor) executeShuffle(ctx context.Context, task distributed.Task, re
 			}
 			n = int64(b.ActiveLen())
 		}
+		b = applyComputedCols(computedAppenders, task.DropCols, b)
 		if sink == nil {
 			sink = newPartitionedShuffleSink(spillDir, task.ShuffleKeys, task.NumPartitions, b.Schema)
 			if err := sink.Init(ctx); err != nil {

--- a/internal/worker/executor_fragment.go
+++ b/internal/worker/executor_fragment.go
@@ -1953,6 +1953,18 @@ func (e *Executor) buildFragmentJoinProbe(ctx context.Context, task distributed.
 			return nil, fmt.Errorf("build source init: %w", err)
 		}
 		defer src.Close()
+		if len(spec.BuildFilterExprs) > 0 {
+			// Exchange subsumption dedup: this build was rewired from a
+			// dropped filtered exchange to a subsuming raw one — apply the
+			// dropped scan's filter (or its computed flag) to the build rows
+			// before insertion. Semantically identical to the dropped scan's
+			// own filter.
+			fops, _, err := compileFilterExprs(spec.BuildFilterExprs)
+			if err != nil {
+				return nil, fmt.Errorf("build filter: %w", err)
+			}
+			src = &filteredSource{Source: src, ops: fops}
+		}
 
 		hj := exec.NewHashJoin(mapJoinTypeString(spec.JoinType), spec.LeftKeys, spec.RightKeys)
 		hj.BuildTableAlias = spec.BuildAlias

--- a/internal/worker/shuffle_computed_cols.go
+++ b/internal/worker/shuffle_computed_cols.go
@@ -1,0 +1,116 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/engine/exec"
+	"github.com/citc-tech/wadjet/internal/engine/expr"
+	pqt "github.com/citc-tech/wadjet/internal/storage/parquet"
+	plansql "github.com/citc-tech/wadjet/internal/planner/sql"
+)
+
+// computedColAppender evaluates one Task.ComputedCols expression per batch
+// and appends the result as a boolean column to the shuffle payload
+// (exchange subsumption dedup: a dropped filtered sibling exchange's filter
+// rides the subsuming raw exchange as a flag).
+type computedColAppender struct {
+	name string
+	ex   expr.Expr
+	be   expr.BoolExpr // non-nil fast path
+}
+
+func newComputedColAppenders(specs []distributed.ComputedColSpec) ([]computedColAppender, error) {
+	if len(specs) == 0 {
+		return nil, nil
+	}
+	out := make([]computedColAppender, 0, len(specs))
+	for _, sp := range specs {
+		node, err := plansql.ParseExpression(sp.Expr)
+		if err != nil {
+			return nil, fmt.Errorf("parse computed col %s (%q): %w", sp.Name, sp.Expr, err)
+		}
+		compiled, err := expr.Compile(node)
+		if err != nil {
+			return nil, fmt.Errorf("compile computed col %s (%q): %w", sp.Name, sp.Expr, err)
+		}
+		a := computedColAppender{name: sp.Name, ex: compiled}
+		if be, ok := compiled.(expr.BoolExpr); ok {
+			a.be = be
+		}
+		out = append(out, a)
+	}
+	return out, nil
+}
+
+// applyComputedCols returns a shallow-copied batch with each appender's
+// boolean column appended. The input batch's vectors are shared, never
+// mutated — source batches may be pooled or cache-shared, so the column
+// append must not write through to them. Values are computed for every
+// PHYSICAL row (shuffle sources are unfiltered scans; Sel is typically nil).
+func applyComputedCols(appenders []computedColAppender, dropCols []string, b *batch.RecordBatch) *batch.RecordBatch {
+	if len(appenders) == 0 {
+		return b
+	}
+	drop := make(map[string]bool, len(dropCols))
+	for _, c := range dropCols {
+		drop[c] = true
+	}
+	cols := make([]*batch.Vector, 0, len(b.Columns)+len(appenders))
+	schema := make([]pqt.Column, 0, len(b.Schema)+len(appenders))
+	for i, sc := range b.Schema {
+		if drop[sc.Name] {
+			continue
+		}
+		cols = append(cols, b.Columns[i])
+		schema = append(schema, sc)
+	}
+	for _, a := range appenders {
+		v := batch.NewVector(batch.TypeBool, b.Len)
+		if a.be != nil {
+			for i := 0; i < b.Len; i++ {
+				v.BoolData[i] = a.be.EvalBool(b, i)
+			}
+		} else {
+			for i := 0; i < b.Len; i++ {
+				val, _ := a.ex.Eval(b, i).(bool)
+				v.BoolData[i] = val
+			}
+		}
+		cols = append(cols, v)
+		schema = append(schema, pqt.Column{Name: a.name, Type: pqt.TypeBool})
+	}
+	return &batch.RecordBatch{Columns: cols, Schema: schema, Len: b.Len, Sel: b.Sel}
+}
+
+// filteredSource applies a chain of filter operators to every batch a
+// wrapped Source yields — the build-input pre-filter for exchange
+// subsumption (executor_fragment.go buildHJ). Batches whose rows are all
+// filtered away are skipped.
+type filteredSource struct {
+	exec.Source
+	ops []exec.UnaryOperator
+}
+
+func (f *filteredSource) Next(ctx context.Context) (*batch.RecordBatch, error) {
+	for {
+		b, err := f.Source.Next(ctx)
+		if err != nil || b == nil {
+			return b, err
+		}
+		for _, op := range f.ops {
+			b, err = op.Execute(ctx, b)
+			if err != nil {
+				return nil, err
+			}
+			if b == nil {
+				break
+			}
+		}
+		if b != nil && b.ActiveLen() > 0 {
+			return b, nil
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Q21 ships lineitem three times. Two legs are: the EXISTS build — raw lineitem, `(l_orderkey, l_suppkey)` hashed by `l_orderkey`/24 — and the NOT-EXISTS build — the **same table, same payload columns, same keys and count**, filtered by `l_receiptdate > l_commitdate`. Filtered scans dispatch as scan-filter materialization + shuffle, so the l3 leg pays a full lineitem scan, a ~300M-row WSHF write+read, and a 24-way shuffle for rows that are exactly a subset of what l2 already shipped.

## Fix

New physical pass `dedupeSubsumedScanExchanges`: when a filtered scan-exchange is fully subsumed by a raw sibling (same table, same keys/count, payload covered, single build-side consumer), the raw exchange **appends the filter as a computed boolean flag column** (~1 byte/row vs a second scan+shuffle) and the consumer's build input filters on the flag at read (`BuildFilterExprs`) — semantically identical to filtering at the dropped scan. The flag's input columns are read by the shuffle scan but **dropped from the payload post-evaluation** (`ExtraReadCols`/`DropCols`).

The coordinator suite earned its keep here: `TestShuffleProjectionNarrowsAbsorbedScans` caught the first version evaluating flags against the pruned payload (missing date columns → flag false everywhere → under-populated anti build → Q21 3 rows instead of 1) and now pins the fix.

Plans change for **Q21 only** (golden: `scan-13` + `exchange-repartition-15` dropped; `join-16`'s build reads `exchange-repartition-11`). Broadcast cache key covers `BuildFilterExprs`.

**Kill switch:** `WADJET_EXCHANGE_SUBSUME=0` (`physical.ExchangeSubsume`).

## Tests & gates

- `TestExchangeSubsumeQ21Shape`: multi-worker e2e, EXISTS/NOT-EXISTS over multi-chunk data, both arms must match computed ground truth.
- `TestExchangeSubsume_Q21ShapeApplies`: pins the pass fires on the shape (guards silent no-op).
- Planner + worker `-race`, `./internal/...`, `wadjet/` (filtered-EXISTS machinery untouched), TPC-H SF0.01 22/22, `tpch-harness --mode=local` at SF0.01 **and SF1** both flag states: row-identical, no hangs.

## Validation plan

Same-window SF100 pair (baseline main first). Expected: Q21 loses a full lineitem scan-filter + shuffle leg (~24s span + slot pressure) — watching the join-16 build-read time (r-11 files + flag filter) and the r-11 payload growth (+1 byte/row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015wewUJXsvVAouAthWFKxWM