### PR TITLE
perf(coordinator): input-locality task placement for 1:1 stage chains

### DIFF
--- a/cmd/tpch-bench/main.go
+++ b/cmd/tpch-bench/main.go
@@ -439,6 +439,11 @@ func setupDistributed(ctx context.Context, logger *slog.Logger, endpoint, region
 		// so a typo'd env var on a remote deploy costs the A/B arm, not
 		// the whole run.
 		ShuffleDurability: shuffleDurabilityFromEnv(logger),
+		// Input-locality placement (docs/design/locality-placement.md):
+		// default-off engine flag, explicit opt-in ("1"/"true") pending
+		// SF100 validation — the EagerDispatch convention, not a kill
+		// switch.
+		LocalityPlacement: os.Getenv("WADJET_LOCALITY_PLACEMENT") == "1" || strings.EqualFold(os.Getenv("WADJET_LOCALITY_PLACEMENT"), "true"),
 	}, cat, nc, js, logger)
 	coord.Workers().StartReaper(ctx)
 	coord.Workers().StartSubStatsLogger(ctx)

--- a/cmd/wadjet/main.go
+++ b/cmd/wadjet/main.go
@@ -107,6 +107,7 @@ var (
 	streamingExchange     bool
 	eagerDispatch         bool
 	shuffleDurability     string
+	localityPlacement     bool
 	peerExchangeAddr      string
 	peerExchangeAdvertise string
 	baseTableCacheBytes   int64
@@ -181,6 +182,7 @@ func main() {
 	rootCmd.PersistentFlags().Int64Var(&localFastPathBytes, "local-fastpath-bytes", coordinator.DefaultLocalFastPathBytes, "Queries whose post-pruning catalog scan bytes stay under this threshold execute in-process on the coordinator (skipping the distributed stage DAG and its per-stage object-store round trips). 0 = disabled.")
 	rootCmd.PersistentFlags().BoolVar(&streamingExchange, "streaming-exchange", true, "Streaming exchange: consumers fetch stage outputs from the producing workers' local disk over gRPC with async S3 upload; every failure falls through to the durable S3 path. Default true (validated 2026-07-02: SF10 −10%, SF100 −23% suite wall, row-identical, zero fault-tolerance events); --streaming-exchange=false restores synchronous S3-only shuffle. See docs/design/streaming-exchange.md.")
 	rootCmd.PersistentFlags().BoolVar(&eagerDispatch, "eager-dispatch", false, "Eager consumer dispatch (Phase C1): eligible non-join consumer stages (aggregate/sort over a standalone repartition) start before their producer stage fully drains, consuming per-producer-task file manifests as tasks finish. Requires --streaming-exchange. Default false until SF100 validation (kill switch thereafter). See docs/design/eager-consumer-dispatch.md.")
+	rootCmd.PersistentFlags().BoolVar(&localityPlacement, "locality-placement", false, "Input-locality task placement (docs/design/locality-placement.md): a task whose peer-location hints all point at one connected worker is dispatched to that worker, so 1:1 stage chains (consumer task i reading producer task i's output) read via same-worker mmap instead of peer gRPC streams. A same-batch cap preserves fan-out anti-clumping. Requires --streaming-exchange and --data-plane=grpc. Default false until SF100 validation.")
 	rootCmd.PersistentFlags().StringVar(&shuffleDurability, "shuffle-durability", "eager", "Stage-output durability policy under --streaming-exchange (docs/design/shuffle-durability.md). eager: background S3 uploads start as outputs finalize (default). lazy: uploads queue unstarted on the workers and run only on demand (consumer missing-input retry against a live producer, coordinator-side stage read, or worker drain); scratch never demanded is elided — no S3 PUT. off: scratch never uploads; a producer lost mid-query degrades to the one-shot streaming-disabled re-execution, including graceful drains. Scalar-subquery producer stages always upload eagerly (the coordinator reads those from S3).")
 	rootCmd.PersistentFlags().StringVar(&peerExchangeAddr, "peer-exchange-addr", ":0", "Peer-exchange (FetchShuffle) listen address. Default :0 picks a free port (the address reaches peers via heartbeats, and a fixed default would collide when multiple workers share a host); pin it when firewalls need a known port.")
 	rootCmd.PersistentFlags().StringVar(&peerExchangeAdvertise, "peer-exchange-advertise", "", "Peer-exchange address advertised in heartbeats (default: derived from the bound listener)")
@@ -967,6 +969,7 @@ func runStandalone(ctx context.Context, store objstore.Store, logger *slog.Logge
 		StreamingExchange:      streamingExchange,
 		EagerDispatch:          eagerDispatch,
 		ShuffleDurability:      durability,
+		LocalityPlacement:      localityPlacement,
 	}, cat, nc, js, logger)
 
 	// Phase A: same-process data-plane server + client when enabled.
@@ -1275,6 +1278,7 @@ func runCoordinator(ctx context.Context, store objstore.Store, logger *slog.Logg
 		StreamingExchange:      streamingExchange,
 		EagerDispatch:          eagerDispatch,
 		ShuffleDurability:      durability,
+		LocalityPlacement:      localityPlacement,
 	}, cat, nc, js, logger)
 
 	// Phase A: start data-plane gRPC server alongside coord when enabled.

