### PR TITLE
perf(coordinator): eager consumer dispatch revival (A1 activation-gating, A2 fused chains, A3 compute producers)

### DIFF
--- a/docs/design/eager-consumer-dispatch.md
+++ b/docs/design/eager-consumer-dispatch.md
@@ -506,3 +506,68 @@ publication today exists only for exchange-repartition producers
 fused consumers eligible (the §3.2 dep-count gate rejects stages whose
 Dependencies grew by chained-build deps) are the two design extensions
 the revival needs.
+
+POST-FUSION ceiling (main da5301a, results/20260725-162139, steady DAG
+wall 399s): 88s = 22.2%. Q21 19.1s, Q18 17.1s, Q03 13.3s, Q10 6.8s,
+Q13 6.4s, Q11 6.3s, Q05 5.1s. Composition: plain 2×-repartition hash
+joins (already C2-eligible) carry roughly half; fused chains (Q18
+join-8, chained_joins=1) and compute-stage producer edges (Q21
+join-12→join-16 9.9s, Q18 final_aggregate-14→join-8 6.1s) the rest.
+Every measured spread except Q21's is BELOW the 12s tail floor — the
+§11 calibration is stale on the 7m2x-era binary (per-task overhead and
+consumer spans shrank ~3×); the re-pair must re-derive the floor
+(treatment arm runs WADJET_EAGER_MIN_TAIL_SECONDS at ~3-5s).
+
+## 14. Revival implementation (2026-07-25, perf/eager-revival)
+
+A1 — clearance-driven manifest activation (precondition 2): eagerFeed
+gains an `active` flag set at first consumer clearance
+(execute_stage_dag.go eagerActive branch). The publisher hook still
+folds every completion into the replay list and the completion
+accounting (clearance decisions read those), but the NATS publish is
+gated on activation; the republisher starts at activation instead of
+producer dispatch; a one-time backlog flush at activation closes the
+snapshot→subscribe window for completions that landed before
+clearance. A feed no consumer clears on generates ZERO NATS traffic.
+Regression: TestEagerTailGate asserts zero manifests published when
+every consumer declines.
+
+A2 — fused-chain consumer eligibility: the C2 dep-count gate accepts
+`2+len(FusedJoins)+len(ChainedJoins)` (stage-chain fusion grows deps
+by one per ChainedJoinSpec). Only the primary probe/build feed
+eagerly; chained-build deps are barrier-complete before the clearance
+decision runs (dependency wait loop ordering). eagerJoinWouldSplit
+mirrors dispatchComputeStage's skew-skip for partitioned chains.
+Engagement marker: EagerChainedEdgesPlanned + chained_joins attr on
+the clearance line. E2E: Q18-shaped chain clears eagerly with
+row-identical results (TestEagerChainedJoinDispatchE2E).
+
+A3 — compute-stage producer manifests: dispatchComputeStage wires the
+same feed + onSuccess publisher as runShuffleSide for hash-partitioned
+hash_join / final_aggregate stages with a plain unpartitioned sink.
+Task DISPATCH ORDER is the partition (the positional contract
+StageOutput.Files already gives partitionFilesForWorker); the manifest
+source maps plain files to partitions via the ProducerTaskIDs ordinal,
+while partition= files keep filename semantics — so shuffle and
+compute producers coexist on one mechanism. Producer declines: skew /
+rr-agg / probe splits (they remap task→partition), gather fusion (no
+retry → no fencing recovery), exchange sinks (v1 scope),
+dynamic-filter and scalar participants, coordinator-read stages.
+Consumer eligibility (eagerFeedableDep) accepts repartition or
+compute-producer deps for both C1 and C2. E2E: with fusion pinned off,
+join-9 clears on TWO compute feeds (probe join-4 + build
+final_aggregate-6) and aggregate-10 cascades as a C1 consumer of
+join-9 — three eager stages deep, rows identical
+(TestEagerComputeProducerE2E).
+
+Known v1 constraints for the re-pair:
+- eagerStageSlot cap=1 serializes cascading clearances (a producer
+  that itself cleared holds the slot until its stage completes, so its
+  consumer takes the barrier). The A3 e2e widens the slot to 2 to
+  exercise the cascade; production keeps 1 until the pair says
+  otherwise.
+- The 12s tail floor declines nearly every current-world edge (§13);
+  the treatment arm overrides WADJET_EAGER_MIN_TAIL_SECONDS≈3.
+- Republisher cadence (3s) bounds the snapshot→subscribe heal window;
+  at toy scale that dominates eager wall (the 21s A3 e2e), at SF100 it
+  is noise against multi-second spreads.

--- a/docs/design/eager-consumer-dispatch.md
+++ b/docs/design/eager-consumer-dispatch.md
@@ -444,3 +444,65 @@ cleared) so the machinery costs nothing when the gate declines;
 (3) only then re-pair. The overlap wins are real (Q05 −23/−29%
 twice, Q04 −11/−12% twice) — the plumbing has to stop costing more
 than they earn.
