### PR TITLE
perf(worker): paced async scratch purge off the query-complete handler

### DIFF
--- a/cmd/wadjet/main.go
+++ b/cmd/wadjet/main.go
@@ -113,6 +113,7 @@ var (
 	baseTableCacheBytes   int64
 	baseTableCacheDir     string
 	streamingShuffleRead  bool
+	asyncScratchPurge     bool
 	scanDecodeAhead       bool
 	scanDecodeAheadBytes  int64
 )
@@ -187,6 +188,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&peerExchangeAddr, "peer-exchange-addr", ":0", "Peer-exchange (FetchShuffle) listen address. Default :0 picks a free port (the address reaches peers via heartbeats, and a fixed default would collide when multiple workers share a host); pin it when firewalls need a known port.")
 	rootCmd.PersistentFlags().StringVar(&peerExchangeAdvertise, "peer-exchange-advertise", "", "Peer-exchange address advertised in heartbeats (default: derived from the bound listener)")
 	rootCmd.PersistentFlags().BoolVar(&streamingShuffleRead, "streaming-shuffle-read", true, "Decode WSHF/WSHC exchange inputs directly from the peer/S3 byte stream instead of staging the whole file to NVMe + mmap first — the first chunk decodes as soon as its frames arrive. Any mid-stream failure falls back to a staged read of the durable copy, skipping already-delivered batches. Default true (SF100-validated); =false is the kill switch restoring the staged read path. See docs/design/exchange-streaming-consumption.md.")
+	rootCmd.PersistentFlags().BoolVar(&asyncScratchPurge, "async-scratch-purge", true, "Defer per-query stage-cache scratch deletion to a paced background janitor instead of unlinking inline on the query-complete broadcast handler — at SF100 the inline unlink storm of a big query's multi-GB scratch stalls the NEXT query's first tasks (Q22/Q14/Q11 straggler tails). Worker-side. Default true; =false is the kill switch restoring inline deletion. See docs/design/async-scratch-purge.md.")
 	rootCmd.PersistentFlags().BoolVar(&scanDecodeAhead, "scan-decode-ahead", true, "Decode parquet row groups ahead of scan consumption: k decode workers per scan source with in-order delivery and a decoded-bytes window bounded by the shared memory pool and the page-cache refault sensor. Worker scan path only. Default true (SF100-validated, steady-state -7.3%); =false is the kill switch restoring the serial row-group path. See docs/design/scan-decode-pipelining.md.")
 	rootCmd.PersistentFlags().Int64Var(&scanDecodeAheadBytes, "scan-decode-ahead-bytes", 0, "Decoded-but-unconsumed byte window per scan source for --scan-decode-ahead. 0 = engine default (256 MiB).")
 	rootCmd.PersistentFlags().Int64Var(&baseTableCacheBytes, "base-table-cache-bytes", 0, "Cross-query disk cache for immutable base-table parquet objects: LRU byte budget on the cache volume. Hits are served from local disk without touching S3 (or the circuit breaker); misses tee the download into the cache. The cache survives restarts (index rebuilt from the directory). 0 = disabled (default until SF100 validation). See docs/design/base-table-nvme-cache.md.")
@@ -942,6 +944,7 @@ func runStandalone(ctx context.Context, store objstore.Store, logger *slog.Logge
 		PeerListenAddr:        peerListenAddr(),
 		PeerAdvertiseAddr:     peerExchangeAdvertise,
 		StreamingShuffleRead:  streamingShuffleRead,
+		AsyncScratchPurge:     asyncScratchPurge,
 		ScanDecodeAhead:       scanDecodeAhead,
 		ScanDecodeAheadBytes:  scanDecodeAheadBytes,
 	}, store, nc, js, logger)
@@ -1527,6 +1530,7 @@ func runWorker(ctx context.Context, store objstore.Store, logger *slog.Logger) e
 		PeerListenAddr:        peerListenAddr(),
 		PeerAdvertiseAddr:     peerExchangeAdvertise,
 		StreamingShuffleRead:  streamingShuffleRead,
