### PR TITLE
perf(worker): episode-cap the refault sensor's decode-ahead collapse (v3)

### DIFF
--- a/internal/engine/memory/pressure_os.go
+++ b/internal/engine/memory/pressure_os.go
@@ -62,7 +62,13 @@ type refaultSensor struct {
 	hotStreak  int // consecutive over-threshold samples
 	active     bool
 
-	activations int64 // inactive->active transitions, for markers
+	activations int64     // inactive->active transitions, for markers
+	activeSince time.Time // start of the current activation episode
+
+	// boundedIgnores counts ActiveBounded calls that returned false while
+	// the sensor was active — episodes that outlived the caller's cap and
+	// were declared non-causal. Rollout marker for the episode-cap v3.
+	boundedIgnores int64
 }
 
 func newRefaultSensor(read func() (int64, bool), threshold float64, interval time.Duration) *refaultSensor {
@@ -117,8 +123,42 @@ func (s *refaultSensor) Active() bool {
 	s.active = s.hotStreak >= 2
 	if s.active && !wasActive {
 		s.activations++
+		s.activeSince = now
 	}
 	return s.active
+}
+
+// ActiveBounded is Active with a per-episode honor budget: it reports
+// true only while the current activation episode is younger than cap.
+//
+// Rationale (refault-sensor v3, 2026-07-22 SF100 investigation): the
+// collapse this sensor gates sheds the caller's own held window bytes.
+// When those bytes ARE the displacement cause (Q06-shape concurrent
+// full-table scans), shedding them drops the refault rate within a
+// sample or two and the episode ends — the cap never binds. When the
+// refaults are ambient (suite traffic re-faulting a legitimately colder
+// cache off local NVMe), collapse sheds nothing, the rate never goes
+// quiet, and v2 semantics locked the throttle on for minutes — measured
+// +22-40% SF100 steady suite loss for zero displacement relief. An
+// episode that outlives cap despite the collapse is therefore declared
+// non-causal and ignored until the sensor genuinely deactivates (one
+// quiet sample), which arms a fresh episode.
+//
+// cap <= 0 means unbounded — identical to Active.
+func (s *refaultSensor) ActiveBounded(cap time.Duration) bool {
+	if !s.Active() {
+		return false
+	}
+	if cap <= 0 {
+		return true
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if time.Since(s.activeSince) > cap {
+		s.boundedIgnores++
+		return false
+	}
+	return true
 }
 
 // Stats returns the last computed rate (pages/sec) and the number of
@@ -130,6 +170,17 @@ func (s *refaultSensor) Stats() (lastRate float64, activations int64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.lastRate, s.activations
+}
+
+// BoundedIgnores returns how many ActiveBounded consultations declined an
+// over-cap episode — the episode-cap v3 rollout marker.
+func (s *refaultSensor) BoundedIgnores() int64 {
+	if s == nil {
+		return 0
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.boundedIgnores
 }
 
 // readRefaultCounter returns a reader for the best available refault
@@ -223,6 +274,19 @@ func pageCachePressureSensor() *refaultSensor {
 // on it; it must not gate correctness-bearing work.
 func PageCachePressureActive() bool {
 	return pageCachePressureSensor().Active()
+}
+
+// PageCachePressureActiveBounded is PageCachePressureActive with the
+// per-episode honor budget (see refaultSensor.ActiveBounded). cap <= 0
+// is unbounded.
+func PageCachePressureActiveBounded(cap time.Duration) bool {
+	return pageCachePressureSensor().ActiveBounded(cap)
+}
+
+// PageCachePressureBoundedIgnores returns the count of episode-cap
+// declines — the v3 rollout marker beside PageCachePressureStats.
+func PageCachePressureBoundedIgnores() int64 {
+	return pageCachePressureSensor().BoundedIgnores()
 }
 
 // PageCachePressureStats returns the sensor's last sampled refault rate

--- a/internal/engine/memory/pressure_os_test.go
+++ b/internal/engine/memory/pressure_os_test.go
@@ -144,3 +144,57 @@ func TestPageCachePressureActive_Smoke(t *testing.T) {
 	}
 	PageCachePressureStats()
 }
+
+// sampleBounded mirrors sample for the episode-capped accessor.
+func sampleBounded(t *testing.T, s *refaultSensor, f *fakeCounter, next int64, cap time.Duration) bool {
+	t.Helper()
+	f.value = next
+	time.Sleep(2 * time.Millisecond)
+	return s.ActiveBounded(cap)
+}
+
+// TestRefaultSensor_EpisodeCap pins the v3 semantics: an activation
+// episode is honored only while younger than cap; an episode that
+// outlives cap (collapse didn't quiet the rate → non-causal ambient
+// thrash) is declined until a quiet sample ends it, and the next
+// activation starts a fresh honored episode.
+func TestRefaultSensor_EpisodeCap(t *testing.T) {
+	f := &fakeCounter{value: 1000, ok: true}
+	s := newRefaultSensor(f.read, 1000, time.Millisecond)
+	const cap = 25 * time.Millisecond
+
+	// Activate (two hot samples) — young episode is honored.
+	sampleBounded(t, s, f, f.value+1_000_000, cap)
+	if !sampleBounded(t, s, f, f.value+1_000_000, cap) {
+		t.Fatal("young episode not honored")
+	}
+	if s.BoundedIgnores() != 0 {
+		t.Fatalf("ignores = %d before cap elapsed", s.BoundedIgnores())
+	}
+	// Stay hot past the cap: raw Active stays true, bounded declines.
+	deadline := time.Now().Add(2 * cap)
+	for time.Now().Before(deadline) {
+		sampleBounded(t, s, f, f.value+1_000_000, cap)
+	}
+	if !s.Active() {
+		t.Fatal("raw Active false while rate is hot")
+	}
+	if s.ActiveBounded(cap) {
+		t.Fatal("episode older than cap still honored")
+	}
+	if s.BoundedIgnores() == 0 {
+		t.Fatal("no ignores recorded for over-cap episode")
+	}
+	// cap <= 0 is unbounded — v2 kill-switch semantics.
+	if !s.ActiveBounded(0) {
+		t.Fatal("cap=0 must behave like raw Active")
+	}
+	// Quiet sample ends the episode; re-activation is honored afresh.
+	if sampleBounded(t, s, f, f.value, cap) {
+		t.Fatal("still active after quiet sample")
+	}
+	sampleBounded(t, s, f, f.value+1_000_000, cap)
+	if !sampleBounded(t, s, f, f.value+1_000_000, cap) {
+		t.Fatal("fresh episode after quiet sample not honored")
+	}
+}

--- a/internal/worker/executor_fragment.go
+++ b/internal/worker/executor_fragment.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -548,13 +549,52 @@ var heapPressureActive = memory.HeapBackpressureActive
 // (the §9 refault-rate sensor), same test-seam rationale.
 var pageCachePressureActive = memory.PageCachePressureActive
 
+// pageCachePressureActiveBounded mirrors the episode-capped variant
+// (refault-sensor v3), same test-seam rationale.
+var pageCachePressureActiveBounded = memory.PageCachePressureActiveBounded
+
+// refaultEpisodeCap bounds how long one cache-pressure activation episode
+// keeps collapsing decode-ahead on non-edge envelopes. If the collapse
+// were shedding the displacement cause (our own held window bytes), the
+// refault rate would go quiet well inside this budget (measured ~2s on
+// the Q06 self-displacement shape); an episode that outlives it is
+// ambient thrash the collapse cannot relieve — v2 semantics locked the
+// throttle on for minutes and cost +22-40% SF100 steady suite wall
+// (2026-07-22 investigation, PR #259 arms). Override with
+// WADJET_REFAULT_EPISODE_CAP (seconds); 0 restores unbounded v2
+// semantics (the kill switch).
+var refaultEpisodeCap = func() time.Duration {
+	const def = 10 * time.Second
+	v := os.Getenv("WADJET_REFAULT_EPISODE_CAP")
+	if v == "" {
+		return def
+	}
+	secs, err := strconv.ParseFloat(v, 64)
+	if err != nil || secs < 0 {
+		return def
+	}
+	return time.Duration(secs * float64(time.Second))
+}()
+
 // scanDecodeAheadPressure gates decode-ahead admission beyond the
 // delivery cursor: Go-heap tide gauge OR kernel page-cache thrash.
 // Discretionary decoded-ahead bytes are the first thing to yield under
 // either pressure channel; the cursor group is exempt inside the
 // iterator, so this can never stall delivery.
+//
+// The cache channel is episode-capped on non-edge envelopes (see
+// refaultEpisodeCap). Strict/edge envelopes (< 2 GiB GOMEMLIMIT) keep
+// the unbounded v2 semantics: the capped repro measured even one extra
+// in-flight group as harmful there, and its thrash is EBS-priced —
+// there is no cheap-refault regime to spare.
 func scanDecodeAheadPressure() bool {
-	return heapPressureActive() || pageCachePressureActive()
+	if heapPressureActive() {
+		return true
+	}
+	if scanDecodeAheadStrictPressure() {
+		return pageCachePressureActive()
+	}
+	return pageCachePressureActiveBounded(refaultEpisodeCap)
 }
 
 // scanDecodeAheadStrictPressure reports whether pressure collapse should

--- a/internal/worker/refault_episode_cap_test.go
+++ b/internal/worker/refault_episode_cap_test.go
@@ -1,0 +1,48 @@
+package worker
+
+import (
+	"testing"
+	"time"
+)
+
+// TestScanDecodeAheadPressure_EpisodeCapChannel pins the v3 gate wiring on
+// non-edge envelopes (test processes run without a < 2 GiB GOMEMLIMIT, so
+// scanDecodeAheadStrictPressure() is false here): the cache channel is
+// consulted through the episode-BOUNDED accessor, so an over-cap episode
+// (bounded=false while raw=true) must not collapse decode-ahead, while
+// heap pressure always does.
+func TestScanDecodeAheadPressure_EpisodeCapChannel(t *testing.T) {
+	if scanDecodeAheadStrictPressure() {
+		t.Skip("strict envelope: cache channel is unbounded by design")
+	}
+	origHeap, origRaw, origBounded := heapPressureActive, pageCachePressureActive, pageCachePressureActiveBounded
+	t.Cleanup(func() {
+		heapPressureActive, pageCachePressureActive, pageCachePressureActiveBounded = origHeap, origRaw, origBounded
+	})
+
+	heapPressureActive = func() bool { return false }
+	pageCachePressureActive = func() bool { return true } // raw sensor hot...
+	pageCachePressureActiveBounded = func(time.Duration) bool { return false }
+	if scanDecodeAheadPressure() {
+		t.Fatal("over-cap episode collapsed decode-ahead on a non-edge envelope")
+	}
+
+	pageCachePressureActiveBounded = func(time.Duration) bool { return true }
+	if !scanDecodeAheadPressure() {
+		t.Fatal("young episode did not collapse decode-ahead")
+	}
+
+	pageCachePressureActiveBounded = func(time.Duration) bool { return false }
+	heapPressureActive = func() bool { return true }
+	if !scanDecodeAheadPressure() {
+		t.Fatal("heap pressure must collapse regardless of the cache episode cap")
+	}
+}
+
+// TestRefaultEpisodeCapDefault pins the default and the parse rules the
+// WADJET_REFAULT_EPISODE_CAP env contract promises (0 = unbounded v2).
+func TestRefaultEpisodeCapDefault(t *testing.T) {
+	if refaultEpisodeCap != 10*time.Second {
+		t.Fatalf("default episode cap = %v, want 10s (env override leaked into test process?)", refaultEpisodeCap)
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -603,7 +603,8 @@ func (w *Worker) startScanDecodeAheadMarkerLoop(ctx context.Context) {
 						"window_full_ms", windowFullNs/1e6, "pressure_stall_ms", pressureNs/1e6,
 						"token_stall_ms", tokenNs/1e6, "ledger_stall_ms", ledgerNs/1e6,
 						"refault_rate", int64(refaultRate),
-						"refault_activations", refaultActivations)
+						"refault_activations", refaultActivations,
+						"refault_episode_ignores", memory.PageCachePressureBoundedIgnores())
 				}
 				w.executor.sweepScanDecodeAheadQueryStats(false)
 			}
@@ -877,7 +878,8 @@ func (w *Worker) Stop() {
 			"window_full_ms", windowFullNs/1e6, "pressure_stall_ms", pressureNs/1e6,
 			"token_stall_ms", tokenNs/1e6, "ledger_stall_ms", ledgerNs/1e6,
 			"refault_rate", int64(refaultRate),
-			"refault_activations", refaultActivations)
+			"refault_activations", refaultActivations,
+			"refault_episode_ignores", memory.PageCachePressureBoundedIgnores())
 	}
 
 	w.logger.Info("worker stopped", "worker_id", w.config.WorkerID)