+
+## 13. Precondition (1) resolved (2026-07-25): the Q08/Q20 signature
+## was refault-sensor v2 whole-run pinning, since fixed by #260
+
+Worker-log forensics on both eager arms (gated Q08 window
+21:34:22-21:35:41, task 0a1884bb; gated Q20 final_aggregate-13 task
+02964f4c; plus §10.1's eager-arm task b87311e0):
+
+- In the gated arm, Q08 had ZERO clearances (join-10/join-14 declined
+  at the tail gate; join-6 is not eager-eligible), and workers never
+  subscribe to manifest subjects unless a task carries EagerInputs —
+  manifest publication and the republisher are coordinator-side NATS
+  publishes with no subscribers. The always-on machinery is therefore
+  invisible to worker execution. The §12 attribution ("per-task
+  manifest publication + 3s republisher + NATS fan-out") is WITHDRAWN
+  as the direct mechanism.
+- The reproducible signature in all three flag-on stragglers: one task
+  of a small multi-task stage (Q08 join-6: 3 probe-split broadcast-join
+  tasks; Q20 final_aggregate-13: 3 tasks) runs its identical row volume
+  at a uniform ~1/3 rate from its first progress line, on a worker that
+  is otherwise idle for most of the run, pool ~1%, siblings normal.
+  That is the documented refault-pressure floor: decode-ahead admission
+  collapsed to the occupancy floor while the sensor stays active
+  (§10.1 measured the sensor active with refault_rate ≈ 22k/s).
+- The flag-linkage is a SCHEDULING side effect, not a load effect:
+  with the flag on, the consumer stage dispatches earlier relative to
+  the sibling repartition burst (gated/eager join-6 dispatched t+2.1s/
+  t+6.0s vs control t+9.9s; control's later dispatch cleared the
+  repartition-9 write burst first). Landing the fused probe scan inside
+  the burst window meant the sensor was active AT SCAN START, and
+  sensor v2 semantics then held the collapse for the task's entire
+  run — ambient refault rates at SF100 (60-115k pages/s in EVERY run,
+  controls included) never go quiet, so v2 never released.
+- That exact failure mode was independently root-caused in the
+  2026-07-22 pagecache-sensor arc and fixed by #260: refault-sensor v3
+  episode cap (`ActiveBounded(refaultEpisodeCap)`,
+  internal/engine/memory/pressure_os.go, wired at
+  internal/worker/executor_fragment.go:597). An activation episode that
+  outlives the cap despite collapse is declared non-causal and ignored.
+  A task can no longer be pinned for its whole run; the +22-40% class
+  this caused is measured gone (#260's SF100 validation, steady −12.4%).
+
+Consequently the Q08/Q20 blocker is RESOLVED by the current tree.
+Precondition (2) — clearance-driven manifest activation — remains
+worthwhile as hygiene (don't publish for stages whose consumers never
+clear), and §12's broad low-single-digit taxes (Q02/Q09/Q19) remain
+unexplained on the 25m-era binary but are below the noise floor of the
+current 7m2x-era suite; the re-pair (precondition 3) re-measures them
+on the world that matters.
+
+2026-07-25 re-measure of the ceiling on bdef5ce (peerwire-treat run,
+results/20260725-123737, steady DAG wall 424s): measured edge ceiling
+133s = 31.3%, concentrated Q18 40.4s (55.8%), Q05 18.1s, Q21 16.2s,
+Q10 10.3s, Q07 9.3s, Q09 7.9s. Post-fusion plan shape moved the
+largest edges to JOIN-stage producers (Q18 join-8→join-17, Q05
+join-4→join-6, Q21 join-12→join-16): a fused chain's terminal join now
+emits the partitioned files the next join consumes. Manifest
+publication today exists only for exchange-repartition producers
+(orchestrate_repartition.go); covering join-producer edges and making
+fused consumers eligible (the §3.2 dep-count gate rejects stages whose
+Dependencies grew by chained-build deps) are the two design extensions
+the revival needs.

--- a/internal/coordinator/eager_dispatch.go
+++ b/internal/coordinator/eager_dispatch.go
@@ -61,20 +61,64 @@ func (c *Coordinator) eagerManifestPublisher(rootQueryID, stageID string, feed *
 			feed.appendReplay(m)
 			feed.noteCompletion(partBytes)
 		}
-		data, err := distributed.Marshal(m)
-		if err != nil {
-			c.logger.Error("eager manifest marshal failed",
-				"stage_id", stageID, "task_id", taskID, "error", err)
+		// Clearance-driven activation (§13 precondition 2): no NATS
+		// traffic until a consumer actually cleared on this feed. A feed
+		// that never activates costs nothing beyond the in-memory replay
+		// list; a consumer clearing later gets history from its task-spec
+		// Replay snapshot plus the activation backlog flush, and the
+		// republisher heals the remaining loss windows.
+		if feed == nil || !feed.isActive() {
 			return
 		}
-		if err := c.nc.Publish(subject, data); err != nil {
-			c.logger.Warn("eager manifest publish failed (replay list covers consumer retries)",
-				"stage_id", stageID, "task_id", taskID, "error", err)
+		if !c.publishEagerManifest(subject, m) {
 			return
 		}
-		EagerManifestsPublished.Add(1)
 		c.logger.Info("eager manifest published",
 			"stage_id", stageID, "task_id", taskID, "attempt", attempt,
 			"files", len(files), "worker", workerID, "final", final)
+	}
+}
+
+// publishEagerManifest marshals and publishes one manifest, counting it
+// on success. Publish failures are fire-and-forget by design (the replay
+// list and republisher cover consumer retries).
+func (c *Coordinator) publishEagerManifest(subject string, m distributed.ProducerTaskManifest) bool {
+	data, err := distributed.Marshal(m)
+	if err != nil {
+		c.logger.Error("eager manifest marshal failed",
+			"stage_id", m.StageID, "task_id", m.TaskID, "error", err)
+		return false
+	}
+	if err := c.nc.Publish(subject, data); err != nil {
+		c.logger.Warn("eager manifest publish failed (replay list covers consumer retries)",
+			"stage_id", m.StageID, "task_id", m.TaskID, "error", err)
+		return false
+	}
+	EagerManifestsPublished.Add(1)
+	return true
+}
+
+// flushEagerManifestBacklog publishes every manifest accumulated before
+// the feed's activation. Called once, at first consumer clearance: the
+// cleared consumer's task spec already carries these in its Replay, but
+// the flush closes the snapshot→subscribe window immediately instead of
+// waiting out a republisher tick, and it is what makes activation-gated
+// publication observable at all for producers that finished before any
+// consumer cleared.
+func (c *Coordinator) flushEagerManifestBacklog(f *eagerFeed) {
+	if c.nc == nil {
+		return
+	}
+	subject := distributed.EagerManifestSubject(f.rootQueryID, f.manifestStageID)
+	backlog := f.replaySnapshot()
+	published := 0
+	for _, m := range backlog {
+		if c.publishEagerManifest(subject, m) {
+			published++
+		}
+	}
+	if published > 0 {
+		c.logger.Info("eager manifest backlog flushed",
+			"stage_id", f.manifestStageID, "manifests", published)
 	}
 }

--- a/internal/coordinator/eager_dispatch.go
+++ b/internal/coordinator/eager_dispatch.go
@@ -29,6 +29,12 @@ var EagerManifestsPublished atomic.Int64
 // this counter's log line in benchmark.log).
 var EagerEdgesPlanned atomic.Int64
 
+// EagerChainedEdgesPlanned counts the subset of EagerEdgesPlanned whose
+// consumer is a stage-chain-fused join (§13/A2): the fused chain cleared
+// on its primary probe/build feeds while its chained-build deps completed
+// at the barrier.
+var EagerChainedEdgesPlanned atomic.Int64
+
 // eagerManifestPublisher returns a taskRetrier onSuccess hook that
 // publishes one manifest per successful producer task, or nil when eager
 // dispatch is disabled or the root query ID is unavailable (legacy

--- a/internal/coordinator/eager_dispatch_e2e_test.go
+++ b/internal/coordinator/eager_dispatch_e2e_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/citc-tech/wadjet/benchmarks/tpch"
 	"github.com/citc-tech/wadjet/internal/distributed"
+	"github.com/citc-tech/wadjet/internal/planner/physical"
 	"github.com/citc-tech/wadjet/internal/storage/catalog"
 	"github.com/citc-tech/wadjet/internal/storage/objstore"
 	"github.com/citc-tech/wadjet/internal/storage/parquet"
@@ -28,7 +29,11 @@ func setupEagerE2E(t *testing.T, tables []string) (context.Context, func(eager b
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	t.Cleanup(cancel)
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	logLevel := slog.LevelWarn
+	if os.Getenv("WADJET_TEST_LOG") == "info" {
+		logLevel = slog.LevelInfo
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel}))
 
 	natsCfg := distributed.DefaultNATSConfig()
 	natsCfg.Port = -1
@@ -242,6 +247,50 @@ func TestEagerJoinDispatchE2E(t *testing.T) {
 	}
 	t.Logf("C2 join eager engaged: edges=%d, %d groups identical",
 		EagerEdgesPlanned.Load()-edgesBefore, len(control))
+}
+
+// TestEagerChainedJoinDispatchE2E runs the A2 fused-chain path: a
+// three-table join whose two shuffled hash joins fuse into one chained
+// stage (stage-chain fusion, #269), which then clears dispatch eagerly on
+// its primary probe/build feeds while the chained build dep completes at
+// the barrier. Results must be row-identical to the barrier arm.
+func TestEagerChainedJoinDispatchE2E(t *testing.T) {
+	restoreTail := eagerMinTailSeconds
+	eagerMinTailSeconds = 0
+	t.Cleanup(func() { eagerMinTailSeconds = restoreTail })
+
+	// Pin fusion ON so the chain exists regardless of environment.
+	restoreFusion := physical.StageFusion.Load()
+	physical.StageFusion.Store(true)
+	t.Cleanup(func() { physical.StageFusion.Store(restoreFusion) })
+
+	ctx, newCoord := setupEagerE2E(t, []string{"lineitem", "orders"})
+	// Q18's chain shape at test scale: both joins key on l_orderkey /
+	// o_orderkey, so the decorrelated semi-join consumes the first join as
+	// its probe with the identical hash partitioning — the 1:1 link
+	// fuseStageChains absorbs (threshold lowered so SF001 returns rows).
+	const sql = `SELECT o_orderkey, SUM(l_quantity) AS qty
+		FROM lineitem
+		JOIN orders ON l_orderkey = o_orderkey
+		WHERE l_orderkey IN (SELECT l_orderkey FROM lineitem
+		     GROUP BY l_orderkey HAVING SUM(l_quantity) > 5)
+		GROUP BY o_orderkey`
+
+	control := runEagerE2EQuery(ctx, t, newCoord(false), sql, "control")
+	if len(control) == 0 {
+		t.Fatal("control returned no rows")
+	}
+	edgesBefore := EagerEdgesPlanned.Load()
+	chainedBefore := EagerChainedEdgesPlanned.Load()
+	treatment := runEagerE2EQuery(ctx, t, newCoord(true), sql, "eager-chained")
+
+	assertEagerArmsIdentical(t, control, treatment)
+	if got := EagerChainedEdgesPlanned.Load() - chainedBefore; got == 0 {
+		t.Error("eager chained run cleared no fused-chain consumer — A2 clearance did not engage")
+	}
+	t.Logf("chained eager engaged: edges=%d chained=%d, %d groups identical",
+		EagerEdgesPlanned.Load()-edgesBefore,
+		EagerChainedEdgesPlanned.Load()-chainedBefore, len(control))
 }
 
 // TestEagerTailGate: with the projected-tail floor in force (set high so

--- a/internal/coordinator/eager_dispatch_e2e_test.go
+++ b/internal/coordinator/eager_dispatch_e2e_test.go
@@ -262,10 +262,18 @@ func TestEagerTailGate(t *testing.T) {
 		t.Fatal("control returned no rows")
 	}
 	edgesBefore := EagerEdgesPlanned.Load()
+	manifestsBefore := EagerManifestsPublished.Load()
 	treatment := runEagerE2EQuery(ctx, t, newCoord(true), sql, "eager-gated")
 
 	assertEagerArmsIdentical(t, control, treatment)
 	if got := EagerEdgesPlanned.Load() - edgesBefore; got != 0 {
 		t.Errorf("gate floor in force but %d consumers cleared early — gate not applied", got)
+	}
+	// Clearance-driven activation (§13 precondition 2): with every
+	// consumer declined, no feed activates, so the flag-on run must
+	// publish ZERO manifests — the always-on NATS fan-out §12 charged to
+	// the flag no longer exists without a cleared consumer.
+	if got := EagerManifestsPublished.Load() - manifestsBefore; got != 0 {
+		t.Errorf("no consumer cleared but %d manifests were published — activation gating not applied", got)
 	}
 }

--- a/internal/coordinator/eager_dispatch_e2e_test.go
+++ b/internal/coordinator/eager_dispatch_e2e_test.go
@@ -293,6 +293,52 @@ func TestEagerChainedJoinDispatchE2E(t *testing.T) {
 		EagerChainedEdgesPlanned.Load()-chainedBefore, len(control))
 }
 
