### PR TITLE
perf(worker): s2-compress raw WSHF payloads on peer-exchange streams

### DIFF
--- a/cmd/wadjet/main.go
+++ b/cmd/wadjet/main.go
@@ -114,6 +114,7 @@ var (
 	baseTableCacheDir     string
 	streamingShuffleRead  bool
 	asyncScratchPurge     bool
+	peerWireCompression   bool
 	scanDecodeAhead       bool
 	scanDecodeAheadBytes  int64
 )
@@ -189,6 +190,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&peerExchangeAdvertise, "peer-exchange-advertise", "", "Peer-exchange address advertised in heartbeats (default: derived from the bound listener)")
 	rootCmd.PersistentFlags().BoolVar(&streamingShuffleRead, "streaming-shuffle-read", true, "Decode WSHF/WSHC exchange inputs directly from the peer/S3 byte stream instead of staging the whole file to NVMe + mmap first — the first chunk decodes as soon as its frames arrive. Any mid-stream failure falls back to a staged read of the durable copy, skipping already-delivered batches. Default true (SF100-validated); =false is the kill switch restoring the staged read path. See docs/design/exchange-streaming-consumption.md.")
 	rootCmd.PersistentFlags().BoolVar(&asyncScratchPurge, "async-scratch-purge", true, "Defer per-query stage-cache scratch deletion to a paced background janitor instead of unlinking inline on the query-complete broadcast handler — at SF100 the inline unlink storm of a big query's multi-GB scratch stalls the NEXT query's first tasks (Q22/Q14/Q11 straggler tails). Worker-side. Default true; =false is the kill switch restoring inline deletion. See docs/design/async-scratch-purge.md.")
+	rootCmd.PersistentFlags().BoolVar(&peerWireCompression, "peer-wire-compression", false, "s2-compress raw WSHF payloads on outgoing peer-exchange streams: the wire carries a standard WSHC envelope every consumer already decodes, cutting peer-stream bytes ~20% for ~1 core-GB/s of producer CPU per stream. Worker-side. Default false pending SF100 validation. See docs/design/peer-wire-compression.md.")
 	rootCmd.PersistentFlags().BoolVar(&scanDecodeAhead, "scan-decode-ahead", true, "Decode parquet row groups ahead of scan consumption: k decode workers per scan source with in-order delivery and a decoded-bytes window bounded by the shared memory pool and the page-cache refault sensor. Worker scan path only. Default true (SF100-validated, steady-state -7.3%); =false is the kill switch restoring the serial row-group path. See docs/design/scan-decode-pipelining.md.")
 	rootCmd.PersistentFlags().Int64Var(&scanDecodeAheadBytes, "scan-decode-ahead-bytes", 0, "Decoded-but-unconsumed byte window per scan source for --scan-decode-ahead. 0 = engine default (256 MiB).")
 	rootCmd.PersistentFlags().Int64Var(&baseTableCacheBytes, "base-table-cache-bytes", 0, "Cross-query disk cache for immutable base-table parquet objects: LRU byte budget on the cache volume. Hits are served from local disk without touching S3 (or the circuit breaker); misses tee the download into the cache. The cache survives restarts (index rebuilt from the directory). 0 = disabled (default until SF100 validation). See docs/design/base-table-nvme-cache.md.")
@@ -945,6 +947,7 @@ func runStandalone(ctx context.Context, store objstore.Store, logger *slog.Logge
 		PeerAdvertiseAddr:     peerExchangeAdvertise,
 		StreamingShuffleRead:  streamingShuffleRead,
 		AsyncScratchPurge:     asyncScratchPurge,
+		PeerWireCompression:   peerWireCompression,
 		ScanDecodeAhead:       scanDecodeAhead,
 		ScanDecodeAheadBytes:  scanDecodeAheadBytes,
 	}, store, nc, js, logger)
@@ -1531,6 +1534,7 @@ func runWorker(ctx context.Context, store objstore.Store, logger *slog.Logger) e
 		PeerAdvertiseAddr:     peerExchangeAdvertise,
 		StreamingShuffleRead:  streamingShuffleRead,
 		AsyncScratchPurge:     asyncScratchPurge,