### PR DESCRIPTION
## What

The §9 refault sensor's collapse response is causally justified only when the caller's own held window bytes are the displacement source — in that regime (Q06-shape self-displacement), collapsing quiets the refault rate within ~2s and the episode self-terminates. When the refaults are ambient (suite traffic re-faulting a colder cache off local NVMe), collapse sheds nothing, the rate never goes quiet, and v2 locked the throttle on for minutes.

Measured (2026-07-22 SF100 investigation, PRs #258/#259): three independent treatment runs whose only physical change was Q18's fused leg no longer streaming ~70 GB of full-width lineitem through the page cache degraded **+22–40% steady suite wall** under v2 semantics; the sensor-off control arm recovered the suite but re-exposed the Q06/Q01 self-displacement regression (+34/+38%) — both regimes are real, so a channel on/off cannot serve them.

**v3 discriminates by response-to-collapse**: honor each activation episode for at most `refaultEpisodeCap` (default 10s). An episode that outlives the cap despite the collapse is non-causal by observation and is ignored until the sensor genuinely deactivates (one quiet sample), which arms a fresh honored episode.

- Strict/edge envelopes (< 2 GiB GOMEMLIMIT) keep unbounded v2 semantics — that code path is unchanged by construction, so the 2 GiB capped-repro protection cannot regress.
- `WADJET_REFAULT_EPISODE_CAP` (seconds) overrides; `0` restores v2 everywhere (kill switch).
- New rollout marker `refault_episode_ignores` on the decode-ahead stats lines.

## Gates

- Sensor episode unit tests (two-sample activation, cap decline, quiet-sample reset, cap=0 kill switch, ignore counter)
- Worker gate-wiring tests (bounded channel consulted on non-edge; heap channel unconditional)
- memory + scan + worker `-race`, planner + coordinator suites, TPC-H SF0.01 22/22, harness SF0.01 rows identical
- **Pending**: SF100 validation pair — this + #259 stacked (merge-intent config) vs main, sensor default-on. Success = steady suite clean, Q18 cold ~−17%/steady ~−14%, Q06/Q01 steady no worse than main, `refault_episode_ignores` > 0 in treatment worker logs.

Merge order once green: this → #259 → re-evaluate #258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)