### PR TITLE
perf(planner): strip aggregate output cols from fused scan-agg read sets

### DIFF
--- a/internal/planner/physical/fused_agg_read_set.go
+++ b/internal/planner/physical/fused_agg_read_set.go
@@ -1,0 +1,52 @@
+package physical
+
+// pruneFusedAggOutputCols removes aggregate OUTPUT column names from a fused
+// scan-aggregate's read set. RequiredColumns accumulates ancestor needs, and
+// for the fused shape those include the aggregate outputs (__having_0,
+// __agg_N) that the scan fragment PRODUCES rather than reads; any name
+// missing from the parquet schema trips the worker's all-or-nothing
+// projection guard into a full-width read.
+//
+// Conservative toward keeping: an output name survives when it is also
+// needed as an INPUT — a group-by key, an aggregate's bare input column, an
+// identifier inside a derived input expression, or referenced by a
+// scan-pushed filter (SUM(x) AS x must still read x).
+func pruneFusedAggOutputCols(cols, groupBy []string, specs []AggSpec, filterExprs []string) []string {
+	outputs := make(map[string]bool, len(specs))
+	for _, s := range specs {
+		if s.OutputCol != "" {
+			outputs[s.OutputCol] = true
+		}
+	}
+	if len(outputs) == 0 {
+		return cols
+	}
+	// Anything read stays, even if it collides with an output name.
+	for _, g := range groupBy {
+		delete(outputs, g)
+	}
+	for _, s := range specs {
+		if s.InputExpr != "" {
+			for _, id := range extractIdentifiers(s.InputExpr) {
+				delete(outputs, baseColName(id))
+			}
+		} else if s.InputCol != "" {
+			delete(outputs, s.InputCol)
+		}
+	}
+	for _, f := range filterExprs {
+		for _, id := range extractIdentifiers(f) {
+			delete(outputs, baseColName(id))
+		}
+	}
+	if len(outputs) == 0 {
+		return cols
+	}
+	kept := cols[:0]
+	for _, c := range cols {
+		if !outputs[c] {
+			kept = append(kept, c)
+		}
+	}
+	return kept
+}

