### PR TITLE
feat(worker): per-tier shuffle-read and upload byte ledgers

### DIFF
--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -116,6 +116,13 @@ type Executor struct {
 	shuffleStreamFallbacks   atomic.Int64
 	shuffleStreamSkipResumes atomic.Int64
 
+	// Per-tier shuffle-read transfer accounting: which tier served each
+	// exchange input open and how many bytes moved. peer/s3 bytes are
+	// wire bytes (WSHC stays compressed in transit); local/kv bytes are
+	// the materialized payload size. Read via ShuffleIOStats for the
+	// worker's 60s "shuffle io stats" marker.
+	shuffleIO shuffleIOCounters
+
 	// Scan decode pipelining (docs/design/scan-decode-pipelining.md):
 	// parquet scan sources decode row groups ahead of consumption with a
 	// bounded window instead of one group per Next. Counters are the §5
@@ -168,6 +175,36 @@ func (e *Executor) SetStreamingShuffleRead(on bool) { e.streamingShuffleRead = o
 // streaming opens, staged fallbacks, and batches skipped by fallbacks.
 func (e *Executor) ShuffleStreamStats() (reads, fallbacks, skipResumes int64) {
 	return e.shuffleStreamReads.Load(), e.shuffleStreamFallbacks.Load(), e.shuffleStreamSkipResumes.Load()
+}
+
+// shuffleIOCounters is the per-tier shuffle-read ledger: one files/bytes
+// pair per serving tier (same-worker LocalStageCache, NATS KV, peer
+// exchange, durable S3). Peer counts include prefetched peer downloads —
+// the transfer happens at fetch time regardless of when the file is opened.
+type shuffleIOCounters struct {
+	localFiles, localBytes atomic.Int64
+	kvFiles, kvBytes       atomic.Int64
+	peerFiles, peerBytes   atomic.Int64
+	s3Files, s3Bytes       atomic.Int64
+}
+
+// ShuffleIOSnapshot is one point-in-time reading of the per-tier
+// shuffle-read ledger.
+type ShuffleIOSnapshot struct {
+	LocalFiles, LocalBytes int64
+	KVFiles, KVBytes       int64
+	PeerFiles, PeerBytes   int64
+	S3Files, S3Bytes       int64
+}
+
+// ShuffleIOStats returns the per-tier shuffle-read transfer counters.
+func (e *Executor) ShuffleIOStats() ShuffleIOSnapshot {
+	return ShuffleIOSnapshot{
+		LocalFiles: e.shuffleIO.localFiles.Load(), LocalBytes: e.shuffleIO.localBytes.Load(),
+		KVFiles: e.shuffleIO.kvFiles.Load(), KVBytes: e.shuffleIO.kvBytes.Load(),
+		PeerFiles: e.shuffleIO.peerFiles.Load(), PeerBytes: e.shuffleIO.peerBytes.Load(),
+		S3Files: e.shuffleIO.s3Files.Load(), S3Bytes: e.shuffleIO.s3Bytes.Load(),
+	}
 }
 
 // SetScanDecodeAhead enables decode-ahead on parquet scan sources

--- a/internal/worker/executor_async_upload.go
+++ b/internal/worker/executor_async_upload.go
@@ -53,5 +53,6 @@ func (e *Executor) finishStageOutputAsync(ctx context.Context, task *distributed
 		srcPath:  adopted,
 		compress: compress,
 		tmpDir:   e.spillDir,
+		size:     size,
 	}, true
 }

--- a/internal/worker/executor_stage.go
+++ b/internal/worker/executor_stage.go
@@ -447,7 +447,7 @@ func (e *Executor) writeUnpartitionedWSHF(ctx context.Context, task distributed.
 			}
 			e.uploads.StartTask(root, task.ID, result.WorkerID, []uploadJob{{
 				bucket: task.ResultBucket, key: key, srcPath: adopted,
-				compress: false, tmpDir: e.spillDir,
+				compress: false, tmpDir: e.spillDir, size: int64(len(payload)),
 			}})
 			return nil
 		}