+		PeerWireCompression:   peerWireCompression,
 		ScanDecodeAhead:       scanDecodeAhead,
 		ScanDecodeAheadBytes:  scanDecodeAheadBytes,
 	}, store, nc, js, logger)

--- a/deploy/benchmark/terraform/main.tf
+++ b/deploy/benchmark/terraform/main.tf
@@ -690,6 +690,7 @@ resource "aws_instance" "worker" {
             --streaming-shuffle-read=${var.streaming_shuffle_read} \
             --scan-decode-ahead=${var.scan_decode_ahead} \
             --async-scratch-purge=${var.async_scratch_purge} \
+            --peer-wire-compression=${var.peer_wire_compression} \
             %{if var.spill_floating_budget~}
             --spill-floating-budget \
             %{endif~}

--- a/deploy/benchmark/terraform/variables.tf
+++ b/deploy/benchmark/terraform/variables.tf
@@ -306,6 +306,12 @@ variable "shuffle_durability" {
   default     = "eager"
 }
 
+variable "peer_wire_compression" {
+  description = "Worker --peer-wire-compression (docs/design/peer-wire-compression.md): s2-compress raw WSHF payloads on outgoing peer-exchange streams (WSHC envelope, consumers already decode it). Default false pending SF100 validation."
+  type        = bool
+  default     = false
+}
+
 variable "async_scratch_purge" {
   description = "Worker --async-scratch-purge (docs/design/async-scratch-purge.md): defer per-query stage-cache deletion to a paced background janitor instead of unlinking inline on the query-complete broadcast handler. Default true; false = inline-deletion control arm / kill switch."
   type        = bool

--- a/docs/design/peer-wire-compression.md
+++ b/docs/design/peer-wire-compression.md
@@ -1,0 +1,46 @@
+# Peer-wire compression (`--peer-wire-compression`)
+
+Status: implemented 2026-07-24. Default off pending SF100 validation.
+
+## Motivation
+
+The #261 ledger: 351.9 GB of SF100 exchange reads per suite pair arrive
+over worker↔worker peer gRPC streams, and those streams carry **raw WSHF
+file bytes** — compression has only ever existed on the S3 upload path
+(`CompressShuffleFile`, s2, ~20% savings on this data), which the
+shuffle-durability knob can now elide entirely. Meanwhile the consumer's
+peer/streaming decode path already accepts WSHC (magic-sniffed in
+`openShuffleFromPeer`), so the wire format for compressed peer streams
+has existed all along — nothing produced it.
+
+## Mechanism
+
+`PeerServerConfig.CompressWire`: `FetchShuffle` sniffs the resolved
+file's first four bytes.
+
+- Raw WSHF → the stream carries a standard **WSHC envelope**: the magic,
+  then the s2 stream of the raw payload, chunked into the usual 256 KiB
+  frames (`chunkStreamWriter` adapts `stream.Send` to `io.Writer`).
+- Anything else (already-WSHC, short, foreign) passes through
+  byte-identical.
+
+No client, consumer, or format changes: the consumer's existing WSHC
+streaming decode handles the envelope, and its peer-tier ledger counts
+the (now smaller) wire bytes — so the #261 `peer_bytes` metric measures
+the win directly.
+
+Cost: s2 encode on the producer, ~1 core-GB/s per stream, bounded by the
+existing 16-stream serve cap. Under lazy durability the same CPU that
+used to compress uploads is idle; under eager it is additive.
+
+## Validation
+
+- Unit: WSHC round-trip through a real server/client pair, pass-through
+  for already-WSHC and short payloads, existing rejection paths.
+- tpch-harness local (gRPC data plane, flag on): a true end-to-end —
+  consumers decode compressed peer streams for every exchange; rows must
+  match the reference.
+- SF100 A/B (flag on vs off): `peer_bytes` should drop ~20% at equal
+  rows; wall judged per the window-noise rule (mechanism metric first).
+  Worth stacking with locality placement (fewer peer streams to compress)
+  once that flips.

--- a/internal/dataplane/peer_server.go
+++ b/internal/dataplane/peer_server.go
@@ -1,6 +1,8 @@
 package dataplane
 
 import (
+	"bytes"
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -9,6 +11,8 @@ import (
 	"net"
 	"os"
 	"time"
+
+	"github.com/klauspost/compress/s2"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -65,6 +69,15 @@ type PeerServerConfig struct {
 	// protecting the producer's NVMe/NIC from consumer fan-in spikes.
 	// 0 = default (16).
 	MaxConcurrentFetches int
+
+	// CompressWire s2-compresses raw WSHF payloads on the stream
+	// (docs/design/peer-wire-compression.md): the served bytes become a
+	// standard WSHC envelope, which every consumer already decodes.
+	// Payloads that are already WSHC (or not WSHF at all) pass through
+	// untouched. Trades ~1 core-GB/s of producer CPU per stream for
+	// ~20% fewer wire bytes (the s2 ratio measured on SF100 shuffle
+	// data). Default false pending validation.
+	CompressWire bool
 }
 
 // PeerServer is the worker-side PeerExchange gRPC listener. Serving is a
@@ -211,12 +224,36 @@ func (s *PeerServer) FetchShuffle(req *dpv1.FetchShuffleRequest, stream grpc.Ser
 	}
 	defer f.Close()
 
+	if s.cfg.CompressWire {
+		// Sniff the payload: raw WSHF is compressed into a WSHC envelope
+		// on the stream; anything else (already-WSHC, short, foreign)
+		// passes through byte-identical via the head+rest copy below.
+		var head [4]byte
+		n, herr := io.ReadFull(f, head[:])
+		if herr == nil && head == wshfMagic {
+			return s.streamCompressed(ctx, io.MultiReader(bytes.NewReader(head[:]), f), stream)
+		}
+		return s.streamRaw(ctx, io.MultiReader(bytes.NewReader(head[:n]), f), stream)
+	}
+	return s.streamRaw(ctx, f, stream)
+}
+
+// Wire-format magics, mirroring internal/worker shuffle_format.go
+// (shuffleMagic / compressedMagic — dataplane cannot import worker without
+// a cycle; these four-byte constants ARE the wire contract).
+var (
+	wshfMagic = [4]byte{'W', 'S', 'H', 'F'}
+	wshcMagic = [4]byte{'W', 'S', 'H', 'C'}
+)
+
+// streamRaw copies r to the stream in peerChunkBytes frames.
+func (s *PeerServer) streamRaw(ctx context.Context, r io.Reader, stream grpc.ServerStreamingServer[dpv1.ShuffleChunk]) error {
 	buf := make([]byte, peerChunkBytes)
 	for {
 		if ctx.Err() != nil {
 			return status.FromContextError(ctx.Err()).Err()
 		}
-		n, rerr := f.Read(buf)
+		n, rerr := r.Read(buf)
 		if n > 0 {
 			if serr := stream.Send(&dpv1.ShuffleChunk{Data: buf[:n]}); serr != nil {
 				return serr
@@ -229,4 +266,64 @@ func (s *PeerServer) FetchShuffle(req *dpv1.FetchShuffleRequest, stream grpc.Ser
 			return status.Errorf(codes.Internal, "reading local file: %v", rerr)
 		}
 	}
+}
+
+// streamCompressed sends a WSHC envelope: the magic, then the s2 stream of
+// the raw payload, chunked into peerChunkBytes frames. The consumer's
+// existing WSHC decode path (magic sniff in openShuffleFromPeer) handles
+// the result; its peer-tier byte ledger counts the compressed wire bytes.
+func (s *PeerServer) streamCompressed(ctx context.Context, r io.Reader, stream grpc.ServerStreamingServer[dpv1.ShuffleChunk]) error {
+	cw := &chunkStreamWriter{ctx: ctx, stream: stream, buf: make([]byte, 0, peerChunkBytes)}
+	if _, err := cw.Write(wshcMagic[:]); err != nil {
+		return err
+	}
+	s2w := s2.NewWriter(cw)
+	if _, err := io.Copy(s2w, r); err != nil {
+		_ = s2w.Close()
+		if serr, ok := status.FromError(err); ok && serr.Code() != codes.Unknown {
+			return err
+		}
+		return status.Errorf(codes.Internal, "compressing stream: %v", err)
+	}
+	if err := s2w.Close(); err != nil {
+		return status.Errorf(codes.Internal, "flushing s2 stream: %v", err)
+	}
+	return cw.Flush()
+}
+
+// chunkStreamWriter adapts stream.Send to io.Writer, buffering to
+// peerChunkBytes frames. Send errors (including consumer cancellation)
+// surface as write errors and abort the s2 copy.
+type chunkStreamWriter struct {
+	ctx    context.Context
+	stream grpc.ServerStreamingServer[dpv1.ShuffleChunk]
+	buf    []byte
+}
+
+func (w *chunkStreamWriter) Write(p []byte) (int, error) {
+	total := len(p)
+	for len(p) > 0 {
+		if err := w.ctx.Err(); err != nil {
+			return 0, status.FromContextError(err).Err()
+		}
+		room := peerChunkBytes - len(w.buf)
+		n := min(room, len(p))
+		w.buf = append(w.buf, p[:n]...)
+		p = p[n:]
+		if len(w.buf) == peerChunkBytes {
+			if err := w.Flush(); err != nil {
+				return 0, err
+			}
+		}
+	}
+	return total, nil
+}
+
+func (w *chunkStreamWriter) Flush() error {
+	if len(w.buf) == 0 {
+		return nil
+	}
+	err := w.stream.Send(&dpv1.ShuffleChunk{Data: w.buf})
+	w.buf = w.buf[:0]
+	return err
 }

--- a/internal/dataplane/peer_test.go
+++ b/internal/dataplane/peer_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/klauspost/compress/s2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -66,6 +67,103 @@ func TestPeerFetchRoundTrip(t *testing.T) {
 	if !bytes.Equal(got, payload) {
 		t.Fatalf("payload mismatch: got %d bytes, want %d", len(got), len(payload))
 	}
+}
+
+// TestPeerFetchCompressWire: with CompressWire the server must deliver a
+// WSHC envelope whose s2 stream round-trips to the original WSHF bytes;
+// non-WSHF payloads must pass through byte-identical.
+func TestPeerFetchCompressWire(t *testing.T) {
+	startCompressed := func(t *testing.T, resolver ShuffleFileResolver) (*PeerClient, string) {
+		t.Helper()
+		srv := NewPeerServer(PeerServerConfig{Addr: "127.0.0.1:0", CompressWire: true}, resolver, nil)
+		if err := srv.Start(); err != nil {
+			t.Fatalf("starting peer server: %v", err)
+		}
+		t.Cleanup(srv.Stop)
+		client := NewPeerClient(nil)
+		t.Cleanup(client.Close)
+		return client, srv.AdvertiseAddr()
+	}
+
+	t.Run("wshf compresses and round-trips", func(t *testing.T) {
+		// Compressible WSHF payload spanning several chunks.
+		payload := append([]byte("WSHF"), bytes.Repeat([]byte("wadjet-shuffle-bytes "), 3*peerChunkBytes/20)...)
+		path := filepath.Join(t.TempDir(), "p.wshf")
+		if err := os.WriteFile(path, payload, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		resolver := &fakeResolver{queryID: "q1", key: "k", token: "tok", path: path}
+		client, addr := startCompressed(t, resolver)
+
+		rc, err := client.FetchShuffle(context.Background(), addr, "q1", "k", "tok")
+		if err != nil {
+			t.Fatalf("FetchShuffle: %v", err)
+		}
+		defer rc.Close()
+		wire, err := io.ReadAll(rc)
+		if err != nil {
+			t.Fatalf("reading stream: %v", err)
+		}
+		if len(wire) < 4 || string(wire[:4]) != "WSHC" {
+			t.Fatalf("wire payload not a WSHC envelope (got %q...)", wire[:min(4, len(wire))])
+		}
+		if len(wire) >= len(payload) {
+			t.Fatalf("compressible payload did not shrink: wire %d >= raw %d", len(wire), len(payload))
+		}
+		decoded, err := io.ReadAll(s2.NewReader(bytes.NewReader(wire[4:])))
+		if err != nil {
+			t.Fatalf("s2 decode: %v", err)
+		}
+		if !bytes.Equal(decoded, payload) {
+			t.Fatalf("round-trip mismatch: got %d bytes, want %d", len(decoded), len(payload))
+		}
+	})
+
+	t.Run("already-wshc passes through untouched", func(t *testing.T) {
+		payload := append([]byte("WSHC"), bytes.Repeat([]byte{0xAB}, 1000)...)
+		path := filepath.Join(t.TempDir(), "p.wshc")
+		if err := os.WriteFile(path, payload, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		resolver := &fakeResolver{queryID: "q1", key: "k", token: "tok", path: path}
+		client, addr := startCompressed(t, resolver)
+
+		rc, err := client.FetchShuffle(context.Background(), addr, "q1", "k", "tok")
+		if err != nil {
+			t.Fatalf("FetchShuffle: %v", err)
+		}
+		defer rc.Close()
+		got, err := io.ReadAll(rc)
+		if err != nil {
+			t.Fatalf("reading stream: %v", err)
+		}
+		if !bytes.Equal(got, payload) {
+			t.Fatal("already-compressed payload was altered on the wire")
+		}
+	})
+
+	t.Run("short payload passes through", func(t *testing.T) {
+		payload := []byte("WS")
+		path := filepath.Join(t.TempDir(), "p.short")
+		if err := os.WriteFile(path, payload, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		resolver := &fakeResolver{queryID: "q1", key: "k", token: "tok", path: path}
+		client, addr := startCompressed(t, resolver)
+
+		rc, err := client.FetchShuffle(context.Background(), addr, "q1", "k", "tok")
+		if err != nil {
+			t.Fatalf("FetchShuffle: %v", err)
+		}
+		defer rc.Close()
+		got, err := io.ReadAll(rc)
+		if err != nil {
+			t.Fatalf("reading stream: %v", err)
+		}
+		if !bytes.Equal(got, payload) {
+			t.Fatal("short payload was altered on the wire")
+		}
+	})
 }
 
 func TestPeerFetchRejections(t *testing.T) {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -66,6 +66,12 @@ type Config struct {
 	// RSS-sampling).
 	FloatingBudgetActive bool
 
+	// PeerWireCompression s2-compresses raw WSHF payloads on outgoing
+	// peer-exchange streams (docs/design/peer-wire-compression.md): the
+	// wire carries a standard WSHC envelope every consumer already
+	// decodes. ~20% fewer peer-stream bytes for ~1 core-GB/s of producer
+	// CPU. Default false pending SF100 validation.
+	PeerWireCompression bool
 	// AsyncScratchPurge defers per-query stage-cache file deletion to a
 	// paced background janitor instead of unlinking inline on the
 	// query-complete broadcast handler (docs/design/async-scratch-purge.md
@@ -308,6 +314,7 @@ func New(cfg Config, store objstore.Store, nc *nats.Conn, js jetstream.JetStream
 		w.peerServer = dataplane.NewPeerServer(dataplane.PeerServerConfig{
 			Addr:          cfg.PeerListenAddr,
 			AdvertiseAddr: cfg.PeerAdvertiseAddr,
+			CompressWire:  cfg.PeerWireCompression,
 		}, executor, logger)
 	}
 	return w


### PR DESCRIPTION
Design record: `docs/design/peer-wire-compression.md`. Follows the #261 finding that peer streams (351.9 GB/pair at SF100) carry raw WSHF while the consumer has always accepted WSHC.

**Mechanism:** `FetchShuffle` sniffs the resolved file; raw WSHF streams as a standard WSHC envelope (magic + s2, 256 KiB frames). Already-WSHC/short/foreign payloads pass through byte-identical. Zero client/consumer/format changes — and the consumer's `peer_bytes` ledger counts wire bytes, so the A/B metric falls out of the existing instrumentation.

**Flag:** `--peer-wire-compression`, default **false** pending SF100 validation; terraform `peer_wire_compression`.

**Validation:** unit WSHC round-trip through a real server/client pair + pass-through cases; dataplane `-race`; TPC-H SF0.01; tpch-harness local SF0.01+SF1 with the flag **on** (every exchange decoded from compressed peer streams) — row-identical.

**Next:** SF100 A/B — success = `peer_bytes` −~20% at identical rows (mechanism metric per the window-noise rule); wall secondary. Best stacked after locality placement flips (fewer, larger streams).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwM2ifvvNiJgfAWSD1Vp5q