+// TestEagerComputeProducerE2E runs the A3 path: with stage-chain fusion
+// pinned OFF, the Q18-shaped plan keeps join-4 → join-9 as separate
+// stages, so join-9's probe is a hash-partitioned COMPUTE producer
+// (join-4) and its build another (final_aggregate-6). Both back eager
+// feeds whose manifests carry plain per-task .wshf files — the consumer's
+// manifest source maps them to partitions by producer-task dispatch
+// ordinal. The v1 eager slot serializes chained clearances, so the test
+// widens it to let the cascade engage deterministically. Results must be
+// row-identical to the barrier arm.
+func TestEagerComputeProducerE2E(t *testing.T) {
+	restoreTail := eagerMinTailSeconds
+	eagerMinTailSeconds = 0
+	t.Cleanup(func() { eagerMinTailSeconds = restoreTail })
+
+	restoreFusion := physical.StageFusion.Load()
+	physical.StageFusion.Store(false)
+	t.Cleanup(func() { physical.StageFusion.Store(restoreFusion) })
+
+	ctx, newCoord := setupEagerE2E(t, []string{"lineitem", "orders"})
+	const sql = `SELECT o_orderkey, SUM(l_quantity) AS qty
+		FROM lineitem
+		JOIN orders ON l_orderkey = o_orderkey
+		WHERE l_orderkey IN (SELECT l_orderkey FROM lineitem
+		     GROUP BY l_orderkey HAVING SUM(l_quantity) > 5)
+		GROUP BY o_orderkey`
+
+	control := runEagerE2EQuery(ctx, t, newCoord(false), sql, "control")
+	if len(control) == 0 {
+		t.Fatal("control returned no rows")
+	}
+	edgesBefore := EagerEdgesPlanned.Load()
+	eagerCoord := newCoord(true)
+	eagerCoord.eagerStageSlot = make(chan struct{}, 2)
+	treatment := runEagerE2EQuery(ctx, t, eagerCoord, sql, "eager-compute")
+
+	assertEagerArmsIdentical(t, control, treatment)
+	// join-4 (C2 over two repartitions) AND join-9 (A3 over two compute
+	// producers) must both clear — join-9 clearing proves manifest-fed
+	// consumption of plain compute outputs end-to-end.
+	if got := EagerEdgesPlanned.Load() - edgesBefore; got < 2 {
+		t.Errorf("expected >=2 eager clearances (C2 join-4 + A3 join-9), got %d", got)
+	}
+	t.Logf("compute-producer eager engaged: edges=%d, %d groups identical",
+		EagerEdgesPlanned.Load()-edgesBefore, len(control))
+}
+
 // TestEagerTailGate: with the projected-tail floor in force (set high so
 // SF001's millisecond producers can never satisfy it), an eager-flagged
 // run must keep the barrier on every edge — zero early clearances — and