--- a/internal/planner/physical/fused_agg_read_set_test.go
+++ b/internal/planner/physical/fused_agg_read_set_test.go
@@ -1,0 +1,103 @@
+package physical
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPruneFusedAggOutputCols(t *testing.T) {
+	cases := []struct {
+		name    string
+		cols    []string
+		groupBy []string
+		specs   []AggSpec
+		filters []string
+		want    []string
+	}{
+		{
+			name:    "strips pure synthetic output (Q18 shape)",
+			cols:    []string{"__having_0", "l_orderkey", "l_quantity"},
+			groupBy: []string{"l_orderkey"},
+			specs:   []AggSpec{{Func: "sum", InputCol: "l_quantity", OutputCol: "__having_0"}},
+			want:    []string{"l_orderkey", "l_quantity"},
+		},
+		{
+			name:    "output aliasing its own input is kept (SUM(x) AS x)",
+			cols:    []string{"g", "x"},
+			groupBy: []string{"g"},
+			specs:   []AggSpec{{Func: "sum", InputCol: "x", OutputCol: "x"}},
+			want:    []string{"g", "x"},
+		},
+		{
+			name:    "output aliasing a group key is kept",
+			cols:    []string{"g", "x"},
+			groupBy: []string{"g"},
+			specs:   []AggSpec{{Func: "count", InputCol: "x", OutputCol: "g"}},
+			want:    []string{"g", "x"},
+		},
+		{
+			name:    "derived input expression identifiers are read",
+			cols:    []string{"__agg_0", "l_extendedprice", "l_discount", "l_partkey"},
+			groupBy: []string{"l_partkey"},
+			specs: []AggSpec{{
+				Func: "sum", InputCol: "__agg_0", OutputCol: "__agg_0",
+				InputExpr: "l_extendedprice * (1 - l_discount)",
+			}},
+			want: []string{"l_extendedprice", "l_discount", "l_partkey"},
+		},
+		{
+			name:    "output referenced by scan filter is kept",
+			cols:    []string{"o", "x", "g"},
+			groupBy: []string{"g"},
+			specs:   []AggSpec{{Func: "sum", InputCol: "x", OutputCol: "o"}},
+			filters: []string{"o > 5"},
+			want:    []string{"o", "x", "g"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := append([]string(nil), tc.cols...)
+			got := pruneFusedAggOutputCols(in, tc.groupBy, tc.specs, tc.filters)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFusedScanAggReadSet_Q18 pins the plan-level effect: the fused
+// scan-aggregate's read set must not carry the HAVING synthetic — one
+// unknown name reverts the worker's parquet projection to full width
+// (143 B/row vs ~25 B/row on Q18's 600M-row fused lineitem leg at SF100).
+func TestFusedScanAggReadSet_Q18(t *testing.T) {
+	cat, ctx := setupTPCHCatalog(t)
+	sql := `SELECT c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice,
+	SUM(l_quantity) as total_qty
+FROM customer
+JOIN orders ON c_custkey = o_custkey
+JOIN lineitem ON o_orderkey = l_orderkey
+WHERE o_orderkey IN (
+	SELECT l_orderkey FROM lineitem GROUP BY l_orderkey HAVING SUM(l_quantity) > 300
+)
+GROUP BY c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice
+ORDER BY o_totalprice DESC, o_orderdate
+LIMIT 100`
+	stages := sqlToStages(t, cat, ctx, sql, 3)
+	fused := 0
+	for _, s := range stages {
+		if s.Type != StageScan || len(s.FusedAggSpecs) == 0 {
+			continue
+		}
+		fused++
+		for _, spec := range s.FusedAggSpecs {
+			for _, c := range s.Columns {
+				if c == spec.OutputCol && c != spec.InputCol {
+					t.Errorf("fused scan %s read set %v contains agg output %q", s.ID, s.Columns, spec.OutputCol)
+				}
+			}
+		}
+	}
+	if fused == 0 {
+		t.Fatal("no fused scan-aggregate stage in Q18 plan (shape changed?)")
+	}
+}

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -3345,6 +3345,18 @@ func (p *Planner) walkStages(node *logical.Node, stages *[]Stage, parentID *stri
 				if (*stages)[i].Type == "scan" {
 					(*stages)[i].FusedAggGroupBy = groupBy
 					(*stages)[i].FusedAggSpecs = aggSpecs
+					// The scan's RequiredColumns carry the aggregate OUTPUT
+					// names (e.g. __having_0) because ancestors reference
+					// them. On a fused scan-aggregate those are produced by
+					// the fragment's HashAggregate, not read from parquet —
+					// but the worker's all-or-nothing projection guard can't
+					// know that: one unknown name silently reverts the whole
+					// scan to full width (Q18's fused lineitem leg measured
+					// 143 B/row vs the ~25 B/row its 2-column read set
+					// needs). Strip pure outputs from the read set; an
+					// output that aliases a real input (SUM(x) AS x) stays.
+					(*stages)[i].Columns = pruneFusedAggOutputCols(
+						(*stages)[i].Columns, groupBy, aggSpecs, (*stages)[i].FilterExprs)
 				}
 			}
 			// Skip the separate aggregate stage — scans produce partial aggs.


### PR DESCRIPTION
## What

A fused scan-aggregate's `RequiredColumns` carry the aggregate **output** names (`__having_0`) because ancestors reference them. The scan fragment produces those columns — but the worker's all-or-nothing parquet projection guard can't know that: one name missing from the file schema silently reverts the scan to **full width**. Q18's fused lineitem leg read 143 B/row instead of the ~25 B/row its 2-column read set needs — ~70 GB of avoidable S3 reads cold, and full-width decode CPU even when NVMe-cache-served in steady (600M rows at SF100, 24 `parquet projection skipped` WARNs per suite pair on main).

Fix at the fusion site (`walkStages` NodeAggregate): `pruneFusedAggOutputCols` strips pure outputs from the scan read set. Conservative toward keeping — an output that is also read survives (group key, bare input `SUM(x) AS x`, derived-expression identifier, or scan-filter reference). The #248 sanitize pass's deliberate `__`-name keep stays untouched for genuine scan-derived columns.

## Provenance

Found via the #258 A/B: the agg-over-exchange arm dropped the fused leg entirely and its projection WARNs vanished, isolating the full-width read as a standalone defect. This captures the narrow-read part of that arm's Q18 cold win (−17%) **without** the rewrite's steady-state S3 shift — no plan-shape change, no new stages, no S3 traffic moved.

## Gates

- New unit tests (`TestPruneFusedAggOutputCols`, incl. `SUM(x) AS x` aliasing, derived-expr, filter-ref guards) + plan-shape regression (`TestFusedScanAggReadSet_Q18`)
- Planner suite — goldens unchanged (no plan-shape change)
- Coordinator + worker suites, TPC-H SF0.01 22/22
- Harness local SF0.01 + SF1: rows identical to same-day main-arm reference (q18 70/70 at SF1)

SF100 same-window pair pending; expected signal: Q18 cold and steady both improve, zero `parquet projection skipped` WARNs, plans byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)