### PR TITLE
perf(planner): feed grouped finals from a sibling raw exchange (agg-over-exchange, v2)

### DIFF
--- a/deploy/benchmark/terraform/main.tf
+++ b/deploy/benchmark/terraform/main.tf
@@ -276,6 +276,7 @@ locals {
     echo "WADJET_LATE_MATERIALIZATION=${var.late_materialization}" >> /etc/environment
     echo "WADJET_BUSHY_JOIN_REORDER=${var.bushy_join_reorder}" >> /etc/environment
     echo "WADJET_SKEW_SPLIT=${var.skew_split}" >> /etc/environment
+    echo "WADJET_AGG_OVER_EXCHANGE=${var.agg_over_exchange}" >> /etc/environment
     echo "WADJET_BLOCK_PROFILE_RATE=${var.block_profile_rate}" >> /etc/environment
     echo "WADJET_MUTEX_PROFILE_FRACTION=${var.mutex_profile_fraction}" >> /etc/environment
     echo "BUILD_COMPLETE=1" >> /etc/environment
@@ -315,6 +316,7 @@ locals {
     echo "WADJET_LATE_MATERIALIZATION=${var.late_materialization}" >> /etc/environment
     echo "WADJET_BUSHY_JOIN_REORDER=${var.bushy_join_reorder}" >> /etc/environment
     echo "WADJET_SKEW_SPLIT=${var.skew_split}" >> /etc/environment
+    echo "WADJET_AGG_OVER_EXCHANGE=${var.agg_over_exchange}" >> /etc/environment
     echo "WADJET_BLOCK_PROFILE_RATE=${var.block_profile_rate}" >> /etc/environment
     echo "WADJET_MUTEX_PROFILE_FRACTION=${var.mutex_profile_fraction}" >> /etc/environment
     echo "BUILD_COMPLETE=1" >> /etc/environment
@@ -388,6 +390,7 @@ locals {
     export WADJET_LATE_MATERIALIZATION="${var.late_materialization}"
     export WADJET_BUSHY_JOIN_REORDER="${var.bushy_join_reorder}"
     export WADJET_SKEW_SPLIT="${var.skew_split}"
+    export WADJET_AGG_OVER_EXCHANGE="${var.agg_over_exchange}"
     export WADJET_SKEW_SUITE="${var.skew_suite}"
     export WADJET_BLOCK_PROFILE_RATE="${var.block_profile_rate}"
     export WADJET_MUTEX_PROFILE_FRACTION="${var.mutex_profile_fraction}"
@@ -552,6 +555,7 @@ resource "aws_instance" "worker" {
     export WADJET_LATE_MATERIALIZATION="${var.late_materialization}"
     export WADJET_BUSHY_JOIN_REORDER="${var.bushy_join_reorder}"
     export WADJET_SKEW_SPLIT="${var.skew_split}"
+    export WADJET_AGG_OVER_EXCHANGE="${var.agg_over_exchange}"
     export WADJET_BLOCK_PROFILE_RATE="${var.block_profile_rate}"
     export WADJET_MUTEX_PROFILE_FRACTION="${var.mutex_profile_fraction}"
 

--- a/deploy/benchmark/terraform/variables.tf
+++ b/deploy/benchmark/terraform/variables.tf
@@ -222,6 +222,12 @@ variable "skew_split" {
   default     = ""
 }
 
+variable "agg_over_exchange" {
+  description = "Aggregate-over-exchange rewrite (rewireAggOverRawExchange): grouped finals consume a sibling raw exchange's partitions directly, dropping duplicate fused scan-agg legs (Q18). Default on (empty/1 = on, matching the engine default); set \"0\" as the A/B kill switch."
+  type        = string
+  default     = ""
+}
+
 variable "skew_suite" {
   description = "Set to 1 to run the hot-key skew fixture (benchmarks/skew) instead of TPC-H — the Phase 3 skew-split A/B. Pair with data_prefix=tables-skew/ and generate_data=true on the first arm to stage the fixture."
   type        = string

--- a/internal/coordinator/agg_over_exchange_e2e_test.go
+++ b/internal/coordinator/agg_over_exchange_e2e_test.go
@@ -1,0 +1,186 @@
+package coordinator
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/citc-tech/wadjet/benchmarks/tpch"
+	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/planner/physical"
+	"github.com/citc-tech/wadjet/internal/storage/catalog"
+	"github.com/citc-tech/wadjet/internal/storage/objstore"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+	"github.com/citc-tech/wadjet/internal/worker"
+)
+
+// TestAggOverExchangeQ18Shape is the e2e regression for the
+// aggregate-over-exchange rewrite: Q18's IN + HAVING subquery re-scans
+// lineitem as a fused scan-agg while the join leg already shuffles the raw
+// table on l_orderkey — the rewrite feeds the subquery's final_aggregate
+// from the raw exchange's partitions (raw mode, exact per-partition groups)
+// and drops the second scan. Both arms (rewrite on / kill switch off) must
+// return identical rows; ground truth pins the semantics. Multi-chunk data
+// ensures every order's lines span several scan/shuffle tasks.
+func TestAggOverExchangeQ18Shape(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	t.Cleanup(cancel)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	natsCfg := distributed.DefaultNATSConfig()
+	natsCfg.Port = -1
+	natsCfg.StoreDir = t.TempDir()
+	embeddedNATS, err := distributed.NewEmbeddedNATS(natsCfg, logger)
+	if err != nil {
+		t.Fatalf("nats: %v", err)
+	}
+	t.Cleanup(embeddedNATS.Shutdown)
+	nc, err := distributed.ConnectInProcess(embeddedNATS.Server())
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { nc.Close() })
+	js, err := distributed.NewJetStream(nc)
+	if err != nil {
+		t.Fatalf("js: %v", err)
+	}
+	if err := distributed.SetupStreams(ctx, js); err != nil {
+		t.Fatalf("streams: %v", err)
+	}
+	store := objstore.NewMemStore()
+	if err := store.MakeBucket(ctx, "test"); err != nil {
+		t.Fatal(err)
+	}
+	kv, err := catalog.NewNATSKV(js)
+	if err != nil {
+		t.Fatalf("kv: %v", err)
+	}
+	cat := catalog.New(kv, store, "test")
+	if err := cat.Init(ctx); err != nil {
+		t.Fatalf("cat init: %v", err)
+	}
+
+	data := tpch.Generate(tpch.SF001)
+	for _, tbl := range []string{"customer", "orders", "lineitem"} {
+		schema := tpch.AllTables[tbl]
+		rows := data[tbl]
+		if err := cat.CreateTable(ctx, tbl, schema, nil); err != nil {
+			t.Fatal(err)
+		}
+		const chunks = 3
+		per := (len(rows) + chunks - 1) / chunks
+		for c := 0; c < chunks; c++ {
+			lo, hi := c*per, c*per+per
+			if hi > len(rows) {
+				hi = len(rows)
+			}
+			if lo >= hi {
+				break
+			}
+			var buf bytes.Buffer
+			pw, _ := parquet.NewWriter(&buf, schema, parquet.DefaultWriterConfig())
+			if err := pw.WriteRows(rows[lo:hi]); err != nil {
+				t.Fatal(err)
+			}
+			pw.Close()
+			fp := fmt.Sprintf("tables/%s/chunk_%04d.parquet", tbl, c)
+			pd := buf.Bytes()
+			store.Put(ctx, "test", fp, bytes.NewReader(pd), int64(len(pd)), "application/octet-stream")
+			cat.AddFiles(ctx, tbl, map[string]string{}, "tables/"+tbl+"/", []catalog.FileEntry{{
+				Path: fp, SizeBytes: int64(len(pd)), NumRows: int64(hi - lo), CreatedAt: time.Now(),
+			}})
+		}
+	}
+
+	for i := 0; i < 3; i++ {
+		w := worker.New(worker.Config{NATSUrl: embeddedNATS.ClientURL(), MaxConcurrent: 4, CacheBytes: 64 << 20}, store, nc, js, logger)
+		wctx, wcancel := context.WithCancel(context.Background())
+		t.Cleanup(wcancel)
+		if err := w.Start(wctx); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(w.Stop)
+	}
+	coord := New(Config{NATSUrl: embeddedNATS.ClientURL(), ResultBucket: "test"}, cat, nc, js, logger)
+	for i := 0; i < 3; i++ {
+		coord.workers.record(distributed.WorkerHeartbeat{WorkerID: fmt.Sprintf("fake-%d", i), Timestamp: time.Now()})
+	}
+
+	// Ground truth from source rows: total quantity per order; orders over
+	// the HAVING threshold survive. The threshold is picked below the SF001
+	// maximum so the qualifying set is non-empty — a 0-row pass would prove
+	// nothing.
+	qtyByOrder := map[int64]int64{}
+	for _, r := range data["lineitem"] {
+		qtyByOrder[toInt64(r["l_orderkey"])] += toInt64(r["l_quantity"])
+	}
+	const havingThreshold = 250
+	truth := map[int64]int64{} // qualifying o_orderkey -> total qty
+	for ok, q := range qtyByOrder {
+		if q > havingThreshold {
+			truth[ok] = q
+		}
+	}
+	if len(truth) == 0 {
+		t.Fatalf("ground truth empty at threshold %d — lower it so the test exercises real rows", havingThreshold)
+	}
+	if len(truth) > 90 {
+		t.Fatalf("ground truth has %d orders; LIMIT 100 would truncate — raise the threshold", len(truth))
+	}
+
+	sql := fmt.Sprintf(`SELECT
+  c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice,
+  SUM(l_quantity) as total_qty
+FROM customer
+JOIN orders ON c_custkey = o_custkey
+JOIN lineitem ON o_orderkey = l_orderkey
+WHERE o_orderkey IN (
+  SELECT l_orderkey
+  FROM lineitem
+  GROUP BY l_orderkey
+  HAVING SUM(l_quantity) > %d
+)
+GROUP BY c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice
+ORDER BY o_totalprice DESC, o_orderdate
+LIMIT 100`, havingThreshold)
+
+	prev := physical.AggOverExchange.Load()
+	t.Cleanup(func() { physical.AggOverExchange.Store(prev) })
+	for _, arm := range []struct {
+		name string
+		on   bool
+	}{
+		{"agg-over-exchange", true},
+		{"kill-switch", false},
+	} {
+		t.Run(arm.name, func(t *testing.T) {
+			physical.AggOverExchange.Store(arm.on)
+			res, err := coord.ExecuteSQL(ctx, sql)
+			if err != nil {
+				t.Fatalf("ExecuteSQL: %v", err)
+			}
+			if res.Error != "" {
+				t.Fatalf("query error: %s", res.Error)
+			}
+			rows := mustRows(t, res)
+			if len(rows) != len(truth) {
+				t.Fatalf("got %d rows, want %d", len(rows), len(truth))
+			}
+			for _, r := range rows {
+				ok := toInt64(r["o_orderkey"])
+				want, present := truth[ok]
+				if !present {
+					t.Errorf("order %d in result but not in ground truth", ok)
+					continue
+				}
+				if got := toInt64(r["total_qty"]); got != want {
+					t.Errorf("order %d total_qty = %d, want %d", ok, got, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -2398,6 +2398,14 @@ func (c *Coordinator) dispatchComputeStage(
 			}
 			t.Operators = ops
 		}
+		// A RawInputAggregate final is only correct on the fragment path —
+		// the legacy worker path derives merge mode from StageType and
+		// would remap the raw AggSpecs into merge form. The planner never
+		// emits the shape outside fragment eligibility (its dep is an
+		// exchange, never a gather); fail loudly if that invariant breaks.
+		if stage.RawInputAggregate && t.Operators == nil {
+			return StageOutput{}, fmt.Errorf("stage %s: RawInputAggregate final_aggregate did not take the fragment path", stage.ID)
+		}
 		// Sort migration: dispatch standalone Sort / merge_sort stages via
 		// the fragment path. The fragment runs:
 		//   [OpShuffleSource, OpSort, OpUnpartitionedSink]
@@ -2899,13 +2907,18 @@ func buildAggregateFragment(stage physical.Stage, t *distributed.Task, taskInput
 	// MergeMode is true for stages that re-aggregate already-partial
 	// outputs (final_aggregate, merge_aggregate). It's false for the
 	// standalone "aggregate" stage, which consumes raw rows from upstream
-	// non-scan input (e.g. a join output) and produces a partial. AVG
+	// non-scan input (e.g. a join output) and produces a partial — and for
+	// a RawInputAggregate final, whose input is raw rows from an exchange
+	// hash-partitioned on the group keys (rewireAggOverRawExchange):
+	// partition-disjoint keys make single-level raw aggregation exact, so
+	// the merge remaps (InputCol→OutputCol, COUNT→SUM) must not run. AVG
 	// fold runs only on the final stage; partial / merge_aggregate
 	// preserve __avg_sum#X / __avg_count#X synthetics for the downstream
-	// final to fold. BuildProject is needed only on partial mode where
+	// final to fold. BuildProject is needed only on non-merge mode where
 	// AggSpec.InputExpr might reference a derived expression that the
 	// upstream hasn't pre-computed.
-	mergeMode := stage.Type == "final_aggregate" || stage.Type == "merge_aggregate"
+	mergeMode := (stage.Type == "final_aggregate" || stage.Type == "merge_aggregate") &&
+		!stage.RawInputAggregate
 	ops = append(ops, distributed.OpSpec{
 		Type:        distributed.OpHashAggregate,
 		GroupByCols: append([]string(nil), stage.GroupByCols...),

--- a/internal/planner/physical/agg_over_exchange.go
+++ b/internal/planner/physical/agg_over_exchange.go
@@ -1,0 +1,204 @@
+package physical
+
+import (
+	"os"
+	"strings"
+	"sync/atomic"
+)
+
+// AggOverExchange gates rewireAggOverRawExchange. Kill switch
+// WADJET_AGG_OVER_EXCHANGE=0. Exported atomic.Bool (ExchangeSubsume
+// pattern) so tests can pin either arm.
+var AggOverExchange atomic.Bool
+
+func init() {
+	AggOverExchange.Store(os.Getenv("WADJET_AGG_OVER_EXCHANGE") != "0")
+}
+
+// rewireAggOverRawExchange drops a fused scan-aggregate leg whose input is a
+// full re-scan of a table some raw sibling exchange already shuffles on the
+// aggregate's exact group keys, and feeds the aggregate's final directly
+// from the sibling's partition files.
+//
+// The Q18 shape that motivates it: join-8's build side shuffles RAW lineitem
+// (l_orderkey, l_quantity) by Hash(l_orderkey); the HAVING subquery scans
+// lineitem AGAIN as a fused scan-agg (partial SUM(l_quantity) GROUP BY
+// l_orderkey) whose partials a final_aggregate merges. Because the raw
+// exchange hash-partitions on the group key, each of its partitions holds
+// every row of the keys it covers — so a RAW (non-merge) aggregate over one
+// partition produces exact groups with no cross-partition merge. The second
+// full table scan (plus its partial-agg shuffle) buys nothing.
+//
+// Rewrite: the final_aggregate consumes the raw exchange's partitions, its
+// AggSpecs switch from merge form to the fused scan's raw specs
+// (Stage.RawInputAggregate makes the dispatcher build the fragment with
+// MergeMode=false), and the fused scan + its exchange are dropped. The
+// final's output distribution mirrors the raw exchange, which typically
+// turns its downstream re-shuffle into an identity exchange that
+// elideCoPartitionedExchanges removes (the caller re-runs it).
+//
+// HAVING is unaffected: it rides Stage.FilterExprs → PostFilterExprs and
+// runs after the (now raw) aggregate exactly as it ran after the merge.
+//
+// Runs BEFORE fuseScanAggregateShuffle, so the fused scan-agg leg is still
+// scan(FusedAgg*) → exchange-repartition → final_aggregate.
+//
+// Conservative eligibility (v1):
+//   - F is a grouped final_aggregate: single dep, no SortKeys/Limit, no
+//     merge-tree grouping, not GroupByAll.
+//   - F's dep is an exchange-repartition B whose sole consumer is F and
+//     whose sole dep is a scan-aggregate (FusedAggGroupBy set) of table T
+//     with no filters and no security barrier.
+//   - A is another exchange-repartition over a RAW scan of T (no filters,
+//     no fused agg, no barrier), with Exchange.Keys exactly equal to F's
+//     GroupByCols — exactness of per-partition groups needs the group keys
+//     to determine the partition, and the exact-name match keeps
+//     OutputDistribution's mirror rule and Satisfies() consistent.
+//   - Aggregate functions are SUM/COUNT/MIN/MAX on bare columns (no AVG
+//     synthetics, no derived input expressions), and every group key and
+//     aggregate input is in A's scan payload.
+func rewireAggOverRawExchange(stages []Stage) []Stage {
+	if !AggOverExchange.Load() {
+		return stages
+	}
+	idIndex := make(map[string]int, len(stages))
+	consumers := make(map[string][]int) // stage ID -> indexes of stages depending on it
+	for i := range stages {
+		idIndex[stages[i].ID] = i
+		for _, d := range stages[i].Dependencies {
+			consumers[d] = append(consumers[d], i)
+		}
+	}
+	scanOf := func(s *Stage) *Stage {
+		if s.Type != StageExchangeRepartition || s.Exchange == nil || len(s.Dependencies) != 1 {
+			return nil
+		}
+		idx, ok := idIndex[s.Dependencies[0]]
+		if !ok || stages[idx].Type != StageScan {
+			return nil
+		}
+		return &stages[idx]
+	}
+
+	dropped := make(map[string]bool) // dropped stage IDs (B exchange + its scan)
+	for fi := range stages {
+		fa := &stages[fi]
+		if fa.Type != "final_aggregate" || len(fa.Dependencies) != 1 ||
+			len(fa.GroupByCols) == 0 || fa.GroupByAll ||
+			len(fa.SortKeys) > 0 || fa.Limit > 0 || fa.MergeGroupCount > 0 {
+			continue
+		}
+		bIdx, ok := idIndex[fa.Dependencies[0]]
+		if !ok || dropped[stages[bIdx].ID] {
+			continue
+		}
+		b := &stages[bIdx]
+		scanB := scanOf(b)
+		if scanB == nil || len(consumers[b.ID]) != 1 || len(consumers[scanB.ID]) != 1 {
+			continue
+		}
+		if len(b.Exchange.ComputedCols) > 0 {
+			continue
+		}
+		if len(scanB.FusedAggGroupBy) == 0 || len(scanB.FusedAggSpecs) == 0 ||
+			len(scanB.FilterExprs) > 0 || len(scanB.SecurityProjectExprs) > 0 ||
+			len(scanB.PartitionFilter) > 0 || scanB.Exchange != nil {
+			continue
+		}
+		if !keysEqual(fa.GroupByCols, scanB.FusedAggGroupBy) {
+			continue
+		}
+		if !rawAggSpecsCompatible(fa.AggSpecs, scanB.FusedAggSpecs) {
+			continue
+		}
+		for ai := range stages {
+			a := &stages[ai]
+			if ai == bIdx || dropped[a.ID] {
+				continue
+			}
+			scanA := scanOf(a)
+			if scanA == nil || scanA.TableName != scanB.TableName ||
+				len(scanA.FilterExprs) > 0 || len(scanA.SecurityProjectExprs) > 0 ||
+				len(scanA.PartitionFilter) > 0 ||
+				len(scanA.FusedAggGroupBy) > 0 || len(scanA.FusedAggSpecs) > 0 {
+				continue
+			}
+			if a.Exchange.Count <= 0 || !keysEqual(a.Exchange.Keys, fa.GroupByCols) {
+				continue
+			}
+			if !aggInputsCovered(fa.GroupByCols, scanB.FusedAggSpecs, scanA.Columns) {
+				continue
+			}
+			// Rewrite: F aggregates A's raw partitions directly.
+			fa.AggSpecs = append([]AggSpec(nil), scanB.FusedAggSpecs...)
+			fa.RawInputAggregate = true
+			fa.Dependencies[0] = a.ID
+			fa.Distribution = Distribution{
+				Kind:  DistHashPartitioned,
+				Keys:  append([]string(nil), a.Exchange.Keys...),
+				Count: a.Exchange.Count,
+			}
+			dropped[b.ID] = true
+			dropped[scanB.ID] = true
+			break
+		}
+	}
+	if len(dropped) == 0 {
+		return stages
+	}
+	out := make([]Stage, 0, len(stages)-len(dropped))
+	for _, s := range stages {
+		if !dropped[s.ID] {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// rawAggSpecsCompatible checks that the final's merge-form specs and the
+// fused scan's raw specs describe the same aggregates (positional: same
+// function, same output column) and that the raw specs are v1-eligible:
+// SUM/COUNT/MIN/MAX over a bare input column. AVG never appears in
+// FusedAggSpecs at this shape today (decomposition happens at dispatch),
+// but the explicit allowlist keeps any future synthetic out of the raw
+// path until it's proven.
+func rawAggSpecsCompatible(finalSpecs, rawSpecs []AggSpec) bool {
+	if len(finalSpecs) != len(rawSpecs) || len(rawSpecs) == 0 {
+		return false
+	}
+	for i, r := range rawSpecs {
+		f := finalSpecs[i]
+		if !strings.EqualFold(f.Func, r.Func) || f.OutputCol != r.OutputCol {
+			return false
+		}
+		switch strings.ToLower(r.Func) {
+		case "sum", "count", "min", "max":
+		default:
+			return false
+		}
+		if r.InputExpr != "" || r.InputCol == "" {
+			return false
+		}
+	}
+	return true
+}
+
+// aggInputsCovered checks every group key and aggregate input column is
+// shipped by the raw exchange's scan payload.
+func aggInputsCovered(groupBy []string, specs []AggSpec, payload []string) bool {
+	cols := make(map[string]bool, len(payload))
+	for _, c := range payload {
+		cols[c] = true
+	}
+	for _, g := range groupBy {
+		if !cols[g] {
+			return false
+		}
+	}
+	for _, s := range specs {
+		if !cols[s.InputCol] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/planner/physical/agg_over_exchange_test.go
+++ b/internal/planner/physical/agg_over_exchange_test.go
@@ -1,0 +1,119 @@
+package physical
+
+import "testing"
+
+const aggOverExchangeQ18SQL = `SELECT
+	c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice,
+	SUM(l_quantity) as total_qty
+FROM customer
+JOIN orders ON c_custkey = o_custkey
+JOIN lineitem ON o_orderkey = l_orderkey
+WHERE o_orderkey IN (
+	SELECT l_orderkey
+	FROM lineitem
+	GROUP BY l_orderkey
+	HAVING SUM(l_quantity) > 300
+)
+GROUP BY c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice
+ORDER BY o_totalprice DESC, o_orderdate
+LIMIT 100`
+
+// TestAggOverExchange_Q18ShapeApplies pins that rewireAggOverRawExchange
+// fires on the Q18 shape: the HAVING subquery's fused scan-agg leg (2nd full
+// lineitem scan + partial shuffle) is dropped, the final_aggregate consumes
+// the raw join-build exchange's partitions in raw mode, and the final's
+// downstream identity re-shuffle is elided so the semi join builds directly
+// from the final's output.
+func TestAggOverExchange_Q18ShapeApplies(t *testing.T) {
+	prev := AggOverExchange.Load()
+	t.Cleanup(func() { AggOverExchange.Store(prev) })
+	AggOverExchange.Store(true)
+	cat, ctx := setupTPCHCatalog(t)
+	stages := sqlToStages(t, cat, ctx, aggOverExchangeQ18SQL, 3)
+
+	byID := make(map[string]Stage, len(stages))
+	lineitemScans := 0
+	var rawFinal *Stage
+	for i := range stages {
+		s := &stages[i]
+		byID[s.ID] = *s
+		if s.Type == StageScan && s.TableName == "lineitem" {
+			lineitemScans++
+		}
+		if s.RawInputAggregate {
+			if rawFinal != nil {
+				t.Fatalf("multiple RawInputAggregate stages: %s and %s", rawFinal.ID, s.ID)
+			}
+			rawFinal = s
+		}
+	}
+	if rawFinal == nil {
+		for _, s := range stages {
+			t.Logf("id=%s type=%s deps=%v", s.ID, s.Type, s.Dependencies)
+		}
+		t.Fatal("no RawInputAggregate final_aggregate (rewrite did not fire)")
+	}
+	if lineitemScans != 1 {
+		t.Errorf("lineitem scans = %d, want 1 (duplicate scan not dropped)", lineitemScans)
+	}
+	if rawFinal.Type != "final_aggregate" || len(rawFinal.Dependencies) != 1 {
+		t.Fatalf("raw final shape: type=%s deps=%v", rawFinal.Type, rawFinal.Dependencies)
+	}
+	dep, ok := byID[rawFinal.Dependencies[0]]
+	if !ok || dep.Type != StageExchangeRepartition {
+		t.Fatalf("raw final's dep %q is %q, want exchange-repartition", rawFinal.Dependencies[0], dep.Type)
+	}
+	depScan, ok := byID[dep.Dependencies[0]]
+	if !ok || depScan.Type != StageScan || depScan.TableName != "lineitem" ||
+		len(depScan.FusedAggGroupBy) > 0 {
+		t.Fatalf("raw final's exchange feeds %+v, want raw lineitem scan", depScan.ID)
+	}
+	if rawFinal.Distribution.Kind != DistHashPartitioned ||
+		rawFinal.Distribution.Count != dep.Exchange.Count ||
+		!keysEqual(rawFinal.Distribution.Keys, dep.Exchange.Keys) {
+		t.Errorf("raw final distribution %+v does not mirror exchange {keys=%v count=%d}",
+			rawFinal.Distribution, dep.Exchange.Keys, dep.Exchange.Count)
+	}
+	if len(rawFinal.AggSpecs) != 1 || rawFinal.AggSpecs[0].InputCol != "l_quantity" {
+		t.Errorf("raw final AggSpecs = %+v, want raw sum(l_quantity)", rawFinal.AggSpecs)
+	}
+	if len(rawFinal.FilterExprs) == 0 {
+		t.Error("HAVING filter lost from raw final")
+	}
+	// Bonus elide: the semi join must build directly from the raw final —
+	// no surviving re-shuffle between them.
+	semiBuildsFromFinal := false
+	for _, s := range stages {
+		if s.Type == StageHashJoin && s.JoinType == "semi" && s.RightDepStage == rawFinal.ID {
+			semiBuildsFromFinal = true
+		}
+	}
+	if !semiBuildsFromFinal {
+		for _, s := range stages {
+			t.Logf("id=%s type=%s join=%s right_dep=%s", s.ID, s.Type, s.JoinType, s.RightDepStage)
+		}
+		t.Error("semi join does not build directly from the raw final (identity exchange not elided)")
+	}
+}
+
+// TestAggOverExchange_KillSwitch pins the WADJET_AGG_OVER_EXCHANGE=0 arm:
+// plans keep the duplicate fused scan-agg leg untouched.
+func TestAggOverExchange_KillSwitch(t *testing.T) {
+	prev := AggOverExchange.Load()
+	t.Cleanup(func() { AggOverExchange.Store(prev) })
+	AggOverExchange.Store(false)
+	cat, ctx := setupTPCHCatalog(t)
+	stages := sqlToStages(t, cat, ctx, aggOverExchangeQ18SQL, 3)
+	lineitemScans := 0
+	for _, s := range stages {
+		if s.RawInputAggregate {
+			t.Errorf("stage %s has RawInputAggregate with the kill switch off", s.ID)
+		}
+		if s.Type == StageScan && s.TableName == "lineitem" {
+			lineitemScans++
+		}
+	}
+	if lineitemScans != 2 {
+		t.Errorf("lineitem scans = %d, want 2 with the kill switch off", lineitemScans)
+	}
+}

--- a/internal/planner/physical/fused_agg_read_set_test.go
+++ b/internal/planner/physical/fused_agg_read_set_test.go
@@ -70,6 +70,13 @@ func TestPruneFusedAggOutputCols(t *testing.T) {
 // unknown name reverts the worker's parquet projection to full width
 // (143 B/row vs ~25 B/row on Q18's 600M-row fused lineitem leg at SF100).
 func TestFusedScanAggReadSet_Q18(t *testing.T) {
+	// Pin agg-over-exchange OFF: that rewrite removes Q18's fused
+	// scan-agg leg entirely (the shape this read-set regression test
+	// guards). The pruning still matters for every remaining fused
+	// scan-agg plan and for the WADJET_AGG_OVER_EXCHANGE=0 arm.
+	prev := AggOverExchange.Load()
+	AggOverExchange.Store(false)
+	t.Cleanup(func() { AggOverExchange.Store(prev) })
 	cat, ctx := setupTPCHCatalog(t)
 	sql := `SELECT c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice,
 	SUM(l_quantity) as total_qty

--- a/internal/planner/physical/plan.go
+++ b/internal/planner/physical/plan.go
@@ -116,6 +116,16 @@ type Stage struct {
 	FusedAggGroupBy []string
 	FusedAggSpecs   []AggSpec
 
+	// RawInputAggregate marks a final_aggregate whose input is RAW rows
+	// from an exchange hash-partitioned on the group keys, not partial
+	// aggregates — set by rewireAggOverRawExchange when it rewires the
+	// final from a duplicate fused scan-agg leg onto a sibling raw
+	// exchange. Partition-disjoint keys make per-partition raw aggregation
+	// exact, so the dispatcher builds the fragment with MergeMode=false
+	// (no InputCol→OutputCol remap, no COUNT→SUM rewrite). AggSpecs carry
+	// the raw form (the dropped scan's FusedAggSpecs).
+	RawInputAggregate bool
+
 	// Probe-split pipeline: partition the probe table's files across workers.
 	// Each worker scans build tables in full and probes its file partition.
 	ProbeSplitAlias string   // scan alias to partition (e.g., "lineitem")
@@ -1778,6 +1788,16 @@ func (p *Planner) PlanDistributed(ctx context.Context, node *logical.Node) ([]St
 		// filters its build input on it. Kill switch
 		// WADJET_EXCHANGE_SUBSUME=0.
 		stages = dedupeSubsumedScanExchanges(stages)
+		// Feed a grouped final_aggregate from a sibling RAW exchange
+		// hash-partitioned on its exact group keys, dropping the duplicate
+		// fused scan-agg leg (Q18's 2nd full lineitem scan). The rewired
+		// final mirrors the raw exchange's partitioning, which typically
+		// turns its downstream re-shuffle into an identity exchange — run
+		// the elide pass again to collect it. Kill switch
+		// WADJET_AGG_OVER_EXCHANGE=0.
+		if rewired := rewireAggOverRawExchange(stages); len(rewired) != len(stages) {
+			stages = elideCoPartitionedExchanges(rewired)
+		}
 		// Fragment fusion passes are intentionally NOT called here.
 		//
 		// fuseScanShuffle / fuseJoinShuffle absorb a downstream

--- a/internal/planner/physical/testdata/ensure_distribution/q18.golden
+++ b/internal/planner/physical/testdata/ensure_distribution/q18.golden
@@ -7,10 +7,8 @@ scan-5	scan	Singleton
 exchange-repartition-6	exchange-repartition	Hash(o_orderkey)/32	deps=join-4
 exchange-repartition-7	exchange-repartition	Hash(l_orderkey)/32	deps=scan-5
 join-8	hash_join	Hash(o_orderkey)/32	deps=exchange-repartition-6,exchange-repartition-7
-scan-9	scan	Hash(l_orderkey)/4
-final_aggregate-48	final_aggregate	Hash(l_orderkey)/4	deps=scan-9
-exchange-repartition-50	exchange-repartition	Hash(l_orderkey)/32	deps=final_aggregate-48
-join-51	hash_join	Hash(o_orderkey)/32	deps=join-8,exchange-repartition-50
+final_aggregate-48	final_aggregate	Hash(l_orderkey)/32	deps=exchange-repartition-7
+join-51	hash_join	Hash(o_orderkey)/32	deps=join-8,final_aggregate-48
 aggregate-52	aggregate	RoundRobin	deps=join-51
 final_aggregate-53	final_aggregate	Hash(c_name,c_custkey,o_orderkey,o_orderdate,o_totalprice)/4	deps=exchange-repartition-final_aggregate-53-15
 sort-54	sort	Singleton	deps=final_aggregate-53


### PR DESCRIPTION
Rebase of #258 onto current main (clean cherry-picks + one test-collision fix: #259's fused read-set test now pins the flag off, since this rewrite removes Q18's fused scan-agg stage by design).

**Why revive:** #258 was parked on two concerns, both since resolved by the shuffle arc:
1. *"Replaces cached scan with uncacheable S3 shuffle re-read of r-7 (read 2×)"* — refuted by the #261 ledger: shuffle reads are never S3 (local mmap/peer tiers serve 100%), and with `locality_placement=true` now default in the SF100 profile, the r-7 re-read is majority-local.
2. The refault-sensor amplification that confounded its original steady numbers was fixed by #260's episode cap.

Q18 remains the #1 wall query (69.8s steady best; its remaining wall is exactly the shuffle-join legs this rewrite restructures).

**Gates (green):** planner/coordinator/worker suites, TPC-H SF0.01 both arms (`WADJET_AGG_OVER_EXCHANGE=0` kill switch), harness local SF0.01 both arms + SF1 — row-identical, Q18 rows correct.

**Merge gate:** SF100 A/B in a clean daytime window on top of the flipped locality profile — kill-switch-on-treatment-binary control (the decisive shape from the Q18 arc). This change is default-on and its previous SF100 attempt degraded steady under the since-fixed sensor, so unlike the default-off levers it does NOT merge on local gates alone.

Supersedes #258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwM2ifvvNiJgfAWSD1Vp5q