### PR TITLE
fix(expr): render TypeDate through FormatDate at string-function boundaries

### DIFF
--- a/internal/engine/expr/date_string_funcs_test.go
+++ b/internal/engine/expr/date_string_funcs_test.go
@@ -1,0 +1,101 @@
+package expr
+
+import (
+	"testing"
+
+	"github.com/citc-tech/wadjet/internal/engine/batch"
+	"github.com/citc-tech/wadjet/internal/storage/parquet"
+)
+
+// Issue #273 regression: string functions over a TypeDate column must see
+// the canonical ISO rendering (batch.FormatDate), not the epoch-day
+// digits. At SF100 (date32 parquet) SUBSTR(o_orderdate,1,4) grouped
+// day-granular — Q09 returned 50,250 rows (= 25 nations × 2,010 distinct
+// 4-digit epoch-day prefixes) instead of the canonical 175. String-date
+// test data never exercised the path, which is why every local gate
+// passed; keep this test on a real Date-typed vector.
+func dateBatch(t *testing.T, days ...int32) *batch.RecordBatch {
+	t.Helper()
+	b := batch.NewRecordBatch([]parquet.Column{{Name: "d", Type: parquet.TypeDate}}, len(days))
+	for i, d := range days {
+		b.Columns[0].Int32Data[i] = d
+	}
+	return b
+}
+
+func TestStringFuncsOverDateColumn(t *testing.T) {
+	// 1994-03-15 = epoch day 8839; 1998-08-02 = 10440 (SF100 o_orderdate max).
+	b := dateBatch(t, 8839, 10440)
+
+	col := &ColRef{Name: "d"}
+	cases := []struct {
+		name string
+		expr Expr
+		want [2]any
+	}{
+		{"substr_year", &FuncCall{Name: "substr", Args: []Expr{col, &Lit{Val: float64(1)}, &Lit{Val: float64(4)}}},
+			[2]any{"1994", "1998"}},
+		{"substring_alias", &FuncCall{Name: "SUBSTRING", Args: []Expr{col, &Lit{Val: float64(6)}, &Lit{Val: float64(2)}}},
+			[2]any{"03", "08"}},
+		{"upper_passthrough", &FuncCall{Name: "upper", Args: []Expr{col}},
+			[2]any{"1994-03-15", "1998-08-02"}},
+		{"length_iso", &FuncCall{Name: "length", Args: []Expr{col}},
+			[2]any{int64(10), int64(10)}},
+		{"concat", &FuncCall{Name: "concat", Args: []Expr{col, &Lit{Val: "!"}}},
+			[2]any{"1994-03-15!", "1998-08-02!"}},
+		{"cast_string", &FuncCall{Name: "cast_string", Args: []Expr{col}},
+			[2]any{"1994-03-15", "1998-08-02"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for row := 0; row < 2; row++ {
+				got := tc.expr.Eval(b, row)
+				// length returns whatever integer width fnLength picks;
+				// normalize for comparison.
+				if wi, ok := tc.want[row].(int64); ok {
+					if ToInt64(got) != wi {
+						t.Errorf("row %d: got %v want %v", row, got, wi)
+					}
+					continue
+				}
+				if got != tc.want[row] {
+					t.Errorf("row %d: got %v (%T) want %v", row, got, got, tc.want[row])
+				}
+			}
+		})
+	}
+}
+
+// TestStringFuncsOverDateColumn_Vec pins the vectorized entry point: a
+// string kernel must not read a Date vector's (empty) BytesData — it
+// routes through the fixed per-row path instead.
+func TestStringFuncsOverDateColumn_Vec(t *testing.T) {
+	b := dateBatch(t, 8839, 10440)
+	fc := &FuncCall{Name: "substr", Args: []Expr{&ColRef{Name: "d"}, &Lit{Val: float64(1)}, &Lit{Val: float64(4)}}}
+	out := batch.NewVector(batch.TypeString, 2)
+	fc.EvalVec(b, out, 2)
+	for i, want := range []string{"1994", "1998"} {
+		got, _ := out.GetString(i)
+		if got != want {
+			t.Errorf("vec row %d: got %q want %q", i, got, want)
+		}
+	}
+}
+
+// Numeric and comparison contexts must keep seeing raw epoch days — the
+// rendering applies ONLY at string-function boundaries.
+func TestDateColumnNumericContextsUnchanged(t *testing.T) {
+	b := dateBatch(t, 8839, 10440)
+	col := &ColRef{Name: "d"}
+	if v := col.Eval(b, 0); v != int64(8839) {
+		t.Errorf("ColRef.Eval changed: got %v (%T) want int64(8839)", v, v)
+	}
+	if f, ok := col.EvalFloat64(b, 1); !ok || f != 10440 {
+		t.Errorf("EvalFloat64 changed: got %v %v", f, ok)
+	}
+	// A non-string function over a date arg keeps numeric semantics.
+	abs := &FuncCall{Name: "abs", Args: []Expr{col}}
+	if got := ToFloat64(abs.Eval(b, 0)); got != 8839 {
+		t.Errorf("abs over date: got %v want 8839", got)
+	}
+}