--- a/internal/coordinator/eager_feed.go
+++ b/internal/coordinator/eager_feed.go
@@ -432,10 +432,20 @@ func eagerAliasForDep(stage physical.Stage, depID string) string {
 //     out of scope (broadcast edges stay S3+KV per memo §7);
 //     sort_merge_join is dormant (gate off) and excluded from slice 1.
 //   - both primary deps are standalone exchange-repartitions (the feeds'
-//     producers); fused-build deps keep the barrier (their real outputs
-//     ride task.FusedJoins[i].BuildFiles).
+//     producers); fused-build and chained-build deps keep the barrier
+//     (their real outputs ride task.FusedJoins[i].BuildFiles /
+//     task.Operators[i].BuildFiles — the dependency wait loop completes
+//     them before the clearance decision runs, so an eager dispatch sees
+//     real outputs for every non-primary dep).
 //   - not the gather-fused stage, no scalar deps (joins never carry
 //     dynamic-filter emits/consumes; checked defensively).
+//
+// Stage-chain fusion (§13, docs/design/stage-chain-fusion.md) grows
+// Dependencies by exactly one per ChainedJoinSpec; a fused chain is
+// eligible like any other hash join — only the primary probe/build feed
+// eagerly, the chain's builds are complete by clearance time. A chain
+// with an absorbed partial aggregate carries ChainedAgg* fields, not
+// GroupByCols, so the fragment-path restriction above is unaffected.
 //
 // The skew decision itself happens later, at the feed threshold
 // (eagerJoinWouldSplit) — this gate is structural only.
@@ -449,7 +459,7 @@ func eagerEligibleJoinConsumer(s physical.Stage, stageByID map[string]physical.S
 	if len(s.EmitDynamicFilters) > 0 || len(s.ConsumeDynamicFilters) > 0 {
 		return false
 	}
-	if len(s.Dependencies) != 2+len(s.FusedJoins) {
+	if len(s.Dependencies) != 2+len(s.FusedJoins)+len(s.ChainedJoins) {
 		return false
 	}
 	probeDep, buildDep := joinPrimaryDeps(s)
@@ -483,6 +493,16 @@ func (c *Coordinator) eagerJoinWouldSplit(stage physical.Stage, probeFeed, build
 		stage.Distribution.Kind != physical.DistHashPartitioned ||
 		numTasks <= 0 || workerCount <= 1 {
 		return false
+	}
+	// Partitioned chained builds bind build partition i to task i, so the
+	// dispatcher never skew-splits such stages (dispatchComputeStage skips
+	// planSkewSplitTasks). Mirror that: projecting a split the full-data
+	// path would never take would send the consumer to the barrier for
+	// nothing.
+	for _, cj := range stage.ChainedJoins {
+		if cj.Partitioned {
+			return false
+		}
 	}
 	switch stage.JoinType {
 	case "inner", "left", "semi", "anti":

--- a/internal/coordinator/eager_feed.go
+++ b/internal/coordinator/eager_feed.go
@@ -424,6 +424,40 @@ func eagerAliasForDep(stage physical.Stage, depID string) string {
 	}
 }
 
+// eagerCapableComputeProducer reports whether compute stage d can back an
+// eager feed (§14/A3): a hash-partitioned hash_join or final_aggregate
+// whose plain unpartitioned sink writes one file per task, so task
+// DISPATCH ORDER is the partition — the same positional contract the
+// barrier path's StageOutput.Files gives partitionFilesForWorker, which
+// the manifest source mirrors via the ProducerTaskIDs ordinal.
+//
+// Exchange-sink producers (stage.Exchange set) are out of A3 v1 scope;
+// dynamic-filter and scalar participants keep the barrier (provisional
+// outputs carry no BuildStats; scalar producers are read by the
+// coordinator). Dispatch-time regroupings (skew split, rr-agg split,
+// probe split, gather fusion) are gated at the wiring site — they remap
+// task→partition and would break the ordinal contract.
+func eagerCapableComputeProducer(d physical.Stage) bool {
+	if d.Type != physical.StageHashJoin && d.Type != "final_aggregate" {
+		return false
+	}
+	return d.Distribution.Kind == physical.DistHashPartitioned &&
+		d.Distribution.Count > 0 &&
+		d.Exchange == nil &&
+		len(d.EmitDynamicFilters) == 0 && len(d.ConsumeDynamicFilters) == 0 &&
+		len(d.ScalarDependencies) == 0
+}
+
+// eagerFeedableDep reports whether dependency stage d can be consumed
+// through an eager feed: a standalone exchange-repartition (C1/C2) or an
+// A3 compute producer.
+func eagerFeedableDep(d physical.Stage) bool {
+	if d.Type == physical.StageExchangeRepartition {
+		return d.Exchange != nil && d.Exchange.Count > 0
+	}
+	return eagerCapableComputeProducer(d)
+}
+
 // eagerEligibleJoinConsumer reports whether join stage s may clear
 // dispatch on its two producers' eager feeds (memo §3.3/§6, Phase C2
 // scope). Requires:
@@ -465,7 +499,7 @@ func eagerEligibleJoinConsumer(s physical.Stage, stageByID map[string]physical.S
 	probeDep, buildDep := joinPrimaryDeps(s)
 	for _, dep := range []string{probeDep, buildDep} {
 		d, ok := stageByID[dep]
-		if !ok || d.Type != physical.StageExchangeRepartition || d.Exchange == nil || d.Exchange.Count <= 0 {
+		if !ok || !eagerFeedableDep(d) {
 			return false
 		}
 	}
@@ -619,8 +653,9 @@ func (g *eagerPublishGovernor) noteTerminal(taskID string) {
 //   - a fragment-migrated single-input stage type: aggregate variants, or
 //     sort variants with SortKeys (a keyless "sort" would fall to the
 //     legacy task path, which reads Task.Inputs and cannot feed eagerly);
-//   - the dependency is a standalone exchange-repartition — the only
-//     producer the shuffle dispatcher registers feeds for in C1;
+//   - the dependency backs an eager feed: a standalone
+//     exchange-repartition, or an A3 compute producer
+//     (eagerFeedableDep);
 //   - not the gather-fused stage (fusion disables task retry, and retry is
 //     the fencing recovery path — memo §5);
 //   - no dynamic-filter participation (provisional outputs carry no
@@ -652,7 +687,7 @@ func eagerEligibleConsumer(s physical.Stage, stageByID map[string]physical.Stage
 		return false
 	}
 	dep, ok := stageByID[s.Dependencies[0]]
-	if !ok || dep.Type != physical.StageExchangeRepartition {
+	if !ok || !eagerFeedableDep(dep) {
 		return false
 	}
 	// Consumer task count (mirrors dispatchComputeStage's derivation for

--- a/internal/coordinator/eager_feed.go
+++ b/internal/coordinator/eager_feed.go
@@ -60,9 +60,20 @@ type eagerFeed struct {
 	decisionThreshold int // completions needed before decisionReady closes
 
 	mu        sync.Mutex
-	replay    []distributed.ProducerTaskManifest // manifests published so far
+	replay    []distributed.ProducerTaskManifest // manifests accumulated so far
 	closed    bool                               // query finished; republisher must stop
-	completed int                                // producer tasks at successful terminal
+	// active is set the first time a consumer stage clears dispatch on
+	// this feed. Until then no NATS traffic leaves the coordinator for
+	// this stage — the replay list and completion accounting still
+	// accumulate (clearance decisions read them), but publication is
+	// pure waste for the flag-on-no-clearance population (§12/§13: the
+	// gated arm declined 37 of 46 stages and still paid for every one).
+	// A consumer that clears later gets full history via its task-spec
+	// Replay snapshot plus the republisher, both of which start at
+	// activation.
+	active             bool
+	republisherStarted bool
+	completed          int // producer tasks at successful terminal
 	// firstDone/lastDone timestamp the first and most recent successful
 	// producer-task completions. Feed the projected-tail eager gate
 	// (projectedTailSeconds): the C3 SF100 pair (design doc §10) showed
@@ -211,6 +222,26 @@ func (f *eagerFeed) replaySnapshot() []distributed.ProducerTaskManifest {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return append([]distributed.ProducerTaskManifest(nil), f.replay...)
+}
+
+// activate marks the feed as having a cleared consumer, enabling live
+// manifest publication. Returns true when the caller should start the
+// republisher (first activation on an open feed). Idempotent.
+func (f *eagerFeed) activate() (startRepublisher bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.active = true
+	if f.republisherStarted || f.closed {
+		return false
+	}
+	f.republisherStarted = true
+	return true
+}
+
+func (f *eagerFeed) isActive() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.active
 }
 
 // markClosed stops the republisher. Idempotent.

--- a/internal/coordinator/eager_feed_test.go
+++ b/internal/coordinator/eager_feed_test.go
@@ -85,6 +85,35 @@ func TestEagerFeedDispatchUnblocksAndSnapshot(t *testing.T) {
 	}
 }
 
+// TestEagerFeedActivate pins the clearance-driven activation contract
+// (§13 precondition 2): inactive until a consumer clears, exactly one
+// republisher start across repeated activations, and no start on a feed
+// already closed by query teardown.
+func TestEagerFeedActivate(t *testing.T) {
+	f := newEagerFeed()
+	if f.isActive() {
+		t.Fatal("fresh feed must be inactive")
+	}
+	if !f.activate() {
+		t.Fatal("first activation must request a republisher start")
+	}
+	if !f.isActive() {
+		t.Fatal("feed must be active after activate()")
+	}
+	if f.activate() {
+		t.Fatal("second activation must not request another republisher")
+	}
+
+	closed := newEagerFeed()
+	closed.markClosed()
+	if closed.activate() {
+		t.Fatal("activation on a closed feed must not start a republisher")
+	}
+	if !closed.isActive() {
+		t.Fatal("activate() still marks a closed feed active (publisher gate reads it)")
+	}
+}
+
 // TestEagerInputRangesMatchFrozenBinding pins the eager partition ranges to
 // partitionRangeForWorker — the contract that makes eager and barrier
 // dispatch read identical row sets per task.

--- a/internal/coordinator/eager_feed_test.go
+++ b/internal/coordinator/eager_feed_test.go
@@ -364,6 +364,14 @@ func TestEagerJoinWouldSplit(t *testing.T) {
 	if !c.eagerJoinWouldSplit(join, hotProbe, coldBuild, 3, 3) {
 		t.Error("skewed projection must report would-split")
 	}
+	// Partitioned chained build: the dispatcher never skew-splits such
+	// stages (dispatchComputeStage skips planSkewSplitTasks), so the
+	// projection must not send the consumer to the barrier either.
+	chained := join
+	chained.ChainedJoins = []physical.ChainedJoinSpec{{Partitioned: true}}
+	if c.eagerJoinWouldSplit(chained, hotProbe, coldBuild, 3, 3) {
+		t.Error("partitioned-chain stage must never report would-split")
+	}
 	// Uniform: every group equal → ratio 1 < 2 → no split (the Q21 lesson).
 	uniform := mkFeed([]int64{1000, 1000, 1000}, 3)
 	if c.eagerJoinWouldSplit(join, uniform, coldBuild, 3, 3) {
@@ -438,6 +446,22 @@ func TestEagerEligibleJoinConsumer(t *testing.T) {
 		}), "", false},
 		{"fused-join dep count mismatch", mutate(func(s *physical.Stage) {
 			s.FusedJoins = []physical.FusedJoinSpec{{}}
+		}), "", false},
+		// Stage-chain fusion: Dependencies grow one per ChainedJoinSpec;
+		// a matching count is eligible (chained builds keep the barrier),
+		// a mismatch is not.
+		{"chained joins with matching deps eligible", mutate(func(s *physical.Stage) {
+			s.ChainedJoins = []physical.ChainedJoinSpec{{BuildDepStage: "scan-1"}}
+			s.Dependencies = []string{"ex-a", "ex-b", "scan-1"}
+		}), "", true},
+		{"chained joins with absorbed partial aggregate eligible", mutate(func(s *physical.Stage) {
+			s.ChainedJoins = []physical.ChainedJoinSpec{{BuildDepStage: "scan-1"}}
+			s.Dependencies = []string{"ex-a", "ex-b", "scan-1"}
+			s.ChainedAggGroupBy = []string{"g"}
+			s.ChainedAggSpecs = []physical.AggSpec{{}}
+		}), "", true},
+		{"chained-join dep count mismatch", mutate(func(s *physical.Stage) {
+			s.ChainedJoins = []physical.ChainedJoinSpec{{BuildDepStage: "scan-1"}}
 		}), "", false},
 	}
 	for _, tc := range cases {

--- a/internal/coordinator/eager_feed_test.go
+++ b/internal/coordinator/eager_feed_test.go
@@ -411,7 +411,20 @@ func TestEagerEligibleJoinConsumer(t *testing.T) {
 	repartB := physical.Stage{ID: "ex-b", Type: physical.StageExchangeRepartition,
 		Exchange: &physical.ExchangeStage{Keys: []string{"k"}, Count: 24}}
 	scan := physical.Stage{ID: "scan-1", Type: physical.StageScan}
-	byID := map[string]physical.Stage{"ex-a": repartA, "ex-b": repartB, "scan-1": scan}
+	joinUp := physical.Stage{ID: "join-up", Type: physical.StageHashJoin,
+		Distribution: physical.Distribution{Kind: physical.DistHashPartitioned, Count: 24}}
+	faggUp := physical.Stage{ID: "fagg-up", Type: "final_aggregate",
+		Distribution: physical.Distribution{Kind: physical.DistHashPartitioned, Count: 24}}
+	joinSingle := physical.Stage{ID: "join-single", Type: physical.StageHashJoin,
+		Distribution: physical.Distribution{Kind: physical.DistSingleton}}
+	joinExch := physical.Stage{ID: "join-exch", Type: physical.StageHashJoin,
+		Distribution: physical.Distribution{Kind: physical.DistHashPartitioned, Count: 24},
+		Exchange:     &physical.ExchangeStage{Keys: []string{"k"}, Count: 24}}
+	byID := map[string]physical.Stage{
+		"ex-a": repartA, "ex-b": repartB, "scan-1": scan,
+		"join-up": joinUp, "fagg-up": faggUp,
+		"join-single": joinSingle, "join-exch": joinExch,
+	}
 
 	base := physical.Stage{
 		ID: "join-1", Type: physical.StageHashJoin, JoinType: "inner",
@@ -462,6 +475,24 @@ func TestEagerEligibleJoinConsumer(t *testing.T) {
 		}), "", true},
 		{"chained-join dep count mismatch", mutate(func(s *physical.Stage) {
 			s.ChainedJoins = []physical.ChainedJoinSpec{{BuildDepStage: "scan-1"}}
+		}), "", false},
+		// A3: a hash-partitioned compute producer backs a feed like a
+		// repartition; a Singleton or exchange-sink one does not.
+		{"compute-producer probe eligible", mutate(func(s *physical.Stage) {
+			s.Dependencies = []string{"join-up", "ex-b"}
+			s.LeftDepStage = "join-up"
+		}), "", true},
+		{"final-aggregate probe eligible", mutate(func(s *physical.Stage) {
+			s.Dependencies = []string{"fagg-up", "ex-b"}
+			s.LeftDepStage = "fagg-up"
+		}), "", true},
+		{"singleton compute probe ineligible", mutate(func(s *physical.Stage) {
+			s.Dependencies = []string{"join-single", "ex-b"}
+			s.LeftDepStage = "join-single"
+		}), "", false},
+		{"exchange-sink compute probe ineligible", mutate(func(s *physical.Stage) {
+			s.Dependencies = []string{"join-exch", "ex-b"}
+			s.LeftDepStage = "join-exch"
 		}), "", false},
 	}
 	for _, tc := range cases {

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -561,6 +561,15 @@ func (c *Coordinator) executeStageDAG(
 				EagerEdgesPlanned.Add(1)
 				producerTasks := 0
 				for _, f := range eagerFeeds {
+					// Clearance-driven activation (§13 precondition 2):
+					// from here on this feed's completions publish live.
+					// The backlog flush covers completions that landed
+					// before clearance; the republisher heals the
+					// snapshot→subscribe window.
+					if f.activate() {
+						c.flushEagerManifestBacklog(f)
+						c.startEagerRepublisher(f)
+					}
 					producerTasks += len(f.producerTaskIDs)
 				}
 				c.logger.Info("eager dispatch: consumer cleared early",

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -572,9 +572,13 @@ func (c *Coordinator) executeStageDAG(
 					}
 					producerTasks += len(f.producerTaskIDs)
 				}
+				if len(s.ChainedJoins) > 0 {
+					EagerChainedEdgesPlanned.Add(1)
+				}
 				c.logger.Info("eager dispatch: consumer cleared early",
 					"query", queryID, "stage_id", s.ID, "stage_type", s.Type,
 					"eager_deps", len(eagerFeeds), "join", eagerJoin,
+					"chained_joins", len(s.ChainedJoins),
 					"producer_tasks", producerTasks)
 			} else if len(eagerFeeds) > 0 {
 				// Barrier fallback: wait out every eager dep's done signal

--- a/internal/coordinator/execute_stage_dag.go
+++ b/internal/coordinator/execute_stage_dag.go
@@ -2606,6 +2606,33 @@ func (c *Coordinator) dispatchComputeStage(
 		}
 	}, c.logger, stage.ID, c.classifyFatalResult)
 	defer c.watchStuckTasks(ctx, retrier)()
+	// A3 (eager-consumer-dispatch.md §14): a hash-partitioned compute
+	// stage backs an eager feed exactly like a shuffle producer — its
+	// plain sink writes one file per task and task dispatch order IS the
+	// partition, which the consumer's manifest source mirrors via the
+	// ProducerTaskIDs ordinal. Dispatch-time regroupings (skew split,
+	// rr-agg split, probe split) remap task→partition and decline; gather
+	// fusion disables the retry that fencing recovery needs; a
+	// coordinator-read stage (scalar extraction) keeps the barrier.
+	// Publication itself stays clearance-gated (§14/A1).
+	if fusion == nil && skewAssign == nil && rrAggGroups == nil && !probeSplit &&
+		len(tasks) > 0 && eagerCapableComputeProducer(stage) {
+		rootID := distributed.TaskRootQueryID(&tasks[0])
+		if rootID != "" && !c.stageReadByCoordinator(rootID, stage.ID) {
+			if feed := c.eagerFeedHandle(queryID, stage.ID); feed != nil {
+				retrier.onSuccess = c.eagerManifestPublisher(rootID, stage.ID, feed)
+				if retrier.onSuccess != nil {
+					ids := make([]string, len(tasks))
+					for i := range tasks {
+						ids[i] = tasks[i].ID
+					}
+					// Dispatch before publish so no completion beats the
+					// feed (same ordering contract as runShuffleSide).
+					feed.dispatch(rootID, stage.ID, ids, len(tasks), workerCount)
+				}
+			}
+		}
+	}
 	// Eager stages with more tasks than the cluster can hold at once
 	// publish in governed waves: eager tasks block on producer manifests
 	// while HOLDING a worker slot, so a full join fan-out (numTasks =

--- a/internal/coordinator/orchestrate_repartition.go
+++ b/internal/coordinator/orchestrate_repartition.go
@@ -280,7 +280,9 @@ func (c *Coordinator) runShuffleSide(
 	// Release eligible consumers: with the task layout fixed (IDs stable
 	// across retries, partition count final), consumers can bind their
 	// partition ranges and start draining manifests. Dispatch before
-	// publish so no completion can beat the feed.
+	// publish so no completion can beat the feed. The republisher is NOT
+	// started here — it starts at consumer clearance (feed activation),
+	// so a feed no consumer ever clears on generates zero NATS traffic.
 	if eagerFeed != nil && retrier.onSuccess != nil {
 		ids := make([]string, len(tasks))
 		for i := range tasks {
@@ -288,7 +290,6 @@ func (c *Coordinator) runShuffleSide(
 		}
 		t0 := tasks[0]
 		eagerFeed.dispatch(distributed.TaskRootQueryID(&t0), stageID, ids, numParts, workerCount)
-		c.startEagerRepublisher(eagerFeed)
 	}
 	defer c.watchStuckTasks(ctx, retrier)()
 

--- a/internal/worker/manifest_stream_source.go
+++ b/internal/worker/manifest_stream_source.go
@@ -62,6 +62,7 @@ type manifestStreamSource struct {
 	consumed  map[string]int           // producer taskID → attempt pinned at first read
 	poisoned  error                    // sticky fencing violation
 	candidate map[string]struct{}      // full producer task ID set
+	ordinal   map[string]int           // producer taskID → dispatch-order index
 
 	inner   *cachedFileStreamSource // current file-set reader
 	current manifestFileSet
@@ -70,8 +71,10 @@ type manifestStreamSource struct {
 
 func newManifestStreamSource(e *Executor, queryID, bucket string, spec distributed.EagerInput) *manifestStreamSource {
 	cand := make(map[string]struct{}, len(spec.ProducerTaskIDs))
-	for _, id := range spec.ProducerTaskIDs {
+	ord := make(map[string]int, len(spec.ProducerTaskIDs))
+	for i, id := range spec.ProducerTaskIDs {
 		cand[id] = struct{}{}
+		ord[id] = i
 	}
 	return &manifestStreamSource{
 		executor:  e,
@@ -83,6 +86,7 @@ func newManifestStreamSource(e *Executor, queryID, bucket string, spec distribut
 		resolved:  make(map[string]int, len(cand)),
 		consumed:  make(map[string]int, len(cand)),
 		candidate: cand,
+		ordinal:   ord,
 	}
 }
 
@@ -118,7 +122,7 @@ func (s *manifestStreamSource) observe(m distributed.ProducerTaskManifest) {
 	if _, ok := s.candidate[m.TaskID]; !ok {
 		return // different edge of a shared producer stage, or garbage
 	}
-	inRange := filesInPartitionRange(m.Files, s.spec.PartitionStart, s.spec.PartitionEnd)
+	inRange := s.filesInRange(m)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -223,14 +227,28 @@ func (s *manifestStreamSource) Close() error {
 
 var _ exec.Source = (*manifestStreamSource)(nil)
 
-// filesInPartitionRange filters shuffle keys whose "partition=NNNN" path
-// segment falls inside [start, end] (inclusive). Keys without the segment
-// are excluded — eager feeds only ever carry partitioned shuffle output.
-func filesInPartitionRange(files []string, start, end int) []string {
+// filesInRange filters one manifest's files to [PartitionStart,
+// PartitionEnd] (inclusive). A key's partition is its "partition=NNNN"
+// path segment when present (partitioned shuffle / exchange-sink
+// output). A key WITHOUT the segment is a plain per-task output
+// (compute-stage producers: hash-partitioned joins and final_aggregates
+// whose unpartitioned sink writes one file per task) — there, task
+// DISPATCH ORDER is the partition, exactly the positional contract the
+// barrier path's StageOutput.Files (retrier.Files, dispatch-ordered)
+// gives partitionFilesForWorker. The ordinal map mirrors that order via
+// spec.ProducerTaskIDs.
+func (s *manifestStreamSource) filesInRange(m distributed.ProducerTaskManifest) []string {
+	ord, hasOrd := s.ordinal[m.TaskID]
 	var out []string
-	for _, f := range files {
+	for _, f := range m.Files {
 		p, ok := partitionOfKey(f)
-		if ok && p >= start && p <= end {
+		if !ok {
+			if !hasOrd {
+				continue
+			}
+			p = ord
+		}
+		if p >= s.spec.PartitionStart && p <= s.spec.PartitionEnd {
 			out = append(out, f)
 		}
 	}

--- a/internal/worker/manifest_stream_source_test.go
+++ b/internal/worker/manifest_stream_source_test.go
@@ -60,6 +60,40 @@ func TestPartitionOfKey(t *testing.T) {
 	}
 }
 
+// A3 ordinal contract: a file WITHOUT a partition= segment (plain
+// per-task compute output) takes its producing task's dispatch-order
+// ordinal as its partition; partition= files keep filename semantics.
+func TestManifestSource_OrdinalPartitionFallback(t *testing.T) {
+	e := &Executor{peers: newPeerExchange()}
+	// Consumer bound to partitions [1,2] of a 4-task producer.
+	s := newManifestStreamSource(e, "q", "b", testEagerSpec([]string{"t0", "t1", "t2", "t3"}, 1, 2))
+
+	plain := func(task string) string { return "queries/rootq/stage-3/" + task + ".wshf" }
+	// t0 (ordinal 0): out of range → resolved, no files queued.
+	got := s.filesInRange(distributed.ProducerTaskManifest{TaskID: "t0", Attempt: 1, Files: []string{plain("t0")}})
+	if len(got) != 0 {
+		t.Fatalf("ordinal 0 outside [1,2] must filter: got %v", got)
+	}
+	// t2 (ordinal 2): in range → its plain file passes.
+	got = s.filesInRange(distributed.ProducerTaskManifest{TaskID: "t2", Attempt: 1, Files: []string{plain("t2")}})
+	if len(got) != 1 || got[0] != plain("t2") {
+		t.Fatalf("ordinal 2 inside [1,2] must pass: got %v", got)
+	}
+	// Mixed manifest: partition= files keep filename semantics (9 is out,
+	// 1 is in) while the plain file rides the ordinal (t1 → 1, in).
+	got = s.filesInRange(distributed.ProducerTaskManifest{TaskID: "t1", Attempt: 1,
+		Files: []string{key("t1", 9), key("t1", 1), plain("t1")}})
+	if len(got) != 2 || got[0] != key("t1", 1) || got[1] != plain("t1") {
+		t.Fatalf("mixed manifest filtering wrong: got %v", got)
+	}
+	// Unknown task (not in ProducerTaskIDs): plain files have no ordinal
+	// and are excluded (observe's candidate gate rejects earlier anyway).
+	got = s.filesInRange(distributed.ProducerTaskManifest{TaskID: "tX", Attempt: 1, Files: []string{plain("tX")}})
+	if len(got) != 0 {
+		t.Fatalf("unknown task's plain files must be excluded: got %v", got)
+	}
+}
+
 // EOF requires every candidate resolved AND all in-range files drained;
 // manifests with no in-range files still resolve their task.
 func TestManifestSource_EOFAfterAllResolved(t *testing.T) {


### PR DESCRIPTION
## Summary

Revival of eager consumer dispatch (docs/design/eager-consumer-dispatch.md §13-§14), executing the §12 preconditions plus the two extensions the post-fusion world needs. `--eager-dispatch` stays **default OFF** — this PR changes nothing on main's default path; the SF100 pair A/Bs the flag next.

- **Precondition 1 resolved (§13)**: the §12 Q08/Q20 flag-on signature was refault-sensor v2 pinning a task's decode-ahead collapse for its whole run, exposed by flag-on's earlier consumer dispatch landing scans inside producer burst windows. Fixed independently by #260's episode cap; §12's manifest-machinery attribution withdrawn after worker-log forensics (gated Q08 had zero clearances yet regressed; workers never subscribe without EagerInputs).
- **A1 — clearance-driven manifest activation** (precondition 2): no NATS traffic for feeds no consumer clears on; backlog flush + republisher start at activation. Regression: TestEagerTailGate asserts zero publishes when all consumers decline.
- **A2 — fused-chain consumer eligibility**: dep-count gate accounts for ChainedJoins; chained builds stay barrier-complete; skew projection mirrors the dispatcher's partitioned-chain skip. New EagerChainedEdgesPlanned marker.
- **A3 — compute-stage producer feeds**: hash-partitioned hash_join/final_aggregate producers publish per-task manifests; plain per-task files map to partitions by producer-task dispatch ordinal (the same positional contract the barrier path uses). Declines anything that remaps task→partition (skew/rr-agg/probe splits), gather fusion, exchange sinks, dyn-filter/scalar participants, coordinator-read stages.

## Motivation

Post-fusion SF100 ceiling re-measure (results/20260725-162139): 88s = 22.2% of steady DAG wall sits behind producer→consumer barriers, concentrated Q21 19.1s, Q18 17.1s, Q03 13.3s — with the largest single edges behind compute-stage producers (Q21 join-12→join-16 9.9s, Q18 final_aggregate-14→join-8 6.1s). Full evidence chain in the design doc §13-§14.

## Validation

- Eager battery + full coordinator suite + worker suite green; TPC-H SF0.01 22/22.
- E2E: fused chain clears eagerly (A2); with fusion pinned off, join-9 clears on two compute feeds and aggregate-10 cascades three eager stages deep — rows identical to barrier arms in all cases.
- SF1 tpch-harness local, 3 arms (off / eager+floor0 / eager+floor12): PASS, per-query row counts identical across arms, no zero-row queries; eager engaged for real in the floor-0 arm (12 clearances, 15 manifest publishes). Checksum wobble on q01/q06/q07 reproduces between two flag-off-equivalent arms → pre-existing float-order nondeterminism, not eager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4GkoBFZwBk89b9SgNnZbj