--- a/internal/worker/peer_exchange.go
+++ b/internal/worker/peer_exchange.go
@@ -165,10 +165,13 @@ func (p *peerExchange) tokenFor(rootID string) string {
 // Errors before openShuffleFile leave no state; openShuffleFile itself cleans
 // its temp file on failure — either way the caller falls through to S3.
 func (s *cachedFileStreamSource) openShuffleFromPeer(ctx context.Context, key, addr, token string) error {
-	rc, err := s.executor.peers.client.FetchShuffle(ctx, addr, s.queryID, key, token)
+	prc, err := s.executor.peers.client.FetchShuffle(ctx, addr, s.queryID, key, token)
 	if err != nil {
 		return err
 	}
+	// Per-tier ledger: count the gRPC stream's wire bytes as peer-tier
+	// transfer (WSHC stays compressed through the wrapper).
+	rc := io.ReadCloser(&countingReadCloser{rc: prc, n: &s.executor.shuffleIO.peerBytes})
 	ownedByReader := false
 	defer func() {
 		if !ownedByReader {

--- a/internal/worker/scan_prefetch.go
+++ b/internal/worker/scan_prefetch.go
@@ -257,10 +257,13 @@ func (p *filePrefetcher) fetchShuffle(ctx context.Context, s *cachedFileStreamSo
 	if addr == "" {
 		return &prefetchResult{skipped: true}
 	}
-	rc, err := peers.client.FetchShuffle(ctx, addr, s.queryID, filePath, token)
+	prc, err := peers.client.FetchShuffle(ctx, addr, s.queryID, filePath, token)
 	if err != nil {
 		return &prefetchResult{err: err}
 	}
+	// Per-tier ledger: prefetched peer downloads are peer-tier transfers,
+	// counted at fetch time (the transfer happens now, not at open).
+	rc := io.ReadCloser(&countingReadCloser{rc: prc, n: &s.executor.shuffleIO.peerBytes})
 	defer rc.Close()
 	var magic [4]byte
 	if _, err := io.ReadFull(rc, magic[:]); err != nil {
@@ -283,6 +286,7 @@ func (p *filePrefetcher) fetchShuffle(ctx context.Context, s *cachedFileStreamSo
 		p.releaseWindow(winBytes)
 		return &prefetchResult{err: err}
 	}
+	s.executor.shuffleIO.peerFiles.Add(1)
 	return &prefetchResult{localPath: localPath, windowBytes: winBytes}
 }
 

--- a/internal/worker/shuffle_io_stats_test.go
+++ b/internal/worker/shuffle_io_stats_test.go
@@ -1,0 +1,103 @@
+package worker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+)
+
+// TestShuffleIOStats_S3Tier: WSHF inputs resolved from the durable store
+// land on the s3 side of the per-tier ledger, with wire-exact byte counts,
+// on both the streaming and the staged read path.
+func TestShuffleIOStats_S3Tier(t *testing.T) {
+	for _, streaming := range []bool{true, false} {
+		wireA := buildMultiTypeWSHF(t, 21, 3, 200)
+		wireB := buildMultiTypeWSHF(t, 22, 2, 150)
+		files := map[string][]byte{
+			"queries/q1/s0/partition=0001/t1.wshf": wireA,
+			"queries/q1/s0/partition=0001/t2.wshf": wireB,
+		}
+		store := objstore.NewMemStore()
+		stageWSHF(t, store, "b", files)
+		ex := &Executor{store: store, spillDir: t.TempDir(), peers: newPeerExchange(), streamingShuffleRead: streaming}
+		drainSource(t, newCachedFileStreamSource(ex, "q1", "b", []string{
+			"queries/q1/s0/partition=0001/t1.wshf",
+			"queries/q1/s0/partition=0001/t2.wshf",
+		}))
+
+		got := ex.ShuffleIOStats()
+		wantBytes := int64(len(wireA) + len(wireB))
+		if got.S3Files != 2 || got.S3Bytes != wantBytes {
+			t.Fatalf("streaming=%v: s3 tier = (%d files, %d bytes), want (2, %d)",
+				streaming, got.S3Files, got.S3Bytes, wantBytes)
+		}
+		if got.LocalFiles != 0 || got.PeerFiles != 0 || got.KVFiles != 0 {
+			t.Fatalf("streaming=%v: non-s3 tiers counted: %+v", streaming, got)
+		}
+	}
+}
+
+// TestShuffleIOStats_LocalTier: a same-worker LocalStageCache hit lands on
+// the local side of the ledger with the file's full size, and nothing on s3.
+func TestShuffleIOStats_LocalTier(t *testing.T) {
+	const (
+		queryID = "q-lst"
+		key     = "queries/q-lst/stage-1/partition=0001/task-1.wshf"
+		bucket  = "scratch"
+	)
+	wshf := makeWshfBytes(t, []int64{1, 2, 3})
+	ex, _ := newConsumer(t, bucket) // store stays empty: local tier must serve
+	ex.SetLocalStageCache(NewLocalStageCache(filepath.Join(t.TempDir(), "stage-cache")))
+	src := filepath.Join(t.TempDir(), "part.wshf")
+	if err := os.WriteFile(src, wshf, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if adopted := ex.localCache.Adopt(queryID, key, src); adopted == "" {
+		t.Fatal("LocalStageCache.Adopt failed")
+	}
+
+	if got := drainRows(t, newCachedFileStreamSource(ex, "st-join-2-"+queryID, bucket, []string{key})); got != 3 {
+		t.Fatalf("rows = %d, want 3", got)
+	}
+	got := ex.ShuffleIOStats()
+	if got.LocalFiles != 1 || got.LocalBytes != int64(len(wshf)) {
+		t.Fatalf("local tier = (%d files, %d bytes), want (1, %d)", got.LocalFiles, got.LocalBytes, len(wshf))
+	}
+	if got.S3Files != 0 || got.PeerFiles != 0 || got.KVFiles != 0 {
+		t.Fatalf("non-local tiers counted: %+v", got)
+	}
+}
+
+// TestShuffleIOStats_PeerTier: a Tier-1.5 peer fetch lands on the peer side
+// of the ledger with the full wire size.
+func TestShuffleIOStats_PeerTier(t *testing.T) {
+	const (
+		queryID = "q-pst"
+		key     = "queries/q-pst/stage-1/partition=0001/task-1.wshf"
+		token   = "tok-1"
+		bucket  = "scratch"
+	)
+	wshf := makeWshfBytes(t, []int64{1, 2, 3, 4, 5})
+	addr := startProducerPeer(t, queryID, key, token, wshf)
+
+	consumer, _ := newConsumer(t, bucket)
+	consumer.peers.registerTask(&distributed.Task{
+		QueryID:        "st-join-2-" + queryID,
+		FetchToken:     token,
+		InputLocations: map[string]string{key: addr},
+	})
+
+	if got := drainRows(t, newCachedFileStreamSource(consumer, "st-join-2-"+queryID, bucket, []string{key})); got != 5 {
+		t.Fatalf("rows = %d, want 5", got)
+	}
+	got := consumer.ShuffleIOStats()
+	if got.PeerFiles != 1 || got.PeerBytes != int64(len(wshf)) {
+		t.Fatalf("peer tier = (%d files, %d bytes), want (1, %d)", got.PeerFiles, got.PeerBytes, len(wshf))
+	}
+	if got.S3Files != 0 || got.LocalFiles != 0 || got.KVFiles != 0 {
+		t.Fatalf("non-peer tiers counted: %+v", got)
+	}
+}

--- a/internal/worker/stream_source.go
+++ b/internal/worker/stream_source.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"syscall"
 
 	"github.com/nats-io/nats.go/jetstream"
@@ -441,6 +442,8 @@ func (s *cachedFileStreamSource) openNextFile(ctx context.Context) error {
 	if s.queryID != "" && s.executor.localCache != nil {
 		if cached := s.executor.localCache.Get(s.queryID, filePath); cached != "" {
 			if err := s.openShuffleFromLocalFile(cached); err == nil {
+				s.executor.shuffleIO.localFiles.Add(1)
+				s.executor.shuffleIO.localBytes.Add(int64(len(s.mmapData)))
 				return nil
 			}
 			// On any failure (file vanished, mmap error), fall through to
@@ -468,7 +471,12 @@ func (s *cachedFileStreamSource) openNextFile(ctx context.Context) error {
 				wshf := magic == shuffleMagic
 				wshc := magic == compressedMagic
 				if wshf || wshc {
-					return s.openShuffleInMemory(filePath, magic[:], bytes.NewReader(data[4:]), wshc)
+					if err := s.openShuffleInMemory(filePath, magic[:], bytes.NewReader(data[4:]), wshc); err != nil {
+						return err
+					}
+					s.executor.shuffleIO.kvFiles.Add(1)
+					s.executor.shuffleIO.kvBytes.Add(int64(kvDataLen))
+					return nil
 				}
 				// Non-shuffle payload (e.g., parquet) — fall through to S3.
 			}
@@ -485,6 +493,7 @@ func (s *cachedFileStreamSource) openNextFile(ctx context.Context) error {
 		if addr, token := peers.hintFor(filePath); addr != "" {
 			if perr := s.openShuffleFromPeer(ctx, filePath, addr, token); perr == nil {
 				peers.fetchHits.Add(1)
+				s.executor.shuffleIO.peerFiles.Add(1)
 				return nil
 			} else {
 				peers.fetchFallthrough.Add(1)
@@ -544,12 +553,19 @@ func (s *cachedFileStreamSource) openNextFile(ctx context.Context) error {
 	wshc := magic == compressedMagic
 
 	if wshf || wshc {
+		// Per-tier ledger: whatever consumes rc past this point drains the
+		// durable-S3 copy, so the counting wrapper records exactly the wire
+		// bytes moved (WSHC stays compressed through it). The 4 magic bytes
+		// were already consumed off the raw stream above — credit them here.
+		crc := &countingReadCloser{rc: rc, n: &s.executor.shuffleIO.s3Bytes}
+		crc.n.Add(int64(len(magic)))
 		// Streaming decode (memo §3 D1): decode chunks off the S3 body as
 		// they arrive instead of staging the file. A failed streaming open
 		// has partially consumed rc — re-resolve the durable copy for the
 		// staged path rather than reusing the stream.
 		if s.executor.streamingShuffleRead {
-			if err := s.openShuffleStreaming(ctx, filePath, rc, wshc); err == nil {
+			if err := s.openShuffleStreaming(ctx, filePath, crc, wshc); err == nil {
+				s.executor.shuffleIO.s3Files.Add(1)
 				rcOwnedByReader = true
 				return nil
 			} else if s.executor.logger != nil {
@@ -558,7 +574,11 @@ func (s *cachedFileStreamSource) openNextFile(ctx context.Context) error {
 			}
 			return s.openShuffleStagedFromStore(ctx, filePath)
 		}
-		return s.openShuffleFile(ctx, filePath, magic[:], rc, wshc)
+		if err := s.openShuffleFile(ctx, filePath, magic[:], crc, wshc); err != nil {
+			return err
+		}
+		s.executor.shuffleIO.s3Files.Add(1)
+		return nil
 	}
 
 	// Parquet path: when a spill dir is available, stream the body to a
@@ -633,6 +653,24 @@ func (p *progressReadCloser) Read(b []byte) (int, error) {
 
 func (p *progressReadCloser) Close() error { return p.rc.Close() }
 
+// countingReadCloser adds every byte read to a tier counter of the per-tier
+// shuffle-read ledger (Executor.shuffleIO). Wire-level: wraps the transfer
+// stream before any decompression, so WSHC counts compressed bytes.
+type countingReadCloser struct {
+	rc io.ReadCloser
+	n  *atomic.Int64
+}
+
+func (c *countingReadCloser) Read(b []byte) (int, error) {
+	n, err := c.rc.Read(b)
+	if n > 0 {
+		c.n.Add(int64(n))
+	}
+	return n, err
+}
+
+func (c *countingReadCloser) Close() error { return c.rc.Close() }
+
 // openShuffleStreaming decodes a WSHF/WSHC body directly from rc
 // (--streaming-shuffle-read, memo §3 D1). rc must be positioned after the
 // outer 4-byte magic. On success the reader owns rc; on error the caller
@@ -675,8 +713,9 @@ func (s *cachedFileStreamSource) openShuffleStagedFromStore(ctx context.Context,
 		}
 	}
 	defer rc.Close()
+	crc := &countingReadCloser{rc: rc, n: &s.executor.shuffleIO.s3Bytes}
 	var magic [4]byte
-	if _, err := io.ReadFull(rc, magic[:]); err != nil {
+	if _, err := io.ReadFull(crc, magic[:]); err != nil {
 		return fmt.Errorf("reading magic from durable copy of %s: %w", srcPath, err)
 	}
 	wshf := magic == shuffleMagic
@@ -684,7 +723,11 @@ func (s *cachedFileStreamSource) openShuffleStagedFromStore(ctx context.Context,
 	if !wshf && !wshc {
 		return fmt.Errorf("durable copy of %s is not a shuffle payload (magic %q)", srcPath, magic[:])
 	}
-	return s.openShuffleFile(ctx, srcPath, magic[:], rc, wshc)
+	if err := s.openShuffleFile(ctx, srcPath, magic[:], crc, wshc); err != nil {
+		return err
+	}
+	s.executor.shuffleIO.s3Files.Add(1)
+	return nil
 }
 
 // fallbackFromStream recovers from a mid-stream failure of the current

--- a/internal/worker/upload_manager.go
+++ b/internal/worker/upload_manager.go
@@ -51,6 +51,8 @@ type uploadManager struct {
 	completed      atomic.Int64 // files uploaded in the background
 	cancelledFiles atomic.Int64 // uploads aborted by query completion
 	failedFiles    atomic.Int64 // uploads abandoned after retries
+	completedBytes atomic.Int64 // wire bytes PUT (post-compression)
+	cancelledBytes atomic.Int64 // local file bytes of aborted uploads (pre-compression)
 }
 
 type queryUploadState struct {
@@ -205,7 +207,7 @@ func (m *uploadManager) runJob(ctx context.Context, tu *taskUploads, j uploadJob
 		defer func() { <-m.sem }()
 	case <-ctx.Done():
 		tu.anyCanceled.Store(true)
-		m.cancelledFiles.Add(1)
+		m.noteCancelled(j)
 		return
 	}
 
@@ -213,7 +215,7 @@ func (m *uploadManager) runJob(ctx context.Context, tu *taskUploads, j uploadJob
 	for attempt := 1; attempt <= uploadRetryAttempts; attempt++ {
 		if ctx.Err() != nil {
 			tu.anyCanceled.Store(true)
-			m.cancelledFiles.Add(1)
+			m.noteCancelled(j)
 			return
 		}
 		lastErr = m.uploadOnce(ctx, j)
@@ -223,7 +225,7 @@ func (m *uploadManager) runJob(ctx context.Context, tu *taskUploads, j uploadJob
 		}
 		if ctx.Err() != nil {
 			tu.anyCanceled.Store(true)
-			m.cancelledFiles.Add(1)
+			m.noteCancelled(j)
 			return
 		}
 		backoff := uploadRetryBackoff << (attempt - 1)
@@ -231,7 +233,7 @@ func (m *uploadManager) runJob(ctx context.Context, tu *taskUploads, j uploadJob
 		case <-time.After(backoff):
 		case <-ctx.Done():
 			tu.anyCanceled.Store(true)
-			m.cancelledFiles.Add(1)
+			m.noteCancelled(j)
 			return
 		}
 	}
@@ -239,6 +241,16 @@ func (m *uploadManager) runJob(ctx context.Context, tu *taskUploads, j uploadJob
 	m.failedFiles.Add(1)
 	m.logger.Error("background stage-output upload abandoned; key stays non-durable",
 		"key", j.key, "task_id", tu.taskID, "attempts", uploadRetryAttempts, "error", lastErr)
+}
+
+// noteCancelled records an aborted upload: file count plus the local
+// (pre-compression) size of the bytes that never had to move — the "S3
+// PUT work a finished query saved" side of the upload ledger.
+func (m *uploadManager) noteCancelled(j uploadJob) {
+	m.cancelledFiles.Add(1)
+	if fi, err := os.Stat(j.srcPath); err == nil {
+		m.cancelledBytes.Add(fi.Size())
+	}
 }
 
 // uploadOnce mirrors the synchronous path: optional s2 compression (≥10%
@@ -278,6 +290,7 @@ func (m *uploadManager) uploadOnce(ctx context.Context, j uploadJob) error {
 	if _, err := m.store.Put(ctx, j.bucket, j.key, f, fi.Size(), "application/octet-stream"); err != nil {
 		return fmt.Errorf("put %s: %w", j.key, err)
 	}
+	m.completedBytes.Add(fi.Size())
 	return nil
 }
 
@@ -313,4 +326,14 @@ func (tu *taskUploads) jobDone() {
 // file counts. Observability/test helper.
 func (m *uploadManager) UploadStats() (completed, cancelled, failed int64) {
 	return m.completed.Load(), m.cancelledFiles.Load(), m.failedFiles.Load()
+}
+
+// UploadByteStats returns the upload ledger's byte sides: wire bytes that
+// landed in S3 (post-compression) and local bytes of uploads aborted by
+// query completion (pre-compression).
+func (m *uploadManager) UploadByteStats() (completedBytes, cancelledBytes int64) {
+	if m == nil {
+		return 0, 0
+	}
+	return m.completedBytes.Load(), m.cancelledBytes.Load()
 }

--- a/internal/worker/upload_manager.go
+++ b/internal/worker/upload_manager.go
@@ -85,6 +85,7 @@ type uploadJob struct {
 	srcPath  string
 	compress bool
 	tmpDir   string // where compressed temps go; must outlive the upload (NOT the task spill dir)
+	size     int64  // srcPath size at job creation; 0 = unknown (stat fallback)
 }
 
 // taskUploads tracks one task's background uploads and publishes
@@ -245,10 +246,14 @@ func (m *uploadManager) runJob(ctx context.Context, tu *taskUploads, j uploadJob
 
 // noteCancelled records an aborted upload: file count plus the local
 // (pre-compression) size of the bytes that never had to move — the "S3
-// PUT work a finished query saved" side of the upload ledger.
+// PUT work a finished query saved" side of the upload ledger. Prefer the
+// creation-time size: cancellation usually races query cleanup, and the
+// cache-owned srcPath is often already unlinked by the time we get here.
 func (m *uploadManager) noteCancelled(j uploadJob) {
 	m.cancelledFiles.Add(1)
-	if fi, err := os.Stat(j.srcPath); err == nil {
+	if j.size > 0 {
+		m.cancelledBytes.Add(j.size)
+	} else if fi, err := os.Stat(j.srcPath); err == nil {
 		m.cancelledBytes.Add(fi.Size())
 	}
 }

--- a/internal/worker/upload_manager_test.go
+++ b/internal/worker/upload_manager_test.go
@@ -79,6 +79,11 @@ func TestUploadManagerLandsFiles(t *testing.T) {
 	if _, _, failed := m.UploadStats(); failed != 0 {
 		t.Fatalf("unexpected failed uploads")
 	}
+	// Byte ledger: both files' wire bytes counted; the uncompressed job
+	// alone contributes its full payload size.
+	if done, cancelled := m.UploadByteStats(); done < int64(len(payload)) || cancelled != 0 {
+		t.Fatalf("byte stats = (done %d, cancelled %d), want done >= %d, cancelled 0", done, cancelled, len(payload))
+	}
 }
 
 func TestUploadManagerCancelQuery(t *testing.T) {
@@ -101,6 +106,9 @@ func TestUploadManagerCancelQuery(t *testing.T) {
 	})
 	if _, _, err := mem.Get(context.Background(), "b", "queries/q1/s/a.wshf"); err == nil {
 		t.Fatal("cancelled upload landed anyway")
+	}
+	if done, cancelled := m.UploadByteStats(); done != 0 || cancelled != 8 {
+		t.Fatalf("byte stats = (done %d, cancelled %d), want (0, 8)", done, cancelled)
 	}
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -621,6 +621,8 @@ func (w *Worker) startShuffleStreamMarkerLoop(ctx context.Context) {
 	go func() {
 		defer w.bgWG.Done()
 		var lastReads, lastFallbacks, lastSkips int64
+		var lastIO ShuffleIOSnapshot
+		var lastUp [5]int64
 		t := time.NewTicker(60 * time.Second)
 		defer t.Stop()
 		for {
@@ -634,9 +636,47 @@ func (w *Worker) startShuffleStreamMarkerLoop(ctx context.Context) {
 					w.logger.Info("streaming shuffle read stats",
 						"reads", reads, "fallbacks", fallbacks, "skip_resumes", skips)
 				}
+				// Per-tier shuffle-read ledger + upload ledger (step-0
+				// measurement for the shuffle NVMe/durability arc): which
+				// tier served exchange inputs, and how much S3 PUT work the
+				// background uploads did vs saved.
+				ioStats, up := w.shuffleIOTotals()
+				if ioStats != lastIO || up != lastUp {
+					lastIO = ioStats
+					lastUp = up
+					w.logShuffleIOStats(ioStats, up)
+				}
 			}
 		}
 	}()
+}
+
+// shuffleIOTotals snapshots the per-tier shuffle-read ledger and the upload
+// ledger ([done, cancelled, failed, doneBytes, cancelledBytes]).
+func (w *Worker) shuffleIOTotals() (ShuffleIOSnapshot, [5]int64) {
+	ioStats := w.executor.ShuffleIOStats()
+	var up [5]int64
+	if w.executor.uploads != nil {
+		up[0], up[1], up[2] = w.executor.uploads.UploadStats()
+		up[3], up[4] = w.executor.uploads.UploadByteStats()
+	}
+	return ioStats, up
+}
+
+// logShuffleIOStats emits one "shuffle io stats" line for the given
+// snapshots — the greppable record of which tier served exchange inputs and
+// how much S3 PUT work the background uploads did vs saved.
+func (w *Worker) logShuffleIOStats(ioStats ShuffleIOSnapshot, up [5]int64) {
+	w.logger.Info("shuffle io stats",
+		"local_files", ioStats.LocalFiles, "local_bytes", ioStats.LocalBytes,
+		"kv_files", ioStats.KVFiles, "kv_bytes", ioStats.KVBytes,
+		"peer_files", ioStats.PeerFiles, "peer_bytes", ioStats.PeerBytes,
+		"s3_files", ioStats.S3Files, "s3_bytes", ioStats.S3Bytes,
+		"peer_hits", w.executor.PeerFetchHits(),
+		"peer_fallthroughs", w.executor.PeerFetchFallthroughs(),
+		"upload_done", up[0], "upload_done_bytes", up[3],
+		"upload_cancelled", up[1], "upload_cancelled_bytes", up[4],
+		"upload_failed", up[2])
 }
 
 // dispatchLoop consumes TaskDispatch envelopes pushed by coord over
@@ -832,6 +872,11 @@ func (w *Worker) Drain() {
 		w.cancel()
 	}
 	w.bgWG.Wait()
+	// Final shuffle-IO ledger totals: workers that lived less than one
+	// marker tick (60s) would otherwise leave no record at all.
+	if ioStats, up := w.shuffleIOTotals(); ioStats != (ShuffleIOSnapshot{}) || up != ([5]int64{}) {
+		w.logShuffleIOStats(ioStats, up)
+	}
 	w.logger.Info("worker drained and stopped", "worker_id", w.config.WorkerID)
 }
 


### PR DESCRIPTION
## Why

Step-0 measurement for the shuffle NVMe/durability arc. The wshf read path had zero byte accounting: `streaming shuffle read stats` counted file opens only (and mixed S3 with peer streams), the LocalStageCache/KV/peer tiers counted nothing, the prefetcher was fully silent, and the background upload manager tracked file counts but not bytes. The S3-vs-peer-vs-local split of exchange traffic — the number the whole arc's design hinges on — was unmeasurable from run logs.

## What

- **`Executor.shuffleIO`** — files/bytes per serving tier: same-worker LocalStageCache, NATS KV, peer exchange (including prefetched peer downloads, counted at fetch time), and durable S3 (streaming + staged + re-staged fallback). Byte counts are wire-exact via a `countingReadCloser` wrapped around each transfer stream (WSHC counts compressed bytes).
- **`uploadManager`** — `completedBytes` (wire PUT bytes, post-compression) and `cancelledBytes` (local size of uploads aborted by query completion): the did-vs-saved sides of the Phase-B upload ledger.
- **Worker marker** — one `shuffle io stats` line next to the existing streaming-read marker (60s ticker, change-gated), including the previously-unlogged `peer_hits`/`peer_fallthroughs`, plus a final line at drain so workers that live less than one tick still leave a record.

Observability only — no behavior change on any read or upload path.

## Validation

- New unit tests: S3 tier (streaming + staged, wire-exact bytes), local tier, peer tier (real PeerServer), upload byte ledger (landed + cancelled).
- `go test -race ./internal/worker/`, full `./internal/...`, TPC-H SF0.01 correctness: green.
- tpch-harness `--mode=local` SF0.01 and SF1: PASS, all rows non-zero.

## First data point (SF1 local, 2 workers)

```
shuffle io stats local_files=142 local_bytes=813972651 kv_files=30 kv_bytes=5416121
  peer_files=308 peer_bytes=1987057215 s3_files=0 s3_bytes=0 peer_hits=56
  peer_fallthroughs=0 upload_done=398 upload_done_bytes=625629314
  upload_cancelled=0 upload_cancelled_bytes=0 upload_failed=0
```

Reads split ~30% local mmap / ~65% peer stream / ~5% KV with **zero S3 read-tier engagement** — first direct evidence that the S3-priced side of shuffle is the background upload, not the read-back the arc kickoff assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Quxy1MHHoDFr6AZeEtQFR