--- a/internal/engine/expr/expr.go
+++ b/internal/engine/expr/expr.go
@@ -1054,6 +1054,42 @@ type FuncCall struct {
 	vecFn   VecScalarFunc
 }
 
+// stringInputFuncs are scalar functions whose arguments are string-typed.
+// A TypeDate ColRef argument evaluates to its raw epoch-day int64 (the
+// representation every comparison/arithmetic path depends on), so these
+// functions must render it through batch.FormatDate first — otherwise
+// SUBSTR(date_col, 1, 4) substrings the DIGITS of the day number
+// (issue #273: SF100's date32 columns grouped Q07/Q08/Q09 day-granular;
+// string-date test data never exercised the path). Keyed lowercase, the
+// registry's convention. Timestamps are excluded deliberately: they have
+// no canonical string form today (GetValue emits raw epoch-ms), and these
+// functions must stay consistent with result-output rendering.
+var stringInputFuncs = map[string]bool{
+	"upper": true, "lower": true, "concat": true, "length": true,
+	"len": true, "substr": true, "substring": true, "trim": true,
+	"ltrim": true, "rtrim": true, "replace": true, "reverse": true,
+	"left": true, "right": true, "starts_with": true, "ends_with": true,
+	"contains": true, "split_part": true, "strpos": true, "lpad": true,
+	"rpad": true, "cast_string": true,
+}
+
+// formatTemporalArgs rewrites boxed TypeDate ColRef argument values to
+// their canonical ISO form for string-input functions. Only direct column
+// references are covered — a nested expression's output type isn't known
+// here (and nothing in the TPC-H or observed customer shapes feeds a
+// computed date into a string function).
+func (e *FuncCall) formatTemporalArgs(args []any) {
+	for i, a := range e.Args {
+		cr, ok := a.(*ColRef)
+		if !ok || cr.typ != batch.TypeDate {
+			continue
+		}
+		if v, ok := args[i].(int64); ok {
+			args[i] = batch.FormatDate(int32(v))
+		}
+	}
+}
+
 func (e *FuncCall) Eval(b *batch.RecordBatch, row int) any {
 	// Allocate args on every call so concurrent goroutines sharing this
 	// *FuncCall don't stomp on each other. For small N (the common case)
@@ -1062,6 +1098,9 @@ func (e *FuncCall) Eval(b *batch.RecordBatch, row int) any {
 	args := make([]any, len(e.Args))
 	for i, a := range e.Args {
 		args[i] = a.Eval(b, row)
+	}
+	if stringInputFuncs[strings.ToLower(e.Name)] {
+		e.formatTemporalArgs(args)
 	}
 	// Cache function pointer to avoid RWMutex contention on every row.
 	// sync.Once ensures concurrent first-time lookups don't race.
@@ -1096,6 +1135,13 @@ func (e *FuncCall) EvalVec(b *batch.RecordBatch, out *batch.Vector, n int) {
 		case *ColRef:
 			a.resolve(b)
 			if a.idx < 0 || a.idx >= len(b.Columns) {
+				e.evalVecPerRow(b, out, n)
+				return
+			}
+			// String-input vec kernels read BytesData; a TypeDate column
+			// has none and must render through the (fixed) per-row path
+			// (issue #273).
+			if a.typ == batch.TypeDate && stringInputFuncs[strings.ToLower(e.Name)] {
 				e.evalVecPerRow(b, out, n)
 				return
 			}


### PR DESCRIPTION
Fixes #273 — see commit message for mechanism and scope. Unit-pinned on a real Date-typed vector (string funcs → ISO; numeric/comparison contexts unchanged; vec entry routed per-row). Engine suites + TPC-H SF0.01 green. SF100 verification (Q07=4/Q08=2/Q09=175 expected) rides the post-merge verification deploy shared with the #272 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4GkoBFZwBk89b9SgNnZbj