--- a/deploy/benchmark/terraform/main.tf
+++ b/deploy/benchmark/terraform/main.tf
@@ -410,6 +410,9 @@ locals {
     # Coordinator-side only — workers act on Task.UploadPolicy stamped at
     # dispatch. eager (default) = pre-knob behavior.
     export WADJET_SHUFFLE_DURABILITY="${var.shuffle_durability}"
+    # Input-locality placement (docs/design/locality-placement.md).
+    # Coordinator-side only; explicit opt-in pending SF100 validation.
+    export WADJET_LOCALITY_PLACEMENT="${var.locality_placement ? "1" : "0"}"
     # Catalog snapshot/restore prefix (PR #115). Non-empty = restore the
     # post-discovery catalog from s3://<bucket>/<prefix> instead of paying
     # ~15 min of discovery+ANALYZE per deploy; first boot writes it.

--- a/deploy/benchmark/terraform/variables.tf
+++ b/deploy/benchmark/terraform/variables.tf
@@ -306,6 +306,12 @@ variable "shuffle_durability" {
   default     = "eager"
 }
 
+variable "locality_placement" {
+  description = "WADJET_LOCALITY_PLACEMENT for the coordinator (docs/design/locality-placement.md): dispatch a task whose peer-location hints all point at one worker onto that worker, converting 1:1 stage-chain reads from peer gRPC streams into same-worker mmaps. Coordinator-side only. Default false pending SF100 validation."
+  type        = bool
+  default     = false
+}
+
 variable "peer_exchange_port" {
   description = "Worker↔worker peer-exchange (FetchShuffle) port; SG opens it intra-cluster whenever streaming_exchange is set."
   type        = number

--- a/docs/design/locality-placement.md
+++ b/docs/design/locality-placement.md
@@ -1,0 +1,82 @@
+# Input-locality task placement (`--locality-placement`)
+
+Status: implemented 2026-07-24. Default off pending SF100 validation.
+
+## Motivation
+
+The shuffle-io ledger (PR #261) split SF100 exchange reads into 237.7 GB
+same-worker mmap vs 351.9 GB peer gRPC streams per suite pair. Decomposing
+that peer share by plan structure:
+
+- **Repartition exchanges** (`partition=NNNN` fan-in): every producer task
+  hash-partitions its slice of the input, so each producer contributes
+  ~uniformly to every partition. Wherever a consumer runs, ~(N−1)/N of its
+  partition's bytes were produced elsewhere. This share is irreducible
+  data movement — no placement can shrink it.
+- **1:1 stage chains** (consumer stage with the same `distribution_count`
+  as its dependency — the `join-8 → join-10` shape, 24→24): consumer task
+  *i* reads exactly producer task *i*'s output. Today placement is
+  memory-binpack/round-robin, so ~1/N of these land co-located by chance;
+  the rest stream over the NIC for no structural reason.
+- Single-producer outputs (replicated builds, small stages) sit between:
+  one producer, one or many consumers.
+
+Placement can convert the second and (partially) third classes to local
+mmaps. Q18 — the #1 wall query — is dominated by exactly the 1:1
+`join-8`/`join-10` class edges (~37 GB/run on that one edge).
+
+## Mechanism
+
+`Scheduler.pickWorkerFor` gains a locality tier between the eager-consumer
+reservation and memory binpack:
+
+1. The streaming-exchange annotator already stamps every dispatched task
+   with `InputLocations` (input key → producer's peer address) before the
+   scheduler picks a worker — the locality signal costs nothing new.
+2. `pickLocalityWorkerFrom`: if every hinted input resolves to ONE address,
+   map it back to a connected worker (registry `PeerAddr`) and place the
+   task there.
+3. **Same-batch cap**: at most `ceil(batchLen / connectedWorkers)` tasks of
+   one fan-out per worker. 1:1 chains inherit their producer stage's
+   uniform spread, so the cap never bites them; batches whose tasks all
+   hint at one worker (replicated build files) get exactly their fair
+   share placed locally and the rest fall through — preserving the
+   anti-clump property the binpack spread established (2026-07-20 Q20
+   diagnosis: a stacked fan-out cost +24s serialization).
+
+Preference, not correctness: hints are best-effort, and wherever the task
+lands its reads fall back through local/KV/peer/S3 tiers unchanged. Tasks
+with hints on multiple workers (repartition consumers) and tasks with no
+hints fall through to binpack/round-robin exactly as before.
+
+Ranked above binpack deliberately: for a 1:1 chain the input bytes already
+live on the hinted worker, so reading locally is also the memory-cheapest
+option; worker-side memory admission remains the backstop.
+
+## Scope and interactions
+
+- Requires `--streaming-exchange` (hint source) and the gRPC data plane
+  (targeted dispatch; the NATS path is worker-pull and places nothing).
+  `coordinator.New` only arms the tier when both configs allow.
+- Skew-split sub-tasks divide a hot group's probe files across producers →
+  hints span workers → fall through. Unaffected.
+- Retries re-annotate with current hints and re-pick; a dead hinted worker
+  is not connected → fall through.
+- Shuffle-durability lazy/off: independent knobs; locality reduces peer
+  streams, durability reduces uploads. Combined arm is the target state.
+
+## Observability
+
+`published tasks` placement counts gain a `local:N` method alongside
+`eager`/`binpack`/`rr`. The #261 ledger's local-vs-peer byte split is the
+decision metric: local share should rise on 1:1-heavy queries.
+
+## Validation
+
+Unit (pure `pickLocalityWorkerFrom` core), coordinator suite + `-race`,
+TPC-H SF0.01, tpch-harness local SF0.01+SF1 both arms, then SF100
+same-window pair (baseline, then `WADJET_LOCALITY_PLACEMENT=1`, ideally on
+top of `WADJET_SHUFFLE_DURABILITY=lazy` once that flips). Success axes:
+peer_bytes share falls, Q18 steady improves, rows 44/44, placement
+`local:N` visible on 1:1 chains, no fan-out clumping (spread stays
+uniform on dispatch lines).

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -132,6 +132,14 @@ type Config struct {
 	// Only meaningful with StreamingExchange (the peer tier is what makes
 	// the durable copy optional).
 	ShuffleDurability distributed.UploadPolicy
+	// LocalityPlacement places a task whose peer-location hints all point
+	// at one connected worker onto that worker (docs/design/locality-
+	// placement.md): 1:1 stage chains read their whole input set via
+	// same-worker mmap instead of peer gRPC streams. Requires
+	// StreamingExchange (the hint source) and the gRPC data plane
+	// (targeted dispatch). Zero value false — default off until SF100
+	// validation (mirrors EagerDispatch).
+	LocalityPlacement bool
 }
 
 // SetAuthProvider wires ABAC enforcement into ExecuteSQL: with a provider
@@ -300,6 +308,11 @@ func New(cfg Config, cat *catalog.Catalog, nc *nats.Conn, js jetstream.JetStream
 	// Memory-aware gRPC placement: the scheduler bin-packs estimated task
 	// footprints against heartbeat pool stats. No-op on the NATS path.
 	c.scheduler.SetWorkerRegistry(c.workers)
+	// Input-locality placement rides the streaming-exchange hints; without
+	// them no task ever carries InputLocations and the tier is inert.
+	if cfg.LocalityPlacement && cfg.StreamingExchange {
+		c.scheduler.SetLocalityPlacement(true)
+	}
 
 	// Streaming exchange (Phase A): annotate every dispatched task — initial
 	// and retried alike, since retries re-enter PublishTasks — with peer

--- a/internal/coordinator/scheduler.go
+++ b/internal/coordinator/scheduler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -68,6 +69,13 @@ type Scheduler struct {
 	// retried) passes through. Used by streaming exchange to attach
 	// peer-location hints and fetch tokens. Must be cheap and thread-safe.
 	annotate func(*distributed.Task)
+
+	// localityPlacement enables input-locality placement (docs/design/
+	// locality-placement.md): a task whose peer-location hints all point
+	// at one connected worker is placed on that worker, converting its
+	// exchange reads from peer gRPC streams into same-worker mmaps. Only
+	// meaningful when the annotator supplies hints (streaming exchange).
+	localityPlacement bool
 }
 
 // NewScheduler creates a new task scheduler.
@@ -107,6 +115,12 @@ func (s *Scheduler) SetWorkerRegistry(wr *WorkerRegistry) {
 // any query runs (same contract as the other Set<X> setters).
 func (s *Scheduler) SetTaskAnnotator(fn func(*distributed.Task)) {
 	s.annotate = fn
+}
+
+// SetLocalityPlacement toggles input-locality placement. Call before any
+// query runs (same contract as the other Set<X> setters).
+func (s *Scheduler) SetLocalityPlacement(on bool) {
+	s.localityPlacement = on
 }
 
 // TaskDone clears the task's in-flight admission estimate. Called by the
@@ -204,7 +218,7 @@ func (s *Scheduler) publishViaDataPlane(batch []preparedTask, deadlineNano int64
 	batchAssigned := make(map[string]int)
 	methods := make(map[string]int)
 	for _, p := range batch {
-		workerID, method, ok := s.pickWorkerFor(p.task, batchAssigned)
+		workerID, method, ok := s.pickWorkerFor(p.task, batchAssigned, len(batch))
 		if !ok {
 			return fmt.Errorf("dispatching task %s: %w", p.task.ID, dataplane.ErrNoWorkers)
 		}
@@ -271,12 +285,17 @@ func formatCounts(m map[string]int) string {
 // them on one worker starves that worker's producer lanes (targeted gRPC
 // dispatch has no work stealing).
 //
-// The returned method ("eager" | "binpack" | "rr") feeds the placement
-// attr on the "published tasks" line.
-func (s *Scheduler) pickWorkerFor(t distributed.Task, batchAssigned map[string]int) (workerID, method string, ok bool) {
+// The returned method ("eager" | "local" | "binpack" | "rr") feeds the
+// placement attr on the "published tasks" line.
+func (s *Scheduler) pickWorkerFor(t distributed.Task, batchAssigned map[string]int, batchLen int) (workerID, method string, ok bool) {
 	if len(t.EagerInputs) > 0 {
 		if id, ok := s.pickEagerWorker(); ok {
 			return id, "eager", true
+		}
+	}
+	if s.localityPlacement && s.registry != nil {
+		if id, ok := pickLocalityWorkerFrom(t, s.dpSrv.ConnectedWorkers(), s.registry.ActiveWorkers(), batchAssigned, batchLen); ok {
+			return id, "local", true
 		}
 	}
 	if t.EstimatedBytes > 0 && s.registry != nil {
@@ -286,6 +305,54 @@ func (s *Scheduler) pickWorkerFor(t distributed.Task, batchAssigned map[string]i
 	}
 	id, ok := s.dpSrv.PickWorker()
 	return id, "rr", ok
+}
+
+// pickLocalityWorkerFrom places a task whose peer-location hints all point
+// at ONE worker onto that worker — the 1:1 stage-chain case (consumer task
+// i reading exactly producer task i's output), where a same-worker mmap
+// replaces a peer gRPC stream for the entire hinted input set. Preference,
+// not correctness: hints are best-effort and reads fall back through the
+// peer/S3 tiers wherever the task lands.
+//
+// Repartition-exchange consumers read from every producer, carry hints on
+// multiple workers, and fall through — their cross-worker bytes are
+// irreducible (each producer contributes ~uniformly to every partition).
+//
+// The same-batch cap (ceil batch/connected) bounds clumping when many
+// tasks of one fan-out share a hinted worker (replicated build files whose
+// single producer would otherwise attract the whole batch), preserving the
+// anti-affinity the binpack spread established (2026-07-20 Q20 diagnosis:
+// a stacked fan-out cost +24s serialization). 1:1 chains inherit the
+// producer stage's uniform spread, so the cap does not bite them.
+func pickLocalityWorkerFrom(t distributed.Task, connected []string, active []*WorkerInfo, batchAssigned map[string]int, batchLen int) (string, bool) {
+	if len(t.InputLocations) == 0 || len(connected) == 0 {
+		return "", false
+	}
+	addr := ""
+	for _, a := range t.InputLocations {
+		if addr == "" {
+			addr = a
+		} else if a != addr {
+			return "", false // inputs span workers: nothing to co-locate with
+		}
+	}
+	var workerID string
+	for _, w := range active {
+		if w.PeerAddr != "" && w.PeerAddr == addr {
+			workerID = w.WorkerID
+			break
+		}
+	}
+	if workerID == "" {
+		return "", false
+	}
+	if !slices.Contains(connected, workerID) {
+		return "", false
+	}
+	if batchAssigned[workerID] >= (batchLen+len(connected)-1)/len(connected) {
+		return "", false
+	}
+	return workerID, true
 }
 
 // pickEagerWorker places one eager consumer task: the connected worker

--- a/internal/coordinator/scheduler_binpack_test.go
+++ b/internal/coordinator/scheduler_binpack_test.go
@@ -42,6 +42,54 @@ func TestPickLeastLoadedWorker(t *testing.T) {
 	}
 }
 
+func TestPickLocalityWorkerFrom(t *testing.T) {
+	active := []*WorkerInfo{
+		{WorkerID: "w1", PeerAddr: "10.0.0.1:9095"},
+		{WorkerID: "w2", PeerAddr: "10.0.0.2:9095"},
+		{WorkerID: "w3"}, // no peer addr advertised
+	}
+	oneWorker := map[string]string{
+		"queries/q/s1/a.wshf": "10.0.0.1:9095",
+		"queries/q/s1/b.wshf": "10.0.0.1:9095",
+	}
+	tests := []struct {
+		name          string
+		locs          map[string]string
+		connected     []string
+		batchAssigned map[string]int
+		batchLen      int
+		wantID        string
+		wantOK        bool
+	}{
+		{"all hints on one worker", oneWorker,
+			[]string{"w1", "w2"}, nil, 3, "w1", true},
+		{"hints span workers fall through", map[string]string{
+			"queries/q/s1/a.wshf": "10.0.0.1:9095",
+			"queries/q/s1/b.wshf": "10.0.0.2:9095",
+		}, []string{"w1", "w2"}, nil, 3, "", false},
+		{"no hints fall through", nil, []string{"w1", "w2"}, nil, 3, "", false},
+		{"hinted worker not connected", oneWorker,
+			[]string{"w2"}, nil, 3, "", false},
+		{"unknown peer addr", map[string]string{
+			"queries/q/s1/a.wshf": "10.9.9.9:9095",
+		}, []string{"w1", "w2"}, nil, 3, "", false},
+		{"batch cap bites", oneWorker,
+			[]string{"w1", "w2"}, map[string]int{"w1": 2}, 3, "", false},
+		{"batch cap admits under ceil", oneWorker,
+			[]string{"w1", "w2"}, map[string]int{"w1": 1}, 3, "w1", true},
+		{"no connected workers", oneWorker, nil, nil, 3, "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			task := distributed.Task{InputLocations: tc.locs}
+			id, ok := pickLocalityWorkerFrom(task, tc.connected, active, tc.batchAssigned, tc.batchLen)
+			if id != tc.wantID || ok != tc.wantOK {
+				t.Fatalf("pickLocalityWorkerFrom = (%q,%v), want (%q,%v)", id, ok, tc.wantID, tc.wantOK)
+			}
+		})
+	}
+}
+
 func TestSchedulerInflightLifecycle(t *testing.T) {
 	s := NewScheduler(nil, nil)
 	s.noteInflight(distributed.Task{ID: "t1", EstimatedBytes: 100}, "w1")


### PR DESCRIPTION
Follows #261/#262. Design record: `docs/design/locality-placement.md`.

## Why

The #261 ledger splits SF100 exchange reads into 237.7 GB same-worker mmap vs **351.9 GB peer gRPC streams** per suite pair. By plan shape, repartition fan-ins are irreducible (every producer hash-partitions its slice, contributing uniformly to every partition), but **1:1 stage chains** — `join-8 → join-10` class, consumer task *i* reading exactly producer task *i*'s output — cross the NIC only because placement is locality-blind. Q18's biggest edge (~37 GB/run) is exactly this shape.

## What

`pickWorkerFor` gains a locality tier (eager → **local** → binpack → rr): a task whose streaming-exchange `InputLocations` hints all resolve to one connected worker is dispatched there. A same-batch cap (`ceil(batch/workers)`) preserves fan-out anti-clumping (the 2026-07-20 Q20 lesson) when a whole batch hints at one producer; 1:1 chains inherit their producer stage's uniform spread so the cap never bites them. Pure preference — hints stay best-effort, every read-tier fallback unchanged; repartition consumers (hints span workers) fall through untouched.

`--locality-placement` default **false** pending SF100 validation (requires `--streaming-exchange` + gRPC data plane); `WADJET_LOCALITY_PLACEMENT` in tpch-bench; terraform var `locality_placement`. Dispatch lines gain a `local:N` placement count.

## Validation

- Pure-core unit table (`pickLocalityWorkerFrom`), coordinator `-race`, TPC-H SF0.01 — green.
- tpch-harness local SF0.01 + SF1 (gRPC data plane, flag on): row-identical, tier verified firing (`placement=local:N` on 1:1 batches, spread stays uniform).
- Next: SF100 same-window A/B (baseline, then `WADJET_LOCALITY_PLACEMENT=1` — ideally stacked on `WADJET_SHUFFLE_DURABILITY=lazy`). Decision metrics: peer_bytes share falls, Q18 steady, rows 44/44, no clumped spreads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwM2ifvvNiJgfAWSD1Vp5q