+		AsyncScratchPurge:     asyncScratchPurge,
 		ScanDecodeAhead:       scanDecodeAhead,
 		ScanDecodeAheadBytes:  scanDecodeAheadBytes,
 	}, store, nc, js, logger)

--- a/deploy/benchmark/terraform/main.tf
+++ b/deploy/benchmark/terraform/main.tf
@@ -689,6 +689,7 @@ resource "aws_instance" "worker" {
             --base-table-cache-bytes=${var.base_table_cache_bytes} \
             --streaming-shuffle-read=${var.streaming_shuffle_read} \
             --scan-decode-ahead=${var.scan_decode_ahead} \
+            --async-scratch-purge=${var.async_scratch_purge} \
             %{if var.spill_floating_budget~}
             --spill-floating-budget \
             %{endif~}

--- a/deploy/benchmark/terraform/variables.tf
+++ b/deploy/benchmark/terraform/variables.tf
@@ -306,6 +306,12 @@ variable "shuffle_durability" {
   default     = "eager"
 }
 
+variable "async_scratch_purge" {
+  description = "Worker --async-scratch-purge (docs/design/async-scratch-purge.md): defer per-query stage-cache deletion to a paced background janitor instead of unlinking inline on the query-complete broadcast handler. Default true; false = inline-deletion control arm / kill switch."
+  type        = bool
+  default     = true
+}
+
 variable "locality_placement" {
   description = "WADJET_LOCALITY_PLACEMENT for the coordinator (docs/design/locality-placement.md): dispatch a task whose peer-location hints all point at one worker onto that worker, converting 1:1 stage-chain reads from peer gRPC streams into same-worker mmaps. Coordinator-side only. Default false pending SF100 validation."
   type        = bool

--- a/docs/design/async-scratch-purge.md
+++ b/docs/design/async-scratch-purge.md
@@ -1,0 +1,64 @@
+# Async scratch purge (`--async-scratch-purge`)
+
+Status: implemented 2026-07-24. Default on; `=false` is the inline-deletion
+kill switch and A/B control arm.
+
+## The bug (diagnosed from SF100 logs, 2026-07-24)
+
+The suite's volatile small queries — Q22, Q14, Q11, swinging ±2–10s across
+otherwise-identical arms all week — share one signature and one position:
+
+- Each runs **immediately after a top-scratch query** (Q22 after Q21's
+  33.6 GB, Q14 after Q13's 23.1 GB, Q11 after Q10's 19.5 GB).
+- In slow runs, most of the query's sub-second tasks complete instantly
+  and then one or more workers' remaining wave sits silent for 7–12s
+  (Q22 join-4: 20/24 tasks < 5s, last task at +12s; dispatch spread
+  uniform; occurs identically under eager/lazy durability and with
+  locality placement off — mechanism-independent).
+
+When a query terminates, the coordinator broadcasts `CompleteSubject` and
+every worker's handler runs `LocalStageCache.CleanupQuery`: an **inline
+unlink of the query's entire adopted scratch** (per-file `os.Remove` +
+`RemoveAll`), gigabytes across thousands of files, precisely while the
+next query's first tasks are starting on the same NVMe volume. The unlink
+storm (journal traffic, extent freeing, page-cache invalidation) is the
+prime suspect for the stalls.
+
+## The fix
+
+`CleanupQuery` keeps its synchronous contract for correctness-relevant
+state — entries dropped, tombstone recorded, `Get` misses immediately,
+late `Adopt` still declined — but detaches the on-disk work:
+
+1. Rename the per-query directory into `<cache>/.trash/<qid>-<seq>`
+   (instant; open fds and mmaps remain valid across rename and unlink,
+   so a straggler reader is no worse off than under inline deletion).
+2. A janitor goroutine unlinks the trashed tree **paced** — bursts of 64
+   files with 5ms pauses — bounding IO contention with the running query.
+3. Fallbacks stay inline: kill switch, rename failure, no on-disk dir,
+   or a full janitor queue (blocking the broadcast handler would
+   recreate the bug). Boot-time `RemoveAll(rootDir)` already reclaims
+   anything a crash strands in `.trash`.
+
+`broadcastJoinCache.CleanupQuery` releases in-memory builds only (no file
+storm) and is untouched.
+
+## Instrumentation (both modes)
+
+- `"scratch purge inline"`: query, entries, bytes, `handler_ms` — in the
+  control arm this measures the storm the broadcast handler absorbs, and
+  its timestamps should overlap the straggler windows if the diagnosis is
+  right.
+- `"scratch purge deferred"` (`handler_us`) + `"scratch purge done"`
+  (files, bytes, `purge_ms`) in the treatment arm.
+
+## Validation
+
+Unit (async purge semantics, tombstone, idempotence, no-adopt path),
+worker `-race`, TPC-H SF0.01, tpch-harness local both arms. SF100
+same-window pair: control `-var=async_scratch_purge=false` (instrumented
+inline — confirms the correlation), then treatment (default). Success:
+`handler_ms` storms in control align with straggler windows; treatment
+collapses the Q22/Q14/Q11 tails; suite steady noise floor drops; rows
+44/44. Local repro is NOT a gate — the effect needs real multi-GB scratch
+churn ([[feedback_local_repro_lies]]).

--- a/internal/worker/local_stage_cache.go
+++ b/internal/worker/local_stage_cache.go
@@ -4,9 +4,11 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/citc-tech/wadjet/internal/distributed"
@@ -31,6 +33,7 @@ import (
 // complete or cancelled.
 type LocalStageCache struct {
 	rootDir string
+	logger  *slog.Logger
 	mu      sync.RWMutex
 	entries map[localStageKey]string
 	// cleaned tombstones queries whose CleanupQuery already ran. A task
@@ -40,7 +43,38 @@ type LocalStageCache struct {
 	// again (the cleanup message fires once per query). Entries are pruned
 	// on insert after tombstoneTTL.
 	cleaned map[string]time.Time
+
+	// asyncPurge defers file deletion to the janitor goroutine
+	// (docs/design/async-scratch-purge.md): CleanupQuery renames the
+	// query's directory into .trash (instant) and the janitor unlinks its
+	// contents with pacing. Without it (kill switch), CleanupQuery
+	// unlinks inline on the caller — the query-complete broadcast
+	// handler — which at SF100 is a multi-GB unlink storm precisely when
+	// the NEXT query's first tasks are starting (the Q22/Q14/Q11
+	// straggler-tail diagnosis, 2026-07-24).
+	asyncPurge  bool
+	janitorOnce sync.Once
+	trashCh     chan trashedQuery
+	trashSeq    atomic.Int64
 }
+
+// trashedQuery is one detached per-query directory awaiting background
+// deletion, plus the ledger identity for the completion log line.
+type trashedQuery struct {
+	dir     string
+	queryID string
+	entries int
+}
+
+// Janitor pacing: unlink in bursts of purgeBatchFiles with purgeBatchPause
+// between bursts, bounding the unlink storm's IO/journal contention with
+// the running query's tasks. ~1-2k files per SF100 query-worker → the
+// pause adds well under a second of janitor wall per query, all off the
+// broadcast handler.
+const (
+	purgeBatchFiles = 64
+	purgeBatchPause = 5 * time.Millisecond
+)
 
 // tombstoneTTL bounds how long a cleaned query refuses late Adopts. It only
 // needs to outlive the slowest straggler task of a terminated query; 30
@@ -83,7 +117,33 @@ func NewLocalStageCache(rootDir string) *LocalStageCache {
 		rootDir: rootDir,
 		entries: make(map[localStageKey]string),
 		cleaned: make(map[string]time.Time),
+		trashCh: make(chan trashedQuery, 64),
 	}
+}
+
+// SetAsyncPurge enables deferred scratch deletion (janitor goroutine,
+// started lazily on first use). Call before the worker serves traffic
+// (same contract as the other Set<X> setters); false = inline unlinks on
+// the cleanup caller, the pre-2026-07-24 behavior and the A/B kill switch.
+func (c *LocalStageCache) SetAsyncPurge(on bool) {
+	if c != nil {
+		c.asyncPurge = on
+	}
+}
+
+// SetLogger attaches the worker's structured logger for the purge ledger
+// lines. nil-safe; without it slog.Default() is used.
+func (c *LocalStageCache) SetLogger(l *slog.Logger) {
+	if c != nil && l != nil {
+		c.logger = l
+	}
+}
+
+func (c *LocalStageCache) log() *slog.Logger {
+	if c.logger != nil {
+		return c.logger
+	}
+	return slog.Default()
 }
 
 // Adopt moves srcPath into the cache's per-query directory and registers it
@@ -138,13 +198,17 @@ func (c *LocalStageCache) Get(queryID, key string) string {
 	return c.entries[localStageKey{queryID, key}]
 }
 
-// CleanupQuery drops all entries for queryID, unlinks the files, and removes
-// the per-query directory. Safe to call multiple times and against unknown
-// query IDs.
+// CleanupQuery drops all entries for queryID and disposes of the files.
+// With asyncPurge the per-query directory is renamed into .trash (instant
+// — open fds and mmaps stay valid across rename and unlink) and the
+// janitor deletes it with pacing; otherwise files are unlinked inline,
+// blocking the caller for the whole storm. Safe to call multiple times
+// and against unknown query IDs.
 func (c *LocalStageCache) CleanupQuery(queryID string) int {
 	if c == nil {
 		return 0
 	}
+	start := time.Now()
 	c.mu.Lock()
 	paths := make([]string, 0)
 	for k, p := range c.entries {
@@ -163,13 +227,94 @@ func (c *LocalStageCache) CleanupQuery(queryID string) int {
 		}
 	}
 	c.mu.Unlock()
+
+	if len(paths) == 0 && c.rootDir == "" {
+		return 0
+	}
+	if c.asyncPurge && c.rootDir != "" && c.deferPurge(queryID, len(paths)) {
+		c.log().Info("scratch purge deferred",
+			"query_id", queryID, "entries", len(paths),
+			"handler_us", time.Since(start).Microseconds())
+		return len(paths)
+	}
+	// Inline (kill switch, empty dir, rename failure, or full janitor
+	// queue): the pre-async behavior, instrumented — handler_ms is the
+	// storm the broadcast handler absorbs.
+	var bytes int64
 	for _, p := range paths {
+		if fi, err := os.Stat(p); err == nil {
+			bytes += fi.Size()
+		}
 		_ = os.Remove(p)
 	}
 	if c.rootDir != "" {
 		_ = os.RemoveAll(filepath.Join(c.rootDir, queryID))
 	}
+	if len(paths) > 0 {
+		c.log().Info("scratch purge inline",
+			"query_id", queryID, "entries", len(paths), "bytes", bytes,
+			"handler_ms", time.Since(start).Milliseconds())
+	}
 	return len(paths)
+}
+
+// deferPurge detaches the query's directory into .trash and hands it to
+// the janitor. Returns false when the caller must delete inline (rename
+// failed, or the janitor queue is full — blocking here would put the
+// storm right back on the broadcast handler).
+func (c *LocalStageCache) deferPurge(queryID string, entries int) bool {
+	qdir := filepath.Join(c.rootDir, queryID)
+	if _, err := os.Stat(qdir); err != nil {
+		return false // nothing on disk (no adopts); inline path is a no-op
+	}
+	trashDir := filepath.Join(c.rootDir, ".trash")
+	if err := os.MkdirAll(trashDir, 0o755); err != nil {
+		return false
+	}
+	dst := filepath.Join(trashDir, fmt.Sprintf("%s-%d", queryID, c.trashSeq.Add(1)))
+	if err := os.Rename(qdir, dst); err != nil {
+		return false
+	}
+	c.janitorOnce.Do(func() { go c.janitor() })
+	select {
+	case c.trashCh <- trashedQuery{dir: dst, queryID: queryID, entries: entries}:
+		return true
+	default:
+		// Queue full — delete the detached dir inline rather than blocking.
+		_ = os.RemoveAll(dst)
+		return true // still off the entries' unlink path; dir handled here
+	}
+}
+
+// janitor deletes trashed query directories with pacing: bursts of
+// purgeBatchFiles unlinks separated by purgeBatchPause, bounding
+// journal/IO contention with the running query. Daemon goroutine, one per
+// cache, lives for the process (boot-time RemoveAll of rootDir reclaims
+// anything a crash strands in .trash).
+func (c *LocalStageCache) janitor() {
+	for t := range c.trashCh {
+		start := time.Now()
+		var files int
+		var bytes int64
+		_ = filepath.WalkDir(t.dir, func(path string, d os.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			if fi, ferr := d.Info(); ferr == nil {
+				bytes += fi.Size()
+			}
+			_ = os.Remove(path)
+			files++
+			if files%purgeBatchFiles == 0 {
+				time.Sleep(purgeBatchPause)
+			}
+			return nil
+		})
+		_ = os.RemoveAll(t.dir)
+		c.log().Info("scratch purge done",
+			"query_id", t.queryID, "entries", t.entries, "files", files,
+			"bytes", bytes, "purge_ms", time.Since(start).Milliseconds())
+	}
 }
 
 // Count returns the total number of cached entries across all queries.

--- a/internal/worker/local_stage_cache_test.go
+++ b/internal/worker/local_stage_cache_test.go
@@ -101,6 +101,68 @@ func TestLocalStageCache_AdoptAfterCleanupDeclined(t *testing.T) {
 	}
 }
 
+// TestLocalStageCache_AsyncPurge: with the janitor enabled, CleanupQuery
+// must return immediately with entries dropped (Get misses, Adopt
+// tombstoned) while the files disappear shortly after in the background.
+func TestLocalStageCache_AsyncPurge(t *testing.T) {
+	root := t.TempDir()
+	c := NewLocalStageCache(root)
+	c.SetAsyncPurge(true)
+
+	var dsts []string
+	for i := 0; i < 3; i++ {
+		src := filepath.Join(t.TempDir(), "src.wshf")
+		if err := os.WriteFile(src, []byte("payload"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		key := filepath.Join("queries/qa/s", string(rune('a'+i))+".wshf")
+		dst := c.Adopt("qa", key, src)
+		if dst == "" {
+			t.Fatalf("Adopt %d failed", i)
+		}
+		dsts = append(dsts, dst)
+	}
+
+	if n := c.CleanupQuery("qa"); n != 3 {
+		t.Fatalf("CleanupQuery = %d, want 3", n)
+	}
+	// Entries are gone synchronously.
+	if got := c.Get("qa", "queries/qa/s/a.wshf"); got != "" {
+		t.Fatalf("Get after async cleanup returned %q", got)
+	}
+	// Late Adopt still declined (tombstone unaffected by purge mode).
+	src := filepath.Join(t.TempDir(), "late.wshf")
+	if err := os.WriteFile(src, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := c.Adopt("qa", "queries/qa/s/late.wshf", src); got != "" {
+		t.Fatal("late Adopt accepted on tombstoned query")
+	}
+	// Files disappear in the background.
+	waitFor(t, "janitor to delete trashed files", func() bool {
+		for _, d := range dsts {
+			if _, err := os.Stat(d); !os.IsNotExist(err) {
+				return false
+			}
+		}
+		return true
+	})
+	// Idempotent second cleanup.
+	if n := c.CleanupQuery("qa"); n != 0 {
+		t.Fatalf("second CleanupQuery = %d, want 0", n)
+	}
+}
+
+// TestLocalStageCache_AsyncPurgeNoAdopts: cleanup of a query with no
+// on-disk directory must not spin up janitor work or fail.
+func TestLocalStageCache_AsyncPurgeNoAdopts(t *testing.T) {
+	c := NewLocalStageCache(t.TempDir())
+	c.SetAsyncPurge(true)
+	if n := c.CleanupQuery("ghost"); n != 0 {
+		t.Fatalf("CleanupQuery(ghost) = %d, want 0", n)
+	}
+}
+
 func TestLocalStageCache_AdoptMissingFile(t *testing.T) {
 	c := NewLocalStageCache(t.TempDir())
 	if got := c.Adopt("q", "k", "/no/such/file"); got != "" {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -66,6 +66,12 @@ type Config struct {
 	// RSS-sampling).
 	FloatingBudgetActive bool
 
+	// AsyncScratchPurge defers per-query stage-cache file deletion to a
+	// paced background janitor instead of unlinking inline on the
+	// query-complete broadcast handler (docs/design/async-scratch-purge.md
+	// — the SF100 Q22/Q14/Q11 straggler-tail fix). False = inline unlinks
+	// (pre-fix behavior, A/B kill switch).
+	AsyncScratchPurge bool
 	// StreamingShuffleRead decodes WSHF/WSHC exchange inputs directly from
 	// the peer/S3 byte stream instead of staging whole files to NVMe +
 	// mmap first (docs/design/exchange-streaming-consumption.md §3 D1).
@@ -268,7 +274,10 @@ func New(cfg Config, store objstore.Store, nc *nats.Conn, js jetstream.JetStream
 	// worker mmap them directly instead of round-tripping S3. Skipped when
 	// no spill dir is configured (tests / minimal embeddings).
 	if cfg.SpillDir != "" {
-		executor.SetLocalStageCache(NewLocalStageCache(filepath.Join(cfg.SpillDir, "stage-cache")))
+		sc := NewLocalStageCache(filepath.Join(cfg.SpillDir, "stage-cache"))
+		sc.SetAsyncPurge(cfg.AsyncScratchPurge)
+		sc.SetLogger(logger)
+		executor.SetLocalStageCache(sc)
 	}
 	// Best-effort bind to the coordinator's shared result KV bucket so small
 	// stage outputs can round-trip via NATS (~10ms) instead of S3 (~500ms).


### PR DESCRIPTION
Design record: `docs/design/async-scratch-purge.md`. Fixes the suite's dominant A/B noise source.

## Diagnosis (from logs already on disk — no deploys)

The volatile small queries (Q22/Q14/Q11, ±2–10s swings in every arm this week) share one signature: each runs **immediately after a top-scratch query** (Q22←Q21 33.6 GB, Q14←Q13 23.1 GB, Q11←Q10 19.5 GB), and slow runs show a 7–12s straggler tail on workers whose identical sub-second tasks otherwise finish instantly (Q22 `join-4`: 20/24 tasks <5s, last at +12s; spread uniform; identical under eager/lazy durability and locality on/off). Prime suspect: `LocalStageCache.CleanupQuery` unlinks the prior query's multi-GB scratch **inline on the `CompleteSubject` broadcast handler** — an unlink storm on the same NVMe volume where the next query's tasks are starting.

## Fix

`CleanupQuery` keeps its synchronous state contract (entries dropped, tombstone recorded, `Get` misses immediately, late `Adopt` declined) and detaches the disk work: rename the per-query dir into `.trash` (instant; open fds/mmaps survive rename+unlink, so straggler readers are no worse off than today), then a janitor goroutine unlinks it **paced** (64-file bursts, 5 ms pauses). Inline fallbacks: kill switch, rename failure, no dir, full janitor queue. Boot-time `RemoveAll(rootDir)` reclaims `.trash` after a crash. `broadcastJoinCache` (memory-only) untouched.

Instrumentation in both modes: `scratch purge inline` (`handler_ms` — the storm the handler absorbs in the control arm), `scratch purge deferred`/`done` (`purge_ms`, bytes).

`--async-scratch-purge` worker flag, default true; `=false` = control arm / kill switch; terraform var `async_scratch_purge`.

## Validation

- Cache unit tests (async semantics, tombstone, idempotence, no-adopt), worker `-race`, TPC-H SF0.01, harness local SF0.01 both arms + SF1 — all green, row-identical.
- **Decision gate = SF100 pair**: control (`-var=async_scratch_purge=false`, instrumented inline — `handler_ms` storms should align with straggler windows, confirming the diagnosis) vs treatment (default). Success: Q22/Q14/Q11 tails collapse, suite noise floor drops, rows 44/44. Local repro cannot show the effect (needs real multi-GB scratch churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwM2ifvvNiJgfAWSD1Vp5q