### PR TITLE
feat(coordinator): log scalar-subquery substitution literals

### DIFF
--- a/internal/coordinator/scalar_extract.go
+++ b/internal/coordinator/scalar_extract.go
@@ -235,6 +235,14 @@ func (c *Coordinator) substituteScalarDependencies(ctx context.Context, stage ph
 		if err != nil {
 			return stage, fmt.Errorf("extracting scalar for %s: %w", placeholder, err)
 		}
+		// One line per placeholder per query: the substituted literal is
+		// otherwise invisible anywhere (dispatched predicates are never
+		// logged), which made #272 — a wrong Q11 threshold at SF100 —
+		// undiagnosable from run artifacts.
+		c.logger.Info("scalar substitution",
+			"stage_id", stage.ID, "placeholder", placeholder,
+			"producer", producerID, "producer_files", len(flattenStageFiles(out)),
+			"projection_exprs", len(projection), "literal", lit)
 		literals[":"+placeholder] = lit
 	}
 	// Deep-copy mutable slice / map fields before rewrite.


### PR DESCRIPTION
Diagnostic rider for #272: the substituted scalar literal is invisible in run artifacts today. Verified locally (literal matches ground-truth threshold exactly at SF0.1 across four plan shapes — all of which return CORRECT Q11 rows, so #272's trigger is SF100-specific and this line is how we catch it). Rides the same verification deploy as the #273 fix (#274, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4GkoBFZwBk89b9SgNnZbj