### PR TITLE
perf(expr): compile temporal-literal comparisons typed, killing per-row parse

### DIFF
--- a/internal/engine/expr/cmp_temporal_lit_test.go
+++ b/internal/engine/expr/cmp_temporal_lit_test.go
@@ -1,0 +1,117 @@
+package expr
+
+import (
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+)
+
+// tempLitBatch builds a batch with a date, timestamp, string, and int64
+// column for the comparison matrix. Values are set per test.
+func tempLitBatch(n int) *batch.RecordBatch {
+	schema := []parquet.Column{
+		{Name: "d", Type: parquet.TypeDate},
+		{Name: "ts", Type: parquet.TypeTimestamp},
+		{Name: "s", Type: parquet.TypeString},
+		{Name: "n", Type: parquet.TypeInt64},
+	}
+	return batch.NewRecordBatch(schema, n)
+}
+
+func TestCmpTemporalLitCompiles(t *testing.T) {
+	e := compileCmp(&ColRef{Name: "d"}, &Lit{Val: "1998-09-02"}, CmpLe)
+	if _, ok := e.(*CmpTemporalLit); !ok {
+		t.Fatalf("date-literal comparison compiled to %T, want *CmpTemporalLit", e)
+	}
+	// Flipped operand order also specializes.
+	e = compileCmp(&Lit{Val: "1998-09-02"}, &ColRef{Name: "d"}, CmpGt)
+	tl, ok := e.(*CmpTemporalLit)
+	if !ok || !tl.Flip {
+		t.Fatalf("flipped literal compiled to %T, want flipped *CmpTemporalLit", e)
+	}
+	// Non-temporal strings stay generic.
+	e = compileCmp(&ColRef{Name: "s"}, &Lit{Val: "BUILDING"}, CmpEq)
+	if _, ok := e.(*Cmp); !ok {
+		t.Fatalf("plain string literal compiled to %T, want *Cmp", e)
+	}
+	// Numeric literals keep their existing typed paths.
+	e = compileCmp(&Lit{Val: int64(3)}, &Lit{Val: int64(4)}, CmpLt)
+	if _, ok := e.(*CmpInt64); !ok {
+		t.Fatalf("int literals compiled to %T, want *CmpInt64", e)
+	}
+}
+
+// TestCmpTemporalLitMatchesGeneric is the semantics gate: for every
+// (column type, column value, literal, op, operand order) cell the
+// specialized node must return exactly what the generic Cmp returns —
+// including the epoch-zero literal guard, NULLs, string columns, and
+// non-temporal columns falling back.
+func TestCmpTemporalLitMatchesGeneric(t *testing.T) {
+	lits := []string{"1998-09-02", "1970-01-01", "1995-01-01T00:00:00", "2049-12-31"}
+	ops := []CmpOp{CmpEq, CmpNe, CmpLt, CmpLe, CmpGt, CmpGe}
+
+	dates := []int32{0, 10471, 10472, 10473, -30, 29220}
+	tss := []int64{0, 904694400000, 904694400001, 788918400000, -1, 2524521600000}
+
+	n := len(dates)
+	b := tempLitBatch(n)
+	for i := 0; i < n; i++ {
+		b.Columns[0].SetValue(i, dates[i])
+		b.Columns[1].SetValue(i, tss[i])
+		b.Columns[2].SetValue(i, "1998-09-02")
+		b.Columns[3].SetValue(i, int64(dates[i]))
+	}
+	b.Columns[0].Nulls.SetNull(n - 1) // one NULL date row
+
+	for _, colName := range []string{"d", "ts", "s", "n"} {
+		for _, lit := range lits {
+			for _, op := range ops {
+				for _, flip := range []bool{false, true} {
+					var generic, specialized Expr
+					if flip {
+						generic = &Cmp{Left: &Lit{Val: lit}, Right: &ColRef{Name: colName}, Op: op}
+						specialized = compileCmp(&Lit{Val: lit}, &ColRef{Name: colName}, op)
+					} else {
+						generic = &Cmp{Left: &ColRef{Name: colName}, Right: &Lit{Val: lit}, Op: op}
+						specialized = compileCmp(&ColRef{Name: colName}, &Lit{Val: lit}, op)
+					}
+					if _, ok := specialized.(*CmpTemporalLit); !ok {
+						t.Fatalf("col %s lit %q op %v flip %v: compiled %T, want *CmpTemporalLit",
+							colName, lit, op, flip, specialized)
+					}
+					for row := 0; row < n; row++ {
+						g := generic.(BoolExpr).EvalBool(b, row)
+						s := specialized.(BoolExpr).EvalBool(b, row)
+						if g != s {
+							t.Fatalf("col %s row %d lit %q op %v flip %v: generic=%v specialized=%v",
+								colName, row, lit, op, flip, g, s)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func BenchmarkCmpDateLit(b *testing.B) {
+	rb := tempLitBatch(2048)
+	for i := 0; i < 2048; i++ {
+		rb.Columns[0].SetValue(i, int32(10000+i%1000))
+	}
+	b.Run("generic", func(b *testing.B) {
+		e := &Cmp{Left: &ColRef{Name: "d"}, Right: &Lit{Val: "1998-09-02"}, Op: CmpLe}
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			e.EvalBool(rb, i%2048)
+		}
+	})
+	b.Run("temporal-lit", func(b *testing.B) {
+		e := compileCmp(&ColRef{Name: "d"}, &Lit{Val: "1998-09-02"}, CmpLe).(*CmpTemporalLit)
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			e.EvalBool(rb, i%2048)
+		}
+	})
+}

--- a/internal/engine/expr/compile.go
+++ b/internal/engine/expr/compile.go
@@ -353,7 +353,42 @@ func compileCmp(left, right Expr, op CmpOp) Expr {
 	if isProvablyFloat64(left) && isProvablyFloat64(right) {
 		return &CmpFloat64{Left: left.(Float64Expr), Right: right.(Float64Expr), Op: op}
 	}
+	// Bare column vs a string literal that parses as a date/timestamp:
+	// pre-parse the literal once (both temporal units) and pick the unit
+	// per batch from the column's resolved type — the dominant pushed-
+	// filter shape (`l_shipdate <= '1998-09-02'`). Column type is unknown
+	// here, so CmpTemporalLit keeps a generic fallback for non-temporal
+	// columns; semantics stay identical to Cmp in every sub-case.
+	if col, ok := left.(*ColRef); ok && col.structField == "" {
+		if tl := tryTemporalLit(col, right, op, false); tl != nil {
+			return tl
+		}
+	}
+	if col, ok := right.(*ColRef); ok && col.structField == "" {
+		if tl := tryTemporalLit(col, left, op, true); tl != nil {
+			return tl
+		}
+	}
 	return &Cmp{Left: left, Right: right, Op: op}
+}
+
+// tryTemporalLit builds a CmpTemporalLit when other is a string literal
+// parseable as a date or timestamp; nil otherwise.
+func tryTemporalLit(col *ColRef, other Expr, op CmpOp, flip bool) *CmpTemporalLit {
+	lit, ok := other.(*Lit)
+	if !ok {
+		return nil
+	}
+	s, ok := lit.Val.(string)
+	if !ok {
+		return nil
+	}
+	days, dok := parseDateToEpochDaysOK(s)
+	ms, mok := parseTimestampToEpochMsOK(s)
+	if !dok && !mok {
+		return nil
+	}
+	return &CmpTemporalLit{Col: col, Lit: s, Op: op, Flip: flip, days: days, ms: ms}
 }
 
 // isProvablyInt64 returns true if the expression definitely produces int64 values.

--- a/internal/engine/expr/expr.go
+++ b/internal/engine/expr/expr.go
@@ -680,6 +680,83 @@ func (e *Cmp) EvalBool(b *batch.RecordBatch, row int) bool {
 	return compare(lv, rv, e.Op)
 }
 
+// CmpTemporalLit compares a bare column against a string literal that
+// parses as a date/timestamp, without per-row parsing, cache lookups, or
+// boxing — the generic path spent 3.2% of SF100 worker CPU inside the
+// date-parse memo's sync.Map.Load (interface-key hashing dominated;
+// 2026-07-25 re-rank). The literal is parsed once into BOTH temporal
+// units at compile time; the unit is chosen from the column's resolved
+// type per batch. Every non-fast sub-case (non-temporal column, the
+// epoch-zero literal guard) delegates to the generic compare() with the
+// original operand order, keeping semantics bit-identical with Cmp.
+type CmpTemporalLit struct {
+	Col  *ColRef
+	Lit  string // original literal text (generic-fallback operand)
+	Op   CmpOp
+	Flip bool  // literal was the LEFT operand: evaluate as (lit OP col)
+	days int64 // literal as epoch days
+	ms   int64 // literal as epoch milliseconds
+}
+
+func (e *CmpTemporalLit) Eval(b *batch.RecordBatch, row int) any {
+	return e.EvalBool(b, row)
+}
+
+func (e *CmpTemporalLit) EvalBool(b *batch.RecordBatch, row int) bool {
+	e.Col.resolve(b)
+	var lit int64
+	switch e.Col.typ {
+	case batch.TypeDate:
+		lit = e.days
+	case batch.TypeTimestamp:
+		lit = e.ms
+	default:
+		// Non-temporal column: exact generic semantics (string columns
+		// compare lexically, numeric columns take the numeric paths).
+		return e.genericFallback(b, row)
+	}
+	v, ok := e.Col.EvalInt64(b, row)
+	if !ok {
+		return false // NULL / unresolved — Cmp returns false for nil operands
+	}
+	if lit == 0 && v != 0 {
+		// The generic guard (`bi != 0 || ai == 0`) treats an epoch-zero
+		// literal against a nonzero column as a parse failure and falls
+		// through to stringified comparison. Preserve that bit-exactly.
+		return e.genericFallback(b, row)
+	}
+	a, bv := v, lit
+	if e.Flip {
+		a, bv = lit, v
+	}
+	switch e.Op {
+	case CmpEq:
+		return a == bv
+	case CmpNe:
+		return a != bv
+	case CmpLt:
+		return a < bv
+	case CmpLe:
+		return a <= bv
+	case CmpGt:
+		return a > bv
+	case CmpGe:
+		return a >= bv
+	}
+	return false
+}
+
+func (e *CmpTemporalLit) genericFallback(b *batch.RecordBatch, row int) bool {
+	cv := e.Col.Eval(b, row)
+	if cv == nil {
+		return false
+	}
+	if e.Flip {
+		return compare(e.Lit, cv, e.Op)
+	}
+	return compare(cv, e.Lit, e.Op)
+}
+
 // CmpInt64 is a typed comparison that operates on int64 without boxing.
 type CmpInt64 struct {
 	Left, Right Int64Expr
@@ -2493,7 +2570,15 @@ func parseDateToEpochDays(s string) int64 {
 	if v, ok := dateEpochDaysCache.Load(s); ok {
 		return v.(int64)
 	}
-	var result int64
+	result, _ := parseDateToEpochDaysOK(s)
+	dateEpochDaysCache.Store(s, result)
+	return result
+}
+
+// parseDateToEpochDaysOK is the uncached parse with an explicit success
+// signal (0 is a valid result for the epoch itself). Used at expression
+// compile time by compileCmp's temporal-literal specialization.
+func parseDateToEpochDaysOK(s string) (int64, bool) {
 	for _, layout := range []string{
 		"2006-01-02",
 		time.RFC3339,
@@ -2502,12 +2587,10 @@ func parseDateToEpochDays(s string) int64 {
 	} {
 		if t, err := time.Parse(layout, s); err == nil {
 			epoch := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-			result = int64(t.Sub(epoch).Hours() / 24)
-			break
+			return int64(t.Sub(epoch).Hours() / 24), true
 		}
 	}
-	dateEpochDaysCache.Store(s, result)
-	return result
+	return 0, false
 }
 
 // parseTimestampToEpochMs parses common timestamp string formats into epoch milliseconds.
@@ -2515,7 +2598,14 @@ func parseTimestampToEpochMs(s string) int64 {
 	if v, ok := timestampEpochMsCache.Load(s); ok {
 		return v.(int64)
 	}
-	var result int64
+	result, _ := parseTimestampToEpochMsOK(s)
+	timestampEpochMsCache.Store(s, result)
+	return result
+}
+
+// parseTimestampToEpochMsOK is the uncached parse with an explicit success
+// signal (see parseDateToEpochDaysOK).
+func parseTimestampToEpochMsOK(s string) (int64, bool) {
 	for _, layout := range []string{
 		time.RFC3339Nano,
 		time.RFC3339,
@@ -2525,12 +2615,10 @@ func parseTimestampToEpochMs(s string) int64 {
 		"2006-01-02",
 	} {
 		if t, err := time.Parse(layout, s); err == nil {
-			result = t.UnixMilli()
-			break
+			return t.UnixMilli(), true
 		}
 	}
-	timestampEpochMsCache.Store(s, result)
-	return result
+	return 0, false
 }
 
 func toBool(e Expr, b *batch.RecordBatch, row int) bool {


### PR DESCRIPTION
Lever #2 from the bdef5ce re-rank: 3.2% of worker CPU was a per-row `sync.Map.Load` in `parseDateToEpochDays`, reached from `Cmp`'s generic boxed compare for `l_shipdate <= '1998-09-02'`-class filters.

`compileCmp` now emits `CmpTemporalLit` for bare-column-vs-temporal-string-literal: literal parsed once at compile into both units, unit picked per batch from the resolved column type, typed int64 compare per row. Bit-identical semantics via delegation to `compare()` for every non-fast sub-case, proven by a full property matrix vs generic `Cmp` (column types × values × ops × operand orders × NULLs, including the epoch-zero guard).

**BenchmarkCmpDateLit: 34.6 → 7.5 ns/row, 1 → 0 allocs/row.** Gates: expr + engine suites, SF0.01, harness SF1 row-identical. Merging on CI green (equivalence-gated optimization class per ADR-0011; CPU delta accrues on future profile runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwM2ifvvNiJgfAWSD1Vp5q